### PR TITLE
Fix some parsing and caching issues

### DIFF
--- a/Assets/Script/Song/BooleanConverter.cs
+++ b/Assets/Script/Song/BooleanConverter.cs
@@ -1,0 +1,34 @@
+using EasySharpIni.Converters;
+
+namespace YARG.Song {
+	public class BooleanConverter : Converter<bool> {
+		public override string GetDefaultName() {
+			return "Boolean";
+		}
+
+		public override bool GetDefaultValue() {
+			return false;
+		}
+
+		public override bool Parse(string arg, out bool result) {
+			arg = arg.ToLower();
+			switch (arg) {
+				case "true":
+				case "1":
+					result = true;
+					break;
+
+				case "false":
+				case "0":
+					result = false;
+					break;
+
+				default:
+					result = false;
+					return false;
+			};
+
+			return true;
+		}
+	}
+}

--- a/Assets/Script/Song/BooleanConverter.cs.meta
+++ b/Assets/Script/Song/BooleanConverter.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b872b7bc978ac194981d3bf8f24013ac
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Script/Song/Preparsers/MidPreparser.cs
+++ b/Assets/Script/Song/Preparsers/MidPreparser.cs
@@ -28,6 +28,12 @@ namespace YARG.Song.Preparsers {
 			{ MidIOHelper.VOCALS_TRACK, Instrument.VOCALS },
 			{ "PART REAL_GUITAR", Instrument.REAL_GUITAR },
 			{ "PART REAL_BASS", Instrument.REAL_BASS },
+			{ "HARM1", Instrument.HARMONY },
+			{ "HARM2", Instrument.HARMONY },
+			{ "HARM3", Instrument.HARMONY },
+			{ "PART HARM1", Instrument.HARMONY },
+			{ "PART HARM2", Instrument.HARMONY },
+			{ "PART HARM3", Instrument.HARMONY },
 
 		};
 

--- a/Assets/Script/Song/SongCache.cs
+++ b/Assets/Script/Song/SongCache.cs
@@ -12,9 +12,11 @@ namespace YARG.Song {
 	public class SongCache {
 
 		/// <summary>
-		/// The date in which the cache version is based on (and cache revision)
+		/// The date revision of the cache format.
+		/// Format is YY_MM_DD_RR: Y = year, M = month, D = day, R = revision (reset across dates, only increment
+		/// if multiple cache version changes happen in a single day).
 		/// </summary>
-		private const int CACHE_VERSION = 01_06_23_01;
+		private const int CACHE_VERSION = 23_06_05_01;
 
 		private readonly string _folder;
 		private readonly string _cacheFile;

--- a/Assets/Script/Song/Types/IniSongEntry.cs
+++ b/Assets/Script/Song/Types/IniSongEntry.cs
@@ -6,6 +6,7 @@ using EasySharpIni;
 namespace YARG.Song {
 	public class IniSongEntry : SongEntry {
 		private static readonly IntConverter IntConverter = new();
+		private static readonly BooleanConverter BooleanConverter = new();
 
 		public string Playlist { get; private set; } = string.Empty;
 		public string SubPlaylist { get; private set; } = string.Empty;
@@ -91,7 +92,7 @@ namespace YARG.Song {
 			}
 
 			HopoThreshold = section.GetField("hopo_frequency", "170").Get(IntConverter);
-			EighthNoteHopo = section.GetField("eighthnote_hopo", "false").Get().ToLower() == "true";
+			EighthNoteHopo = section.GetField("eighthnote_hopo", "false").Get(BooleanConverter);
 			MultiplierNote = section.GetField("multiplier_note", "116").Get(IntConverter);
 
 			PartDifficulties = new() {
@@ -123,26 +124,16 @@ namespace YARG.Song {
 			}
 
 			DrumType = DrumType.Unknown;
-			if (section.ContainsField("pro_drums")) {
-				switch (section.GetField("pro_drums")) {
-					case "true":
-					case "1":
-						DrumType = DrumType.FourLane;
-						break;
-				}
-			} else if (section.ContainsField("five_lane_drums")) {
-				switch (section.GetField("five_lane_drums")) {
-					case "true":
-					case "1":
-						DrumType = DrumType.FiveLane;
-						break;
-				}
+			if (section.GetField("pro_drums", "false").Get(BooleanConverter)) {
+				DrumType = DrumType.FourLane;
+			} else if (section.GetField("five_lane_drums", "false").Get(BooleanConverter)) {
+				DrumType = DrumType.FiveLane;
 			}
 
 			LoadingPhrase = section.GetField("loading_phrase");
 			Source = section.GetField("icon");
-			HasLyrics = section.GetField("lyrics").Get().ToLower() == "true";
-			IsModChart = section.GetField("modchart").Get().ToLower() == "true";
+			HasLyrics = section.GetField("lyrics").Get(BooleanConverter);
+			IsModChart = section.GetField("modchart").Get(BooleanConverter);
 			VideoStartOffset = section.GetField("video_start_time", "0").Get(IntConverter);
 			return ScanResult.Ok;
 		}

--- a/Assets/Script/UI/DifficultySelect.cs
+++ b/Assets/Script/UI/DifficultySelect.cs
@@ -70,6 +70,8 @@ namespace YARG.UI {
 				})
 			}, false));
 
+			Debug.Log(GameManager.Instance.SelectedSong.AvailableParts);
+
 			playerIndex = 0;
 			playersToConfigure.Clear();
 
@@ -217,8 +219,6 @@ namespace YARG.UI {
 			// Get available instruments
 			var availableInstruments = allInstruments
 				.Where(instrument => GameManager.Instance.SelectedSong.HasInstrument(instrument)).ToList();
-
-			Debug.Log(GameManager.Instance.SelectedSong.AvailableParts);
 
 			// Force add pro drums and five lane
 			if (availableInstruments.Contains(Instrument.DRUMS)) {

--- a/Assets/Script/UI/DifficultySelect.cs
+++ b/Assets/Script/UI/DifficultySelect.cs
@@ -15,10 +15,15 @@ namespace YARG.UI {
 		private enum State {
 			INSTRUMENT,
 			DIFFICULTY,
-
-			VOCALS,
-			VOCALS_DIFFICULTY
 		}
+
+		private static List<string> _expertPlusAllowedList = new() {
+			"drums",
+			"realDrums",
+			"ghDrums",
+			"vocals",
+			"harmVocals",
+		};
 
 		[SerializeField]
 		private GenericOption[] options;
@@ -29,7 +34,8 @@ namespace YARG.UI {
 		[SerializeField]
 		private Toggle brutalModeCheckbox;
 
-		private int playerIndex;
+		private List<PlayerManager.Player> playersToConfigure = new(); // Used to more cleanly handle vocals players
+		private int playerIndex; // The current player index (not used for vocals)
 		private string[] instruments;
 		private Difficulty[] difficulties;
 		private State state;
@@ -64,22 +70,34 @@ namespace YARG.UI {
 				})
 			}, false));
 
+			playerIndex = 0;
+			playersToConfigure.Clear();
+
 			// See if there are any mics
 			bool anyMics = false;
-			foreach (var player in PlayerManager.players) {
+			for (int index = 0; index < PlayerManager.players.Count; index++) {
+				var player = PlayerManager.players[index];
 				if (player.inputStrategy is MicInputStrategy) {
+					playersToConfigure.Add(player);
 					anyMics = true;
 				}
 			}
 
-			// Update options
-			playerIndex = 0;
-			if (anyMics) {
-				UpdateVocalOptions();
-				brutalModeCheckbox.interactable = false;
-			} else {
-				UpdateInstrument();
+			// Use first player otherwise
+			if (playersToConfigure.Count < 1) {
+				playersToConfigure.Add(PlayerManager.players[playerIndex]);
 			}
+
+			// Get player info
+			var allowedInstruments = playersToConfigure[0].inputStrategy.GetAllowedInstruments();
+			string headerText = playersToConfigure[0].DisplayName;
+			if (anyMics) {
+				headerText = "Options for All Vocals";
+				brutalModeCheckbox.interactable = false;
+				playerIndex = -1;
+			}
+
+			UpdateInstrument(headerText, allowedInstruments);
 		}
 
 		private void OnDestroy() {
@@ -128,44 +146,25 @@ namespace YARG.UI {
 		}
 
 		public void Next() {
-			var player = PlayerManager.players[playerIndex];
-
 			if (state == State.INSTRUMENT) {
 				if (selected >= instruments.Length) {
-					player.chosenInstrument = null;
+					foreach (var player in playersToConfigure) {
+						player.chosenInstrument = null;
+					}
 					IncreasePlayerIndex();
 				} else {
-					player.chosenInstrument = instruments[selected];
-					bool showExpertPlus = player.chosenInstrument == "drums"
-						|| player.chosenInstrument == "realDrums"
-						|| player.chosenInstrument == "ghDrums";
-					UpdateDifficulty(player.chosenInstrument, showExpertPlus);
+					string instrument = instruments[selected];
+					foreach (var player in playersToConfigure) {
+						player.chosenInstrument = instrument;
+					}
+					bool showExpertPlus = _expertPlusAllowedList.Contains(instrument);
+					UpdateDifficulty(instrument, showExpertPlus);
 				}
 			} else if (state == State.DIFFICULTY) {
-				player.chosenDifficulty = difficulties[selected];
-				OnInstrumentSelection?.Invoke(player);
-				IncreasePlayerIndex();
-			} else if (state == State.VOCALS) {
-				if (selected == 2) {
-					foreach (var p in PlayerManager.players) {
-						p.chosenInstrument = null;
-					}
-
-					playerIndex = -1;
-					IncreasePlayerIndex();
-				} else {
-					foreach (var p in PlayerManager.players) {
-						p.chosenInstrument = selected == 0 ? "vocals" : "harmVocals";
-					}
-					UpdateVocalDifficulties();
+				foreach (var player in playersToConfigure) {
+					player.chosenDifficulty = difficulties[selected];
+					OnInstrumentSelection?.Invoke(player);
 				}
-			} else if (state == State.VOCALS_DIFFICULTY) {
-				foreach (var p in PlayerManager.players) {
-					p.chosenDifficulty = (Difficulty) selected;
-				}
-
-				playerIndex = -1;
-				OnInstrumentSelection?.Invoke(player);
 				IncreasePlayerIndex();
 			}
 		}
@@ -199,16 +198,18 @@ namespace YARG.UI {
 				// Play song
 				GameManager.Instance.LoadScene(SceneIndex.PLAY);
 			} else {
-				UpdateInstrument();
+				var player = PlayerManager.players[playerIndex];
+				playersToConfigure.Clear();
+				playersToConfigure.Add(player);
+				UpdateInstrument(player.DisplayName, player.inputStrategy.GetAllowedInstruments());
 			}
 		}
 
-		private void UpdateInstrument() {
-			// Header
-			var player = PlayerManager.players[playerIndex];
-			header.text = player.DisplayName;
-
+		private void UpdateInstrument(string headerText, Instrument[] allowedInstruments) {
 			state = State.INSTRUMENT;
+
+			// Header
+			header.text = headerText;
 
 			// Get allowed instruments
 			var allInstruments = (Instrument[]) Enum.GetValues(typeof(Instrument));
@@ -233,7 +234,7 @@ namespace YARG.UI {
 			}
 
 			// Filter out to only allowed instruments
-			availableInstruments.RemoveAll(i => !player.inputStrategy.GetAllowedInstruments().Contains(i));
+			availableInstruments.RemoveAll(i => !allowedInstruments.Contains(i));
 
 			optionCount = availableInstruments.Count + 1;
 
@@ -247,7 +248,7 @@ namespace YARG.UI {
 			ops[^1] = "Sit Out";
 
 			// Set text and sprites
-			for (int i = 0; i < 6; i++) {
+			for (int i = 0; i < options.Length; i++) {
 				options[i].SetText("");
 				options[i].SetSelected(false);
 
@@ -316,62 +317,6 @@ namespace YARG.UI {
 
 			selected = optionCount - 1;
 			options[optionCount - 1].SetSelected(true);
-		}
-
-		private void UpdateVocalOptions() {
-			header.text = "Options for All Vocals";
-
-			state = State.VOCALS;
-
-			optionCount = 3;
-			string[] ops = {
-				"Solo",
-				"Harmony",
-				"Sit Out (All Vocals)",
-				null,
-				null,
-				null
-			};
-
-			for (int i = 0; i < 6; i++) {
-				options[i].SetText(ops[i]);
-				options[i].SetSelected(false);
-
-				if (i == 0) {
-					var sprite = Addressables.LoadAssetAsync<Sprite>("FontSprites[vocals]").WaitForCompletion();
-					options[i].SetImage(sprite);
-				} else if (i == 1) {
-					var sprite = Addressables.LoadAssetAsync<Sprite>("FontSprites[harmVocals]").WaitForCompletion();
-					options[i].SetImage(sprite);
-				}
-			}
-
-			selected = 0;
-			options[0].SetSelected(true);
-		}
-
-		private void UpdateVocalDifficulties() {
-			header.text = "Options for All Vocals";
-
-			state = State.VOCALS_DIFFICULTY;
-
-			optionCount = 5;
-			string[] ops = {
-				"Easy",
-				"Medium",
-				"Hard",
-				"Expert",
-				"Expert+",
-				null
-			};
-
-			for (int i = 0; i < 6; i++) {
-				options[i].SetText(ops[i]);
-				options[i].SetSelected(false);
-			}
-
-			selected = 3;
-			options[3].SetSelected(true);
 		}
 	}
 }


### PR DESCRIPTION
Parsing of boolean values in song.ini files is now handled through a BooleanConverter, rather than manually checking the string values. Since there's no regulation of how these are written, they can show up as a variety of things (e.x. `true`, `False`, `1`), which the new converter accounts for correctly.

Harmonies was never checked for explicitly in chart files, causing issues when a song didn't have them charted. The presence of harmonies is now cached and checked for correctly, so it will no longer be selectable if it is no longer charted.