### PR TITLE
Strip rich text tags from strings to prevent text issues

### DIFF
--- a/Assets/Script/UI/MusicLibrary/Sidebar.cs
+++ b/Assets/Script/UI/MusicLibrary/Sidebar.cs
@@ -1,20 +1,18 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Threading;
-using System.Threading.Tasks;
 using Cysharp.Threading.Tasks;
 using TMPro;
 using UnityEngine;
 using UnityEngine.Networking;
 using UnityEngine.UI;
 using XboxSTFS;
-using static XboxSTFS.XboxSTFSParser;
 using YARG.Data;
 using YARG.Serialization;
 using YARG.Song;
 using YARG.UI.MusicLibrary.ViewTypes;
+using YARG.Util;
 
 namespace YARG.UI.MusicLibrary {
 	public class Sidebar : MonoBehaviour {
@@ -113,7 +111,7 @@ namespace YARG.UI.MusicLibrary {
 			_charter.text = songEntry.Charter;
 			_genre.text = songEntry.Genre;
 			_year.text = songEntry.Year;
-			HelpBar.Instance.SetInfoText(songEntry.LoadingPhrase);
+			HelpBar.Instance.SetInfoText(RichTextUtils.StripRichTextTagsExclude(songEntry.LoadingPhrase, RichTextUtils.GOOD_TAGS));
 
 			// Format and show length
 			if (songEntry.SongLengthTimeSpan.Hours > 0) {
@@ -135,10 +133,10 @@ namespace YARG.UI.MusicLibrary {
 			}
 
 			/*
-			
-				Guitar               ; Bass               ; 4 or 5 lane ; Keys     ; Mic (dependent on mic count) 
+
+				Guitar               ; Bass               ; 4 or 5 lane ; Keys     ; Mic (dependent on mic count)
 				Pro Guitar or Co-op  ; Pro Bass or Rhythm ; True Drums  ; Pro Keys ; Band
-			
+
 			*/
 
 			difficultyRings[0].SetInfo(songEntry, Instrument.GUITAR);

--- a/Assets/Script/Util/RichTextUtils.cs
+++ b/Assets/Script/Util/RichTextUtils.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Text;
 using System.Text.RegularExpressions;
 
@@ -51,6 +52,8 @@ namespace YARG.Util {
                                                          RichTextTags.Strikethrough | RichTextTags.Underline |
                                                          RichTextTags.Subscript | RichTextTags.Superscript);
 
+        private static readonly Dictionary<ulong, Regex> RegexCache = new();
+
 		public static string StripRichTextTags(string text) {
 			return StripRichTextTagsPrivate(text, ALL_TAGS);
 		}
@@ -64,6 +67,10 @@ namespace YARG.Util {
 		}
 
 		private static string StripRichTextTagsPrivate(string text, RichTextTags tags) {
+			if(RegexCache.TryGetValue((ulong)tags, out var cachedRegex)) {
+				return cachedRegex.Replace(text, "");
+			}
+
 			var regexFormat = @"<\/*{0}.*?>|";
 
 			var sb = new StringBuilder();
@@ -76,7 +83,8 @@ namespace YARG.Util {
             if(sb.Length > 0)
 			    regexFormat = sb.Remove(sb.Length - 1, 1).ToString();
 
-			var regex = new Regex(regexFormat);
+			var regex = new Regex(regexFormat, RegexOptions.Compiled);
+			RegexCache.Add((ulong)tags, regex);
 
 			return regex.Replace(text, "");
 		}

--- a/Assets/Script/Util/RichTextUtils.cs
+++ b/Assets/Script/Util/RichTextUtils.cs
@@ -123,10 +123,10 @@ namespace YARG.Util {
 		Superscript        = 1 << 28,
 		BaselineOffset     = 1 << 29,
 		Width              = 1 << 30,
-        LineBreak          = 1UL << 31,
-        FontWeight         = 1UL << 32,
-        Gradient 		   = 1UL << 33,
-        Rotate 			   = 1UL << 34,
-        AllCaps 		   = 1UL << 35
+		LineBreak          = 1UL << 31,
+		FontWeight         = 1UL << 32,
+		Gradient           = 1UL << 33,
+		Rotate             = 1UL << 34,
+		AllCaps            = 1UL << 35
 	}
 }

--- a/Assets/Script/Util/RichTextUtils.cs
+++ b/Assets/Script/Util/RichTextUtils.cs
@@ -1,0 +1,124 @@
+﻿using System;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace YARG.Util {
+	public static class RichTextUtils {
+		private static readonly string[] RichTextTagStrings = {
+			"align",
+			"alpha",
+			"color",
+			"b",
+			"i",
+			"cspace",
+			"font",
+			"indent",
+			"line-height",
+			"line-indent",
+			"link",
+			"lowercase",
+			"uppercase",
+			"smallcaps",
+			"margin",
+			"mark",
+			"mspace",
+			"noparse",
+			"nobr",
+			"page",
+			"pos",
+			"size",
+			"space",
+			"sprite",
+			"s",
+			"u",
+			"style",
+			"sub",
+			"sup",
+			"voffset",
+			"width",
+            "br",
+            "font-weight",
+            "gradient",
+            "rotate",
+            "allcaps"
+		};
+
+		public const RichTextTags ALL_TAGS  = (RichTextTags)~(ulong)0;
+		public const RichTextTags GOOD_TAGS = ALL_TAGS & ~BAD_TAGS;
+        public const RichTextTags BAD_TAGS = ALL_TAGS & ~(RichTextTags.Alpha | RichTextTags.Color | RichTextTags.Bold |
+                                                         RichTextTags.Italics | RichTextTags.LowerCase |
+                                                         RichTextTags.Uppercase | RichTextTags.SmallCaps |
+                                                         RichTextTags.Strikethrough | RichTextTags.Underline |
+                                                         RichTextTags.Subscript | RichTextTags.Superscript);
+
+		public static string StripRichTextTags(string text) {
+			return StripRichTextTagsPrivate(text, ALL_TAGS);
+		}
+
+		public static string StripRichTextTags(string text, RichTextTags tags) {
+			return StripRichTextTagsPrivate(text, tags);
+		}
+
+		public static string StripRichTextTagsExclude(string text, RichTextTags excludeTags) {
+			return StripRichTextTagsPrivate(text, ALL_TAGS & ~excludeTags);
+		}
+
+		private static string StripRichTextTagsPrivate(string text, RichTextTags tags) {
+			var regexFormat = @"<\/*{0}.*?>|";
+
+			var sb = new StringBuilder();
+            int enumLength = Enum.GetValues(typeof(RichTextTags)).Length;
+			for (int i = 0; i < enumLength; i++) {
+				if((tags & (RichTextTags)(1 << i)) != 0) {
+					sb.AppendFormat(regexFormat, RichTextTagStrings[i]);
+				}
+			}
+            if(sb.Length > 0)
+			    regexFormat = sb.Remove(sb.Length - 1, 1).ToString();
+
+			var regex = new Regex(regexFormat);
+
+			return regex.Replace(text, "");
+		}
+	}
+
+	[Flags]
+	public enum RichTextTags : ulong {
+		Align              = 1 << 0,
+		Alpha              = 1 << 1,
+		Color              = 1 << 2,
+		Bold               = 1 << 3,
+		Italics            = 1 << 4,
+		CSpace             = 1 << 5,
+		Font               = 1 << 6,
+		Indent             = 1 << 7,
+		LineHeight         = 1 << 8,
+		LineIndent         = 1 << 9,
+		Link               = 1 << 10,
+		LowerCase          = 1 << 11,
+		Uppercase          = 1 << 12,
+		SmallCaps          = 1 << 13,
+		Margin             = 1 << 14,
+		Mark               = 1 << 15,
+		Monospace          = 1 << 16,
+		NoParsing          = 1 << 17,
+		NoSpaceBreak       = 1 << 18,
+		Page               = 1 << 19,
+		HorizontalPosition = 1 << 20,
+		FontSize           = 1 << 21,
+		HorizontalSpace    = 1 << 22,
+		Sprite             = 1 << 23,
+		Strikethrough      = 1 << 24,
+		Underline          = 1 << 25,
+		Style              = 1 << 26,
+		Subscript          = 1 << 27,
+		Superscript        = 1 << 28,
+		BaselineOffset     = 1 << 29,
+		Width              = 1 << 30,
+        LineBreak          = 1UL << 31,
+        FontWeight         = 1UL << 32,
+        Gradient 		   = 1UL << 33,
+        Rotate 			   = 1UL << 34,
+        AllCaps 		   = 1UL << 35
+	}
+}

--- a/Assets/Script/Util/RichTextUtils.cs.meta
+++ b/Assets/Script/Util/RichTextUtils.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 45014e4b795e427aa824e6f8d16544de
+timeCreated: 1685482343

--- a/Assets/Script/Util/Utils.cs
+++ b/Assets/Script/Util/Utils.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using TMPro;
 using UnityEngine;
 using YARG.Chart;
 
@@ -12,10 +13,10 @@ namespace YARG.Util {
 		/// </summary>
 		public static bool PathsEqual(string a, string b) {
 #if UNITY_EDITOR_LINUX || UNITY_STANDALONE_LINUX
-			
+
 			// Linux is case sensitive
 			return Path.GetFullPath(a).Equals(Path.GetFullPath(b), StringComparison.CurrentCulture);
-			
+
 #else
 
 			// Windows and OSX are not case sensitive


### PR DESCRIPTION
Some strings such as loading phrases can contain Unity/TMP rich text tags and some of those tags break sizing or other constraints such as offsets.

Currently it is only implemented on the help bar for loading phrases when using the music library. Should be applied to other places where necessary

- Added a couple utility functions which strip rich text tags.
- Can specify which rich text tags to remove, or which to keep.
- Uses regex and caches regex objects to be faster after first use.