### PR TITLE
Update PlasticBand-Unity to v0.3.1

### DIFF
--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "com.cysharp.unitask": "https://github.com/Cysharp/UniTask.git?path=src/UniTask/Assets/Plugins/UniTask",
     "com.thenathannator.hidrogen": "https://github.com/TheNathannator/HIDrogen.git?path=/Packages/com.thenathannator.hidrogen#v0.2.0",
-    "com.thenathannator.plasticband": "https://github.com/TheNathannator/PlasticBand-Unity.git?path=/Packages/com.thenathannator.plasticband#v0.3.0",
+    "com.thenathannator.plasticband": "https://github.com/TheNathannator/PlasticBand-Unity.git?path=/Packages/com.thenathannator.plasticband#v0.3.1",
     "com.unity.2d.sprite": "1.0.0",
     "com.unity.addressables": "1.21.9",
     "com.unity.ai.navigation": "1.1.1",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -17,13 +17,13 @@
       "hash": "73285a031b0a978420ad08c64f0205e07d8dcec5"
     },
     "com.thenathannator.plasticband": {
-      "version": "https://github.com/TheNathannator/PlasticBand-Unity.git?path=/Packages/com.thenathannator.plasticband#v0.3.0",
+      "version": "https://github.com/TheNathannator/PlasticBand-Unity.git?path=/Packages/com.thenathannator.plasticband#v0.3.1",
       "depth": 0,
       "source": "git",
       "dependencies": {
         "com.unity.inputsystem": "1.4.4"
       },
-      "hash": "57a632d823c3ede765292ad26978f0cef3b486c5"
+      "hash": "320038472ce28b2d17922cf8398d656d54a389f6"
     },
     "com.unity.2d.sprite": {
       "version": "1.0.0",


### PR DESCRIPTION
Another Unity moment, HID Santroller device support is causing the same crashes that PS4 instrument support does :/

Other changes:
- Fixed some initialization issues when entering Play mode in the editor
- Fixed XInput layout overrides not being evaluated correctly due to a logic error