### PR TITLE
Update FPS Counter with Memory status Now

### DIFF
--- a/Assets/Scenes/PersistantScene.unity
+++ b/Assets/Scenes/PersistantScene.unity
@@ -1360,7 +1360,7 @@ MonoBehaviour:
   m_fontSizeMax: 72
   m_fontStyle: 0
   m_HorizontalAlignment: 1
-  m_VerticalAlignment: 4096
+  m_VerticalAlignment: 8192
   m_textAlignment: 65535
   m_characterSpacing: 0
   m_wordSpacing: 0

--- a/Assets/Script/GameManager.cs
+++ b/Assets/Script/GameManager.cs
@@ -2,7 +2,6 @@ using System.IO;
 using UnityEngine;
 using UnityEngine.Audio;
 using UnityEngine.InputSystem;
-using UnityEngine.Profiling;
 using UnityEngine.SceneManagement;
 using YARG.Settings;
 using YARG.Song;
@@ -81,13 +80,13 @@ namespace YARG {
 		}
 
 #if UNITY_EDITOR
-		private void OnGUI() {
+		/*private void OnGUI() {
 			// FPS and Memory
 			GUI.skin.label.fontSize = 20;
 			GUI.color = Color.green;
 			GUI.Label(new Rect(10, 20, 500, 40), $"FPS: {1f / Time.unscaledDeltaTime:0.0}");
 			GUI.Label(new Rect(10, 40, 500, 40), $"Memory: {Profiler.GetTotalAllocatedMemoryLong() / 1024 / 1024} MB");
-		}
+		}*/
 #endif
 
 		private void LoadSceneAdditive(SceneIndex scene) {

--- a/Assets/Script/Settings/SettingsManager.Settings.cs
+++ b/Assets/Script/Settings/SettingsManager.Settings.cs
@@ -85,6 +85,12 @@ namespace YARG.Settings {
 				FpsCounter.Instance.enabled = value;
 				// UpdateSettings()
 				FpsCounter.Instance.UpdateSettings(value);
+
+				// enable script if in editor
+				#if UNITY_EDITOR
+					FpsCounter.Instance.enabled = true;
+					FpsCounter.Instance.setVisible(true);
+				#endif
 			}
 
 			private static void FpsCapCallback(int value) {

--- a/Assets/Script/Settings/SettingsManager.Settings.cs
+++ b/Assets/Script/Settings/SettingsManager.Settings.cs
@@ -89,7 +89,7 @@ namespace YARG.Settings {
 				// enable script if in editor
 				#if UNITY_EDITOR
 					FpsCounter.Instance.enabled = true;
-					FpsCounter.Instance.setVisible(true);
+					FpsCounter.Instance.SetVisible(true);
 				#endif
 			}
 

--- a/Assets/Script/UI/FpsCounter.cs
+++ b/Assets/Script/UI/FpsCounter.cs
@@ -9,79 +9,79 @@ using Debug = UnityEngine.Debug;
 
 public class FpsCounter : MonoBehaviour {
 
-    // Instance
-    public static FpsCounter Instance { get; private set; } = null;
+	// Instance
+	public static FpsCounter Instance { get; private set; } = null;
 
-    // FPS Counter
-    public Image fpsCircle;
-    public TextMeshProUGUI fpsText;
-    private float updateTime = 1f;
+	// FPS Counter
+	public Image fpsCircle;
+	public TextMeshProUGUI fpsText;
+	private float updateTime = 1f;
 
-    // Awake
-    private void Awake() {
-        Instance = this;
-    }
+	// Awake
+	private void Awake() {
+		Instance = this;
+	}
 
-    // check if the settings have changed and update the fps counter accordingly
-    public void UpdateSettings(bool value) {
-        setVisible(value);
-    }
+	// check if the settings have changed and update the fps counter accordingly
+	public void UpdateSettings(bool value) {
+		SetVisible(value);
+	}
 
-    public void setVisible(bool value) {
-        fpsText.gameObject.SetActive(value);
-        fpsCircle.gameObject.SetActive(value);
-    }
+	public void SetVisible(bool value) {
+		fpsText.gameObject.SetActive(value);
+		fpsCircle.gameObject.SetActive(value);
+	}
 
-    // OnDestroy - set the instance to null
-    private void OnDestroy() {
-        Instance = null;
-    }
+	// OnDestroy - set the instance to null
+	private void OnDestroy() {
+		Instance = null;
+	}
 
-    // Update is called once per frame
-    void Update() {
-        // update fps per second
-        if (Time.unscaledTime > updateTime) {
+	// Update is called once per frame
+	void Update() {
+		// update fps per second
+		if (Time.unscaledTime > updateTime) {
 
-            // (1 / unscaledDeltaTime) = FPS
-            int fps = (int)(1f / Time.unscaledDeltaTime);
+			// (1 / unscaledDeltaTime) = FPS
+			int fps = (int)(1f / Time.unscaledDeltaTime);
 
-            // Clear the FPS text
-            fpsText.text = "";
+			// Clear the FPS text
+			fpsText.text = "";
 
-            // Color the FPS sprite based on the FPS
-            if (fps < 30) {
-                // RED
-                if ( ColorUtility.TryParseHtmlString("#FF0035", out Color color)){ 
-                    fpsCircle.color = color; 
-                } else { 
-                    fpsCircle.color = Color.red;
-                }
-            } else if (fps < 60) {
-                // YELLOW
-                if ( ColorUtility.TryParseHtmlString("#FFD43A", out Color color)){ 
-                    fpsCircle.color = color; 
-                } else { 
-                    fpsCircle.color = Color.yellow;
-                }
-            } else {
-                // GREEN
-                if ( ColorUtility.TryParseHtmlString("#46E74F", out Color color)){ 
-                    fpsCircle.color = color; 
-                } else { 
-                    fpsCircle.color = Color.green;
-                }
-            }
+			// Color the FPS sprite based on the FPS
+			if (fps < 30) {
+				// RED
+				if ( ColorUtility.TryParseHtmlString("#FF0035", out Color color)){ 
+					fpsCircle.color = color; 
+				} else { 
+					fpsCircle.color = Color.red;
+				}
+			} else if (fps < 60) {
+				// YELLOW
+				if ( ColorUtility.TryParseHtmlString("#FFD43A", out Color color)){ 
+					fpsCircle.color = color; 
+				} else { 
+					fpsCircle.color = Color.yellow;
+				}
+			} else {
+				// GREEN
+				if ( ColorUtility.TryParseHtmlString("#46E74F", out Color color)){ 
+					fpsCircle.color = color; 
+				} else { 
+					fpsCircle.color = Color.green;
+				}
+			}
 
-            // Display the FPS
-            fpsText.text += "FPS: " + fps.ToString();
+			// Display the FPS
+			fpsText.text += "FPS: " + fps.ToString();
 
-            #if UNITY_EDITOR
-                // Display the memory usage
-                fpsText.text += "\nMemory: " + (Profiler.GetTotalAllocatedMemoryLong() / 1024 / 1024).ToString() + " MB";
-            #endif
+			#if UNITY_EDITOR
+				// Display the memory usage
+				fpsText.text += "\nMemory: " + (Profiler.GetTotalAllocatedMemoryLong() / 1024 / 1024).ToString() + " MB";
+			#endif
 
-            // reset the update time
-            updateTime = Time.unscaledTime + 1f;
-        }
+			// reset the update time
+			updateTime = Time.unscaledTime + 1f;
+		}
 	}
 }

--- a/Assets/Script/UI/FpsCounter.cs
+++ b/Assets/Script/UI/FpsCounter.cs
@@ -4,7 +4,8 @@ using UnityEngine.UI;
 using TMPro;
 using YARG.Settings;
 using YARG.Data;
-
+using UnityEngine.Profiling;
+using Debug = UnityEngine.Debug;
 
 public class FpsCounter : MonoBehaviour {
 
@@ -23,14 +24,12 @@ public class FpsCounter : MonoBehaviour {
 
     // check if the settings have changed and update the fps counter accordingly
     public void UpdateSettings(bool value) {
-        if (!value) {
-            fpsText.gameObject.SetActive(false);
-            fpsCircle.gameObject.SetActive(false);
-        }
-        else {
-            fpsText.gameObject.SetActive(true);
-            fpsCircle.gameObject.SetActive(true);
-        }
+        setVisible(value);
+    }
+
+    public void setVisible(bool value) {
+        fpsText.gameObject.SetActive(value);
+        fpsCircle.gameObject.SetActive(value);
     }
 
     // OnDestroy - set the instance to null
@@ -51,15 +50,35 @@ public class FpsCounter : MonoBehaviour {
 
             // Color the FPS sprite based on the FPS
             if (fps < 30) {
-                fpsCircle.color = Color.red;
+                // RED
+                if ( ColorUtility.TryParseHtmlString("#FF0035", out Color color)){ 
+                    fpsCircle.color = color; 
+                } else { 
+                    fpsCircle.color = Color.red;
+                }
             } else if (fps < 60) {
-                fpsCircle.color = Color.yellow;
+                // YELLOW
+                if ( ColorUtility.TryParseHtmlString("#FFD43A", out Color color)){ 
+                    fpsCircle.color = color; 
+                } else { 
+                    fpsCircle.color = Color.yellow;
+                }
             } else {
-                fpsCircle.color = Color.green;
+                // GREEN
+                if ( ColorUtility.TryParseHtmlString("#46E74F", out Color color)){ 
+                    fpsCircle.color = color; 
+                } else { 
+                    fpsCircle.color = Color.green;
+                }
             }
 
             // Display the FPS
             fpsText.text += "FPS: " + fps.ToString();
+
+            #if UNITY_EDITOR
+                // Display the memory usage
+                fpsText.text += "\nMemory: " + (Profiler.GetTotalAllocatedMemoryLong() / 1024 / 1024).ToString() + " MB";
+            #endif
 
             // reset the update time
             updateTime = Time.unscaledTime + 1f;


### PR DESCRIPTION
Replace the Green FPS counter and Memory status with the new one. When in Editor the counter will be Persistent even if you disable from settings

[Changed]
- Update the layout of the components at PersistantScene
- Update the Settings Callback to enable always in Editor to override the settings
- Commented the Old GUIUpdate function
- Added the Memory code in FpsCounter.cs