### PR TITLE
Fixing more preview audio bugs

### DIFF
--- a/Assets/Script/Audio/Bass/BassAudioManager.cs
+++ b/Assets/Script/Audio/Bass/BassAudioManager.cs
@@ -362,6 +362,10 @@ namespace YARG {
 		}
 
 		public void StopPreviewAudio() {
+			if (IsFadingOut || _cancellationTokenSource == null) {
+				return;
+			}
+			
 			StopPreviewAudioTask().Forget();
 		}
 

--- a/Assets/Script/UI/MusicLibrary/SongSelection.cs
+++ b/Assets/Script/UI/MusicLibrary/SongSelection.cs
@@ -72,8 +72,7 @@ namespace YARG.UI.MusicLibrary {
 				}
 
 				GameManager.Instance.SelectedSong = song.SongEntry;
-
-				if (_songs[SelectedIndex] is SongViewType) {
+				if (!refreshFlag) {
 					GameManager.AudioManager.StartPreviewAudio().Forget();
 				}
 			}
@@ -139,6 +138,7 @@ namespace YARG.UI.MusicLibrary {
 				UpdateSearch();
 				refreshFlag = false;
 			}
+			GameManager.AudioManager.StartPreviewAudio().Forget();
 		}
 
 		private void OnDisable() {


### PR DESCRIPTION
1. Going in & out of music library into a different menu doesn't replay the preview audio. I fixed that here!
2. Gong back to Music Library then back to Main Menu while fading out causes null reference for cancellation token. I fixed that here also!