### PR TITLE
Improve CON parsing speed

### DIFF
--- a/Assets/Script/Serialization/Xbox/XboxSTFS.cs
+++ b/Assets/Script/Serialization/Xbox/XboxSTFS.cs
@@ -42,7 +42,6 @@ namespace XboxSTFS {
 
         public FileListing(byte[] data){
             filename = System.Text.Encoding.UTF8.GetString(data, 0, 0x28).TrimEnd('\0');
-            Assert.IsTrue(filename != "", "FileListing has empty filename");
             flags = data[0x28];
             
             numBlocks = BitConverter.ToUInt32(new byte[4] { data[0x29], data[0x2A], data[0x2B], 0x00 });
@@ -85,15 +84,12 @@ namespace XboxSTFS {
             var data = ReadFileTable(ref fs, ref br, fileTableBlockNumber, fileTableBlockCount);
 
             byte[] buf = new byte[0x40];
-            FileListing cur;
             for (int x = 0; x < data.Length; x += 0x40) {
-                Array.Copy(data, x, buf, 0, 0x40);
-                try {
-                    cur = new FileListing(buf);
-                    fLists.Add(cur);
-                } catch (Exception e) {
-
-                }
+				Array.Copy(data, x, buf, 0, 0x40);
+				FileListing file = new FileListing(buf);
+				if (file.filename.Length == 0)
+					break;
+				fLists.Add(file);
             }
 
             List<string> pathComponents = new List<string>();

--- a/Assets/Script/Serialization/Xbox/XboxSTFS.cs
+++ b/Assets/Script/Serialization/Xbox/XboxSTFS.cs
@@ -85,11 +85,11 @@ namespace XboxSTFS {
 
             byte[] buf = new byte[0x40];
             for (int x = 0; x < data.Length; x += 0x40) {
-				Array.Copy(data, x, buf, 0, 0x40);
-				FileListing file = new FileListing(buf);
+                Array.Copy(data, x, buf, 0, 0x40);
+                FileListing file = new FileListing(buf);
 				if (file.filename.Length == 0)
 					break;
-				fLists.Add(file);
+                fLists.Add(file);
             }
 
             List<string> pathComponents = new List<string>();

--- a/Assets/Script/Serialization/Xbox/XboxSTFS.cs
+++ b/Assets/Script/Serialization/Xbox/XboxSTFS.cs
@@ -148,8 +148,8 @@ namespace XboxSTFS {
         private byte[] ReadBlocks_Continuguous(ref FileStream fs, ref BinaryReader br, uint blocknum, uint blockCount, uint fileSize) {
             byte[] fileBytes = new byte[fileSize];
             for (uint i = 0; i < blockCount;) {
-                uint block = FixBlocknum(blocknum + i);
-                fs.Seek(0xC000 + block * 0x1000, SeekOrigin.Begin);
+                uint block = blocknum + i;
+                fs.Seek(0xC000 + FixBlocknum(block) * 0x1000, SeekOrigin.Begin);
                 uint readCount = 170 - (block % 170);
                 uint readSize = 0x1000 * readCount;
                 uint offset = i * 0x1000;

--- a/Assets/Script/Serialization/Xbox/XboxSTFS.cs
+++ b/Assets/Script/Serialization/Xbox/XboxSTFS.cs
@@ -82,7 +82,7 @@ namespace XboxSTFS {
         }
 
         private byte[] ReadFileTable(ref FileStream fs, ref BinaryReader br, uint firstBlock, ushort numBlocks) {
-            return ReadBlocks_Continuguous(ref fs, ref br, firstBlock, numBlocks, (uint) 0x1000 * numBlocks);
+            return ReadBlocks_Contiguous(ref fs, ref br, firstBlock, numBlocks, (uint) 0x1000 * numBlocks);
         }
 
         private void ParseFileTable(ref FileStream fs, ref BinaryReader br) {
@@ -145,7 +145,7 @@ namespace XboxSTFS {
             return fileBytes;
         }
 
-        private byte[] ReadBlocks_Continuguous(ref FileStream fs, ref BinaryReader br, uint blocknum, uint blockCount, uint fileSize) {
+        private byte[] ReadBlocks_Contiguous(ref FileStream fs, ref BinaryReader br, uint blocknum, uint blockCount, uint fileSize) {
             byte[] fileBytes = new byte[fileSize];
             for (uint i = 0; i < blockCount;) {
                 uint block = blocknum + i;
@@ -181,7 +181,7 @@ namespace XboxSTFS {
 
         private byte[] ReadFile(ref FileStream fs, ref BinaryReader br, FileListing fl) {
             if (fl.isContinguous())
-                return ReadBlocks_Continuguous(ref fs, ref br, fl.firstBlock, fl.numBlocks, fl.size);
+                return ReadBlocks_Contiguous(ref fs, ref br, fl.firstBlock, fl.numBlocks, fl.size);
             else
                 return ReadBlocks_Separate(ref fs, ref br, fl.firstBlock, fl.numBlocks, fl.size);
         }

--- a/Assets/Script/Serialization/Xbox/XboxSTFS.cs
+++ b/Assets/Script/Serialization/Xbox/XboxSTFS.cs
@@ -94,8 +94,8 @@ namespace XboxSTFS {
             for (int x = 0; x < data.Length; x += 0x40) {
                 Array.Copy(data, x, buf, 0, 0x40);
                 FileListing file = new FileListing(buf);
-				if (file.filename.Length == 0)
-					break;
+                if (file.filename.Length == 0)
+                    break;
                 fLists.Add(file);
             }
 
@@ -128,7 +128,7 @@ namespace XboxSTFS {
             // This is the part of the Free60 STFS page that needed work
             uint blockAdjust = 0;
 
-            if (blocknum >= 0xAA) blockAdjust += (blocknum / 0xAA) + 1 << tableSizeShift;
+            if (blocknum >= 0xAA) blockAdjust += ((blocknum / 0xAA) + 1) << tableSizeShift;
             if (blocknum >= 0x70E4) blockAdjust += ((blocknum / 0x70E4) + 1) << tableSizeShift;
             return blockAdjust + blocknum;
         }

--- a/Assets/Script/Serialization/Xbox/XboxSTFS.cs
+++ b/Assets/Script/Serialization/Xbox/XboxSTFS.cs
@@ -7,18 +7,25 @@ using System.Threading.Tasks;
 using UnityEngine;
 using UnityEngine.Assertions;
 
-// Copyright 2011 Arkem. All rights reserved.
+/*
+    Copyright 2011 Arkem. All rights reserved.
 
-// Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+    Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 
-// Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
-// Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+    Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+    Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
 
-// THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+    THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+    IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+    HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-// The below code was originally written by Arkem in Python, on this repo: https://github.com/arkem/py360
-// For the purposes of YARG, I (rjkiv on GitHub) have ported the necessary code to C#,
-// so that YARG can read the contents of a Rock Band CON file (.mid, .mogg, .dta, .png_xbox, etc)
+    The below code was originally written by Arkem in Python, on this repo: https://github.com/arkem/py360
+    For the purposes of YARG, I (rjkiv on GitHub) have ported the necessary code to C#,
+    so that YARG can read the contents of a Rock Band CON file (.mid, .mogg, .dta, .png_xbox, etc)
+
+    Further parsing improvements provided by Sonicfind (also github)
+*/
 
 namespace XboxSTFS {
 


### PR DESCRIPTION
The seemingly biggest bottleneck resided in the lack of optimization for contiguous blocks of data. Prior, for every block, a new filestream would be opened, a new offset would be calculated, and a new array the size of the block would be created and then copied.

The change here was to immediately read into the data byte array in chunks (if contiguous). Should provide an immense speedup.