### PR TITLE
Make combo-recovery-strum not break existing combo

### DIFF
--- a/Assets/Script/PlayMode/FiveFretTrack.cs
+++ b/Assets/Script/PlayMode/FiveFretTrack.cs
@@ -188,12 +188,14 @@ namespace YARG.PlayMode {
 		private void UpdateInput() {
 			// Only want to decrease strum leniency on frames where we didn't strum
 			bool strummedCurrentNote = false;
+			bool strumLeniencyEnded = false;
 			if (strumLeniency > 0f && !strummed) {
 				strumLeniency -= Time.deltaTime;
 
 				if (strumLeniency <= 0f) {
 					UpdateOverstrums();
 					strumLeniency = 0f;
+					strumLeniencyEnded = true;
 				} else {
 					RemoveOldAllowedOverstrums();
 					if (IsOverstrumForgiven()) { // Consume allowed overstrum as soon as it's "hit"
@@ -252,7 +254,8 @@ namespace YARG.PlayMode {
 
 			// If strumming to recover combo, skip to first valid note within the timing window.
 			// This will make it easier to recover.
-			if ((strummed || strumLeniency > 0f) && !ChordPressed(chord)) {
+			bool recoveryStrum = Combo > 0 ? strumLeniencyEnded : (strummed || strumLeniency > 0f);
+			if (recoveryStrum && !ChordPressed(chord)) {
 				RemoveOldAllowedOverstrums();
 				var overstrumForgiven = IsOverstrumForgiven(false); // Do NOT consume allowed overstrums; this is done in other parts of the code
 

--- a/Assets/Script/PlayMode/FiveFretTrack.cs
+++ b/Assets/Script/PlayMode/FiveFretTrack.cs
@@ -193,7 +193,7 @@ namespace YARG.PlayMode {
 				strumLeniency -= Time.deltaTime;
 
 				if (strumLeniency <= 0f) {
-					UpdateOverstrums();
+					//UpdateOverstrums();
 					strumLeniency = 0f;
 					strumLeniencyEnded = true;
 				} else {
@@ -224,6 +224,9 @@ namespace YARG.PlayMode {
 			}
 
 			if (expectedHits.Count <= 0) {
+				if (strumLeniencyEnded) {
+					UpdateOverstrums();
+				}
 				return;
 			}
 
@@ -274,6 +277,7 @@ namespace YARG.PlayMode {
 
 					// If found...
 					if (found) {
+						strumLeniencyEnded = false;
 						// Miss all notes previous to the strummed note
 						while (expectedHits.Peek() != chord) {
 							var missedChord = expectedHits.Dequeue();
@@ -288,6 +292,9 @@ namespace YARG.PlayMode {
 						missedAnyNote = true;
 					}
 				}
+			}
+			if (strumLeniencyEnded) { // Strum leniency ended, and suitable strummable note wasn't found; overstrum
+				UpdateOverstrums();
 			}
 			// If tapping to recover combo during tap note section, skip to first valid note within the timing window.
 			// This will make it easier to recover.


### PR DESCRIPTION
Currently, the "strum to recover combo" wasn't respecting the strum leniency. This causes the wrong note to be detected as strummed in some scenarios (skipping to the next note, instead of waiting for the strum leniency to end).
This fix makes it so, if there's an ongoing combo, it waits for the strum leniency to end before triggering the "combo recovery strum" code (by which point it would've been an overstrum already).
~~(This has _not_ been thoroughly tested, so some additional testing to see if strumming feels better would be helpful!)~~
Edit: Tested by other players, who confirm this indeed makes it better to play certain strumming sections