### PR TITLE
Beats-based SP drain only

### DIFF
--- a/Assets/Script/PlayMode/AbstractTrack.cs
+++ b/Assets/Script/PlayMode/AbstractTrack.cs
@@ -413,7 +413,7 @@ namespace YARG.PlayMode {
 					SetReverb(false);
 				} else {
 					//starpowerCharge -= Time.deltaTime / 25f * Play.speed; //original logic
-					starpowerCharge -= (float) ((Time.deltaTime * Play.Instance.CurrentBeatsPerSecond) * 0.03125); // calculates based on 32 beats for a full bar
+					starpowerCharge -= (float)((Time.deltaTime * Play.Instance.CurrentBeatsPerSecond) * 0.03125); // calculates based on 32 beats for a full bar
 				}
 				if (!trackAnims.spShakeAscended) {
 					trackAnims.StarpowerTrackAnim();

--- a/Assets/Script/PlayMode/AbstractTrack.cs
+++ b/Assets/Script/PlayMode/AbstractTrack.cs
@@ -412,7 +412,8 @@ namespace YARG.PlayMode {
 					GameManager.AudioManager.PlaySoundEffect(SfxSample.StarPowerRelease);
 					SetReverb(false);
 				} else {
-					starpowerCharge -= Time.deltaTime / 25f * Play.speed;
+					//starpowerCharge -= Time.deltaTime / 25f * Play.speed; //original logic
+					starpowerCharge -= (float) ((Time.deltaTime * Play.Instance.CurrentBeatsPerSecond) * 0.03125); // calculates based on 32 beats for a full bar
 				}
 				if (!trackAnims.spShakeAscended) {
 					trackAnims.StarpowerTrackAnim();


### PR DESCRIPTION
This PR has no sustain SP gain, only the 32-beat calculation for drain.