### PR TITLE
Update PlasticBand-Unity to v0.3.0

### DIFF
--- a/Assets/Script/GameManager.cs
+++ b/Assets/Script/GameManager.cs
@@ -3,6 +3,7 @@ using UnityEngine;
 using UnityEngine.Audio;
 using UnityEngine.InputSystem;
 using UnityEngine.SceneManagement;
+using YARG.Input;
 using YARG.Settings;
 using YARG.Song;
 
@@ -58,6 +59,8 @@ namespace YARG {
 
 			AudioManager = gameObject.AddComponent<BassAudioManager>();
 			AudioManager.Initialize();
+
+			StageKitHapticsManager.Initialize();
 		}
 
 		private void Start() {

--- a/Assets/Script/Input/InputStrategy.cs
+++ b/Assets/Script/Input/InputStrategy.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using PlasticBand.Haptics;
 using UnityEngine.InputSystem;
 using UnityEngine.InputSystem.Controls;
 using UnityEngine.InputSystem.LowLevel;
@@ -14,6 +15,7 @@ namespace YARG.Input {
 		protected int botChartIndex;
 
 		private InputDevice _inputDevice;
+		private ISantrollerHaptics _haptics;
 		public InputDevice InputDevice {
 			get => _inputDevice;
 			set {
@@ -23,6 +25,9 @@ namespace YARG.Input {
 				}
 
 				_inputDevice = value;
+				if (_inputDevice is ISantrollerHaptics haptics) {
+					_haptics = haptics;
+				}
 
 				if (enabled) {
 					Enable();
@@ -254,5 +259,20 @@ namespace YARG.Input {
 				Navigator.Instance.EndNavigationHold(action, this);
 			}
 		}
+
+		public void SendStarPowerFill(float fill)
+			=> _haptics?.SetStarPowerFill(fill);
+
+		public void SendStarPowerActive(bool enabled)
+			=> _haptics?.SetStarPowerActive(enabled);
+
+		public void SendMultiplier(uint multiplier)
+			=> _haptics?.SetMultiplier(multiplier);
+
+		public void SendSolo(bool enabled)
+			=> _haptics?.SetSolo(enabled);
+
+		public virtual void ResetHaptics()
+			=> _haptics?.ResetHaptics();
 	}
 }

--- a/Assets/Script/Input/RealGuitarInputStrategy.cs
+++ b/Assets/Script/Input/RealGuitarInputStrategy.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using PlasticBand.Devices;
 using UnityEngine;
-using UnityEngine.InputSystem.Controls;
 using YARG.Data;
 using YARG.PlayMode;
 
@@ -31,8 +30,8 @@ namespace YARG.Input {
 
 		private List<NoteInfo> botChart;
 
-		private int[] fretCache = new int[6];
-		private float[] velocityCache = new float[6];
+		private int[] fretCache = new int[ProGuitar.StringCount];
+		private float[] velocityCache = new float[ProGuitar.StringCount];
 
 		private float? stringGroupingTimer = null;
 		private StrumFlag stringGroupingFlag = StrumFlag.NONE;
@@ -60,8 +59,8 @@ namespace YARG.Input {
 			}
 
 			// Update frets
-			for (int i = 0; i < 6; i++) {
-				int fret = GetFret(input, i).ReadValue();
+			for (int i = 0; i < ProGuitar.StringCount; i++) {
+				int fret = input.GetFret(i).ReadValue();
 				if (fret != fretCache[i]) {
 					FretChangeEvent?.Invoke(i, fret);
 					fretCache[i] = fret;
@@ -69,8 +68,8 @@ namespace YARG.Input {
 			}
 
 			// Update strums
-			for (int i = 0; i < 6; i++) {
-				float vel = GetVelocity(input, i).ReadValue();
+			for (int i = 0; i < ProGuitar.StringCount; i++) {
+				float vel = input.GetVelocity(i).ReadValue();
 				if (vel != velocityCache[i]) {
 					stringGroupingFlag |= StrumFlagFromInt(i);
 					velocityCache[i] = vel;
@@ -82,31 +81,6 @@ namespace YARG.Input {
 
 			// Constantly activate starpower (for now)
 			CallStarpowerEvent();
-		}
-
-		// TODO: Ideally these should be directly implemented in PlasticBand
-		private IntegerControl GetFret(ProGuitar input, int i) {
-			return i switch {
-				0 => input.fret1,
-				1 => input.fret2,
-				2 => input.fret3,
-				3 => input.fret4,
-				4 => input.fret5,
-				5 => input.fret6,
-				_ => null
-			};
-		}
-
-		private AxisControl GetVelocity(ProGuitar input, int i) {
-			return i switch {
-				0 => input.velocity1,
-				1 => input.velocity2,
-				2 => input.velocity3,
-				3 => input.velocity4,
-				4 => input.velocity5,
-				5 => input.velocity6,
-				_ => null
-			};
 		}
 
 		public override void InitializeBotMode(object rawChart) {
@@ -125,7 +99,7 @@ namespace YARG.Input {
 				var note = botChart[botChartIndex];
 
 				// Press correct frets
-				for (int i = 0; i < 6; i++) {
+				for (int i = 0; i < ProGuitar.StringCount; i++) {
 					int fret = note.stringFrets[i];
 					if (fret == -1) {
 						fret = 0;
@@ -136,7 +110,7 @@ namespace YARG.Input {
 
 				// Strum correct strings
 				StrumFlag flag = StrumFlag.NONE;
-				for (int i = 0; i < 6; i++) {
+				for (int i = 0; i < ProGuitar.StringCount; i++) {
 					if (note.stringFrets[i] != -1) {
 						flag |= StrumFlagFromInt(i);
 					}

--- a/Assets/Script/Input/StageKitHapticsManager.cs
+++ b/Assets/Script/Input/StageKitHapticsManager.cs
@@ -1,0 +1,76 @@
+using System.Collections.Generic;
+using PlasticBand.Haptics;
+using UnityEngine.InputSystem;
+
+namespace YARG.Input {
+	public static class StageKitHapticsManager {
+		private static List<IStageKitHaptics> stageKits = new();
+
+		public static void Initialize() {
+			InputSystem.onDeviceChange += OnDeviceChange;
+			foreach (var device in InputSystem.devices) {
+				if (device is IStageKitHaptics stageKit) {
+					stageKits.Add(stageKit);
+				}
+			}
+		}
+
+		private static void OnDeviceChange(InputDevice device, InputDeviceChange change) {
+			if (device is not IStageKitHaptics stageKit) {
+				return;
+			}
+
+			switch (change) {
+				case InputDeviceChange.Added:
+				case InputDeviceChange.Enabled:
+				case InputDeviceChange.Reconnected:
+					if (!stageKits.Contains(stageKit)) {
+						stageKits.Add(stageKit);
+					}
+					break;
+
+				case InputDeviceChange.Disabled:
+				case InputDeviceChange.Disconnected:
+				case InputDeviceChange.Removed:
+					stageKits.Remove(stageKit);
+					break;
+			}
+		}
+
+		public static void SetFogMachine(bool enabled) {
+			foreach (var stageKit in stageKits) {
+				stageKit.SetFogMachine(enabled);
+			}
+		}
+
+		public static void SetStrobeSpeed(StageKitStrobeSpeed speed) {
+			foreach (var stageKit in stageKits) {
+				stageKit.SetStrobeSpeed(speed);
+			}
+		}
+
+		public static void SetLeds(StageKitLedColor color, StageKitLed leds) {
+			foreach (var stageKit in stageKits) {
+				stageKit.SetLeds(color, leds);
+			}
+		}
+
+		public static void SetRedLeds(StageKitLed leds)
+			=> SetLeds(StageKitLedColor.Red, leds);
+
+		public static void SetYellowLeds(StageKitLed leds)
+			=> SetLeds(StageKitLedColor.Yellow, leds);
+
+		public static void SetBlueLeds(StageKitLed leds)
+			=> SetLeds(StageKitLedColor.Blue, leds);
+
+		public static void SetGreenLeds(StageKitLed leds)
+			=> SetLeds(StageKitLedColor.Green, leds);
+
+		public static void Reset() {
+			foreach (var stageKit in stageKits) {
+				stageKit.ResetHaptics();
+			}
+		}
+	}
+}

--- a/Assets/Script/Input/StageKitHapticsManager.cs.meta
+++ b/Assets/Script/Input/StageKitHapticsManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5776d7934e6d77242a03f63cc9536268
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -11,7 +11,7 @@
 	"dependencies": {
 		"com.cysharp.unitask": "https://github.com/Cysharp/UniTask.git?path=src/UniTask/Assets/Plugins/UniTask",
 		"com.thenathannator.hidrogen": "https://github.com/TheNathannator/HIDrogen.git?path=/Packages/com.thenathannator.hidrogen#v0.2.0",
-		"com.thenathannator.plasticband": "https://github.com/TheNathannator/PlasticBand-Unity.git?path=/Packages/com.thenathannator.plasticband#v0.2.3",
+		"com.thenathannator.plasticband": "https://github.com/TheNathannator/PlasticBand-Unity.git?path=/Packages/com.thenathannator.plasticband#v0.3.0",
 		"com.unity.2d.sprite": "1.0.0",
 		"com.unity.addressables": "1.21.9",
 		"com.unity.ai.navigation": "1.1.1",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -17,13 +17,13 @@
       "hash": "73285a031b0a978420ad08c64f0205e07d8dcec5"
     },
     "com.thenathannator.plasticband": {
-      "version": "https://github.com/TheNathannator/PlasticBand-Unity.git?path=/Packages/com.thenathannator.plasticband#v0.2.3",
+      "version": "https://github.com/TheNathannator/PlasticBand-Unity.git?path=/Packages/com.thenathannator.plasticband#v0.3.0",
       "depth": 0,
       "source": "git",
       "dependencies": {
         "com.unity.inputsystem": "1.4.4"
       },
-      "hash": "5cea9d1938c6545096248ee922da3bd72544c106"
+      "hash": "57a632d823c3ede765292ad26978f0cef3b486c5"
     },
     "com.unity.2d.sprite": {
       "version": "1.0.0",


### PR DESCRIPTION
This version brings support for Rock Band stage kits and sanjay900's new firmware. Some scaffolding code has been added for the haptics these devices support.

This version also adds a bunch of convenience APIs for retrieving controls by index or enum (which I switched the Pro Guitar input strategy over to), as well as hopefully support for the World Tour slider bar.