### PR TITLE
Some adjustments to the drums kick flash animation's playback

### DIFF
--- a/Assets/Script/PlayMode/DrumsTrack.cs
+++ b/Assets/Script/PlayMode/DrumsTrack.cs
@@ -296,13 +296,14 @@ namespace YARG.PlayMode {
 				drums[drum].Pulse();
 			} else {
 				PlayKickFretAnimation();
-
-				if (shakeOnKick) {
-					//commonTrack.PlayKickCameraAnimation();
-					trackAnims.PlayKickShakeCameraAnim();
+				// Only play kick flash/shake now when outside of the chart,
+				// otherwise only play it when actually hitting a kick
+				if (Chart.Count < 1 || CurrentTime < Chart[0].time || CurrentTime >= Chart[^1].time) {
+					commonTrack.kickFlash.PlayAnimation();
+					if (shakeOnKick) {
+						trackAnims.PlayKickShakeCameraAnim();
+					}
 				}
-
-				commonTrack.kickFlash.PlayAnimation();
 			}
 
 			// Overstrum if no expected
@@ -328,6 +329,13 @@ namespace YARG.PlayMode {
 					hit = note;
 					if (note.isActivator) {
 						(input as DrumsInputStrategy).ActivateStarpower();
+					}
+					// Play kick flash/shake
+					if (note.fret == kickIndex) {
+						commonTrack.kickFlash.PlayAnimation();
+						if (shakeOnKick) {
+							trackAnims.PlayKickShakeCameraAnim();
+						}
 					}
 					break;
 				}

--- a/Assets/Script/PlayMode/KickFlashAnimation.cs
+++ b/Assets/Script/PlayMode/KickFlashAnimation.cs
@@ -23,16 +23,11 @@ namespace YARG.PlayMode {
 		}
 
 		private void Update() {
-			if (_currentSprite >= _textures.Length) {
-				return;
-			}
-
-			if (_updateTimer > SecondsPerFrame) {
-				_updateTimer = 0f;
+			_updateTimer += Time.deltaTime;
+			while (_updateTimer >= SecondsPerFrame && _currentSprite < _textures.Length) {
+				_updateTimer -= SecondsPerFrame;
 				UpdateTexture();
 				_currentSprite++;
-			} else {
-				_updateTimer += Time.deltaTime;
 			}
 		}
 


### PR DESCRIPTION
The kick flash now plays only when hitting a note (or when kicking outside of the chart), to clearly differentiate between hitting a kick and not hitting one. It also will no longer update a maximum of once per frame, it can update multiple times if the timer still exceeds the threshold after updating.