### PR TITLE
Implement max combo on results screen

### DIFF
--- a/Assets/Script/PlayMode/AbstractTrack.cs
+++ b/Assets/Script/PlayMode/AbstractTrack.cs
@@ -78,6 +78,7 @@ namespace YARG.PlayMode {
 
 		private int _combo = 0;
 		private int _recentCombo = 0;  // For tracking note streak of size interval / 2
+		private int _maxCombo = 0;
 
 		protected int Combo {
 			get => _combo;
@@ -88,6 +89,10 @@ namespace YARG.PlayMode {
 
 				_combo = value;
 
+				if (value > _maxCombo) {
+					_maxCombo = value;
+				}
+
 				// End starpower if combo ends
 				if (StarpowerSection?.time <= Play.Instance.SongTime && value == 0) {
 					StarpowerSection = null;
@@ -95,6 +100,8 @@ namespace YARG.PlayMode {
 				}
 			}
 		}
+		
+		public int MaxCombo => _maxCombo;
 
 		public int MaxMultiplier => (player.chosenInstrument == "bass" ? 6 : 4) * (IsStarPowerActive ? 2 : 1);
 		public int Multiplier => Mathf.Min((Combo / 10 + 1) * (IsStarPowerActive ? 2 : 1), MaxMultiplier);

--- a/Assets/Script/PlayMode/AbstractTrack.cs
+++ b/Assets/Script/PlayMode/AbstractTrack.cs
@@ -209,7 +209,8 @@ namespace YARG.PlayMode {
 					stars = math.clamp((int) starsKeeper.Stars, 0, 6)
 				},
 				notesHit = notesHit,
-				notesMissed = GetChartCount() - notesHit
+				notesMissed = GetChartCount() - notesHit,
+				maxCombo = MaxCombo
 			};
 		}
 

--- a/Assets/Script/PlayerManager.cs
+++ b/Assets/Script/PlayerManager.cs
@@ -15,6 +15,7 @@ namespace YARG {
 			public DiffScore score;
 			public int notesHit;
 			public int notesMissed;
+			public int maxCombo;
 
 		}
 

--- a/Assets/Script/UI/PlayResultScreen/PlayerCard.cs
+++ b/Assets/Script/UI/PlayResultScreen/PlayerCard.cs
@@ -111,7 +111,7 @@ namespace YARG.UI.PlayResultScreen {
 
 			// detailed combo info
 			detailNotesHit.text = $"{scr.notesHit}<color=#ffffff> / {scr.notesHit + scr.notesMissed}";
-			detailMaxStreak.text = "TODO"; // TODO
+			detailMaxStreak.text = scr.maxCombo.ToString();
 			detailMissedNotes.text = scr.notesMissed.ToString();
 
 			/* Bottom banner */


### PR DESCRIPTION
 * Added a `MaxCombo` variable to `AbstractTrack` and  `PlayerManager.LastScore`.
 * The max combo is now displayed on the results screen.