### PR TITLE
Add sorting and ordering on blue and yellow frets

### DIFF
--- a/Assets/Script/UI/MusicLibrary/SongSelection.cs
+++ b/Assets/Script/UI/MusicLibrary/SongSelection.cs
@@ -14,6 +14,13 @@ using YARG.Song;
 using YARG.UI.MusicLibrary.ViewTypes;
 using Random = UnityEngine.Random;
 
+public enum SortCriteria
+{
+	SongName = 1,
+	ArtistName,
+	SourceName,
+}
+
 namespace YARG.UI.MusicLibrary {
 	public class SongSelection : MonoBehaviour {
 		public static SongSelection Instance { get; private set; }
@@ -36,6 +43,9 @@ namespace YARG.UI.MusicLibrary {
 		private GameObject noSongsText;
 		[SerializeField]
 		private Scrollbar scrollbar;
+
+
+		private SortCriteria _sortCriteria = SortCriteria.SongName;
 
 		private List<ViewType> _songs;
 		private List<SongEntry> _recommendedSongs;
@@ -114,12 +124,11 @@ namespace YARG.UI.MusicLibrary {
 				new NavigationScheme.Entry(MenuAction.Back, "Back", () => {
 					Back();
 				}),
-				new NavigationScheme.Entry(MenuAction.Shortcut1, "Search Artist", () => {
-					SearchByArtist();
+				new NavigationScheme.Entry(MenuAction.Shortcut1, "Change Order", () => {
+					ChangeSongOrder();
 				}),
-				new NavigationScheme.Entry(MenuAction.Shortcut2, "Random song", () => {
-					ClearSearchBox();
-					SelectRandomSong();
+				new NavigationScheme.Entry(MenuAction.Shortcut2, "Search Artist/Source", () => {
+					ChangeFilter();
 				}),
 				new NavigationScheme.Entry(MenuAction.Shortcut3, "Next section", () => {
 					SelectNextSection();
@@ -155,6 +164,37 @@ namespace YARG.UI.MusicLibrary {
 			}
 
 			sidebar.UpdateSidebar().Forget();
+		}
+
+		private void ChangeSongOrder() {
+			if (_sortCriteria == SortCriteria.SongName) {
+				_sortCriteria = SortCriteria.ArtistName;
+			} else if (_sortCriteria == SortCriteria.ArtistName) {
+				_sortCriteria = SortCriteria.SourceName;
+			} else {
+				_sortCriteria = SortCriteria.SongName;
+			}
+			UpdateSearch();
+		}
+
+		private string GetSortName(SongEntry song) {
+			if (_sortCriteria == SortCriteria.ArtistName) {
+				return song.Artist;
+			} else if (_sortCriteria == SortCriteria.SourceName) {
+				return song.Source;
+			} else {
+				return song.NameNoParenthesis;
+			}
+		}
+
+		private void ChangeFilter() {
+			if (_songs[SelectedIndex] is SongViewType view) {
+				if (string.IsNullOrEmpty(searchField.text) || searchField.text.StartsWith("source:")) {
+					searchField.text = $"artist:{view.SongEntry.Artist}";
+				} else if (searchField.text.StartsWith("artist:")) {
+					searchField.text = $"source:{view.SongEntry.Source}";
+				}
+			}
 		}
 
 		private void Update() {
@@ -203,7 +243,7 @@ namespace YARG.UI.MusicLibrary {
 			if (string.IsNullOrEmpty(searchField.text)) {
 				// Add all songs
 				_songs = SongContainer.Songs
-					.OrderBy(song => song.NameNoParenthesis)
+					.OrderBy(song => GetSortName(song))
 					.Select(i => new SongViewType(i))
 					.Cast<ViewType>()
 					.ToList();
@@ -299,7 +339,7 @@ namespace YARG.UI.MusicLibrary {
 
 				// Sort
 				if (!searched) {
-					songsOut = songsOut.OrderBy(song => song.NameNoParenthesis);
+					songsOut = songsOut.OrderBy(song => GetSortName(song));
 				}
 
 				// Add header
@@ -346,7 +386,7 @@ namespace YARG.UI.MusicLibrary {
 			songsFirstLetter =
 				_songs
 				.OfType<SongViewType>()
-				.Select(song => song.SongEntry.NameNoParenthesis)
+				.Select(song => GetSortName(song.SongEntry))
 				.Where(name => !string.IsNullOrEmpty(name))
 				.Select(name => Char.ToUpper(name[0]))
 				.Distinct()
@@ -464,7 +504,11 @@ namespace YARG.UI.MusicLibrary {
 
 		public void Back() {
 			if (string.IsNullOrEmpty(searchField.text)) {
-				MainMenu.Instance.ShowMainMenu();
+				if (SelectedIndex > 2) {
+					SelectedIndex = 2;
+				} else {
+					MainMenu.Instance.ShowMainMenu();
+				}
 			} else {
 				ClearSearchBox();
 				UpdateSearch();
@@ -483,20 +527,14 @@ namespace YARG.UI.MusicLibrary {
 			SelectedIndex = Random.Range(skip, SongContainer.Songs.Count);
 		}
 
-		private void SearchByArtist(){
-			if (_songs[SelectedIndex] is SongViewType view) {
-				searchField.text = $"artist:{view.SongEntry.Artist}";
-			}
-		}
-
 		private void SelectNextSection(){
 			if (_songs[_selectedIndex] is not SongViewType song) {
 				return;
 			}
 
 			int skip = Mathf.Max(1, _songs.Count - SongContainer.Songs.Count);
-			var nameWithoutParenthesis = song.SongEntry.NameNoParenthesis;
-			string nextCharacter = GetNextLetterOrNumber(nameWithoutParenthesis);
+			var sortName = GetSortName(song.SongEntry);
+			string nextCharacter = GetNextLetterOrNumber(sortName);
 
 			// If an error occurs no change is made
 			if (string.IsNullOrEmpty(nextCharacter)) {
@@ -505,7 +543,7 @@ namespace YARG.UI.MusicLibrary {
 
 			var index = _songs.FindIndex(skip, song =>
 				song is SongViewType songType &&
-					songType.SongEntry.NameNoParenthesis[..1] == nextCharacter
+					GetSortName(songType.SongEntry)[..1] == nextCharacter
 				);
 
 			SelectedIndex = index;


### PR DESCRIPTION
Small improvement on the current song navigation:

- Red button now goes back to the top of the list if there is no search filter active (allows to get back to the top and select "Random" or "Recommended"
- Yellow button now changes the sort order between song name (default), artist name, and source name.
- Blue button filters on artist if no filter is set, and a second press filters on source instead.

Could be improved:
- Text for navigation menu does not change (I would like to switch it to "Select Source", or "Back to Top")
- Orange button for selecting next section works for song name and artist name, but is broken on source name (it tries to get to the bottom of the list every time, it could be due to the fact that some sources are empty)