### PR TITLE
Only one note in a chord can be an activator

### DIFF
--- a/Assets/Script/PlayMode/DrumsTrack.cs
+++ b/Assets/Script/PlayMode/DrumsTrack.cs
@@ -130,10 +130,10 @@ namespace YARG.PlayMode {
 				var chosenActivatorType = 0;
 				NoteInfo chosenActivatorNote = null;
 
-				for (int i = 0; i < 5; i++) {
-
-					// Prevent out-of-bounds access at the end of a chart
-					if (Chart.Count <= visualChartIndex + i) {
+				// Check three notes before and after the current note to ensure none of the notes in the chord are skipped.
+				for (int i = -3; i < 3; i++) {
+					// Prevent out-of-bounds access at the beginning or end of a chart
+					if (Chart.Count <= visualChartIndex + i || visualChartIndex <= 3) {
 						break;
 					}
 
@@ -143,29 +143,23 @@ namespace YARG.PlayMode {
 						if (chordNote.hopo) {
 							chosenActivatorType = 3;
 							chosenActivatorNote = chordNote;
-							continue;
+							break;
 						}
 
 						// If there are no cymbals on this beat, pads are second.
-						if (!chordNote.hopo && chosenActivatorType < 3) {
+						if (chordNote.fret != 4) {
 							chosenActivatorType = 2;
 							chosenActivatorNote = chordNote;
 							continue;
 						}
 
 						// Finally, if there's nothing else, kick notes must be used. 
-						if (chordNote.fret == 4 && chosenActivatorType < 2) {
+						if (chosenActivatorType < 2) {
 							chosenActivatorType = 1;
 							chosenActivatorNote = chordNote;
 							continue;
 						}
 					}
-				}
-
-				// If, somehow, none of the above conditions are met, the current note will become an activator forcibly.
-				// This is fallback code that will (hopefully) never be needed.
-				if (chosenActivatorNote == null) {
-					chosenActivatorNote = noteInfo;
 				}
 
 				// Skip kick notes if noKickMode is enabled
@@ -176,7 +170,9 @@ namespace YARG.PlayMode {
 
 				// TODO: Only one note should be an activator at any given timestamp
 				if (CurrentVisualFill?.EndTime == noteInfo.time && starpowerCharge >= 0.5f && !IsStarPowerActive) {
-					chosenActivatorNote.isActivator = true;
+					if (chosenActivatorNote != null) {
+						chosenActivatorNote.isActivator = true;
+					}
 				}
 
 				SpawnNote(noteInfo, TrackStartTime);

--- a/Assets/Script/PlayMode/DrumsTrack.cs
+++ b/Assets/Script/PlayMode/DrumsTrack.cs
@@ -131,6 +131,12 @@ namespace YARG.PlayMode {
 				NoteInfo chosenActivatorNote = null;
 
 				for (int i = 0; i < 5; i++) {
+
+					// Prevent out-of-bounds access at the end of a chart
+					if (Chart.Count <= visualChartIndex + i) {
+						break;
+					}
+
 					var chordNote = Chart[visualChartIndex + i];
 					if (chordNote.time == noteInfo.time) {
 						// Cymbals always take priority.
@@ -153,13 +159,13 @@ namespace YARG.PlayMode {
 							chosenActivatorNote = chordNote;
 							continue;
 						}
-
-						// If, somehow, none of these conditions are met, the current note will become an activator forcibly.
-						// This is fallback code that will (hopefully) never be needed.
-						if (chosenActivatorType == 0) {
-							chosenActivatorNote = noteInfo;
-						}
 					}
+				}
+
+				// If, somehow, none of the above conditions are met, the current note will become an activator forcibly.
+				// This is fallback code that will (hopefully) never be needed.
+				if (chosenActivatorNote == null) {
+					chosenActivatorNote = noteInfo;
 				}
 
 				// Skip kick notes if noKickMode is enabled


### PR DESCRIPTION
 * On drums, only one note in a chord will now be converted to an activator.
     * Cymbals are preferred first.  If a chord does not contain any cymbals, a pad will be chosen instead.
     * In the event that only a kick note is present, it will become the activator.