### PR TITLE
Some quick UI-related code cleanups

### DIFF
--- a/Assets/Scenes/PersistantScene.unity
+++ b/Assets/Scenes/PersistantScene.unity
@@ -4487,6 +4487,10 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   fpsCircle: {fileID: 1604709612}
   fpsText: {fileID: 647926893}
+  fpsCircleGreen: {r: 0.2745098, g: 0.9058823, b: 0.3098039, a: 1}
+  fpsCircleYellow: {r: 1, g: 0.8313725, b: 0.2274509, a: 1}
+  fpsCircleRed: {r: 1, g: 0, b: 0.2078431, a: 1}
+  fpsUpdateRate: 1
 --- !u!1 &1953023866
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Script/Settings/SettingsManager.Settings.cs
+++ b/Assets/Script/Settings/SettingsManager.Settings.cs
@@ -109,10 +109,8 @@ namespace YARG.Settings {
 			}
 
 			private static void FpsCouterCallback(bool value) {
-				// disable script
 				FpsCounter.Instance.enabled = value;
-				// UpdateSettings()
-				FpsCounter.Instance.UpdateSettings(value);
+				FpsCounter.Instance.SetVisible(value);
 
 				// enable script if in editor
 #if UNITY_EDITOR

--- a/Assets/Script/Song/SongCache.cs
+++ b/Assets/Script/Song/SongCache.cs
@@ -5,6 +5,7 @@ using System.Security.Cryptography;
 using System.Text;
 using UnityEngine;
 using YARG.Data;
+using YARG.UI;
 
 namespace YARG.Song {
 	public class SongCache {

--- a/Assets/Script/ThirdParty/UpdateChecker.cs
+++ b/Assets/Script/ThirdParty/UpdateChecker.cs
@@ -6,6 +6,7 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using UnityEngine;
 using YARG.Data;
+using YARG.UI;
 
 namespace YARG {
 	public class UpdateChecker : MonoBehaviour {

--- a/Assets/Script/UI/DevWatermark.cs
+++ b/Assets/Script/UI/DevWatermark.cs
@@ -1,27 +1,23 @@
-using System.Collections;
-using System.Collections.Generic;
 using TMPro;
 using UnityEngine;
-using YARG;
-using Debug = UnityEngine.Debug;
 
-public class DevWatermark : MonoBehaviour {
+namespace YARG.UI {
+	public class DevWatermark : MonoBehaviour {
+		[SerializeField]
+		private TextMeshProUGUI watermarkText;
 
-	[SerializeField]
-	private TextMeshProUGUI watermarkText;
+		void Start() {
+			// check if Constants.VERSION_TAG ends with "b"
+			if (Constants.VERSION_TAG.beta) {
+				watermarkText.text = $"<b>YARG {Constants.VERSION_TAG}</b>  Developer Build";
+				watermarkText.gameObject.SetActive(true);
+			} else {
+				this.gameObject.SetActive(false);
+			}
 
-	// Start is called before the first frame update
-	void Start() {
-		// check if Constants.VERSION_TAG ends with "b"
-		if (Constants.VERSION_TAG.beta) {
-			watermarkText.text = $"<b>YARG {Constants.VERSION_TAG}</b>  Developer Build";
-			watermarkText.gameObject.SetActive(true);
-		} else {
-			this.gameObject.SetActive(false);
+			// disable script
+			this.enabled = false;
+			Debug.Log("DevWatermark script disabled");
 		}
-
-		// disable script
-		this.enabled = false;
-		Debug.Log("DevWatermark script disabled");
 	}
 }

--- a/Assets/Script/UI/DevWatermark.cs
+++ b/Assets/Script/UI/DevWatermark.cs
@@ -17,7 +17,6 @@ namespace YARG.UI {
 
 			// disable script
 			this.enabled = false;
-			Debug.Log("DevWatermark script disabled");
 		}
 	}
 }

--- a/Assets/Script/UI/FpsCounter.cs
+++ b/Assets/Script/UI/FpsCounter.cs
@@ -3,81 +3,67 @@ using UnityEngine;
 using UnityEngine.Profiling;
 using UnityEngine.UI;
 
-public class FpsCounter : MonoBehaviour {
+namespace YARG.UI {
+	public class FpsCounter : MonoBehaviour {
+		public static FpsCounter Instance { get; private set; } = null;
 
-	// Instance
-	public static FpsCounter Instance { get; private set; } = null;
+		[SerializeField]
+		private Image fpsCircle;
+		[SerializeField]
+		private TextMeshProUGUI fpsText;
 
-	// FPS Counter
-	public Image fpsCircle;
-	public TextMeshProUGUI fpsText;
-	private float updateTime = 1f;
+		[SerializeField]
+		private Color fpsCircleGreen;
+		[SerializeField]
+		private Color fpsCircleYellow;
+		[SerializeField]
+		private Color fpsCircleRed;
 
-	// Awake
-	private void Awake() {
-		Instance = this;
-	}
+		[SerializeField]
+		private float fpsUpdateRate;
 
-	// check if the settings have changed and update the fps counter accordingly
-	public void UpdateSettings(bool value) {
-		SetVisible(value);
-	}
+		private float nextUpdateTime;
 
-	public void SetVisible(bool value) {
-		fpsText.gameObject.SetActive(value);
-		fpsCircle.gameObject.SetActive(value);
-	}
+		private void Awake() {
+			Instance = this;
+		}
 
-	// OnDestroy - set the instance to null
-	private void OnDestroy() {
-		Instance = null;
-	}
+		public void SetVisible(bool value) {
+			fpsText.gameObject.SetActive(value);
+			fpsCircle.gameObject.SetActive(value);
+		}
 
-	// Update is called once per frame
-	void Update() {
-		// update fps per second
-		if (Time.unscaledTime > updateTime) {
+		private void OnDestroy() {
+			Instance = null;
+		}
 
-			// (1 / unscaledDeltaTime) = FPS
+		void Update() {
+			// Wait for next update period
+			if (Time.unscaledTime < nextUpdateTime) {
+				return;
+			}
+
 			int fps = (int)(1f / Time.unscaledDeltaTime);
 
-			// Clear the FPS text
-			fpsText.text = "";
-
-			// Color the FPS sprite based on the FPS
+			// Color the circle sprite based on the FPS
 			if (fps < 30) {
-				// RED
-				if (ColorUtility.TryParseHtmlString("#FF0035", out Color color)) {
-					fpsCircle.color = color;
-				} else {
-					fpsCircle.color = Color.red;
-				}
+				fpsCircle.color = fpsCircleRed;
 			} else if (fps < 60) {
-				// YELLOW
-				if (ColorUtility.TryParseHtmlString("#FFD43A", out Color color)) {
-					fpsCircle.color = color;
-				} else {
-					fpsCircle.color = Color.yellow;
-				}
+				fpsCircle.color = fpsCircleYellow;
 			} else {
-				// GREEN
-				if (ColorUtility.TryParseHtmlString("#46E74F", out Color color)) {
-					fpsCircle.color = color;
-				} else {
-					fpsCircle.color = Color.green;
-				}
+				fpsCircle.color = fpsCircleGreen;
 			}
 
 			// Display the FPS
-			fpsText.text += "FPS: " + fps.ToString();
+			fpsText.text = $"FPS: {fps}";
 
 #if UNITY_EDITOR
 			// Display the memory usage
-			fpsText.text += "\nMemory: " + (Profiler.GetTotalAllocatedMemoryLong() / 1024 / 1024).ToString() + " MB";
+			fpsText.text += $"\nMemory: {Profiler.GetTotalAllocatedMemoryLong() / 1024 / 1024} MB";
 #endif
 
 			// reset the update time
-			updateTime = Time.unscaledTime + 1f;
+			nextUpdateTime = Time.unscaledTime + fpsUpdateRate;
 		}
 	}
 }

--- a/Assets/Script/UI/ToastManager.cs
+++ b/Assets/Script/UI/ToastManager.cs
@@ -1,207 +1,216 @@
 using System.Collections;
 using System.Collections.Generic;
-using UnityEngine;
 using TMPro;
-using UnityEngine.UI;
+using UnityEngine;
 using UnityEngine.InputSystem;
-public class ToastManager : MonoBehaviour{
-    /* Currently handles:
-    Devices at startup
-    Devices connected - not keyboard or mouse or microphone
-    Device disconnected - not keyboard or mouse or microphone
+using UnityEngine.UI;
 
-    Colors:
-    General: #00DDFB
-    Success: #46E74F
-    Information: #00AFF7
-    Warning: #FFEE57
-    Error: #FF0031
-    Message Color: #FFFFFF    
-    */
-    [Header("Colors")]
-    [SerializeField]
-    private Color generalColor;
-    [SerializeField]
-    private Color successColor;
-    [SerializeField]
-    private Color warningColor;
-    [SerializeField]
-    private Color informationColor;
-    [SerializeField]
-    private Color errorColor;
-    [SerializeField]
-    private Color messageColor;
-    [Space]
-    [Header("Icons")]
-    [SerializeField]
-    private Sprite iconGeneral;
-    [SerializeField]
-    private Sprite iconSuccess;
-    [SerializeField]
-    private Sprite iconWarning;
-    [SerializeField]
-    private Sprite iconInformation;
-    [SerializeField]
-    private Sprite iconError;
-    [Space]
-    [Header("UI Elements")]
-    [SerializeField]
-    private TMP_Text messageTypeText;
-    [SerializeField]
-    private Image messageTypeIcon;
-    [SerializeField]
-    private TMP_Text messageBody;
-    [SerializeField]
-    private GameObject toastFab;
-    [SerializeField]
-    private Animator toastAnimator;
+namespace YARG.UI {
+	public class ToastManager : MonoBehaviour {
+		/* Currently handles:
+		Devices at startup
+		Devices connected - not keyboard or mouse or microphone
+		Device disconnected - not keyboard or mouse or microphone
 
-    [SerializeField]
-    private Image messageBackground;
+		Colors:
+		General: #00DDFB
+		Success: #46E74F
+		Information: #00AFF7
+		Warning: #FFEE57
+		Error: #FF0031
+		Message Color: #FFFFFF    
+		*/
+		[Header("Colors")]
+		[SerializeField]
+		private Color generalColor;
+		[SerializeField]
+		private Color successColor;
+		[SerializeField]
+		private Color warningColor;
+		[SerializeField]
+		private Color informationColor;
+		[SerializeField]
+		private Color errorColor;
+		[SerializeField]
+		private Color messageColor;
 
-    private static Queue<Toast> toastQueue = new Queue<Toast>();
-    private Coroutine queueChecker;
+		[Space]
+		[Header("Icons")]
+		[SerializeField]
+		private Sprite iconGeneral;
+		[SerializeField]
+		private Sprite iconSuccess;
+		[SerializeField]
+		private Sprite iconWarning;
+		[SerializeField]
+		private Sprite iconInformation;
+		[SerializeField]
+		private Sprite iconError;
 
-    public enum ToastType{
-        general,
-        success,
-        warning,
-        information,
-        error,
-    }
+		[Space]
+		[Header("UI Elements")]
+		[SerializeField]
+		private TMP_Text messageTypeText;
+		[SerializeField]
+		private Image messageTypeIcon;
+		[SerializeField]
+		private TMP_Text messageBody;
+		[SerializeField]
+		private GameObject toastFab;
+		[SerializeField]
+		private Animator toastAnimator;
+		[SerializeField]
+		private Image messageBackground;
 
-    public struct Toast{ //this is so we can pass 2 things into the queue
-        public ToastType type;
-        public string text;
-        public Toast(ToastType type, string text){
-            this.type = type;
-            this.text = text;
-        }
-    }
-    public static ToastManager Instance {
-        get;
-        private set;
-    }
+		private static Queue<Toast> toastQueue = new Queue<Toast>();
+		private Coroutine queueChecker;
 
-    private void Start(){
-        Instance = this;
-        toastFab.SetActive(false);
-        ToastInformation("Devices found: " + (Microphone.devices.Length + InputSystem.devices.Count));
-        InputSystem.onDeviceChange += OnDeviceChange; //listen to devices added or removed when running. Know what is awesome? This doesn't include things already connected at start up. so time for a bunch of code just to handle that:
-    }
-    /// <summary>
-    /// Adds a general message toast to the toast queue.
-    /// </summary>
-    /// <param name="text">Text of the toast.</param>
-    public static void ToastMessage(string text){ //the public facing function to use to add a toast to the queue
-        toastQueue.Enqueue(new Toast(ToastType.general, text));
-        if (Instance.queueChecker == null){
-            Instance.queueChecker = Instance.StartCoroutine(Instance.CheckQueue());
-        }
-    }
-    /// <summary>
-    /// Adds a success message toast to the toast queue.
-    /// </summary>
-    /// <param name="text">Text of the toast.</param>
-    public static void ToastSuccess(string text){ //the public facing function to use to add a toast to the queue
-        toastQueue.Enqueue(new Toast(ToastType.success, text));
-        if (Instance.queueChecker == null){
-            Instance.queueChecker = Instance.StartCoroutine(Instance.CheckQueue());
-        }
-    }
-    /// <summary>
-    /// Adds a warning message toast to the toast queue.
-    /// </summary>
-    /// <param name="text">Text of the toast.</param>
-    public static void ToastWarning(string text){ //the public facing function to use to add a toast to the queue
-        toastQueue.Enqueue(new Toast(ToastType.warning, text));
-        if (Instance.queueChecker == null){
-            Instance.queueChecker = Instance.StartCoroutine(Instance.CheckQueue());
-        }
-    }
-    /// <summary>
-    /// Adds an information message toast to the toast queue.
-    /// </summary>
-    /// <param name="text">Text of the toast.</param>
-    public static void ToastInformation(string text){ //the public facing function to use to add a toast to the queue
-        toastQueue.Enqueue(new Toast(ToastType.information, text));
-        if (Instance.queueChecker == null){
-            Instance.queueChecker = Instance.StartCoroutine(Instance.CheckQueue());
-        }
-    }
-    /// <summary>
-    /// Adds an error message toast to the toast queue.
-    /// </summary>
-    /// <param name="text">Text of the toast.</param>
-    public static void ToastError(string text){ //the public facing function to use to add a toast to the queue
-        toastQueue.Enqueue(new Toast(ToastType.error, text));
-        if (Instance.queueChecker == null){
-            Instance.queueChecker = Instance.StartCoroutine(Instance.CheckQueue());
-        }
-    }
+		public enum ToastType {
+			General,
+			Information,
+			Success,
+			Warning,
+			Error,
+		}
 
-    private void ShowToast(ToastType type, string body){ 
-        toastFab.SetActive(true);
-        switch(type){
-        case ToastType.general:
-        messageTypeText.text = "General";
-        messageTypeText.color = generalColor;
-        messageTypeIcon.sprite = iconGeneral;             
-        break;
+		public struct Toast { //this is so we can pass 2 things into the queue
+			public ToastType type;
+			public string text;
+			public Toast(ToastType type, string text) {
+				this.type = type;
+				this.text = text;
+			}
+		}
 
-        case ToastType.success:
-        messageTypeText.text = "Success";
-        messageTypeText.color = successColor;
-        messageTypeIcon.sprite = iconSuccess;             
-        break;
+		public static ToastManager Instance { get; private set; }
 
-        case ToastType.warning:
-        messageTypeText.text = "Warning";
-        messageTypeText.color = warningColor;
-        messageTypeIcon.sprite = iconWarning;             
-        break;
 
-        case ToastType.information:
-        messageTypeText.text = "Information";
-        messageTypeText.color = informationColor;
-        messageTypeIcon.sprite = iconInformation;             
-        break;
+		private void Start() {
+			Instance = this;
+			toastFab.SetActive(false);
+			ToastInformation("Devices found: " + (Microphone.devices.Length + InputSystem.devices.Count));
+            // Watch for added or removed devices
+			InputSystem.onDeviceChange += OnDeviceChange;
+		}
 
-        case ToastType.error:
-        messageTypeText.text = "Error";
-        messageTypeText.color = errorColor;
-        messageTypeIcon.sprite = iconError;             
-        break;
+		/// <summary>
+		/// Adds a general message toast to the toast queue.
+		/// </summary>
+		/// <param name="text">Text of the toast.</param>
+		public static void ToastMessage(string text) {
+			toastQueue.Enqueue(new Toast(ToastType.General, text));
+			if (Instance.queueChecker == null) {
+				Instance.queueChecker = Instance.StartCoroutine(Instance.CheckQueue());
+			}
+		}
 
-        default:
-        messageTypeText.text = "Unknown";
-        messageTypeText.color = generalColor;
-        messageTypeIcon.sprite = iconGeneral;             
-        break;
-        }
-        messageBody.color = new Color(0xFF, 0xFF, 0xFF, 0xFF); //set text color to white
-        messageBody.text = body;
-        messageBackground.color = messageTypeText.color;
-        toastAnimator.Play("ToastAnimation");
-    }
+		/// <summary>
+		/// Adds an information message toast to the toast queue.
+		/// </summary>
+		/// <param name="text">Text of the toast.</param>
+		public static void ToastInformation(string text) {
+			toastQueue.Enqueue(new Toast(ToastType.Information, text));
+			if (Instance.queueChecker == null) {
+				Instance.queueChecker = Instance.StartCoroutine(Instance.CheckQueue());
+			}
+		}
 
-    private IEnumerator CheckQueue(){
-        do{
-            Toast thing = toastQueue.Dequeue();
-            ShowToast(thing.type, thing.text);
-            do{
-                yield return null;
-            } while (!toastAnimator.GetCurrentAnimatorStateInfo(0).IsTag("Idle"));
-        } while ( toastQueue.Count > 0);
-        toastFab.SetActive(false);
-        queueChecker = null;
-    }
+		/// <summary>
+		/// Adds a success message toast to the toast queue.
+		/// </summary>
+		/// <param name="text">Text of the toast.</param>
+		public static void ToastSuccess(string text) {
+			toastQueue.Enqueue(new Toast(ToastType.Success, text));
+			if (Instance.queueChecker == null) {
+				Instance.queueChecker = Instance.StartCoroutine(Instance.CheckQueue());
+			}
+		}
 
-    private void OnDeviceChange(InputDevice device, InputDeviceChange change){
-        if (change == InputDeviceChange.Added){
-            ToastMessage("Device added: " + device.name);
-        }else if (change == InputDeviceChange.Removed){
-            ToastMessage("Device removed: " + device.name);
-        }
-    }
+		/// <summary>
+		/// Adds a warning message toast to the toast queue.
+		/// </summary>
+		/// <param name="text">Text of the toast.</param>
+		public static void ToastWarning(string text) {
+			toastQueue.Enqueue(new Toast(ToastType.Warning, text));
+			if (Instance.queueChecker == null) {
+				Instance.queueChecker = Instance.StartCoroutine(Instance.CheckQueue());
+			}
+		}
+
+		/// <summary>
+		/// Adds an error message toast to the toast queue.
+		/// </summary>
+		/// <param name="text">Text of the toast.</param>
+		public static void ToastError(string text) {
+			toastQueue.Enqueue(new Toast(ToastType.Error, text));
+			if (Instance.queueChecker == null) {
+				Instance.queueChecker = Instance.StartCoroutine(Instance.CheckQueue());
+			}
+		}
+
+		private void ShowToast(ToastType type, string body) {
+			toastFab.SetActive(true);
+			switch (type) {
+				case ToastType.General:
+					messageTypeText.text = "General";
+					messageTypeText.color = generalColor;
+					messageTypeIcon.sprite = iconGeneral;
+					break;
+
+				case ToastType.Success:
+					messageTypeText.text = "Success";
+					messageTypeText.color = successColor;
+					messageTypeIcon.sprite = iconSuccess;
+					break;
+
+				case ToastType.Warning:
+					messageTypeText.text = "Warning";
+					messageTypeText.color = warningColor;
+					messageTypeIcon.sprite = iconWarning;
+					break;
+
+				case ToastType.Information:
+					messageTypeText.text = "Information";
+					messageTypeText.color = informationColor;
+					messageTypeIcon.sprite = iconInformation;
+					break;
+
+				case ToastType.Error:
+					messageTypeText.text = "Error";
+					messageTypeText.color = errorColor;
+					messageTypeIcon.sprite = iconError;
+					break;
+
+				default:
+					messageTypeText.text = "Unknown";
+					messageTypeText.color = generalColor;
+					messageTypeIcon.sprite = iconGeneral;
+					break;
+			}
+			messageBody.color = new Color(0xFF, 0xFF, 0xFF, 0xFF); //set text color to white
+			messageBody.text = body;
+			messageBackground.color = messageTypeText.color;
+			toastAnimator.Play("ToastAnimation");
+		}
+
+		private IEnumerator CheckQueue() {
+			do {
+				Toast thing = toastQueue.Dequeue();
+				ShowToast(thing.type, thing.text);
+				do {
+					yield return null;
+				} while (!toastAnimator.GetCurrentAnimatorStateInfo(0).IsTag("Idle"));
+			} while (toastQueue.Count > 0);
+			toastFab.SetActive(false);
+			queueChecker = null;
+		}
+
+		private void OnDeviceChange(InputDevice device, InputDeviceChange change) {
+			if (change == InputDeviceChange.Added) {
+				ToastMessage("Device added: " + device.name);
+			} else if (change == InputDeviceChange.Removed) {
+				ToastMessage("Device removed: " + device.name);
+			}
+		}
+	}
 }

--- a/Assets/Script/UI/ToastManager.cs
+++ b/Assets/Script/UI/ToastManager.cs
@@ -207,9 +207,9 @@ namespace YARG.UI {
 
 		private void OnDeviceChange(InputDevice device, InputDeviceChange change) {
 			if (change == InputDeviceChange.Added) {
-				ToastMessage("Device added: " + device.name);
+				ToastMessage("Device added: " + device.displayName);
 			} else if (change == InputDeviceChange.Removed) {
-				ToastMessage("Device removed: " + device.name);
+				ToastMessage("Device removed: " + device.displayName);
 			}
 		}
 	}


### PR DESCRIPTION
- ToastManager:
  - Move into the YARG.UI namespace
  - Reformat the file
  - Re-ordered a couple things 
  - Use `displayName` instead of `name` when toasting device connections/disconnections
- DevWatermark:
  - Move into the YARG.UI namespace
  - Remove unused using directives
  - Remove 'disabled' log message
- FpsCounter:
  - Move into the YARG.UI namespace
  - Serialize color values and update rate instead of hard-coding them
  - Remove UpdateSettings and replace calls to it with calls to SetVisible