### PR TITLE
Added Song Preview to Music Library

### DIFF
--- a/Assets/Script/Audio/AudioHelpers.cs
+++ b/Assets/Script/Audio/AudioHelpers.cs
@@ -44,7 +44,7 @@ namespace YARG {
 			1.0,
 		};
 
-		public static ICollection<string> GetSupportedStems(string folder, params SongStem[] exceptions) {
+		public static ICollection<string> GetSupportedStems(string folder) {
 			var stems = new List<string>();
 
 			foreach (string filePath in Directory.GetFiles(folder)) {
@@ -55,11 +55,6 @@ namespace YARG {
 
 				// Check if file is a valid stem
 				if (!SupportedStems.Contains(Path.GetFileNameWithoutExtension(filePath).ToLowerInvariant())) {
-					continue;
-				}
-				
-				// Check if valid stem is in the exceptions parameter
-				if (exceptions.Contains(GetStemFromName(Path.GetFileNameWithoutExtension(filePath)))) {
 					continue;
 				}
 

--- a/Assets/Script/Audio/AudioHelpers.cs
+++ b/Assets/Script/Audio/AudioHelpers.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 
 namespace YARG {
 	public static class AudioHelpers {
@@ -43,7 +44,7 @@ namespace YARG {
 			1.0,
 		};
 
-		public static ICollection<string> GetSupportedStems(string folder) {
+		public static ICollection<string> GetSupportedStems(string folder, params SongStem[] exceptions) {
 			var stems = new List<string>();
 
 			foreach (string filePath in Directory.GetFiles(folder)) {
@@ -54,6 +55,11 @@ namespace YARG {
 
 				// Check if file is a valid stem
 				if (!SupportedStems.Contains(Path.GetFileNameWithoutExtension(filePath).ToLowerInvariant())) {
+					continue;
+				}
+				
+				// Check if valid stem is in the exceptions parameter
+				if (exceptions.Contains(GetStemFromName(Path.GetFileNameWithoutExtension(filePath)))) {
 					continue;
 				}
 

--- a/Assets/Script/Audio/Bass/BassAudioManager.cs
+++ b/Assets/Script/Audio/Bass/BassAudioManager.cs
@@ -256,7 +256,7 @@ namespace YARG {
 			if (song is ExtractedConSongEntry conSong) {
 				LoadMogg(conSong, false);
 			} else {
-				LoadSong(AudioHelpers.GetSupportedStems(song.Location), false);
+				LoadSong(AudioHelpers.GetSupportedStems(song.Location, SongStem.Crowd), false);
 			}
 
 			SetPosition(song.PreviewStartTimeSpan.TotalSeconds);

--- a/Assets/Script/Audio/Bass/BassAudioManager.cs
+++ b/Assets/Script/Audio/Bass/BassAudioManager.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using Cysharp.Threading.Tasks;
 using ManagedBass;
 using UnityEngine;
 using YARG.Serialization;
@@ -302,10 +303,12 @@ namespace YARG {
 			}
 		}
 
-		public void FadeOut() {
+		public UniTask FadeOut() {
 			if (IsPlaying) {
-				_mixer?.FadeOut();
+				return _mixer.FadeOut();
 			}
+
+			return default;
 		}
 
 		public void PlaySoundEffect(SfxSample sample) {

--- a/Assets/Script/Audio/Bass/BassAudioManager.cs
+++ b/Assets/Script/Audio/Bass/BassAudioManager.cs
@@ -295,10 +295,10 @@ namespace YARG {
 			IsPlaying = _mixer.IsPlaying;
 		}
 
-		public void FadeIn() {
+		public void FadeIn(float maxVolume) {
 			Play(true);
 			if (IsPlaying) {
-				_mixer?.FadeIn();
+				_mixer?.FadeIn(maxVolume);
 			}
 		}
 

--- a/Assets/Script/Audio/Bass/BassAudioManager.cs
+++ b/Assets/Script/Audio/Bass/BassAudioManager.cs
@@ -19,6 +19,7 @@ namespace YARG {
 
 		public bool IsAudioLoaded { get; private set; }
 		public bool IsPlaying { get; private set; }
+		public bool IsPreviewing { get; private set; }
 
 		public double MasterVolume { get; private set; }
 		public double SfxVolume { get; private set; }
@@ -260,6 +261,10 @@ namespace YARG {
 		}
 
 		public void LoadPreviewAudio(SongEntry song) {
+			if (IsPreviewing) {
+				return;
+			}
+			
 			if (song is ExtractedConSongEntry conSong) {
 				LoadMogg(conSong, false);
 			} else {
@@ -280,8 +285,11 @@ namespace YARG {
 		}
 		
 		public async void StartPreviewAudio() {
+			IsPreviewing = false;
 			_cancellationTokenSource = new CancellationTokenSource();
 			await StartPreviewAudioTask();
+			
+			IsPreviewing = true;
 			await LoopPreviewAudioTask();
 		}
 
@@ -319,6 +327,7 @@ namespace YARG {
 			UnloadSong();
 			_cancellationTokenSource.Dispose();
 			_cancellationTokenSource = null;
+			IsPreviewing = false;
 		}
 
 		public void Play() => Play(false);

--- a/Assets/Script/Audio/Bass/BassAudioManager.cs
+++ b/Assets/Script/Audio/Bass/BassAudioManager.cs
@@ -304,7 +304,9 @@ namespace YARG {
 					SetPosition(PreviewStartTime);
 					FadeIn(SettingsManager.Settings.PreviewVolume.Data);
 				}
-			} catch (OperationCanceledException) { }
+			} catch {
+				// Exit out of loop
+			}
 		}
 
 		public void StopPreviewAudio() {

--- a/Assets/Script/Audio/Bass/BassHelpers.cs
+++ b/Assets/Script/Audio/Bass/BassHelpers.cs
@@ -8,7 +8,7 @@ namespace YARG {
 
 		public const float SONG_VOLUME_MULTIPLIER = 0.7f;
 
-		public const int FADE_TIME_MILLISECONDS = 2000;
+		public const int FADE_TIME_MILLISECONDS = 1000;
 		
 		public const int REVERB_SLIDE_IN_MILLISECONDS = 300;
 		public const int REVERB_SLIDE_OUT_MILLISECONDS = 500;

--- a/Assets/Script/Audio/Bass/BassMoggStem.cs
+++ b/Assets/Script/Audio/Bass/BassMoggStem.cs
@@ -120,12 +120,10 @@ namespace YARG {
 			return 0;
 		}
 
-		public void FadeIn() {
-			double volumeSetting = _manager.GetVolumeSetting(Stem);
-			
+		public void FadeIn(float maxVolume) {
 			foreach (int channel in BassChannels) {
 				Bass.ChannelSetAttribute(channel, ChannelAttribute.Volume, 0);
-				Bass.ChannelSlideAttribute(channel, ChannelAttribute.Volume, (float)volumeSetting, BassHelpers.FADE_TIME_MILLISECONDS);
+				Bass.ChannelSlideAttribute(channel, ChannelAttribute.Volume, maxVolume, BassHelpers.FADE_TIME_MILLISECONDS);
 			}
 		}
 

--- a/Assets/Script/Audio/Bass/BassMoggStem.cs
+++ b/Assets/Script/Audio/Bass/BassMoggStem.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Cysharp.Threading.Tasks;
 using ManagedBass;
 using ManagedBass.Fx;
 using ManagedBass.Mix;
@@ -127,10 +128,18 @@ namespace YARG {
 			}
 		}
 
-		public void FadeOut() {
+		public UniTask FadeOut() {
+			var fadeOuts = new List<UniTask>();
 			foreach (int channel in BassChannels) {
 				Bass.ChannelSlideAttribute(channel, ChannelAttribute.Volume, 0, BassHelpers.FADE_TIME_MILLISECONDS);
+				var fadeOutTask = UniTask.WaitUntil(() => {
+					Bass.ChannelGetAttribute(channel, ChannelAttribute.Volume, out var currentVolume);
+					return Mathf.Abs(currentVolume) <= 0.01f;
+				});
+				fadeOuts.Add(fadeOutTask);
 			}
+
+			return UniTask.WhenAll(fadeOuts);
 		}
 
 		public void SetVolume(double newVolume) {

--- a/Assets/Script/Audio/Bass/BassStemChannel.cs
+++ b/Assets/Script/Audio/Bass/BassStemChannel.cs
@@ -112,10 +112,9 @@ namespace YARG {
 			return 0;
 		}
 
-		public void FadeIn() {
-			double volumeSetting = _manager.GetVolumeSetting(Stem);
+		public void FadeIn(float maxVolume) {
 			Bass.ChannelSetAttribute(StreamHandle, ChannelAttribute.Volume, 0);
-			Bass.ChannelSlideAttribute(StreamHandle, ChannelAttribute.Volume, (float)volumeSetting, BassHelpers.FADE_TIME_MILLISECONDS);
+			Bass.ChannelSlideAttribute(StreamHandle, ChannelAttribute.Volume, maxVolume, BassHelpers.FADE_TIME_MILLISECONDS);
 		}
 
 		public void FadeOut() {

--- a/Assets/Script/Audio/Bass/BassStemChannel.cs
+++ b/Assets/Script/Audio/Bass/BassStemChannel.cs
@@ -1,8 +1,10 @@
 using System;
 using System.Collections.Generic;
+using Cysharp.Threading.Tasks;
 using ManagedBass;
 using ManagedBass.Fx;
 using ManagedBass.Mix;
+using UnityEngine;
 
 namespace YARG {
 	public class BassStemChannel : IStemChannel {
@@ -117,8 +119,12 @@ namespace YARG {
 			Bass.ChannelSlideAttribute(StreamHandle, ChannelAttribute.Volume, maxVolume, BassHelpers.FADE_TIME_MILLISECONDS);
 		}
 
-		public void FadeOut() {
+		public UniTask FadeOut() {
 			Bass.ChannelSlideAttribute(StreamHandle, ChannelAttribute.Volume, 0, BassHelpers.FADE_TIME_MILLISECONDS);
+			return UniTask.WaitUntil(() => {
+				Bass.ChannelGetAttribute(StreamHandle, ChannelAttribute.Volume, out var currentVolume);
+				return Mathf.Abs(currentVolume) <= 0.01f;
+			});
 		}
 
 		public void SetVolume(double newVolume) {

--- a/Assets/Script/Audio/Bass/BassStemMixer.cs
+++ b/Assets/Script/Audio/Bass/BassStemMixer.cs
@@ -158,10 +158,22 @@ namespace YARG {
 			}
 
 			foreach (var channel in Channels.Values) {
-				int handle = ((BassStemChannel)channel).StreamHandle;
+				long channelPosition;
+				switch (channel)
+				{
+					case BassStemChannel bassStemChannel:
+						int handle = bassStemChannel.StreamHandle;
+						channelPosition = Bass.ChannelSeconds2Bytes(handle, position);
+						BassMix.ChannelSetPosition(handle, channelPosition);
+						break;
+					case BassMoggStem bassMoggStem:
+						foreach (var bassHandle in bassMoggStem.BassChannels) {
+							channelPosition = Bass.ChannelSeconds2Bytes(bassHandle, position);
+							BassMix.ChannelSetPosition(bassHandle, channelPosition);
+						}
+						break;
+				}
 				
-				long channelPosition = Bass.ChannelSeconds2Bytes(handle, position);
-				BassMix.ChannelSetPosition(handle, channelPosition);
 			}
 		}
 

--- a/Assets/Script/Audio/Bass/BassStemMixer.cs
+++ b/Assets/Script/Audio/Bass/BassStemMixer.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Cysharp.Threading.Tasks;
 using ManagedBass;
 using ManagedBass.Mix;
 using UnityEngine;
@@ -124,10 +125,9 @@ namespace YARG {
 			}
 		}
 
-		public void FadeOut() {
-			foreach (var channel in Channels.Values) {
-				channel.FadeOut();
-			}
+		public UniTask FadeOut() {
+			var fadeOuts = Enumerable.Select(Channels.Values, channel => channel.FadeOut()).ToList();
+			return UniTask.WhenAll(fadeOuts);
 		}
 
 		public int Pause() {

--- a/Assets/Script/Audio/Bass/BassStemMixer.cs
+++ b/Assets/Script/Audio/Bass/BassStemMixer.cs
@@ -159,8 +159,7 @@ namespace YARG {
 
 			foreach (var channel in Channels.Values) {
 				long channelPosition;
-				switch (channel)
-				{
+				switch (channel) {
 					case BassStemChannel bassStemChannel:
 						int handle = bassStemChannel.StreamHandle;
 						channelPosition = Bass.ChannelSeconds2Bytes(handle, position);

--- a/Assets/Script/Audio/Bass/BassStemMixer.cs
+++ b/Assets/Script/Audio/Bass/BassStemMixer.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using Cysharp.Threading.Tasks;
 using ManagedBass;
 using ManagedBass.Mix;
@@ -125,9 +126,9 @@ namespace YARG {
 			}
 		}
 
-		public UniTask FadeOut() {
+		public UniTask FadeOut(CancellationToken token = default) {
 			var fadeOuts = Enumerable.Select(Channels.Values, channel => channel.FadeOut()).ToList();
-			return UniTask.WhenAll(fadeOuts);
+			return UniTask.WhenAll(fadeOuts).AttachExternalCancellation(token);
 		}
 
 		public int Pause() {

--- a/Assets/Script/Audio/Bass/BassStemMixer.cs
+++ b/Assets/Script/Audio/Bass/BassStemMixer.cs
@@ -118,9 +118,9 @@ namespace YARG {
 			return 0;
 		}
 
-		public void FadeIn() {
+		public void FadeIn(float maxVolume) {
 			foreach (var channel in Channels.Values) {
-				channel.FadeIn();
+				channel.FadeIn(maxVolume);
 			}
 		}
 

--- a/Assets/Script/Audio/Interfaces/IAudioManager.cs
+++ b/Assets/Script/Audio/Interfaces/IAudioManager.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Threading;
 using Cysharp.Threading.Tasks;
 using YARG.Serialization;
 using YARG.Song;
@@ -12,7 +13,6 @@ namespace YARG {
 
 		public bool IsAudioLoaded { get; }
 		public bool IsPlaying { get; }
-		public bool IsPreviewing { get; }
 
 		public double MasterVolume { get; }
 		public double SfxVolume { get; }
@@ -43,7 +43,7 @@ namespace YARG {
 		public void Pause();
 
 		public void FadeIn(float maxVolume);
-		public UniTask FadeOut();
+		public UniTask FadeOut(CancellationToken token = default);
 
 		public void PlaySoundEffect(SfxSample sample);
 

--- a/Assets/Script/Audio/Interfaces/IAudioManager.cs
+++ b/Assets/Script/Audio/Interfaces/IAudioManager.cs
@@ -15,7 +15,10 @@ namespace YARG {
 
 		public double MasterVolume { get; }
 		public double SfxVolume { get; }
-
+		
+		public double PreviewStartTime { get; }
+		public double PreviewEndTime { get; }
+		
 		public double CurrentPositionD { get; }
 		public double AudioLengthD { get; }
 
@@ -32,6 +35,8 @@ namespace YARG {
 		public void UnloadSong();
 
 		public void LoadPreviewAudio(SongEntry song);
+		public void StartPreviewAudio();
+		public void StopPreviewAudio();
 
 		public void Play();
 		public void Pause();

--- a/Assets/Script/Audio/Interfaces/IAudioManager.cs
+++ b/Assets/Script/Audio/Interfaces/IAudioManager.cs
@@ -35,8 +35,8 @@ namespace YARG {
 		public void Play();
 		public void Pause();
 
-		public void FadeIn();
 		public void FadeOut();
+		public void FadeIn(float maxVolume);
 
 		public void PlaySoundEffect(SfxSample sample);
 

--- a/Assets/Script/Audio/Interfaces/IAudioManager.cs
+++ b/Assets/Script/Audio/Interfaces/IAudioManager.cs
@@ -31,8 +31,8 @@ namespace YARG {
 
 		public void LoadSfx();
 
-		public void LoadSong(ICollection<string> stems, bool isSpeedUp);
-		public void LoadMogg(ExtractedConSongEntry exConSong, bool isSpeedUp);
+		public void LoadSong(ICollection<string> stems, bool isSpeedUp, params SongStem[] ignoreStems);
+		public void LoadMogg(ExtractedConSongEntry exConSong, bool isSpeedUp, params SongStem[] ignoreStems);
 		public void UnloadSong();
 
 		public void LoadPreviewAudio(SongEntry song);

--- a/Assets/Script/Audio/Interfaces/IAudioManager.cs
+++ b/Assets/Script/Audio/Interfaces/IAudioManager.cs
@@ -12,6 +12,7 @@ namespace YARG {
 
 		public bool IsAudioLoaded { get; }
 		public bool IsPlaying { get; }
+		public bool IsPreviewing { get; }
 
 		public double MasterVolume { get; }
 		public double SfxVolume { get; }

--- a/Assets/Script/Audio/Interfaces/IAudioManager.cs
+++ b/Assets/Script/Audio/Interfaces/IAudioManager.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Cysharp.Threading.Tasks;
 using YARG.Serialization;
 using YARG.Song;
 
@@ -35,8 +36,8 @@ namespace YARG {
 		public void Play();
 		public void Pause();
 
-		public void FadeOut();
 		public void FadeIn(float maxVolume);
+		public UniTask FadeOut();
 
 		public void PlaySoundEffect(SfxSample sample);
 

--- a/Assets/Script/Audio/Interfaces/IStemChannel.cs
+++ b/Assets/Script/Audio/Interfaces/IStemChannel.cs
@@ -1,4 +1,5 @@
 using System;
+using Cysharp.Threading.Tasks;
 
 namespace YARG {
 	public interface IStemChannel : IDisposable {
@@ -11,8 +12,8 @@ namespace YARG {
 
 		public int Load(bool isSpeedUp, float speed);
 
-		public void FadeOut();
 		public void FadeIn(float maxVolume);
+		public UniTask FadeOut();
 		
 		public void SetVolume(double newVolume);
 		

--- a/Assets/Script/Audio/Interfaces/IStemChannel.cs
+++ b/Assets/Script/Audio/Interfaces/IStemChannel.cs
@@ -11,8 +11,8 @@ namespace YARG {
 
 		public int Load(bool isSpeedUp, float speed);
 
-		public void FadeIn();
 		public void FadeOut();
+		public void FadeIn(float maxVolume);
 		
 		public void SetVolume(double newVolume);
 		

--- a/Assets/Script/Audio/Interfaces/IStemMixer.cs
+++ b/Assets/Script/Audio/Interfaces/IStemMixer.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Cysharp.Threading.Tasks;
 
 namespace YARG {
 	public interface IStemMixer : IDisposable {
@@ -17,8 +18,8 @@ namespace YARG {
 
 		public int Play(bool restart = false);
 
-		public void FadeOut();
 		public void FadeIn(float maxVolume);
+		public UniTask FadeOut();
 		
 		public int Pause();
 

--- a/Assets/Script/Audio/Interfaces/IStemMixer.cs
+++ b/Assets/Script/Audio/Interfaces/IStemMixer.cs
@@ -17,8 +17,8 @@ namespace YARG {
 
 		public int Play(bool restart = false);
 
-		public void FadeIn();
 		public void FadeOut();
+		public void FadeIn(float maxVolume);
 		
 		public int Pause();
 

--- a/Assets/Script/Audio/Interfaces/IStemMixer.cs
+++ b/Assets/Script/Audio/Interfaces/IStemMixer.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using Cysharp.Threading.Tasks;
 
 namespace YARG {
@@ -19,7 +20,7 @@ namespace YARG {
 		public int Play(bool restart = false);
 
 		public void FadeIn(float maxVolume);
-		public UniTask FadeOut();
+		public UniTask FadeOut(CancellationToken token = default);
 		
 		public int Pause();
 

--- a/Assets/Script/Constants.cs
+++ b/Assets/Script/Constants.cs
@@ -17,5 +17,8 @@ namespace YARG {
 		public const bool ALLOW_DESC_GHOSTS = true;
 		public const bool ALLOW_GHOST_IF_NO_NOTES = true; // seems to allow more ghosting than it should...
 		public const float ALLOW_GHOST_IF_NO_NOTES_THRESHOLD = 2f; // this should solve the above
+		
+		// Preview
+		public const double PREVIEW_DURATION = 30.0;
 	}
 }

--- a/Assets/Script/Settings/SettingsManager.Settings.cs
+++ b/Assets/Script/Settings/SettingsManager.Settings.cs
@@ -38,6 +38,7 @@ namespace YARG.Settings {
 			public VolumeSetting SongVolume                 { get; private set; } = new(1f,   v   => VolumeCallback(SongStem.Song,   v));
 			public VolumeSetting CrowdVolume                { get; private set; } = new(0.5f,   v => VolumeCallback(SongStem.Crowd,  v));
 			public VolumeSetting SfxVolume                  { get; private set; } = new(0.8f, v   => VolumeCallback(SongStem.Sfx,    v));
+			public VolumeSetting PreviewVolume              { get; private set; } = new(0.25f);	
 			public VolumeSetting VocalMonitoring            { get; private set; } = new(0.7f,      VocalMonitoringCallback);
 			public ToggleSetting MuteOnMiss                 { get; private set; } = new(true);
 			public ToggleSetting UseStarpowerFx             { get; private set; } = new(true,      UseStarpowerFxChange);

--- a/Assets/Script/Settings/SettingsManager.cs
+++ b/Assets/Script/Settings/SettingsManager.cs
@@ -49,6 +49,7 @@ namespace YARG.Settings {
 					"SongVolume",
 					"CrowdVolume",
 					"SfxVolume",
+					"PreviewVolume",
 					"VocalMonitoring",
 					new HeaderMetadata("Other"),
 					"MuteOnMiss",

--- a/Assets/Script/UI/MainMenu.cs
+++ b/Assets/Script/UI/MainMenu.cs
@@ -140,6 +140,7 @@ namespace YARG.UI {
 
 		public void ShowPreSong() {
 			HideAll();
+			GameManager.AudioManager.StopPreviewAudio();
 			difficultySelect.gameObject.SetActive(true);
 		}
 

--- a/Assets/Script/UI/MusicLibrary/SongSelection.cs
+++ b/Assets/Script/UI/MusicLibrary/SongSelection.cs
@@ -48,7 +48,6 @@ namespace YARG.UI.MusicLibrary {
 			get => _selectedIndex;
 			private set {
 				_selectedIndex = value;
-				isSelectingStopped = false;
 
 				if (_songs.Count <= 0) {
 					return;
@@ -172,12 +171,16 @@ namespace YARG.UI.MusicLibrary {
 			var scroll = Mouse.current.scroll.ReadValue().y;
 			if (scroll > 0f) {
 				SelectedIndex--;
+				isSelectingStopped = false;
 			} else if (scroll < 0f) {
 				SelectedIndex++;
+				isSelectingStopped = false;
 			}
 			else if (Mathf.Abs(scroll) < float.Epsilon && !isSelectingStopped) {
-				GameManager.AudioManager.StartPreviewAudio();
-				isSelectingStopped = true;
+				if (_songs[SelectedIndex] is SongViewType) {
+					GameManager.AudioManager.StartPreviewAudio();
+					isSelectingStopped = true;
+				}
 			}
 		}
 
@@ -189,7 +192,10 @@ namespace YARG.UI.MusicLibrary {
 			}
 
 			if (!pressed) {
-				GameManager.AudioManager.StartPreviewAudio();
+				if (_songs[SelectedIndex] is SongViewType) {
+					GameManager.AudioManager.StartPreviewAudio();
+				}
+
 				return;
 			}
 

--- a/Assets/Script/UI/MusicLibrary/SongSelection.cs
+++ b/Assets/Script/UI/MusicLibrary/SongSelection.cs
@@ -62,11 +62,17 @@ namespace YARG.UI.MusicLibrary {
 
 				UpdateScrollbar();
 				UpdateSongViews();
-				
-				if (_songs[_selectedIndex] is SongViewType song) {
-					GameManager.Instance.SelectedSong = song.SongEntry;
-					GameManager.AudioManager.FadeOut();
+
+				if (_songs[_selectedIndex] is not SongViewType song) {
+					return;
 				}
+				
+				if (song.SongEntry == GameManager.Instance.SelectedSong) {
+					return;
+				}
+					
+				GameManager.AudioManager.FadeOut();
+				GameManager.Instance.SelectedSong = song.SongEntry;
 			}
 		}
 
@@ -336,6 +342,9 @@ namespace YARG.UI.MusicLibrary {
 				});
 
 				SelectedIndex = Mathf.Max(1, index);
+				if (SelectedIndex == 1) {
+					GameManager.AudioManager.StartPreviewAudio();
+				}
 			}
 
 			UpdateSongViews();

--- a/Assets/Script/UI/MusicLibrary/SongSelection.cs
+++ b/Assets/Script/UI/MusicLibrary/SongSelection.cs
@@ -71,7 +71,7 @@ namespace YARG.UI.MusicLibrary {
 					return;
 				}
 					
-				GameManager.AudioManager.FadeOut();
+				GameManager.AudioManager.FadeOut().Forget();
 				GameManager.Instance.SelectedSong = song.SongEntry;
 			}
 		}

--- a/Assets/Script/UI/MusicLibrary/SongSelection.cs
+++ b/Assets/Script/UI/MusicLibrary/SongSelection.cs
@@ -413,6 +413,7 @@ namespace YARG.UI.MusicLibrary {
 
 		public void Back() {
 			if (string.IsNullOrEmpty(searchField.text)) {
+				GameManager.AudioManager.StopPreviewAudio();
 				MainMenu.Instance.ShowMainMenu();
 			} else {
 				searchField.text = "";

--- a/Assets/Script/UI/MusicLibrary/SongSelection.cs
+++ b/Assets/Script/UI/MusicLibrary/SongSelection.cs
@@ -48,6 +48,7 @@ namespace YARG.UI.MusicLibrary {
 			get => _selectedIndex;
 			private set {
 				_selectedIndex = value;
+				isSelectingStopped = false;
 
 				if (_songs.Count <= 0) {
 					return;
@@ -60,13 +61,13 @@ namespace YARG.UI.MusicLibrary {
 					_selectedIndex = 0;
 				}
 
-				if (_songs[_selectedIndex] is SongViewType song) {
-					GameManager.Instance.SelectedSong = song.SongEntry;
-					GameManager.AudioManager.StartPreviewAudio();
-				}
-
 				UpdateScrollbar();
 				UpdateSongViews();
+				
+				if (_songs[_selectedIndex] is SongViewType song) {
+					GameManager.Instance.SelectedSong = song.SongEntry;
+					GameManager.AudioManager.FadeOut();
+				}
 			}
 		}
 
@@ -78,6 +79,8 @@ namespace YARG.UI.MusicLibrary {
 		private NavigationType direction;
 		private bool directionHeld = false;
 		private float inputTimer = 0f;
+		private float scroll;
+		private bool isSelectingStopped = true;
 
 		private void Awake() {
 			refreshFlag = true;
@@ -127,9 +130,9 @@ namespace YARG.UI.MusicLibrary {
 				// Get songs
 				UpdateSearch();
 				refreshFlag = false;
-			} else {
-				GameManager.AudioManager.StartPreviewAudio();
 			}
+			
+			GameManager.AudioManager.StartPreviewAudio();
 		}
 
 		private void OnDisable() {
@@ -172,6 +175,10 @@ namespace YARG.UI.MusicLibrary {
 			} else if (scroll < 0f) {
 				SelectedIndex++;
 			}
+			else if (Mathf.Abs(scroll) < float.Epsilon && !isSelectingStopped) {
+				GameManager.AudioManager.StartPreviewAudio();
+				isSelectingStopped = true;
+			}
 		}
 
 		private void OnGenericNavigation(NavigationType navigationType, bool pressed) {
@@ -182,6 +189,7 @@ namespace YARG.UI.MusicLibrary {
 			}
 
 			if (!pressed) {
+				GameManager.AudioManager.StartPreviewAudio();
 				return;
 			}
 

--- a/Assets/Script/UI/MusicLibrary/SongSelection.cs
+++ b/Assets/Script/UI/MusicLibrary/SongSelection.cs
@@ -62,6 +62,7 @@ namespace YARG.UI.MusicLibrary {
 
 				if (_songs[_selectedIndex] is SongViewType song) {
 					GameManager.Instance.SelectedSong = song.SongEntry;
+					GameManager.AudioManager.StartPreviewAudio();
 				}
 
 				UpdateScrollbar();
@@ -126,6 +127,8 @@ namespace YARG.UI.MusicLibrary {
 				// Get songs
 				UpdateSearch();
 				refreshFlag = false;
+			} else {
+				GameManager.AudioManager.StartPreviewAudio();
 			}
 		}
 

--- a/Assets/Settings/Localization/Settings Shared Data.asset
+++ b/Assets/Settings/Localization/Settings Shared Data.asset
@@ -215,6 +215,10 @@ MonoBehaviour:
     m_Key: FpsStats
     m_Metadata:
       m_Items: []
+  - m_Id: 17867012767817728
+    m_Key: PreviewVolume
+    m_Metadata:
+      m_Items: []
   m_Metadata:
     m_Items: []
   m_KeyGenerator:

--- a/Assets/Settings/Localization/Settings_en-US.asset
+++ b/Assets/Settings/Localization/Settings_en-US.asset
@@ -222,6 +222,10 @@ MonoBehaviour:
     m_Localized: Enable FPS Counter
     m_Metadata:
       m_Items: []
+  - m_Id: 17867012767817728
+    m_Localized: Preview Volume
+    m_Metadata:
+      m_Items: []
   references:
     version: 2
     RefIds: []


### PR DESCRIPTION
- Configured 30s preview duration & shorter fade-in time
- Added Preview Volume Button to Settings (25% by default)
- Added max volume parameter to FadeIn function
- Made FadeOut function a UniTask that runs until all playing stems are fully muted
- Disable crowd stem when previewing audio from ini file
- Disable crowd stem when previewing audio from con file
- Added functions for start & stopping preview audio (with looping mechanic at Start function)