### PR TITLE
Fix caches not being scanned in parallel on error

### DIFF
--- a/Assets/Script/Song/SongContainer.cs
+++ b/Assets/Script/Song/SongContainer.cs
@@ -46,7 +46,7 @@ namespace YARG.Song {
 			return output.ErroredCaches;
 		}
 
-		public static async UniTask ScanFolders(ICollection<string> folders, Action<SongScanner> updateUi = null) {
+		public static async UniTask ScanFolders(ICollection<string> folders, bool fast, Action<SongScanner> updateUi = null) {
 			var songsToRemove = _songs.Where(song => folders.Contains(song.CacheRoot)).ToList();
 			
 			_songs.RemoveAll(x => songsToRemove.Contains(x));
@@ -55,12 +55,12 @@ namespace YARG.Song {
 			}
 			
 			var scanner = new SongScanner(folders);
-			var songs = await scanner.StartScan(false, updateUi);
+			var songs = await scanner.StartScan(fast, updateUi);
 
 			AddSongs(songs.SongEntries);
 		}
 		
-		public static async UniTask ScanSingleFolder(string path, Action<SongScanner> updateUi = null) {
+		public static async UniTask ScanSingleFolder(string path, bool fast, Action<SongScanner> updateUi = null) {
 			var songsToRemove = _songs.Where(song => song.CacheRoot == path).ToList();
 
 			_songs.RemoveAll(x => songsToRemove.Contains(x));
@@ -69,7 +69,7 @@ namespace YARG.Song {
 			}
 
 			var scanner = new SongScanner(new[] { path });
-			var songs = await scanner.StartScan(false, updateUi);
+			var songs = await scanner.StartScan(fast, updateUi);
 
 			AddSongs(songs.SongEntries);
 		}


### PR DESCRIPTION
Changes how caches are full scanned on startup, previously they were queued individually which prevents any parallel scanning. Adjusted it so that they are passed all at once and can be threaded properly