### PR TITLE
Minor ALLOW_GHOST_IF_NO_NOTES fix

### DIFF
--- a/Assets/Script/Constants.cs
+++ b/Assets/Script/Constants.cs
@@ -16,6 +16,6 @@ namespace YARG {
 		public const int EXTRA_ALLOWED_GHOSTS = 0;
 		public const bool ALLOW_DESC_GHOSTS = true;
 		public const bool ALLOW_GHOST_IF_NO_NOTES = true; // seems to allow more ghosting than it should...
-		public const float ALLOW_GHOST_IF_NO_NOTES_THRESHOLD = 1.5f;
+		public const float ALLOW_GHOST_IF_NO_NOTES_THRESHOLD = 2f; // this should solve the above
 	}
 }


### PR DESCRIPTION
Sometimes it would allow more ghosts than it should; that's because (at the time I didn't realize this) the hit window is actually `2 * Constants.HIT_MARGIN`. Setting the threshold var to 2 solved this issue.