### PR TITLE
Handle some exceptions with chart preparsing

### DIFF
--- a/Assets/Script/Song/Preparsers/ChartPreparser.cs
+++ b/Assets/Script/Song/Preparsers/ChartPreparser.cs
@@ -29,17 +29,29 @@ namespace YARG.Song.Preparsers {
 			// { Instrument.GHLiveCoop, "GHLCoop" }
 		};
 
-		public static ulong GetAvailableTracks(byte[] chartData) {
+		public static bool GetAvailableTracks(byte[] chartData, out ulong tracks) {
 			using var stream = new MemoryStream(chartData);
 
 			using var reader = new StreamReader(stream);
-			return ReadStream(reader);
+			try {
+				tracks = ReadStream(reader);
+				return true;
+			} catch {
+				tracks = 0;
+				return false;
+			}
 		}
 		
-		public static ulong GetAvailableTracks(SongEntry song) {
+		public static bool GetAvailableTracks(SongEntry song, out ulong tracks) {
 			using var reader = File.OpenText(Path.Combine(song.Location, song.NotesFile));
 
-			return ReadStream(reader);
+			try {
+				tracks = ReadStream(reader);
+				return true;
+			} catch {
+				tracks = 0;
+				return false;
+			}
 		}
 
 		private static ulong ReadStream(StreamReader reader) {

--- a/Assets/Script/Song/Preparsers/MidPreparser.cs
+++ b/Assets/Script/Song/Preparsers/MidPreparser.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.IO;
 using Melanchall.DryWetMidi.Core;
 using MoonscraperChartEditor.Song.IO;
-using UnityEngine;
 using YARG.Data;
 
 namespace YARG.Song.Preparsers {
@@ -31,26 +30,28 @@ namespace YARG.Song.Preparsers {
 
 		};
 
-		public static ulong GetAvailableTracks(byte[] chartData) {
+		public static bool GetAvailableTracks(byte[] chartData, out ulong tracks) {
 			using var stream = new MemoryStream(chartData);
 			try {
 				var midi = MidiFile.Read(stream, ReadSettings);
-				return ReadStream(midi);
+				tracks = ReadStream(midi);
+				return true;
 			} catch (Exception e) {
-				Debug.LogError(e.Message);
-				Debug.LogError(e.StackTrace);
-				return ulong.MaxValue;
+				// Debug.LogError(e.Message);
+				// Debug.LogError(e.StackTrace);
+				tracks = 0;
+				return false;
 			}
 		}
 
-		public static ulong GetAvailableTracks(SongEntry song) {
+		public static bool GetAvailableTracks(SongEntry song, out ulong tracks) {
 			try {
 				var midi = MidiFile.Read(Path.Combine(song.Location, song.NotesFile), ReadSettings);
-				return ReadStream(midi);
-			} catch (Exception e) {
-				Debug.LogError(e.Message);
-				Debug.LogError(e.StackTrace);
-				return ulong.MaxValue;
+				tracks = ReadStream(midi);
+				return true;
+			} catch {
+				tracks = 0;
+				return false;
 			}
 		}
 

--- a/Assets/Script/Song/ScanHelpers.cs
+++ b/Assets/Script/Song/ScanHelpers.cs
@@ -10,6 +10,9 @@ namespace YARG.Song {
 
 		public static ScanResult ParseSongIni(string iniFile, IniSongEntry entry) {
 			var file = new IniFile(iniFile);
+			
+			// Had some reports that ini parsing might throw an exception, leaving this in for now
+			// in as I don't know the cause just yet and I want to investigate it further.
 			file.Parse();
 
 			string sectionName = file.ContainsSection("song") ? "song" : "Song";

--- a/Assets/Script/Song/Scanning/SongScanThread.cs
+++ b/Assets/Script/Song/Scanning/SongScanThread.cs
@@ -147,7 +147,7 @@ namespace YARG.Song {
 					_errorsEncountered++;
 					errorsEncountered = _errorsEncountered;
 					_songErrors[cacheFolder].Add(new SongError(subDir, result));
-					Debug.LogWarning($"Error encountered with {subDir}");
+					Debug.LogWarning($"Error encountered with {subDir}: {result}");
 					return;
 			}
 
@@ -251,9 +251,15 @@ namespace YARG.Song {
 			var tracks = ulong.MaxValue;
 
 			if (notesFile.EndsWith(".mid")) {
-				tracks = MidPreparser.GetAvailableTracks(bytes);
+				if (!MidPreparser.GetAvailableTracks(bytes, out ulong availTracks)) {
+					return ScanResult.CorruptedNotesFile;
+				}
+				tracks = availTracks;
 			} else if (notesFile.EndsWith(".chart")) {
-				tracks = ChartPreparser.GetAvailableTracks(bytes);
+				if (!ChartPreparser.GetAvailableTracks(bytes, out ulong availTracks)) {
+					return ScanResult.CorruptedNotesFile;
+				}
+				tracks = availTracks;
 			}
 
 			// We have a song.ini, notes file and audio. The song is scannable.
@@ -289,7 +295,9 @@ namespace YARG.Song {
 
 			string checksum = BitConverter.ToString(SHA1.Create().ComputeHash(bytes)).Replace("-", "");
 
-			ulong tracks = MidPreparser.GetAvailableTracks(bytes);
+			if (!MidPreparser.GetAvailableTracks(bytes, out ulong tracks)) {
+				return ScanResult.CorruptedNotesFile;
+			}
 
 			file.CacheRoot = cache;
 			file.Checksum = checksum;
@@ -321,7 +329,9 @@ namespace YARG.Song {
 
 			string checksum = BitConverter.ToString(SHA1.Create().ComputeHash(bytes)).Replace("-", "");
 
-			ulong tracks = MidPreparser.GetAvailableTracks(bytes);
+			if (!MidPreparser.GetAvailableTracks(bytes, out ulong tracks)) {
+				return ScanResult.CorruptedNotesFile;
+			}
 
 			file.CacheRoot = cache;
 			file.Checksum = checksum;

--- a/Assets/Script/Song/Scanning/SongScanner.cs
+++ b/Assets/Script/Song/Scanning/SongScanner.cs
@@ -12,7 +12,9 @@ namespace YARG.Song {
 		NotASong,
 		NoNotesFile,
 		NoAudioFile,
-		EncryptedMogg
+		EncryptedMogg,
+		CorruptedNotesFile,
+		CorruptedMetadataFile
 	}
 
 	public readonly struct SongError {
@@ -230,6 +232,9 @@ namespace YARG.Song {
 									break;
 								case ScanResult.EncryptedMogg:
 									await writer.WriteLineAsync("These songs contain encrypted moggs!");
+									break;
+								case ScanResult.CorruptedNotesFile:
+									await writer.WriteLineAsync("These songs contain a corrupted notes.chart/notes.mid file!");
 									break;
 							}
 							lastResult = error.Result;


### PR DESCRIPTION
Found some very odd songs and charts which broke the preparser entirely so added some exception handling with a CorruptedNotesFile result to handle these cases now.