### PR TITLE
Remove Library and ProjectSettings folders from VS Code file exclude settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,11 +6,8 @@
         "**/*.meta":true,
         "build/":true,
         "Build/":true,
-        "Library/":true,
-        "library/":true,
         "obj/":true,
         "Obj/":true,
-        "ProjectSettings/":true,
         "temp/":true,
         "Temp/":true
     }


### PR DESCRIPTION
I keep finding myself temporarily un-hiding the Library folder to look into something the input system or some other package is doing, got tired of it so here's this lol

Included ProjectSettings too because might as well, it's tracked by git and doesn't really harm much to unhide.