### PR TITLE
Clear phrase after ending for generic vox

### DIFF
--- a/Assets/Script/Data/GenericLyricInfo.cs
+++ b/Assets/Script/Data/GenericLyricInfo.cs
@@ -1,12 +1,12 @@
 using System.Collections.Generic;
 
 namespace YARG.Data {
-	public class GenericLyricInfo {
-		public float time;
+	public class GenericLyricInfo : AbstractInfo {
 		public List<(float time, string word)> lyric;
 
-		public GenericLyricInfo(float time, List<(float, string)> lyric) {
+		public GenericLyricInfo(float time, float length, List<(float, string)> lyric) {
 			this.time = time;
+			this.length = length;
 			this.lyric = lyric;
 		}
 	}

--- a/Assets/Script/PlayMode/Play.cs
+++ b/Assets/Script/PlayMode/Play.cs
@@ -322,10 +322,14 @@ namespace YARG.PlayMode {
 			// Update lyrics
 			if (lyricIndex < chart.genericLyrics.Count) {
 				var lyric = chart.genericLyrics[lyricIndex];
-				if (lyricPhraseIndex >= lyric.lyric.Count) {
+
+				if (lyricPhraseIndex >= lyric.lyric.Count && lyric.EndTime < SongTime) {
+					// Clear phrase
+					GameUI.Instance.SetGenericLyric(string.Empty);
+
 					lyricPhraseIndex = 0;
 					lyricIndex++;
-				} else if (lyric.lyric[lyricPhraseIndex].time < SongTime) {
+				} else if (lyricPhraseIndex < lyric.lyric.Count && lyric.lyric[lyricPhraseIndex].time < SongTime) {
 					// Consolidate lyrics
 					string o = "<color=#ffb700>";
 					for (int i = 0; i < lyric.lyric.Count; i++) {

--- a/Assets/Script/Serialization/Parser/MidiParser.Vocals.cs
+++ b/Assets/Script/Serialization/Parser/MidiParser.Vocals.cs
@@ -74,7 +74,10 @@ namespace YARG.Serialization.Parser {
 				}
 
 				// Add phrase to result
-				lyrics.Add(lyric);
+				// Ignore phrases w/o lyrics (i.e. percussion)
+				if (lyric.lyric.Count > 0) {
+					lyrics.Add(lyric);
+				}
 			}
 
 			return lyrics;

--- a/Assets/Script/Serialization/Parser/MidiParser.Vocals.cs
+++ b/Assets/Script/Serialization/Parser/MidiParser.Vocals.cs
@@ -28,7 +28,8 @@ namespace YARG.Serialization.Parser {
 				// Create lyric
 				startTimings.Add(note.Time);
 				var time = (float) TimeConverter.ConvertTo<MetricTimeSpan>(note.Time, tempo).TotalSeconds;
-				GenericLyricInfo lyric = new(time, new());
+				var length = (float) TimeConverter.ConvertTo<MetricTimeSpan>(note.EndTime, tempo).TotalSeconds - time;
+				GenericLyricInfo lyric = new(time, length, new());
 
 				// Get lyrics from this phrase
 				long totalDelta = 0;


### PR DESCRIPTION
Changes:
- Parse phrase length and ignore empty phrases from midi for generic vox
- Clear generic vocal phrase in UI after phrase ends

Addresses #228