### PR TITLE
Some song length/end fixes and QoL changes

### DIFF
--- a/Assets/Script/Data/YargChart.cs
+++ b/Assets/Script/Data/YargChart.cs
@@ -12,9 +12,13 @@ namespace YARG.Data {
 
 		private MoonSong _song;
 
-		public List<List<NoteInfo>[]> allParts;
-		
 #pragma warning disable format
+
+		private List<List<NoteInfo>[]> allParts;
+		public List<List<NoteInfo>[]> AllParts {
+			get => allParts ??= new() { Guitar, GuitarCoop, Rhythm, Bass, Keys, RealGuitar, RealBass, Drums, RealDrums, GhDrums };
+			set => allParts = value;
+		}
 
 		private List<NoteInfo>[] guitar;
 		public List<NoteInfo>[] Guitar {
@@ -45,9 +49,17 @@ namespace YARG.Data {
 			set => keys = value;
 		}
 
-		public  List<NoteInfo>[] RealGuitar { get; set; }
+		private List<NoteInfo>[] realGuitar;
+		public List<NoteInfo>[] RealGuitar {
+			get => keys ??= CreateArray(); // TODO: Needs chartloaders once Pro Guitar parsing is implemented in the MS code
+			set => keys = value;
+		}
 
-		public  List<NoteInfo>[] RealBass { get; set; }
+		private List<NoteInfo>[] realBass;
+		public List<NoteInfo>[] RealBass {
+			get => keys ??= CreateArray(); // TODO: Needs chartloaders once Pro Guitar parsing is implemented in the MS code
+			set => keys = value;
+		}
 
 		private List<NoteInfo>[] drums;
 		public List<NoteInfo>[] Drums {
@@ -134,10 +146,6 @@ namespace YARG.Data {
 			Drums = CreateArray(5);
 			RealDrums = CreateArray(5);
 			GhDrums = CreateArray(5);
-
-			allParts = new() {
-				guitar, guitarCoop, rhythm, bass, keys, RealGuitar, RealBass, drums, realDrums, ghDrums
-			};
 		}
 
 		private List<NoteInfo>[] LoadArray(ChartLoader<NoteInfo> loader) {
@@ -146,6 +154,10 @@ namespace YARG.Data {
 			string instrumentName = loader.InstrumentName;
 
 			var notes = new List<NoteInfo>[(int) (maxDifficulty + 1)];
+			if (_song == null) {
+				return notes;
+			}
+
 			for (Difficulty diff = Difficulty.EASY; diff <= maxDifficulty; diff++) {
 				notes[(int) diff] = loader.GetNotesFromChart(_song, diff);
 			}

--- a/Assets/Script/Data/YargChart.cs
+++ b/Assets/Script/Data/YargChart.cs
@@ -1,10 +1,14 @@
 using System;
 using System.Collections.Generic;
+using System.Text.RegularExpressions;
 using MoonscraperChartEditor.Song;
 using YARG.Chart;
 
 namespace YARG.Data {
 	public sealed class YargChart {
+		// Matches text inside [brackets], not including the brackets
+		// '[end]' -> 'end', '[section Solo] - "Solo"' -> 'section Solo'
+		private static readonly Regex textEventRegex = new(@"\[(.*?)\]", RegexOptions.Compiled | RegexOptions.Singleline);
 
 		private MoonSong _song;
 
@@ -87,6 +91,20 @@ namespace YARG.Data {
 
 		public YargChart(MoonSong song) {
 			_song = song;
+			if (song == null) {
+				return;
+			}
+
+			foreach (var globalEvent in song.eventsAndSections) {
+				string text = globalEvent.title;
+				// Strip away the [brackets] from events (and any garbage outside them)
+				var match = textEventRegex.Match(text);
+				if (match.Success) {
+					text = match.Groups[1].Value;
+				}
+
+				events.Add(new EventInfo(text, (float) globalEvent.time));
+			}
 		}
 
 		public List<NoteInfo>[] GetChartByName(string name) {

--- a/Assets/Script/PlayMode/Play.cs
+++ b/Assets/Script/PlayMode/Play.cs
@@ -29,6 +29,7 @@ namespace YARG.PlayMode {
 		public static float speed = 1f;
 
 		public const float SONG_START_OFFSET = -2f;
+		public const float SONG_END_DELAY = 2f;
 
 		public delegate void BeatAction();
 		public static event BeatAction BeatEvent;
@@ -186,6 +187,9 @@ namespace YARG.PlayMode {
 					}
 				}
 			}
+
+			// Finally, append some additional time so the song doesn't just end immediately
+			SongLength += SONG_END_DELAY * speed;
 
 			GameUI.Instance.SetLoadingText("Spawning tracks...");
 

--- a/Assets/Script/PlayMode/Play.cs
+++ b/Assets/Script/PlayMode/Play.cs
@@ -175,7 +175,7 @@ namespace YARG.PlayMode {
 			}
 
 			// The song length must include all notes in the chart
-			foreach (var part in chart.allParts) {
+			foreach (var part in chart.AllParts) {
 				foreach (var difficulty in part) {
 					if (difficulty.Count < 1) {
 						continue;

--- a/Assets/Script/PlayMode/Play.cs
+++ b/Assets/Script/PlayMode/Play.cs
@@ -57,10 +57,8 @@ namespace YARG.PlayMode {
 		private float realSongTime;
 		public float SongTime => realSongTime - PlayerManager.AudioCalibration * speed - (float)Song.Delay;
 
-		public float SongLength {
-			get;
-			private set;
-		}
+		private float audioLength;
+		public float SongLength { get; private set; }
 
 		public YargChart chart;
 
@@ -152,7 +150,9 @@ namespace YARG.PlayMode {
 				GameManager.AudioManager.LoadSong(stems, isSpeedUp);
 			}
 
-			SongLength = GameManager.AudioManager.AudioLengthF;
+			// Get song length
+			audioLength = GameManager.AudioManager.AudioLengthF;
+			SongLength = audioLength;
 
 			GameUI.Instance.SetLoadingText("Loading chart...");
 
@@ -327,7 +327,13 @@ namespace YARG.PlayMode {
 
 			// Update this every frame to make sure all notes are spawned at the same time.
 			if (audioStarted) {
-				realSongTime = GameManager.AudioManager.CurrentPositionF;
+				float audioTime = GameManager.AudioManager.CurrentPositionF;
+				// We need to update the song time ourselves if the audio finishes before the song actually ends
+				if (audioTime < audioLength) {
+					realSongTime = GameManager.AudioManager.CurrentPositionF;
+				} else {
+					realSongTime += Time.deltaTime * speed;
+				}
 			}
 
 			UpdateAudio(new[] {

--- a/Assets/Script/Serialization/Parser/MidiParser.cs
+++ b/Assets/Script/Serialization/Parser/MidiParser.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using Melanchall.DryWetMidi.Core;
 using Melanchall.DryWetMidi.Interaction;
 using Melanchall.DryWetMidi.MusicTheory;
@@ -23,6 +24,10 @@ namespace YARG.Serialization.Parser {
 			NoHeaderChunkPolicy = NoHeaderChunkPolicy.Ignore,
 			InvalidChannelEventParameterValuePolicy = InvalidChannelEventParameterValuePolicy.ReadValid,
 		};
+
+		// Matches text inside [brackets], not including the brackets
+		// '[end]' -> 'end', '[section Solo] - "Solo"' -> 'section Solo'
+		private static readonly Regex textEventRegex = new(@"\[(.*?)\]", RegexOptions.Compiled | RegexOptions.Singleline);
 
 		private struct EventIR {
 			public long startTick;
@@ -161,6 +166,9 @@ namespace YARG.Serialization.Parser {
 
 						// Parse everything else
 						switch (trackName.Text) {
+							case "EVENTS":
+								ParseGlobalEvents(eventIR, trackChunk);
+								break;
 							case "PART GUITAR":
 								for (int i = 0; i < 4; i++) {
 									chart.Guitar[i] = ParseFiveFret(trackChunk, i);
@@ -372,6 +380,29 @@ namespace YARG.Serialization.Parser {
 			// Look for bonus star power
 
 			// TODO
+		}
+
+		private void ParseGlobalEvents(List<EventIR> eventIR, TrackChunk trackChunk) {
+			long totalDelta = 0;
+
+			// Convert track events into intermediate representation
+			foreach (var trackEvent in trackChunk.Events) {
+				totalDelta += trackEvent.DeltaTime;
+
+				if (trackEvent is BaseTextEvent textEvent) {
+					string text = textEvent.Text;
+					// Strip away the [brackets] from events (and any garbage outside them)
+					var match = textEventRegex.Match(text);
+					if (match.Success) {
+						text = match.Groups[1].Value;
+					}
+
+					eventIR.Add(new EventIR {
+						startTick = totalDelta,
+						name = text
+					});
+				}
+			}
 		}
 
 		private void ParseStarpower(List<EventIR> eventIR, TrackChunk trackChunk, string instrument) {

--- a/Assets/Script/Serialization/Parser/MidiParser.cs
+++ b/Assets/Script/Serialization/Parser/MidiParser.cs
@@ -266,7 +266,7 @@ namespace YARG.Serialization.Parser {
 
 			// Downsample instruments
 
-			foreach (var subChart in chart.allParts) {
+			foreach (var subChart in chart.AllParts) {
 				try {
 					// Downsample Five Fret instruments
 					if (subChart == chart.Guitar || subChart == chart.Bass || subChart == chart.Keys) {
@@ -294,7 +294,7 @@ namespace YARG.Serialization.Parser {
 			// Sort notes by time (just in case) and add delay
 
 			float lastNoteTime = 0f;
-			foreach (var part in chart.allParts) {
+			foreach (var part in chart.AllParts) {
 				foreach (var difficulty in part) {
 					if (difficulty == null || difficulty.Count <= 0) {
 						continue;


### PR DESCRIPTION
Global events are now parsed from both .chart and .mid files in order to allow accounting for the `[end]` event when determining song length.

In addition, song loading now ensures that the song length will never be smaller than the time of the last note in the chart, and a small delay of 2 seconds is added on to the length after both `[end]` event and last-note handling to prevent songs that have no trailing silence from ending instantly.

Also had to make a fix to YargChart since some properties weren't being initialized with .chart files, and would cause errors with these changes.