### PR TITLE
Disable keyboard navigation while typing

### DIFF
--- a/Assets/Script/Input/InputStrategy.cs
+++ b/Assets/Script/Input/InputStrategy.cs
@@ -1,6 +1,9 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using PlasticBand.Haptics;
+using TMPro;
+using UnityEngine.EventSystems;
 using UnityEngine.InputSystem;
 using UnityEngine.InputSystem.Controls;
 using UnityEngine.InputSystem.LowLevel;
@@ -185,6 +188,14 @@ namespace YARG.Input {
 		private void OnInputEvent(InputEventPtr eventPtr) {
 			// Only take state events
 			if (!eventPtr.IsA<StateEvent>() && !eventPtr.IsA<DeltaStateEvent>()) {
+				return;
+			}
+
+			// Ignore navigation events from the keyboard while a text box is selected
+			// We detect whether a text box is selected by seeing if a focused input field is a component of the currently selected object
+			if (eventPtr.deviceId == Keyboard.current.deviceId &&
+				(EventSystem.current.currentSelectedGameObject?.GetComponents<TMP_InputField>().Any(i => i.isFocused) ?? false)) {
+
 				return;
 			}
 


### PR DESCRIPTION
This prevents the consumption of keyboard input events by the game while a text input box is active. For example, it allows typing in the search bar using characters that have been mapped to controls such as back and select. It does not make the Quickplay menu entirely navigable by a keyboard, as a mouse is required to escape the text box after a search has been made and subsequently exited. Fixing that would likely be part of making the main menu navigable at all with a controller, as a mouse is required anyway currently. This resolves issue #378 .