### PR TITLE
Fix some issues with listing microphones in the device list

### DIFF
--- a/Assets/Script/Audio/Bass/BassAudioManager.cs
+++ b/Assets/Script/Audio/Bass/BassAudioManager.cs
@@ -124,7 +124,8 @@ namespace YARG.Audio.BASS {
 
 				// We do not check the device type since there are too many that a recording device can be,
 				// instead we only exclude loopback devices
-				if (info.IsLoopback) {
+				// The "Default" device is also excluded here since we want the user to explicitly pick which microphone to use
+				if (info.IsLoopback || info.Name == "Default") {
 					continue;
 				}
 

--- a/Assets/Script/Audio/Bass/BassAudioManager.cs
+++ b/Assets/Script/Audio/Bass/BassAudioManager.cs
@@ -122,7 +122,9 @@ namespace YARG.Audio.BASS {
 					continue;
 				}
 
-				if (info.Type != DeviceType.Microphone) {
+				// We do not check the device type since there are too many that a recording device can be,
+				// instead we only exclude loopback devices
+				if (info.IsLoopback) {
 					continue;
 				}
 

--- a/Assets/Script/UI/AddPlayer.cs
+++ b/Assets/Script/UI/AddPlayer.cs
@@ -202,7 +202,11 @@ namespace YARG.UI {
 			var mics = GameManager.AudioManager.GetAllInputDevices();
 			foreach (var mic in mics) {
 				var button = Instantiate(deviceButtonPrefab, devicesContainer);
-				button.GetComponentInChildren<TextMeshProUGUI>().text = $"(MIC) <b>{mic.DisplayName}</b>";
+				var textBox = button.GetComponentInChildren<TextMeshProUGUI>();
+				textBox.text = $"(MIC) <b>{mic.DisplayName}</b>";
+				if (mic.IsDefault) {
+					textBox.text += " <i>(Default)</i>";
+				}
 
 				var capture = mic;
 				button.GetComponentInChildren<Button>().onClick.AddListener(() => {


### PR DESCRIPTION
Some microphones were not getting listed due to their BASS device type not being Microphone. Now instead of checking for the device type, only devices specified as loopback devices by BASS are excluded.

The "Default" device entry has also been excluded, instead the default microphone is marked as such in the device list:
![image](https://github.com/YARC-Official/YARG/assets/29052821/15aae02d-9afa-45df-ab14-739e67e5dd98)
