### PR TITLE
Fix mic navigation and only allow selecting vocals mode when a microphone is selected

### DIFF
--- a/Assets/Scenes/MenuScene.unity
+++ b/Assets/Scenes/MenuScene.unity
@@ -11533,17 +11533,7 @@ MonoBehaviour:
   m_ItemImage: {fileID: 0}
   m_Value: 0
   m_Options:
-    m_Options:
-    - m_Text: Five Fret
-      m_Image: {fileID: 0}
-    - m_Text: Microphone
-      m_Image: {fileID: 0}
-    - m_Text: Pro Guitar
-      m_Image: {fileID: 0}
-    - m_Text: Drums (Standard)
-      m_Image: {fileID: 0}
-    - m_Text: Drums (5-lane)
-      m_Image: {fileID: 0}
+    m_Options: []
   m_OnValueChanged:
     m_PersistentCalls:
       m_Calls: []

--- a/Assets/Script/Input/MicInputStrategy.cs
+++ b/Assets/Script/Input/MicInputStrategy.cs
@@ -9,7 +9,9 @@ namespace YARG.Input {
 	public sealed class MicInputStrategy : InputStrategy {
 		public const string CONFIRM = "confirm";
 		public const string BACK = "back";
-		public const string MENU_ACTION = "menu_action";
+		public const string MENU_ACTION_1 = "menu_action_1";
+		public const string MENU_ACTION_2 = "menu_action_2";
+		public const string MENU_ACTION_3 = "menu_action_3";
 
 		public const string PAUSE = "pause";
 		public const string UP = "up";
@@ -59,7 +61,9 @@ namespace YARG.Input {
 		protected override Dictionary<string, ControlBinding> GetMappings() => new() {
 			{ CONFIRM,       new(BindingType.BUTTON, "Confirm/Select (Green)", CONFIRM) },
 			{ BACK,          new(BindingType.BUTTON, "Back (Red)", BACK) },
-			{ MENU_ACTION,     new(BindingType.BUTTON, "Menu Action (Yellow)", MENU_ACTION) },
+			{ MENU_ACTION_1, new(BindingType.BUTTON, "Menu Action 1 (Yellow)", MENU_ACTION_1) },
+			{ MENU_ACTION_2, new(BindingType.BUTTON, "Menu Action 2 (Blue)", MENU_ACTION_2) },
+			{ MENU_ACTION_3, new(BindingType.BUTTON, "Menu Action 3 (Orange)", MENU_ACTION_3) },
 
 			{ PAUSE,         new(BindingType.BUTTON, "Pause", PAUSE) },
 			{ UP,            new(BindingType.BUTTON, "Navigate Up", UP) },
@@ -277,7 +281,9 @@ namespace YARG.Input {
 			NavigationEventForMapping(MenuAction.Confirm, CONFIRM);
 			NavigationEventForMapping(MenuAction.Back, BACK);
 
-			NavigationEventForMapping(MenuAction.Shortcut1, MENU_ACTION);
+			NavigationEventForMapping(MenuAction.Shortcut1, MENU_ACTION_1);
+			NavigationEventForMapping(MenuAction.Shortcut2, MENU_ACTION_2);
+			NavigationEventForMapping(MenuAction.Shortcut3, MENU_ACTION_3);
 
 			NavigationEventForMapping(MenuAction.Up, UP);
 			NavigationEventForMapping(MenuAction.Down, DOWN);

--- a/Assets/Script/Input/MicInputStrategy.cs
+++ b/Assets/Script/Input/MicInputStrategy.cs
@@ -66,12 +66,11 @@ namespace YARG.Input {
 			{ DOWN,          new(BindingType.BUTTON, "Navigate Down", DOWN) },
 		};
 
+		protected override void UpdatePlayerMode() { }
+
 		protected override void OnUpdate() {
 			base.OnUpdate();
-			UpdatePlayerMode();
-		}
 
-		protected override void UpdatePlayerMode() {
 			if (microphoneIndex == INVALID_MIC_INDEX) {
 				return;
 			}

--- a/Assets/Script/PlayMode/MicPlayer.cs
+++ b/Assets/Script/PlayMode/MicPlayer.cs
@@ -212,6 +212,7 @@ namespace YARG.PlayMode {
 				};
 
 				// Bind events
+				player.inputStrategy.PauseEvent += PauseAction;
 				player.inputStrategy.StarpowerEvent += StarpowerAction;
 
 				// Add to players
@@ -312,6 +313,7 @@ namespace YARG.PlayMode {
 				playerInfo.player.lastScore = score;
 
 				// Unbind events
+				playerInfo.player.inputStrategy.PauseEvent -= PauseAction;
 				playerInfo.player.inputStrategy.StarpowerEvent -= StarpowerAction;
 			}
 		}
@@ -906,6 +908,10 @@ namespace YARG.PlayMode {
 
 		private void BeatAction() {
 			beat = true;
+		}
+
+		private void PauseAction() {
+			Play.Instance.Paused = !Play.Instance.Paused;
 		}
 
 		private void StarpowerAction(InputStrategy inputStrategy) {

--- a/Assets/Script/UI/AddPlayer.cs
+++ b/Assets/Script/UI/AddPlayer.cs
@@ -23,6 +23,14 @@ namespace YARG.UI {
 			RESOLVE
 		}
 
+		private enum StrategyType {
+			FiveFretGuitar,
+			Vocals,
+			RealGuitar,
+			FourLaneDrums,
+			FiveLaneDrums
+		}
+
 		[Flags]
 		private enum AllowedControl {
 			NONE = 0x00,
@@ -201,21 +209,21 @@ namespace YARG.UI {
 
 			if (selectedMicIndex != InputStrategy.INVALID_MIC_INDEX) {
 				// Set to MIC if the selected device is a MIC
-				inputStrategyDropdown.value = 1;
+				inputStrategyDropdown.value = (int)StrategyType.Vocals;
 				inputStrategyDropdown.interactable = false;
 			} else {
-				inputStrategyDropdown.value = 0;
+				inputStrategyDropdown.value = (int)StrategyType.FiveFretGuitar;
 				inputStrategyDropdown.interactable = true;
 			}
 		}
 
 		public void DoneConfigure() {
-			inputStrategy = inputStrategyDropdown.value switch {
-				0 => new FiveFretInputStrategy(),
-				1 => new MicInputStrategy(),
-				2 => new RealGuitarInputStrategy(),
-				3 => new DrumsInputStrategy(),
-				4 => new GHDrumsInputStrategy(),
+			inputStrategy = (StrategyType)inputStrategyDropdown.value switch {
+				StrategyType.FiveFretGuitar => new FiveFretInputStrategy(),
+				StrategyType.Vocals => new MicInputStrategy(),
+				StrategyType.RealGuitar => new RealGuitarInputStrategy(),
+				StrategyType.FourLaneDrums => new DrumsInputStrategy(),
+				StrategyType.FiveLaneDrums => new GHDrumsInputStrategy(),
 				_ => throw new Exception("Invalid input strategy type!")
 			};
 

--- a/Assets/Script/UI/AddPlayer.cs
+++ b/Assets/Script/UI/AddPlayer.cs
@@ -202,8 +202,10 @@ namespace YARG.UI {
 			if (selectedMicIndex != InputStrategy.INVALID_MIC_INDEX) {
 				// Set to MIC if the selected device is a MIC
 				inputStrategyDropdown.value = 1;
+				inputStrategyDropdown.interactable = false;
 			} else {
 				inputStrategyDropdown.value = 0;
+				inputStrategyDropdown.interactable = true;
 			}
 		}
 


### PR DESCRIPTION
Cleaned up AddPlayer a little along the way as well.

When selecting a microphone, you are now prompted to select a navigation device, with an option to go with no device. This fixes the issue of no device being available when binding was being started, so now the bindings menu can be shown correctly. I also added additional bindings for menu shortcuts 2 and 3, and implemented pausing into MicPlayer.

In addition, I've also reworked the input strategy selection list so that vocals is only ever shown (and is the only option available) when a microphone is selected. Can't even play vocals with only a guitar lol, no point in showing it.