### PR TITLE
Gold star progress graphic tweak

### DIFF
--- a/Assets/Prefabs/UI/ScoreDisplay/ScoreDisplay.prefab
+++ b/Assets/Prefabs/UI/ScoreDisplay/ScoreDisplay.prefab
@@ -697,7 +697,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 0.8980392, b: 0.44705883, a: 0.7607843}
+  m_Color: {r: 1, g: 0.8980392, b: 0.44705883, a: 0.6039216}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1


### PR DESCRIPTION
Slightly decrease the alpha of the top bar to better blend it in with the GS progress sprite.