### PR TITLE
added support for multiple shortname song arrays in songs_updates.dta

### DIFF
--- a/Assets/Script/Serialization/Xbox/MoggBassInfoGenerator.cs
+++ b/Assets/Script/Serialization/Xbox/MoggBassInfoGenerator.cs
@@ -11,7 +11,7 @@ using YARG.Song;
 
 namespace YARG.Serialization {
 	public static class MoggBASSInfoGenerator {
-        public static void Generate(ConSongEntry song, DataArray dta, DataArray dta_update_root){
+        public static void Generate(ConSongEntry song, DataArray dta, List<DataArray> dta_update_roots = null){
             var Tracks = new Dictionary<string, int[]>();
 			float[] PanData = null, VolumeData = null;
 			int[] CrowdChannels = null;
@@ -21,12 +21,14 @@ namespace YARG.Serialization {
 			dtas_to_parse.Add(dta);
 
 			// determine whether or not we even NEED to parse the update dta for mogg information
-			if(dta_update_root != null){
-				dta_update = dta_update_root.Array("song");
-				if(dta_update != null){
-					if(dta_update.Array("tracks") != null || dta_update.Array("pans") != null || 
-						dta_update.Array("vols") != null || dta_update.Array("crowd_channels") != null)
-						dtas_to_parse.Add(dta_update);
+			if(dta_update_roots != null){
+				foreach(var dta_update_root in dta_update_roots){
+					dta_update = dta_update_root.Array("song");
+					if(dta_update != null){
+						if(dta_update.Array("tracks") != null || dta_update.Array("pans") != null || 
+							dta_update.Array("vols") != null || dta_update.Array("crowd_channels") != null)
+							dtas_to_parse.Add(dta_update);
+					}
 				}
 			}
 			

--- a/Assets/Script/Serialization/Xbox/XboxCONFileBrowser.cs
+++ b/Assets/Script/Serialization/Xbox/XboxCONFileBrowser.cs
@@ -10,10 +10,9 @@ using YARG.Song;
 
 namespace YARG.Serialization {
 	public static class XboxCONFileBrowser {
-		public static List<ConSongEntry> BrowseCON(string conName, string update_folder, List<string> update_shortnames){
+		public static List<ConSongEntry> BrowseCON(string conName, string update_folder, Dictionary<string, List<DataArray>> update_dict){
 			var songList = new List<ConSongEntry>();
 			var dtaTree = new DataArray();
-			var dtaUpdateTree = new DataArray();
 
 			// Attempt to read songs.dta
 			STFS theCON = new STFS(conName);
@@ -25,18 +24,6 @@ namespace YARG.Serialization {
 				return null;
 			}
 
-			// Attempt to read songs_updates.dta, if it exists
-			if(update_folder != string.Empty){
-				try {
-					using var sr_upd = new StreamReader(Path.Combine(update_folder, "songs_updates.dta"), Encoding.GetEncoding("iso-8859-1"));
-					dtaUpdateTree = DTX.FromDtaString(sr_upd.ReadToEnd());
-				} catch (Exception e_upd) {
-					Debug.LogError($"Failed to parse songs_updates.dta for `{update_folder}`.");
-					Debug.LogException(e_upd);
-					return null;
-				}
-			}
-
 			// Read each song the dta file lists
 			for (int i = 0; i < dtaTree.Count; i++) {
 				try {
@@ -46,11 +33,14 @@ namespace YARG.Serialization {
 					ConSongEntry currentSong = XboxDTAParser.ParseFromDta(currentArray);
 
 					// check if song has applicable updates
-					bool songCanBeUpdated = (!String.IsNullOrEmpty(update_folder) && (update_shortnames.Find(s => s == currentSong.ShortName) != null));
+					bool songCanBeUpdated = (update_dict.TryGetValue(currentSong.ShortName, out var val));
 
 					// if shortname was found in songs_updates.dta, update the metadata
-					if(songCanBeUpdated)
-						currentSong = XboxDTAParser.ParseFromDta(dtaUpdateTree.Array(currentSong.ShortName), currentSong);
+					if(songCanBeUpdated){
+						foreach(var dtaUpdate in update_dict[currentSong.ShortName]){
+							currentSong = XboxDTAParser.ParseFromDta(dtaUpdate, currentSong);
+						}
+					}
 
 					// since Location is currently set to the name of the folder before mid/mogg/png, set those paths now
 					// since we're dealing with a CON and not an ExCON, grab each relevant file's sizes and memory block offsets
@@ -117,8 +107,7 @@ namespace YARG.Serialization {
 						currentSong.MoggAddressAudioOffset = br.ReadInt32();
 						currentSong.MoggAudioLength = fs.Length - currentSong.MoggAddressAudioOffset;
 					}
-					
-					MoggBASSInfoGenerator.Generate(currentSong, currentArray.Array("song"), dtaUpdateTree.Array(currentSong.ShortName));
+					MoggBASSInfoGenerator.Generate(currentSong, currentArray.Array("song"), val);
 
 					// Debug.Log($"{currentSong.ShortName}:\nMidi path: {currentSong.NotesFile}\nMogg path: {currentSong.MoggPath}\nImage path: {currentSong.ImagePath}");
 

--- a/Assets/Script/Serialization/Xbox/XboxSongUpdateBrowser.cs
+++ b/Assets/Script/Serialization/Xbox/XboxSongUpdateBrowser.cs
@@ -11,9 +11,9 @@ using YARG.Song;
 
 namespace YARG.Serialization {
 	public static class XboxSongUpdateBrowser {
-        public static List<string> GetUpdatableShortnames(string update_folder){
-            var songList = new List<string>();
+        public static Dictionary<string, List<DataArray>> FetchSongUpdates(string update_folder){
 			var dtaTree = new DataArray();
+			var UpdateSongDict = new Dictionary<string, List<DataArray>>();
 
             // Attempt to read songs_updates.dta
 			try {
@@ -28,14 +28,30 @@ namespace YARG.Serialization {
             // Read each shortname the dta file lists
 			for (int i = 0; i < dtaTree.Count; i++) {
 				try {
-					string currentName = ((DataArray) dtaTree[i]).Name;
-					songList.Add(currentName);
+					var currentArray = (DataArray) dtaTree[i];
+					string currentName = currentArray.Name;
+
+					if(UpdateSongDict.TryGetValue(currentName, out var value)){
+						UpdateSongDict[currentName].Add(currentArray);
+					}
+					else {
+						var dArray = new List<DataArray>();
+						dArray.Add(currentArray);
+						UpdateSongDict.Add(currentName, dArray);
+					}
+
 				} catch (Exception e) {
 					Debug.Log($"Failed to get shortname, skipping...");
 					Debug.LogException(e);
 				}
 			}
-            return songList;
+
+			// Debug.Log($"Song updates:");
+			// foreach(var item in UpdateSongDict){
+			// 	Debug.Log($"{item.Key} has update array count of {item.Value.Count}");
+			// }
+
+            return UpdateSongDict;
         }
     }
 }


### PR DESCRIPTION
When applying song updates, you no longer require all updates for a particular shortname to be contained a singular data array. You can now have as many data arrays with the same shortname as you like!