### PR TITLE
Fix hit window not scaling correctly to different song speeds; allow asymmetrical hit windows

### DIFF
--- a/Assets/Script/Constants.cs
+++ b/Assets/Script/Constants.cs
@@ -5,7 +5,8 @@ namespace YARG {
 		public static readonly YargVersion VERSION_TAG = YargVersion.Parse("v0.10.4");
 
 		// General
-		public const float HIT_MARGIN = 0.095f;
+		public const float HIT_MARGIN_FRONT = 0.095f;
+		public const float HIT_MARGIN_BACK = 0.095f;
 		// Guitar
 		public const float STRUM_LENIENCY = 0.065f;
 		public const bool ANCHORING = true;

--- a/Assets/Script/PlayMode/AbstractTrack.cs
+++ b/Assets/Script/PlayMode/AbstractTrack.cs
@@ -24,12 +24,15 @@ namespace YARG.PlayMode {
 
 		// Time values
 
+		public float HitMarginHalf => Constants.HIT_MARGIN * Play.speed;
+		public float HitMargin => HitMarginHalf * 2;
+
 		// Convenience name for current song time
 		public float CurrentTime => Play.Instance.SongTime;
 		// Time relative to the start of the hit window
-		public float HitMarginStartTime => Play.Instance.SongTime + Constants.HIT_MARGIN;
+		public float HitMarginStartTime => Play.Instance.SongTime + HitMarginHalf;
 		// Time relative to the end of the hit window
-		public float HitMarginEndTime => Play.Instance.SongTime - Constants.HIT_MARGIN;
+		public float HitMarginEndTime => Play.Instance.SongTime - HitMarginHalf;
 		// Time relative to the beginning of the track, used for spawning notes and other visuals
 		public float TrackStartTime => Play.Instance.SongTime +
 			((TRACK_SPAWN_OFFSET + TRACK_END_OFFSET) / (player.trackSpeed / Play.speed));

--- a/Assets/Script/PlayMode/FiveFretTrack.cs
+++ b/Assets/Script/PlayMode/FiveFretTrack.cs
@@ -550,7 +550,7 @@ namespace YARG.PlayMode {
 				if (checkGhosting) {
 					var nextNote = GetNextNote(Chart[hitChartIndex - 1].time);
 					if ((nextNote == null || (!nextNote[0].hopo && !nextNote[0].tap)) ||
-					(Constants.ALLOW_GHOST_IF_NO_NOTES && nextNote[0].time - CurrentTime > Constants.HIT_MARGIN * Constants.ALLOW_GHOST_IF_NO_NOTES_THRESHOLD)) {
+					(Constants.ALLOW_GHOST_IF_NO_NOTES && nextNote[0].time - CurrentTime > HitMarginHalf * Constants.ALLOW_GHOST_IF_NO_NOTES_THRESHOLD)) {
 						checkGhosting = false;
 					}
 					if (checkGhosting) {

--- a/Assets/Script/PlayMode/FiveFretTrack.cs
+++ b/Assets/Script/PlayMode/FiveFretTrack.cs
@@ -550,7 +550,7 @@ namespace YARG.PlayMode {
 				if (checkGhosting) {
 					var nextNote = GetNextNote(Chart[hitChartIndex - 1].time);
 					if ((nextNote == null || (!nextNote[0].hopo && !nextNote[0].tap)) ||
-					(Constants.ALLOW_GHOST_IF_NO_NOTES && nextNote[0].time - CurrentTime > HitMarginHalf * Constants.ALLOW_GHOST_IF_NO_NOTES_THRESHOLD)) {
+					(Constants.ALLOW_GHOST_IF_NO_NOTES && nextNote[0].time - CurrentTime > HitMarginFront * Constants.ALLOW_GHOST_IF_NO_NOTES_THRESHOLD)) {
 						checkGhosting = false;
 					}
 					if (checkGhosting) {


### PR DESCRIPTION
Somehow we ended up with a system that made it dead-easy to split the timing for the front and back of the hit window lol, if we ever wanna experiment with that we now can.