### PR TITLE
Open extended sustain fix

### DIFF
--- a/Assets/Script/PlayMode/AbstractTrack.cs
+++ b/Assets/Script/PlayMode/AbstractTrack.cs
@@ -409,6 +409,7 @@ namespace YARG.PlayMode {
 				if (!soloInProgress) {
 					soloInProgress = true;
 					soloNotesHit = 0;
+					soloNoteCount = 0;
 
 					float lastNoteTime = -1f;
 					for (int i = hitChartIndex; i < Chart.Count; i++) {

--- a/Assets/Script/PlayMode/FiveFretTrack.cs
+++ b/Assets/Script/PlayMode/FiveFretTrack.cs
@@ -482,6 +482,9 @@ namespace YARG.PlayMode {
 				if (fret == 5) {
 					// Deal with open notes
 					for (int i = 0; i < frets.Length; i++) {
+						if (overlap && heldNotes.Any(j => j.fret == i)) {
+							continue;
+						}
 						if (frets[i].IsPressed) {
 							return false;
 						}


### PR DESCRIPTION
![image](https://github.com/YARC-Official/YARG/assets/23385965/0bb9237e-2f97-45f7-8ead-186de0b65509)
These are playable on CH; I've made it so the open note hit detection ignores held sustains if it's an extended sustain
(why do charters do this, though?)

Edit: this also fixes total solo note count not resetting between solos