### PR TITLE
songs_upgrades implemented

### DIFF
--- a/Assets/Script/Serialization/Parser/MidiParser.cs
+++ b/Assets/Script/Serialization/Parser/MidiParser.cs
@@ -94,8 +94,9 @@ namespace YARG.Serialization.Parser {
 				}
 				
 				// also, if this RB song has a pro upgrade, merge it as well
-				if(oof.UpgradeMidiPath != string.Empty){
-					MidiFile upgrade = MidiFile.Read(oof.UpgradeMidiPath, new ReadingSettings() { TextEncoding = Encoding.GetEncoding("iso-8859-1") });
+				if(oof.SongUpgrade.UpgradeMidiPath != string.Empty){
+					using var stream = new MemoryStream(oof.SongUpgrade.GetUpgradeMidi());
+					MidiFile upgrade = MidiFile.Read(stream, new ReadingSettings() { TextEncoding = Encoding.GetEncoding("iso-8859-1") });
 
 					foreach(var trackChunk in upgrade.GetTrackChunks()){
 						foreach(var trackEvent in trackChunk.Events){

--- a/Assets/Script/Serialization/Xbox/XboxCONFileBrowser.cs
+++ b/Assets/Script/Serialization/Xbox/XboxCONFileBrowser.cs
@@ -10,7 +10,9 @@ using YARG.Song;
 
 namespace YARG.Serialization {
 	public static class XboxCONFileBrowser {
-		public static List<ConSongEntry> BrowseCON(string conName, string update_folder, Dictionary<string, List<DataArray>> update_dict){
+		public static List<ConSongEntry> BrowseCON(string conName, 
+				string update_folder, Dictionary<string, List<DataArray>> update_dict,
+				Dictionary<SongProUpgrade, DataArray> upgrade_dict){
 			var songList = new List<ConSongEntry>();
 			var dtaTree = new DataArray();
 
@@ -32,15 +34,24 @@ namespace YARG.Serialization {
 					// Get song metadata from songs.dta
 					ConSongEntry currentSong = XboxDTAParser.ParseFromDta(currentArray);
 
-					// check if song has applicable updates
+					// check if song has applicable updates and/or upgrades
 					bool songCanBeUpdated = (update_dict.TryGetValue(currentSong.ShortName, out var val));
-
-					// if shortname was found in songs_updates.dta, update the metadata
-					if(songCanBeUpdated){
-						foreach(var dtaUpdate in update_dict[currentSong.ShortName]){
-							currentSong = XboxDTAParser.ParseFromDta(dtaUpdate, currentSong);
+					bool songHasUpgrade = false;
+					foreach(var upgr in upgrade_dict){
+						if(upgr.Key.ShortName == currentSong.ShortName){
+							songHasUpgrade = true;
+							currentSong.SongUpgrade = upgr.Key;
+							break;
 						}
 					}
+
+					// if shortname was found in songs_updates.dta, update the metadata
+					if(songCanBeUpdated)
+						foreach(var dtaUpdate in update_dict[currentSong.ShortName])
+							currentSong = XboxDTAParser.ParseFromDta(dtaUpdate, currentSong);
+
+					// if shortname was found in upgrades.dta, apply the upgrade metadata (upgrade midi has already been captured)
+					if(songHasUpgrade) currentSong = XboxDTAParser.ParseFromDta(upgrade_dict[currentSong.SongUpgrade], currentSong);
 
 					// since Location is currently set to the name of the folder before mid/mogg/png, set those paths now
 					// since we're dealing with a CON and not an ExCON, grab each relevant file's sizes and memory block offsets

--- a/Assets/Script/Serialization/Xbox/XboxRawfileBrowser.cs
+++ b/Assets/Script/Serialization/Xbox/XboxRawfileBrowser.cs
@@ -11,7 +11,9 @@ using YARG.Song;
 
 namespace YARG.Serialization {
 	public static class ExCONBrowser {
-		public static List<ExtractedConSongEntry> BrowseFolder(string folder, string update_folder, Dictionary<string, List<DataArray>> update_dict){
+		public static List<ExtractedConSongEntry> BrowseFolder(string folder, 
+				string update_folder, Dictionary<string, List<DataArray>> update_dict, 
+				string upgrade_folder, Dictionary<string, DataArray> upgrade_dict){
 			var songList = new List<ExtractedConSongEntry>();
 			var dtaTree = new DataArray();
 
@@ -32,14 +34,15 @@ namespace YARG.Serialization {
 					// Parse songs.dta for song metadata
 					var currentSong = XboxDTAParser.ParseFromDta(currentArray);
 
-					// check if song has applicable updates
+					// check if song has applicable updates and/or upgrades
 					bool songCanBeUpdated = (update_dict.TryGetValue(currentSong.ShortName, out var val));
+					bool songHasUpgrade = (upgrade_dict.TryGetValue(currentSong.ShortName, out var upgrade_dta));
 
 					// if shortname was found in songs_updates.dta, update the metadata
 					if(songCanBeUpdated)
 						foreach(var dtaUpdate in update_dict[currentSong.ShortName])
 							currentSong = XboxDTAParser.ParseFromDta(dtaUpdate, currentSong);
-					
+
 					// since Location is currently set to the name of the folder before mid/mogg/png, set those paths now:
 					
 					// capture base midi, and if an update midi was provided, capture that as well

--- a/Assets/Script/Serialization/Xbox/XboxRawfileBrowser.cs
+++ b/Assets/Script/Serialization/Xbox/XboxRawfileBrowser.cs
@@ -43,6 +43,13 @@ namespace YARG.Serialization {
 						foreach(var dtaUpdate in update_dict[currentSong.ShortName])
 							currentSong = XboxDTAParser.ParseFromDta(dtaUpdate, currentSong);
 
+					// if shortname was found in upgrades.dta, apply the upgrade metadata and capture the upgrade midi
+					if(songHasUpgrade){
+						currentSong = XboxDTAParser.ParseFromDta(upgrade_dict[currentSong.ShortName], currentSong);
+						currentSong.UpgradeMidiPath = Path.Combine(upgrade_folder, $"{currentSong.ShortName}_plus.mid");
+						Debug.Log($"upgrade midi found at {currentSong.UpgradeMidiPath}");
+					}
+
 					// since Location is currently set to the name of the folder before mid/mogg/png, set those paths now:
 					
 					// capture base midi, and if an update midi was provided, capture that as well

--- a/Assets/Script/Serialization/Xbox/XboxRawfileBrowser.cs
+++ b/Assets/Script/Serialization/Xbox/XboxRawfileBrowser.cs
@@ -11,18 +11,20 @@ using YARG.Song;
 
 namespace YARG.Serialization {
 	public static class ExCONBrowser {
-		public static List<ExtractedConSongEntry> BrowseFolder(string folder, 
+		public static List<ExtractedConSongEntry> BrowseFolder(string root_folder, 
 				string update_folder, Dictionary<string, List<DataArray>> update_dict, 
 				Dictionary<SongProUpgrade, DataArray> upgrade_dict){
 			var songList = new List<ExtractedConSongEntry>();
 			var dtaTree = new DataArray();
+			string songs_folder = Path.Combine(root_folder, "songs");
+			string songs_upgrades_folder = Path.Combine(root_folder, "songs_upgrades"); // TODO: implement this
 
 			// Attempt to read songs.dta
 			try {
-				using var sr = new StreamReader(Path.Combine(folder, "songs.dta"), Encoding.GetEncoding("iso-8859-1"));
+				using var sr = new StreamReader(Path.Combine(songs_folder, "songs.dta"), Encoding.GetEncoding("iso-8859-1"));
 				dtaTree = DTX.FromDtaString(sr.ReadToEnd());
 			} catch (Exception e) {
-				Debug.LogError($"Failed to parse songs.dta for `{folder}`.");
+				Debug.LogError($"Failed to parse songs.dta for `{songs_folder}`.");
 				Debug.LogException(e);
 				return null;
 			}
@@ -56,7 +58,7 @@ namespace YARG.Serialization {
 					// since Location is currently set to the name of the folder before mid/mogg/png, set those paths now:
 					
 					// capture base midi, and if an update midi was provided, capture that as well
-					currentSong.NotesFile = Path.Combine(folder, currentSong.Location, $"{currentSong.Location}.mid");
+					currentSong.NotesFile = Path.Combine(songs_folder, currentSong.Location, $"{currentSong.Location}.mid");
 					if(songCanBeUpdated && currentSong.DiscUpdate){
 						string updateMidiPath = Path.Combine(update_folder, currentSong.ShortName, $"{currentSong.ShortName}_update.mid");
 						if(File.Exists(updateMidiPath)) currentSong.UpdateMidiPath = updateMidiPath;
@@ -67,7 +69,7 @@ namespace YARG.Serialization {
 					}
 
 					// capture base mogg path, OR, if update mogg was found, capture that instead
-					currentSong.MoggPath = Path.Combine(folder, currentSong.Location, $"{currentSong.Location}.mogg");
+					currentSong.MoggPath = Path.Combine(songs_folder, currentSong.Location, $"{currentSong.Location}.mogg");
 					if(songCanBeUpdated){
 						string updateMoggPath = Path.Combine(update_folder, currentSong.ShortName, $"{currentSong.ShortName}_update.mogg");
 						if(File.Exists(updateMoggPath)){
@@ -77,7 +79,7 @@ namespace YARG.Serialization {
 					}
 
 					// capture base image (if one was provided), OR if update image was found, capture that instead
-					string imgPath = Path.Combine(folder, currentSong.Location, "gen", $"{currentSong.Location}_keep.png_xbox");
+					string imgPath = Path.Combine(songs_folder, currentSong.Location, "gen", $"{currentSong.Location}_keep.png_xbox");
 					if(currentSong.HasAlbumArt && File.Exists(imgPath))
 						currentSong.ImagePath = imgPath;
 					if(songCanBeUpdated){
@@ -89,7 +91,7 @@ namespace YARG.Serialization {
 					}
 
 					// Get song folder path for mid, mogg, png_xbox
-					currentSong.Location = Path.Combine(folder, currentSong.Location);
+					currentSong.Location = Path.Combine(songs_folder, currentSong.Location);
 					
 					// Parse the mogg
 					using var fs = new FileStream(currentSong.MoggPath, FileMode.Open, FileAccess.Read);

--- a/Assets/Script/Serialization/Xbox/XboxRawfileBrowser.cs
+++ b/Assets/Script/Serialization/Xbox/XboxRawfileBrowser.cs
@@ -19,6 +19,26 @@ namespace YARG.Serialization {
 			string songs_folder = Path.Combine(root_folder, "songs");
 			string songs_upgrades_folder = Path.Combine(root_folder, "songs_upgrades"); // TODO: implement this
 
+			// capture any extra upgrades local to this excon, if they exist
+			if(File.Exists(Path.Combine(songs_upgrades_folder, "upgrades.dta"))){
+				using var sr_upgr = new StreamReader(Path.Combine(songs_upgrades_folder, "upgrades.dta"), Encoding.GetEncoding("iso-8859-1"));
+				var dtaUpgradeTree = DTX.FromDtaString(sr_upgr.ReadToEnd());
+
+				// Read each shortname the dta file lists
+				for (int i = 0; i < dtaUpgradeTree.Count; i++) {
+					try {
+						var currentArray = (DataArray) dtaUpgradeTree[i];
+						var upgr = new SongProUpgrade();
+						upgr.ShortName = currentArray.Name;
+						upgr.UpgradeMidiPath = Path.Combine(songs_upgrades_folder, $"{currentArray.Name}_plus.mid");
+						upgrade_dict.Add(upgr, currentArray);
+					} catch (Exception e) {
+						Debug.Log($"Failed to get upgrade, skipping...");
+						Debug.LogException(e);
+					}
+				}
+			}
+
 			// Attempt to read songs.dta
 			try {
 				using var sr = new StreamReader(Path.Combine(songs_folder, "songs.dta"), Encoding.GetEncoding("iso-8859-1"));

--- a/Assets/Script/Serialization/Xbox/XboxSongUpgradeBrowser.cs
+++ b/Assets/Script/Serialization/Xbox/XboxSongUpgradeBrowser.cs
@@ -6,39 +6,81 @@ using System.Text;
 using DtxCS;
 using DtxCS.DataTypes;
 using UnityEngine;
+using XboxSTFS;
 using YARG.Data;
 using YARG.Song;
 
 namespace YARG.Serialization {
 	public static class XboxSongUpgradeBrowser {
-        public static Dictionary<string, DataArray> FetchSongUpgrades(string upgrade_folder){
+        public static Dictionary<SongProUpgrade, DataArray> FetchSongUpgrades(string upgrade_folder){
             var dtaTree = new DataArray();
-			var UpgradeSongDict = new Dictionary<string, DataArray>();
+			var UpgradeSongDict = new Dictionary<SongProUpgrade, DataArray>();
 
-            // Attempt to read upgrades.dta
-			try {
+			// TODO: tweak this function so you parse raw upgrades, and THEN upgrades contained within CONs
+			// FIRST, parse raw upgrades - start by attempting to read upgrades.dta
+			if(File.Exists(Path.Combine(upgrade_folder, "upgrades.dta"))){
 				using var sr = new StreamReader(Path.Combine(upgrade_folder, "upgrades.dta"), Encoding.GetEncoding("iso-8859-1"));
 				dtaTree = DTX.FromDtaString(sr.ReadToEnd());
-			} catch (Exception e) {
-				Debug.LogError($"Failed to parse upgrades.dta for `{upgrade_folder}`.");
-				Debug.LogException(e);
-				return null;
+
+				// Read each shortname the dta file lists
+				for (int i = 0; i < dtaTree.Count; i++) {
+					try {
+						var currentArray = (DataArray) dtaTree[i];
+						var upgr = new SongProUpgrade();
+						upgr.ShortName = currentArray.Name;
+						upgr.UpgradeMidiPath = Path.Combine(upgrade_folder, $"{currentArray.Name}_plus.mid");
+						UpgradeSongDict.Add(upgr, currentArray);
+					} catch (Exception e) {
+						Debug.Log($"Failed to get upgrade, skipping...");
+						Debug.LogException(e);
+					}
+				}
 			}
 
-            // Read each shortname the dta file lists
-			for (int i = 0; i < dtaTree.Count; i++) {
-				try {
-					var currentArray = (DataArray) dtaTree[i];
-                    UpgradeSongDict.Add(currentArray.Name, currentArray);
-				} catch (Exception e) {
-					Debug.Log($"Failed to get upgrade, skipping...");
-					Debug.LogException(e);
+			// THEN, find any loose CONs in this directory and parse those for upgrades as well
+			foreach (var file in Directory.EnumerateFiles(upgrade_folder)) {
+				if(Path.GetExtension(file) != ".mid" && Path.GetExtension(file) != ".dta"){
+					// for each file found, read first 4 bytes and check for "CON " or "LIVE"
+					using var fs = new FileStream(file, FileMode.Open, FileAccess.Read);
+					using var br = new BinaryReader(fs);
+					string fHeader = Encoding.UTF8.GetString(br.ReadBytes(4));
+					if (fHeader == "CON " || fHeader == "LIVE") {
+						Debug.Log($"can confirm, {file} is a CON");
+						STFS thisUpgradeCON = new STFS(file);
+
+						// attempt to read the CON's upgrades.dta
+						try {
+							dtaTree = DTX.FromPlainTextBytes(thisUpgradeCON.GetFile(Path.Combine("songs_upgrades", "upgrades.dta")));
+						} catch (Exception e) {
+							Debug.LogError($"Failed to parse upgrades.dta for `{file}`.");
+							Debug.LogException(e);
+							continue;
+						}
+
+						// Read each shortname the dta file lists
+						for(int i = 0; i < dtaTree.Count; i++){
+							try {
+								var currentArray = (DataArray) dtaTree[i];
+								var upgr = new SongProUpgrade();
+								upgr.ShortName = currentArray.Name;
+								upgr.UpgradeMidiPath = Path.Combine("songs_upgrades", $"{currentArray.Name}_plus.mid");
+								upgr.CONFilePath = file;
+								upgr.UpgradeMidiFileSize = thisUpgradeCON.GetFileSize(upgr.UpgradeMidiPath);
+								upgr.UpgradeMidiFileMemBlockOffsets = thisUpgradeCON.GetMemOffsets(upgr.UpgradeMidiPath);
+								UpgradeSongDict.Add(upgr, currentArray);
+							} catch (Exception e) {
+								Debug.Log($"Failed to get upgrade, skipping...");
+								Debug.LogException(e);
+							}
+						}
+
+					}
 				}
 			}
 
             // Debug.Log($"Song upgrades:");
 			// foreach(var item in UpgradeSongDict){
-			// 	Debug.Log($"{item.Key} has a pro upgrade");
+			// 	Debug.Log($"{item.Key.ShortName} has a pro upgrade");
 			// }
 
             return UpgradeSongDict;

--- a/Assets/Script/Serialization/Xbox/XboxSongUpgradeBrowser.cs
+++ b/Assets/Script/Serialization/Xbox/XboxSongUpgradeBrowser.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using DtxCS;
+using DtxCS.DataTypes;
+using UnityEngine;
+using YARG.Data;
+using YARG.Song;
+
+namespace YARG.Serialization {
+	public static class XboxSongUpgradeBrowser {
+        public static Dictionary<string, DataArray> FetchSongUpgrades(string upgrade_folder){
+            var dtaTree = new DataArray();
+			var UpgradeSongDict = new Dictionary<string, DataArray>();
+
+            // Attempt to read upgrades.dta
+			try {
+				using var sr = new StreamReader(Path.Combine(upgrade_folder, "upgrades.dta"), Encoding.GetEncoding("iso-8859-1"));
+				dtaTree = DTX.FromDtaString(sr.ReadToEnd());
+			} catch (Exception e) {
+				Debug.LogError($"Failed to parse upgrades.dta for `{upgrade_folder}`.");
+				Debug.LogException(e);
+				return null;
+			}
+
+            // Read each shortname the dta file lists
+			for (int i = 0; i < dtaTree.Count; i++) {
+				try {
+					var currentArray = (DataArray) dtaTree[i];
+                    UpgradeSongDict.Add(currentArray.Name, currentArray);
+				} catch (Exception e) {
+					Debug.Log($"Failed to get upgrade, skipping...");
+					Debug.LogException(e);
+				}
+			}
+
+            // Debug.Log($"Song upgrades:");
+			// foreach(var item in UpgradeSongDict){
+			// 	Debug.Log($"{item.Key} has a pro upgrade");
+			// }
+
+            return UpgradeSongDict;
+
+        }
+    }
+}

--- a/Assets/Script/Serialization/Xbox/XboxSongUpgradeBrowser.cs
+++ b/Assets/Script/Serialization/Xbox/XboxSongUpgradeBrowser.cs
@@ -45,7 +45,6 @@ namespace YARG.Serialization {
 					using var br = new BinaryReader(fs);
 					string fHeader = Encoding.UTF8.GetString(br.ReadBytes(4));
 					if (fHeader == "CON " || fHeader == "LIVE") {
-						Debug.Log($"can confirm, {file} is a CON");
 						STFS thisUpgradeCON = new STFS(file);
 
 						// attempt to read the CON's upgrades.dta

--- a/Assets/Script/Serialization/Xbox/XboxSongUpgradeBrowser.cs.meta
+++ b/Assets/Script/Serialization/Xbox/XboxSongUpgradeBrowser.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: df139733406ef4c799b53a4f1a4a0a62
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Script/Song/CacheHelpers.cs
+++ b/Assets/Script/Song/CacheHelpers.cs
@@ -11,6 +11,21 @@ namespace YARG.Song {
 			writer.Write(ExCONSong.DiscUpdate);
 			writer.Write(ExCONSong.UpdateMidiPath);
 
+			// pro upgrade data
+			writer.Write(ExCONSong.UpgradeMidiPath);
+			if(ExCONSong.RealGuitarTuning != null){
+				writer.Write(ExCONSong.RealGuitarTuning.Length);
+				for(int i = 0; i < 6; i++)
+					writer.Write(ExCONSong.RealGuitarTuning[i]);
+			}
+			else writer.Write(0);
+			if(ExCONSong.RealBassTuning != null){
+				writer.Write(ExCONSong.RealBassTuning.Length);
+				for(int i = 0; i < 4; i++)
+					writer.Write(ExCONSong.RealBassTuning[i]);
+			}
+			else writer.Write(0);
+
 			// mogg data
 			writer.Write(ExCONSong.UsingUpdateMogg);
 			writer.Write(ExCONSong.MoggPath);
@@ -73,9 +88,26 @@ namespace YARG.Song {
 
 		public static void ReadExtractedConData(BinaryReader reader, ExtractedConSongEntry ExCONSong) {
 
+			// update midi data
 			ExCONSong.DiscUpdate = reader.ReadBoolean();
 			ExCONSong.UpdateMidiPath = reader.ReadString();
 
+			// pro upgrade data
+			ExCONSong.UpgradeMidiPath = reader.ReadString();
+			int guitarTuneLength = reader.ReadInt32();
+			if(guitarTuneLength > 0){
+				ExCONSong.RealGuitarTuning = new int[guitarTuneLength];
+				for(int i = 0; i < guitarTuneLength; i++)
+					ExCONSong.RealGuitarTuning[i] = reader.ReadInt32();
+			}
+			int bassTuneLength = reader.ReadInt32();
+			if(bassTuneLength > 0){
+				ExCONSong.RealBassTuning = new int[bassTuneLength];
+				for(int i = 0; i < bassTuneLength; i++)
+					ExCONSong.RealBassTuning[i] = reader.ReadInt32();
+			}
+
+			// mogg data
 			ExCONSong.UsingUpdateMogg = reader.ReadBoolean();
 			ExCONSong.MoggPath = reader.ReadString();
 			ExCONSong.MoggHeader = reader.ReadInt32();

--- a/Assets/Script/Song/CacheHelpers.cs
+++ b/Assets/Script/Song/CacheHelpers.cs
@@ -12,7 +12,17 @@ namespace YARG.Song {
 			writer.Write(ExCONSong.UpdateMidiPath);
 
 			// pro upgrade data
-			writer.Write(ExCONSong.UpgradeMidiPath);
+			writer.Write(ExCONSong.SongUpgrade.ShortName);
+			writer.Write(ExCONSong.SongUpgrade.UpgradeMidiPath);
+			writer.Write(ExCONSong.SongUpgrade.CONFilePath);
+			writer.Write(ExCONSong.SongUpgrade.UpgradeMidiFileSize);
+			if(ExCONSong.SongUpgrade.UpgradeMidiFileMemBlockOffsets != null){
+				writer.Write(ExCONSong.SongUpgrade.UpgradeMidiFileMemBlockOffsets.Length);
+				for(int i = 0; i < ExCONSong.SongUpgrade.UpgradeMidiFileMemBlockOffsets.Length; i++)
+					writer.Write(ExCONSong.SongUpgrade.UpgradeMidiFileMemBlockOffsets[i]);
+			}
+			else writer.Write(0u);
+
 			if(ExCONSong.RealGuitarTuning != null){
 				writer.Write(ExCONSong.RealGuitarTuning.Length);
 				for(int i = 0; i < 6; i++)
@@ -93,7 +103,20 @@ namespace YARG.Song {
 			ExCONSong.UpdateMidiPath = reader.ReadString();
 
 			// pro upgrade data
-			ExCONSong.UpgradeMidiPath = reader.ReadString();
+			SongProUpgrade upgr = new SongProUpgrade();
+			upgr.ShortName = reader.ReadString();
+			upgr.UpgradeMidiPath = reader.ReadString();
+			upgr.CONFilePath = reader.ReadString();
+			upgr.UpgradeMidiFileSize = reader.ReadUInt32();
+			uint upgrMidOffsetLength = reader.ReadUInt32();
+			if(upgrMidOffsetLength > 0){
+				upgr.UpgradeMidiFileMemBlockOffsets = new uint[upgrMidOffsetLength];
+				for(int i = 0; i < upgrMidOffsetLength; i++){
+					upgr.UpgradeMidiFileMemBlockOffsets[i] = reader.ReadUInt32();
+				}
+			}
+			ExCONSong.SongUpgrade = upgr;
+
 			int guitarTuneLength = reader.ReadInt32();
 			if(guitarTuneLength > 0){
 				ExCONSong.RealGuitarTuning = new int[guitarTuneLength];

--- a/Assets/Script/Song/Scanning/SongScanThread.cs
+++ b/Assets/Script/Song/Scanning/SongScanThread.cs
@@ -218,7 +218,8 @@ namespace YARG.Song {
 					using var br = new BinaryReader(fs);
 					string fHeader = Encoding.UTF8.GetString(br.ReadBytes(4));
 					if (fHeader == "CON " || fHeader == "LIVE") {
-						List<ConSongEntry> SongsInsideCON = XboxCONFileBrowser.BrowseCON(file, _updateFolderPath, _songUpdateDict);
+						List<ConSongEntry> SongsInsideCON = XboxCONFileBrowser.BrowseCON(file, 
+							_updateFolderPath, _songUpdateDict, _songUpgradeDict);
 						// for each CON song that was found (assuming some WERE found)
 						if (SongsInsideCON != null) {
 							foreach (ConSongEntry SongInsideCON in SongsInsideCON) {
@@ -395,6 +396,15 @@ namespace YARG.Song {
 					return ScanResult.CorruptedNotesFile;
 				}
 				tracks |= update_tracks;
+			}
+			// add upgrade midi, if it exists
+			if(!string.IsNullOrEmpty(file.SongUpgrade.UpgradeMidiPath)){
+				var upgrade_midi = file.SongUpgrade.GetUpgradeMidi();
+				bytes.AddRange(upgrade_midi);
+				if(!MidPreparser.GetAvailableTracks(upgrade_midi, out ulong upgrade_tracks)){
+					return ScanResult.CorruptedNotesFile;
+				}
+				tracks |= upgrade_tracks;
 			}
 
 			string checksum = BitConverter.ToString(SHA1.Create().ComputeHash(bytes.ToArray())).Replace("-", "");

--- a/Assets/Script/Song/Scanning/SongScanThread.cs
+++ b/Assets/Script/Song/Scanning/SongScanThread.cs
@@ -22,8 +22,12 @@ namespace YARG.Song {
 		private int _foldersScanned;
 		private int _songsScanned;
 		private int _errorsEncountered;
+
 		private string _updateFolderPath = string.Empty;
 		private Dictionary<string, List<DataArray>> _songUpdateDict = new();
+
+		private string _upgradeFolderPath = string.Empty;
+		private Dictionary<string, DataArray> _songUpgradeDict = new();
 
 		private readonly Dictionary<string, List<SongEntry>> _songsByCacheFolder;
 		private readonly Dictionary<string, List<SongError>> _songErrors;
@@ -135,6 +139,7 @@ namespace YARG.Song {
 			_foldersScanned++;
 			foldersScanned = _foldersScanned;
 
+			// scan the songs_updates folder at the root before base song scanning
 			string updatePath = Path.Combine(subDir, "songs_updates");
 			if (Directory.Exists(updatePath)) {
 				if (_updateFolderPath == string.Empty) {
@@ -142,6 +147,17 @@ namespace YARG.Song {
 					Debug.Log($"Song updates found at {_updateFolderPath}");
 					_songUpdateDict = XboxSongUpdateBrowser.FetchSongUpdates(_updateFolderPath);
 					Debug.Log($"Total count of song updates found: {_songUpdateDict.Count}");
+				}
+			}
+
+			// scan the songs_upgrades folder at the root before base song scanning
+			string upgradePath = Path.Combine(subDir, "songs_upgrades");
+			if(Directory.Exists(upgradePath)){
+				if(_upgradeFolderPath == string.Empty){
+					_upgradeFolderPath = upgradePath;
+					Debug.Log($"Song upgrades found at {_upgradeFolderPath}");
+					_songUpgradeDict = XboxSongUpgradeBrowser.FetchSongUpgrades(_upgradeFolderPath);
+					Debug.Log($"Total count of song upgrades found: {_songUpgradeDict.Count}");
 				}
 			}
 
@@ -167,7 +183,8 @@ namespace YARG.Song {
 			// Raw CON folder, so don't scan anymore subdirectories here
 			string songsPath = Path.Combine(subDir, "songs");
 			if (File.Exists(Path.Combine(songsPath, "songs.dta"))) {
-				List<ExtractedConSongEntry> files = ExCONBrowser.BrowseFolder(songsPath, _updateFolderPath, _songUpdateDict);
+				List<ExtractedConSongEntry> files = ExCONBrowser.BrowseFolder(songsPath, 
+					_updateFolderPath, _songUpdateDict, _upgradeFolderPath, _songUpgradeDict);
 
 				foreach (ExtractedConSongEntry file in files) {
 					// validate that the song is good to add in-game
@@ -191,8 +208,8 @@ namespace YARG.Song {
 
 				return;
 			}
+			
 			// Iterate through the files in this current directory to look for CON files
-
 			try { // try-catch to prevent crash if user doesn't have permission to access a folder
 				foreach (var file in Directory.EnumerateFiles(subDir)) {
 					// for each file found, read first 4 bytes and check for "CON " or "LIVE"
@@ -227,7 +244,7 @@ namespace YARG.Song {
 				}
 				string[] subdirectories = Directory.GetDirectories(subDir);
 				foreach (string subdirectory in subdirectories) {
-					if (subdirectory != Path.Combine(subDir, "songs_updates")) {
+					if (subdirectory != _updateFolderPath && subdirectory != _upgradeFolderPath) {
 						ScanSubDirectory(cacheFolder, subdirectory, songs);
 					}
 				}

--- a/Assets/Script/Song/Scanning/SongScanThread.cs
+++ b/Assets/Script/Song/Scanning/SongScanThread.cs
@@ -208,7 +208,7 @@ namespace YARG.Song {
 
 				return;
 			}
-			
+
 			// Iterate through the files in this current directory to look for CON files
 			try { // try-catch to prevent crash if user doesn't have permission to access a folder
 				foreach (var file in Directory.EnumerateFiles(subDir)) {
@@ -341,6 +341,14 @@ namespace YARG.Song {
 					return ScanResult.CorruptedNotesFile;
 				}
 				tracks |= update_tracks;
+			}
+			// add upgrade midi, if it exists
+			if(file.UpgradeMidiPath != string.Empty){
+				bytes.AddRange(File.ReadAllBytes(file.UpgradeMidiPath));
+				if(!MidPreparser.GetAvailableTracks(File.ReadAllBytes(file.UpgradeMidiPath), out ulong upgrade_tracks)){
+					return ScanResult.CorruptedNotesFile;
+				}
+				tracks |= upgrade_tracks;
 			}
 
 			string checksum = BitConverter.ToString(SHA1.Create().ComputeHash(bytes.ToArray())).Replace("-", "");

--- a/Assets/Script/Song/Scanning/SongScanThread.cs
+++ b/Assets/Script/Song/Scanning/SongScanThread.cs
@@ -182,9 +182,8 @@ namespace YARG.Song {
 			}
 
 			// Raw CON folder, so don't scan anymore subdirectories here
-			string songsPath = Path.Combine(subDir, "songs");
-			if (File.Exists(Path.Combine(songsPath, "songs.dta"))) {
-				List<ExtractedConSongEntry> files = ExCONBrowser.BrowseFolder(songsPath, 
+			if (File.Exists(Path.Combine(subDir, "songs", "songs.dta"))) {
+				List<ExtractedConSongEntry> files = ExCONBrowser.BrowseFolder(subDir, 
 					_updateFolderPath, _songUpdateDict, _songUpgradeDict);
 
 				foreach (ExtractedConSongEntry file in files) {

--- a/Assets/Script/Song/SongCache.cs
+++ b/Assets/Script/Song/SongCache.cs
@@ -12,7 +12,7 @@ namespace YARG.Song {
 		/// <summary>
 		/// The date in which the cache version is based on (and cache revision)
 		/// </summary>
-		private const int CACHE_VERSION = 23_05_17_03;
+		private const int CACHE_VERSION = 23_05_18_01;
 
 		private readonly string _folder;
 		private readonly string _cacheFile;

--- a/Assets/Script/Song/SongCache.cs
+++ b/Assets/Script/Song/SongCache.cs
@@ -12,7 +12,7 @@ namespace YARG.Song {
 		/// <summary>
 		/// The date in which the cache version is based on (and cache revision)
 		/// </summary>
-		private const int CACHE_VERSION = 23_05_17_02;
+		private const int CACHE_VERSION = 23_05_17_03;
 
 		private readonly string _folder;
 		private readonly string _cacheFile;

--- a/Assets/Script/Song/Types/ExConSongEntry.cs
+++ b/Assets/Script/Song/Types/ExConSongEntry.cs
@@ -26,9 +26,16 @@ namespace YARG.Song {
 		public string UpdateMidiPath { get; set; } = string.Empty;
 
 		// pro upgrade info, if it exists
-		public string UpgradeMidiPath { get; set; } = string.Empty;
+		public SongProUpgrade SongUpgrade { get; set; } = new();
 		public int[] RealGuitarTuning { get; set; }
 		public int[] RealBassTuning { get; set; }
+
+		// TODO: cover the following circumstances:
+		// an excon receiving an upgrade that's inside a CON
+		// a CON receiving an upgrade that's extracted
+		// a CON receiving an upgrade that's inside a CON	
+		
+		// TODO: also cover what happens when both excons AND CONs have songs_upgrades folders right beside their songs folders
 
 		// .mogg info
 		public bool UsingUpdateMogg { get; set; } = false;

--- a/Assets/Script/Song/Types/ExConSongEntry.cs
+++ b/Assets/Script/Song/Types/ExConSongEntry.cs
@@ -20,12 +20,15 @@ namespace YARG.Song {
 		public int VocalTonicNote { get; set; }
 		public bool SongTonality { get; set; } // 0 = major, 1 = minor
 		public int TuningOffsetCents { get; set; }
-		public int[] RealGuitarTuning { get; set; }
-		public int[] RealBassTuning { get; set; }
 
 		// _update.mid info, if it exists
 		public bool DiscUpdate { get; set; } = false;
 		public string UpdateMidiPath { get; set; } = string.Empty;
+
+		// pro upgrade info, if it exists
+		public string UpgradeMidiPath { get; set; } = string.Empty;
+		public int[] RealGuitarTuning { get; set; }
+		public int[] RealBassTuning { get; set; }
 
 		// .mogg info
 		public bool UsingUpdateMogg { get; set; } = false;

--- a/Assets/Script/Song/Types/ExConSongEntry.cs
+++ b/Assets/Script/Song/Types/ExConSongEntry.cs
@@ -29,8 +29,6 @@ namespace YARG.Song {
 		public SongProUpgrade SongUpgrade { get; set; } = new();
 		public int[] RealGuitarTuning { get; set; }
 		public int[] RealBassTuning { get; set; }
-		
-		// TODO: cover what happens when both CONs have songs_upgrades folders right beside their songs folders
 
 		// .mogg info
 		public bool UsingUpdateMogg { get; set; } = false;

--- a/Assets/Script/Song/Types/ExConSongEntry.cs
+++ b/Assets/Script/Song/Types/ExConSongEntry.cs
@@ -30,7 +30,7 @@ namespace YARG.Song {
 		public int[] RealGuitarTuning { get; set; }
 		public int[] RealBassTuning { get; set; }
 		
-		// TODO: cover what happens when both excons AND CONs have songs_upgrades folders right beside their songs folders
+		// TODO: cover what happens when both CONs have songs_upgrades folders right beside their songs folders
 
 		// .mogg info
 		public bool UsingUpdateMogg { get; set; } = false;

--- a/Assets/Script/Song/Types/ExConSongEntry.cs
+++ b/Assets/Script/Song/Types/ExConSongEntry.cs
@@ -29,13 +29,8 @@ namespace YARG.Song {
 		public SongProUpgrade SongUpgrade { get; set; } = new();
 		public int[] RealGuitarTuning { get; set; }
 		public int[] RealBassTuning { get; set; }
-
-		// TODO: cover the following circumstances:
-		// an excon receiving an upgrade that's inside a CON
-		// a CON receiving an upgrade that's extracted
-		// a CON receiving an upgrade that's inside a CON	
 		
-		// TODO: also cover what happens when both excons AND CONs have songs_upgrades folders right beside their songs folders
+		// TODO: cover what happens when both excons AND CONs have songs_upgrades folders right beside their songs folders
 
 		// .mogg info
 		public bool UsingUpdateMogg { get; set; } = false;

--- a/Assets/Script/Song/Types/SongProUpgrade.cs
+++ b/Assets/Script/Song/Types/SongProUpgrade.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+using System.IO;
+using YARG.Serialization;
+
+namespace YARG.Song {
+	public class SongProUpgrade {
+        public string ShortName { get; set; }
+        public string UpgradeMidiPath { get; set; }
+
+        // only used if an upgrade is contained inside a CON!
+        public string CONFilePath { get; set; } 
+        public uint UpgradeMidiFileSize { get; set; }
+        public uint[] UpgradeMidiFileMemBlockOffsets { get; set; }
+
+        public byte[] GetUpgradeMidi(){
+            if(string.IsNullOrEmpty(CONFilePath)) return File.ReadAllBytes(UpgradeMidiPath);
+            else return XboxCONInnerFileRetriever.RetrieveFile(CONFilePath, UpgradeMidiFileSize, UpgradeMidiFileMemBlockOffsets);
+        }
+    }
+}

--- a/Assets/Script/Song/Types/SongProUpgrade.cs.meta
+++ b/Assets/Script/Song/Types/SongProUpgrade.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a1b7bc8fa000f415c99cab57aedb6d52
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
YARG can now scan songs_upgrades baked within an excon or CON.
And in addition, can also scan a user-provided songs_upgrades folder placed at the root of your songs folder, just like how songs_updates works.