### PR TITLE
Reimplement, reorganize, and fix a number of solo handling things

### DIFF
--- a/Assets/Art/UI/TextGradient_Gold.asset
+++ b/Assets/Art/UI/TextGradient_Gold.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 54d21f6ece3b46479f0c328f8c6007e0, type: 3}
+  m_Name: TextGradient_Gold
+  m_EditorClassIdentifier: 
+  colorMode: 3
+  topLeft: {r: 1, g: 0.619472, b: 0, a: 1}
+  topRight: {r: 1, g: 0.619472, b: 0, a: 1}
+  bottomLeft: {r: 0.5377358, g: 0.2550798, b: 0, a: 1}
+  bottomRight: {r: 0.5377358, g: 0.2550798, b: 0, a: 1}

--- a/Assets/Art/UI/TextGradient_Gold.asset.meta
+++ b/Assets/Art/UI/TextGradient_Gold.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: abc1f28caa461884799e14ec182504e8
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Art/UI/TextGradient_Red.asset
+++ b/Assets/Art/UI/TextGradient_Red.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 54d21f6ece3b46479f0c328f8c6007e0, type: 3}
+  m_Name: TextGradient_Red
+  m_EditorClassIdentifier: 
+  colorMode: 3
+  topLeft: {r: 1, g: 0.1933962, b: 0.1933962, a: 1}
+  topRight: {r: 1, g: 0.1933962, b: 0.1933962, a: 1}
+  bottomLeft: {r: 1, g: 0.1332366, b: 0.06132078, a: 1}
+  bottomRight: {r: 1, g: 0.1332366, b: 0.06132078, a: 1}

--- a/Assets/Art/UI/TextGradient_Red.asset.meta
+++ b/Assets/Art/UI/TextGradient_Red.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0ec55dfdb30cdb349bfb21ff2285f6b0
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Art/UI/TextGradient_Silver.asset
+++ b/Assets/Art/UI/TextGradient_Silver.asset
@@ -1,0 +1,19 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 54d21f6ece3b46479f0c328f8c6007e0, type: 3}
+  m_Name: TextGradient_Silver
+  m_EditorClassIdentifier: 
+  colorMode: 3
+  topLeft: {r: 1, g: 1, b: 1, a: 1}
+  topRight: {r: 1, g: 1, b: 1, a: 1}
+  bottomLeft: {r: 0.1320755, g: 0.1320755, b: 0.1320755, a: 1}
+  bottomRight: {r: 0.1320755, g: 0.1320755, b: 0.1320755, a: 1}

--- a/Assets/Art/UI/TextGradient_Silver.asset.meta
+++ b/Assets/Art/UI/TextGradient_Silver.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 132f88818a8eedb488c1ffe3e9b3b56d
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/UI/TrackView.prefab
+++ b/Assets/Prefabs/UI/TrackView.prefab
@@ -58,7 +58,14 @@ MonoBehaviour:
   _soloFullText: {fileID: 1690064270221596410}
   _soloBoxCanvasGroup: {fileID: 4653678781618251725}
   _soloBox: {fileID: 1298843830327042085}
-  _normalSoloBox: {fileID: 21300000, guid: cecf11e1b10fd7d4aba2b460a1ed8c1a, type: 3}
+  _soloSpriteNormal: {fileID: 21300000, guid: cecf11e1b10fd7d4aba2b460a1ed8c1a, type: 3}
+  _soloSpritePerfect: {fileID: 21300000, guid: d366b747c8f99cb458e8ff931d4f2003, type: 3}
+  _soloSpriteMessy: {fileID: 21300000, guid: 229a7b90eb98f3845ac0c87daa9fe207, type: 3}
+  _soloGradientNormal: {fileID: 11400000, guid: 132f88818a8eedb488c1ffe3e9b3b56d,
+    type: 2}
+  _soloGradientPerfect: {fileID: 11400000, guid: abc1f28caa461884799e14ec182504e8,
+    type: 2}
+  _soloGradientMessy: {fileID: 11400000, guid: 0ec55dfdb30cdb349bfb21ff2285f6b0, type: 2}
 --- !u!1 &547032022231682811
 GameObject:
   m_ObjectHideFlags: 0
@@ -455,14 +462,15 @@ MonoBehaviour:
     serializedVersion: 2
     rgba: 4294967295
   m_fontColor: {r: 1, g: 1, b: 1, a: 1}
-  m_enableVertexGradient: 0
+  m_enableVertexGradient: 1
   m_colorMode: 3
   m_fontColorGradient:
     topLeft: {r: 1, g: 1, b: 1, a: 1}
     topRight: {r: 1, g: 1, b: 1, a: 1}
     bottomLeft: {r: 1, g: 1, b: 1, a: 1}
     bottomRight: {r: 1, g: 1, b: 1, a: 1}
-  m_fontColorGradientPreset: {fileID: 0}
+  m_fontColorGradientPreset: {fileID: 11400000, guid: 132f88818a8eedb488c1ffe3e9b3b56d,
+    type: 2}
   m_spriteAsset: {fileID: 0}
   m_tintAllSprites: 0
   m_StyleSheet: {fileID: 0}
@@ -591,14 +599,15 @@ MonoBehaviour:
     serializedVersion: 2
     rgba: 4294967295
   m_fontColor: {r: 1, g: 1, b: 1, a: 1}
-  m_enableVertexGradient: 0
+  m_enableVertexGradient: 1
   m_colorMode: 3
   m_fontColorGradient:
     topLeft: {r: 1, g: 1, b: 1, a: 1}
     topRight: {r: 1, g: 1, b: 1, a: 1}
     bottomLeft: {r: 1, g: 1, b: 1, a: 1}
     bottomRight: {r: 1, g: 1, b: 1, a: 1}
-  m_fontColorGradientPreset: {fileID: 0}
+  m_fontColorGradientPreset: {fileID: 11400000, guid: 132f88818a8eedb488c1ffe3e9b3b56d,
+    type: 2}
   m_spriteAsset: {fileID: 0}
   m_tintAllSprites: 0
   m_StyleSheet: {fileID: 0}
@@ -727,14 +736,15 @@ MonoBehaviour:
     serializedVersion: 2
     rgba: 4294967295
   m_fontColor: {r: 1, g: 1, b: 1, a: 1}
-  m_enableVertexGradient: 0
+  m_enableVertexGradient: 1
   m_colorMode: 3
   m_fontColorGradient:
     topLeft: {r: 1, g: 1, b: 1, a: 1}
     topRight: {r: 1, g: 1, b: 1, a: 1}
     bottomLeft: {r: 1, g: 1, b: 1, a: 1}
     bottomRight: {r: 1, g: 1, b: 1, a: 1}
-  m_fontColorGradientPreset: {fileID: 0}
+  m_fontColorGradientPreset: {fileID: 11400000, guid: 132f88818a8eedb488c1ffe3e9b3b56d,
+    type: 2}
   m_spriteAsset: {fileID: 0}
   m_tintAllSprites: 0
   m_StyleSheet: {fileID: 0}

--- a/Assets/Script/PlayMode/AbstractTrack.cs
+++ b/Assets/Script/PlayMode/AbstractTrack.cs
@@ -232,10 +232,16 @@ namespace YARG.PlayMode {
 			string spName = $"starpower_{player.chosenInstrument}";
 			string soloName = $"solo_{player.chosenInstrument}";
 			string fillName = $"fill_{player.chosenInstrument}";
-			int soloNoteIndex = 0; // Solos cannot share notes, so we can save some iteration time and only go start-to-end once
+			// Solos and SP cannot share notes, so we can save some iteration time and only go start-to-end once overall
+			int spNoteIndex = 0;
+			int soloNoteIndex = 0;
 			foreach (var eventInfo in Play.Instance.chart.events) {
 				if (eventInfo.name == spName) {
-					starpowerSections.Add(eventInfo);
+					// Don't add empty SP phrases
+					int noteCount = GetNoteCountForPhrase(eventInfo, out spNoteIndex, startIndex: spNoteIndex);
+					if (noteCount > 0) {
+						starpowerSections.Add(eventInfo);
+					}
 				} else if (eventInfo.name == soloName) {
 					// Get note count of solo
 					int noteCount = GetNoteCountForPhrase(eventInfo, out soloNoteIndex, startIndex: soloNoteIndex);

--- a/Assets/Script/PlayMode/AbstractTrack.cs
+++ b/Assets/Script/PlayMode/AbstractTrack.cs
@@ -600,7 +600,10 @@ namespace YARG.PlayMode {
 
 		private void UpdateSolo() {
 			// Set solo box and text
-			if (CurrentSolo.info?.time <= HitMarginStartTime && CurrentSolo.info?.EndTime >= HitMarginEndTime) {
+			// Solo active when within hit window bounds,
+			// enabled after the first note is the front note in the hit window and disabled after the last note is hit
+			if (CurrentSolo.info?.time <= HitMarginStartTime && CurrentSolo.info?.EndTime >= HitMarginEndTime
+				&& CurrentNote?.time >= CurrentSolo.info?.time) {
 				if (!soloInProgress) {
 					soloInProgress = true;
 					soloNotesHit = 0;

--- a/Assets/Script/PlayMode/AbstractTrack.cs
+++ b/Assets/Script/PlayMode/AbstractTrack.cs
@@ -86,9 +86,8 @@ namespace YARG.PlayMode {
 		protected bool soloInProgress = false;
 		protected int soloNoteCount = -1;
 		protected int soloNotesHit = 0;
-		private int soloHitPercent = 0;
+		private int SoloHitPercent => soloNoteCount > 0 ? Mathf.FloorToInt((float) soloNotesHit / soloNoteCount * 100f) : 0;
 		private int lastHit = -1;
-		private double soloPtsEarned;
 
 		private bool FullCombo = true;
 
@@ -617,20 +616,9 @@ namespace YARG.PlayMode {
 				// );
 				// commonTrack.soloText.gameObject.SetActive(true);
 
-				soloHitPercent = Mathf.FloorToInt((float) soloNotesHit / soloNoteCount * 100f);
-				commonTrack.TrackView.SetSoloBox(soloHitPercent + "%", $"{soloNotesHit}/{soloNoteCount}");
+				commonTrack.TrackView.SetSoloBox(SoloHitPercent, soloNotesHit, soloNoteCount);
 			} else if (soloInProgress) {
-				commonTrack.TrackView.HideSoloBox(soloHitPercent + "%", soloHitPercent switch {
-					69 => "<i>NICE</i>\nSOLO",
-
-					>= 100 => "PERFECT\nSOLO!",
-					>= 95  => "AWESOME\nSOLO!",
-					>= 90  => "GREAT\nSOLO!",
-					>= 80  => "GOOD\nSOLO!",
-					>= 70  => "SOLID\nSOLO",
-					>= 60  => "OKAY\nSOLO",
-					_      => "MESSY\nSOLO",
-				});
+				commonTrack.TrackView.HideSoloBox(SoloHitPercent);
 
 				soloInProgress = false;
 			}

--- a/Assets/Script/PlayMode/AbstractTrack.cs
+++ b/Assets/Script/PlayMode/AbstractTrack.cs
@@ -316,6 +316,7 @@ namespace YARG.PlayMode {
 			UpdateStarpower();
 			UpdateFullComboState();
 			UpdateInfo();
+			UpdateSolo();
 
 			if (Multiplier >= MaxMultiplier) {
 				commonTrack.comboSunburst.gameObject.SetActive(true);
@@ -495,91 +496,6 @@ namespace YARG.PlayMode {
 				commonTrack.comboText.text = $"{Multiplier}<sub>x</sub>";
 			}
 
-			// Set solo box and text
-			if (CurrentSolo.info?.time <= HitMarginStartTime && CurrentSolo.info?.EndTime >= HitMarginEndTime) {
-				if (!soloInProgress) {
-					soloInProgress = true;
-					soloNotesHit = 0;
-					soloNoteCount = CurrentSolo.noteCount;
-				}
-
-				// Set text color
-				// commonTrack.soloText.colorGradient = new VertexGradient(
-				// 	new Color(1f, 1f, 1f),
-				// 	new Color(1f, 1f, 1f),
-				// 	new Color(0.1320755f, 0.1320755f, 0.1320755f),
-				// 	new Color(0.1320755f, 0.1320755f, 0.1320755f)
-				// );
-				// commonTrack.soloText.gameObject.SetActive(true);
-
-				soloHitPercent = Mathf.FloorToInt((float) soloNotesHit / soloNoteCount * 100f);
-				commonTrack.TrackView.SetSoloBox(soloHitPercent + "%", $"{soloNotesHit}/{soloNoteCount}");
-			} else if (soloInProgress) {
-				commonTrack.TrackView.HideSoloBox(soloHitPercent + "%", soloHitPercent switch {
-					69 => "<i>NICE</i>\nSOLO",
-
-					>= 100 => "PERFECT\nSOLO!",
-					>= 95  => "AWESOME\nSOLO!",
-					>= 90  => "GREAT\nSOLO!",
-					>= 80  => "GOOD\nSOLO!",
-					>= 70  => "SOLID\nSOLO",
-					>= 60  => "OKAY\nSOLO",
-					_      => "MESSY\nSOLO",
-				});
-
-				soloInProgress = false;
-			}
-			// } else if (HitMarginEndTime >= SoloSection?.EndTime && HitWindowEndTime <= SoloSection?.EndTime + 3) {
-			// 	// run ONCE
-			// 	if (soloInProgress) {
-			// 		soloPtsEarned = scoreKeeper.AddSolo(soloNotesHit, soloNoteCount);
-			// 		soloNotesHit = 0; // Reset count
-
-			// 		// set box text
-			// 		if (soloHitPercent >= 100f) {
-			// 			// Set text color
-			// 			commonTrack.soloText.colorGradient = new VertexGradient(
-			// 				new Color(1f, 0.619472f, 0f),
-			// 				new Color(1f, 0.619472f, 0f),
-			// 				new Color(0.5377358f, 0.2550798f, 0f),
-			// 				new Color(0.5377358f, 0.2550798f, 0f)
-			// 			);
-			// 			commonTrack.soloBox.sprite = commonTrack.soloPerfectSprite;
-			// 			commonTrack.soloText.text = "PERFECT\nSOLO!";
-			// 		} else if (soloHitPercent >= 95f) {
-			// 			commonTrack.soloText.text = "AWESOME\nSOLO!";
-			// 		} else if (soloHitPercent >= 90f) {
-			// 			commonTrack.soloText.text = "GREAT\nSOLO!";
-			// 		} else if (soloHitPercent >= 80f) {
-			// 			commonTrack.soloText.text = "GOOD\nSOLO!";
-			// 		} else if (soloHitPercent >= 70f) {
-			// 			commonTrack.soloText.text = "SOLID\nSOLO!";
-			// 		} else if (soloHitPercent >= 60f) {
-			// 			commonTrack.soloText.text = "OKAY\nSOLO!";
-			// 		} else {
-			// 			// Set text color
-			// 			commonTrack.soloText.colorGradient = new VertexGradient(
-			// 				new Color(1f, 0.1933962f, 0.1933962f),
-			// 				new Color(1f, 0.1933962f, 0.1933962f),
-			// 				new Color(1f, 0.1332366f, 0.06132078f),
-			// 				new Color(1f, 0.1332366f, 0.06132078f)
-			// 			);
-
-			// 			commonTrack.soloBox.sprite = commonTrack.soloMessySprite;
-			// 			commonTrack.soloText.text = "MESSY\nSOLO!";
-			// 		}
-
-			// 		// show points earned after some time
-			// 		StartCoroutine(SoloBoxShowScore());
-
-			// 		soloInProgress = false;
-			// 	}
-			// } else {
-			// 	commonTrack.soloText.text = null;
-			// 	commonTrack.soloText.gameObject.SetActive(false);
-			// 	commonTrack.soloBox.gameObject.SetActive(false);
-			// }
-
 			// Update status
 			int index = Combo % 10;
 			if (Multiplier != 1 && index == 0) {
@@ -681,6 +597,93 @@ namespace YARG.PlayMode {
 			recentNoteStreakInterval = currentNoteStreakInterval;
 			recentlyBelowMaxMultiplier = Multiplier < MaxMultiplier;
 			recentStarpowerCharge = starpowerCharge;
+		}
+
+		private void UpdateSolo() {
+			// Set solo box and text
+			if (CurrentSolo.info?.time <= HitMarginStartTime && CurrentSolo.info?.EndTime >= HitMarginEndTime) {
+				if (!soloInProgress) {
+					soloInProgress = true;
+					soloNotesHit = 0;
+					soloNoteCount = CurrentSolo.noteCount;
+				}
+
+				// Set text color
+				// commonTrack.soloText.colorGradient = new VertexGradient(
+				// 	new Color(1f, 1f, 1f),
+				// 	new Color(1f, 1f, 1f),
+				// 	new Color(0.1320755f, 0.1320755f, 0.1320755f),
+				// 	new Color(0.1320755f, 0.1320755f, 0.1320755f)
+				// );
+				// commonTrack.soloText.gameObject.SetActive(true);
+
+				soloHitPercent = Mathf.FloorToInt((float) soloNotesHit / soloNoteCount * 100f);
+				commonTrack.TrackView.SetSoloBox(soloHitPercent + "%", $"{soloNotesHit}/{soloNoteCount}");
+			} else if (soloInProgress) {
+				commonTrack.TrackView.HideSoloBox(soloHitPercent + "%", soloHitPercent switch {
+					69 => "<i>NICE</i>\nSOLO",
+
+					>= 100 => "PERFECT\nSOLO!",
+					>= 95  => "AWESOME\nSOLO!",
+					>= 90  => "GREAT\nSOLO!",
+					>= 80  => "GOOD\nSOLO!",
+					>= 70  => "SOLID\nSOLO",
+					>= 60  => "OKAY\nSOLO",
+					_      => "MESSY\nSOLO",
+				});
+
+				soloInProgress = false;
+			}
+			// } else if (HitMarginEndTime >= SoloSection?.EndTime && HitWindowEndTime <= SoloSection?.EndTime + 3) {
+			// 	// run ONCE
+			// 	if (soloInProgress) {
+			// 		soloPtsEarned = scoreKeeper.AddSolo(soloNotesHit, soloNoteCount);
+			// 		soloNotesHit = 0; // Reset count
+
+			// 		// set box text
+			// 		if (soloHitPercent >= 100f) {
+			// 			// Set text color
+			// 			commonTrack.soloText.colorGradient = new VertexGradient(
+			// 				new Color(1f, 0.619472f, 0f),
+			// 				new Color(1f, 0.619472f, 0f),
+			// 				new Color(0.5377358f, 0.2550798f, 0f),
+			// 				new Color(0.5377358f, 0.2550798f, 0f)
+			// 			);
+			// 			commonTrack.soloBox.sprite = commonTrack.soloPerfectSprite;
+			// 			commonTrack.soloText.text = "PERFECT\nSOLO!";
+			// 		} else if (soloHitPercent >= 95f) {
+			// 			commonTrack.soloText.text = "AWESOME\nSOLO!";
+			// 		} else if (soloHitPercent >= 90f) {
+			// 			commonTrack.soloText.text = "GREAT\nSOLO!";
+			// 		} else if (soloHitPercent >= 80f) {
+			// 			commonTrack.soloText.text = "GOOD\nSOLO!";
+			// 		} else if (soloHitPercent >= 70f) {
+			// 			commonTrack.soloText.text = "SOLID\nSOLO!";
+			// 		} else if (soloHitPercent >= 60f) {
+			// 			commonTrack.soloText.text = "OKAY\nSOLO!";
+			// 		} else {
+			// 			// Set text color
+			// 			commonTrack.soloText.colorGradient = new VertexGradient(
+			// 				new Color(1f, 0.1933962f, 0.1933962f),
+			// 				new Color(1f, 0.1933962f, 0.1933962f),
+			// 				new Color(1f, 0.1332366f, 0.06132078f),
+			// 				new Color(1f, 0.1332366f, 0.06132078f)
+			// 			);
+
+			// 			commonTrack.soloBox.sprite = commonTrack.soloMessySprite;
+			// 			commonTrack.soloText.text = "MESSY\nSOLO!";
+			// 		}
+
+			// 		// show points earned after some time
+			// 		StartCoroutine(SoloBoxShowScore());
+
+			// 		soloInProgress = false;
+			// 	}
+			// } else {
+			// 	commonTrack.soloText.text = null;
+			// 	commonTrack.soloText.gameObject.SetActive(false);
+			// 	commonTrack.soloBox.gameObject.SetActive(false);
+			// }
 
 			// Clear out passed solo sections
 			while (CurrentSolo.info?.EndTime < HitMarginEndTime) {

--- a/Assets/Script/PlayMode/AbstractTrack.cs
+++ b/Assets/Script/PlayMode/AbstractTrack.cs
@@ -607,15 +607,6 @@ namespace YARG.PlayMode {
 					soloNoteCount = CurrentSolo.noteCount;
 				}
 
-				// Set text color
-				// commonTrack.soloText.colorGradient = new VertexGradient(
-				// 	new Color(1f, 1f, 1f),
-				// 	new Color(1f, 1f, 1f),
-				// 	new Color(0.1320755f, 0.1320755f, 0.1320755f),
-				// 	new Color(0.1320755f, 0.1320755f, 0.1320755f)
-				// );
-				// commonTrack.soloText.gameObject.SetActive(true);
-
 				commonTrack.TrackView.SetSoloBox(SoloHitPercent, soloNotesHit, soloNoteCount);
 			} else if (soloInProgress) {
 				double soloPtsEarned = scoreKeeper.AddSolo(soloNotesHit, soloNoteCount);
@@ -623,56 +614,6 @@ namespace YARG.PlayMode {
 
 				soloInProgress = false;
 			}
-			// } else if (HitMarginEndTime >= SoloSection?.EndTime && HitWindowEndTime <= SoloSection?.EndTime + 3) {
-			// 	// run ONCE
-			// 	if (soloInProgress) {
-			// 		soloPtsEarned = scoreKeeper.AddSolo(soloNotesHit, soloNoteCount);
-			// 		soloNotesHit = 0; // Reset count
-
-			// 		// set box text
-			// 		if (soloHitPercent >= 100f) {
-			// 			// Set text color
-			// 			commonTrack.soloText.colorGradient = new VertexGradient(
-			// 				new Color(1f, 0.619472f, 0f),
-			// 				new Color(1f, 0.619472f, 0f),
-			// 				new Color(0.5377358f, 0.2550798f, 0f),
-			// 				new Color(0.5377358f, 0.2550798f, 0f)
-			// 			);
-			// 			commonTrack.soloBox.sprite = commonTrack.soloPerfectSprite;
-			// 			commonTrack.soloText.text = "PERFECT\nSOLO!";
-			// 		} else if (soloHitPercent >= 95f) {
-			// 			commonTrack.soloText.text = "AWESOME\nSOLO!";
-			// 		} else if (soloHitPercent >= 90f) {
-			// 			commonTrack.soloText.text = "GREAT\nSOLO!";
-			// 		} else if (soloHitPercent >= 80f) {
-			// 			commonTrack.soloText.text = "GOOD\nSOLO!";
-			// 		} else if (soloHitPercent >= 70f) {
-			// 			commonTrack.soloText.text = "SOLID\nSOLO!";
-			// 		} else if (soloHitPercent >= 60f) {
-			// 			commonTrack.soloText.text = "OKAY\nSOLO!";
-			// 		} else {
-			// 			// Set text color
-			// 			commonTrack.soloText.colorGradient = new VertexGradient(
-			// 				new Color(1f, 0.1933962f, 0.1933962f),
-			// 				new Color(1f, 0.1933962f, 0.1933962f),
-			// 				new Color(1f, 0.1332366f, 0.06132078f),
-			// 				new Color(1f, 0.1332366f, 0.06132078f)
-			// 			);
-
-			// 			commonTrack.soloBox.sprite = commonTrack.soloMessySprite;
-			// 			commonTrack.soloText.text = "MESSY\nSOLO!";
-			// 		}
-
-			// 		// show points earned after some time
-			// 		StartCoroutine(SoloBoxShowScore());
-
-			// 		soloInProgress = false;
-			// 	}
-			// } else {
-			// 	commonTrack.soloText.text = null;
-			// 	commonTrack.soloText.gameObject.SetActive(false);
-			// 	commonTrack.soloBox.gameObject.SetActive(false);
-			// }
 
 			// Clear out passed solo sections
 			while (CurrentSolo.info?.EndTime < HitMarginEndTime) {
@@ -681,11 +622,6 @@ namespace YARG.PlayMode {
 			while (CurrentVisualSolo.info?.EndTime < TrackStartTime) {
 				soloVisualIndex++;
 			}
-		}
-
-		IEnumerator SoloBoxShowScore() {
-			yield return new WaitForSeconds(1.5f);
-			// commonTrack.soloText.text = $"{soloPtsEarned:n0}\nPOINTS";
 		}
 
 		private void BeatAction() {

--- a/Assets/Script/PlayMode/AbstractTrack.cs
+++ b/Assets/Script/PlayMode/AbstractTrack.cs
@@ -235,16 +235,17 @@ namespace YARG.PlayMode {
 			// Solos and SP cannot share notes, so we can save some iteration time and only go start-to-end once overall
 			int spNoteIndex = 0;
 			int soloNoteIndex = 0;
+			bool chordsAreSingleNote = player.chosenInstrument is "drums" or "realDrums" or "ghDrums";
 			foreach (var eventInfo in Play.Instance.chart.events) {
 				if (eventInfo.name == spName) {
 					// Don't add empty SP phrases
-					int noteCount = GetNoteCountForPhrase(eventInfo, out spNoteIndex, startIndex: spNoteIndex);
+					int noteCount = GetNoteCountForPhrase(eventInfo, out spNoteIndex, chordsAreSingleNote, spNoteIndex);
 					if (noteCount > 0) {
 						starpowerSections.Add(eventInfo);
 					}
 				} else if (eventInfo.name == soloName) {
 					// Get note count of solo
-					int noteCount = GetNoteCountForPhrase(eventInfo, out soloNoteIndex, startIndex: soloNoteIndex);
+					int noteCount = GetNoteCountForPhrase(eventInfo, out soloNoteIndex, chordsAreSingleNote, soloNoteIndex);
 					if (noteCount > 0) {
 						soloSections.Add((eventInfo, noteCount));
 					}

--- a/Assets/Script/PlayMode/AbstractTrack.cs
+++ b/Assets/Script/PlayMode/AbstractTrack.cs
@@ -618,7 +618,8 @@ namespace YARG.PlayMode {
 
 				commonTrack.TrackView.SetSoloBox(SoloHitPercent, soloNotesHit, soloNoteCount);
 			} else if (soloInProgress) {
-				commonTrack.TrackView.HideSoloBox(SoloHitPercent);
+				double soloPtsEarned = scoreKeeper.AddSolo(soloNotesHit, soloNoteCount);
+				commonTrack.TrackView.HideSoloBox(SoloHitPercent, soloPtsEarned);
 
 				soloInProgress = false;
 			}

--- a/Assets/Script/PlayMode/StarScoreKeeper.cs
+++ b/Assets/Script/PlayMode/StarScoreKeeper.cs
@@ -110,10 +110,9 @@ namespace YARG.PlayMode {
 					if (ev.time <= note.time && note.time < ev.EndTime) {
 						// solo notes get double score, effectively
 						BaseScore += ptPerNote;
-						goto leaveSoloCheck;
+						break;
 					}
 				}
-				leaveSoloCheck:;
 			}
 
 			SetupScoreThreshold(instrument);

--- a/Assets/Script/UI/TrackView.cs
+++ b/Assets/Script/UI/TrackView.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using DG.Tweening;
 using TMPro;
@@ -69,19 +70,20 @@ namespace YARG.UI {
 			_soloBottomText.text = noteCountText;
 		}
 
-		public void HideSoloBox(int finalPercent) {
+		public void HideSoloBox(int finalPercent, double scoreBonus) {
 			string percentageText = $"{finalPercent}%";
 
 			_soloTopText.text = string.Empty;
 			_soloBottomText.text = string.Empty;
 			_soloFullText.text = percentageText;
 
-			_soloBoxHide = StartCoroutine(HideSoloBoxCoroutine(finalPercent));
+			_soloBoxHide = StartCoroutine(HideSoloBoxCoroutine(finalPercent, scoreBonus));
 		}
 
-		private IEnumerator HideSoloBoxCoroutine(int finalPercent) {
+		private IEnumerator HideSoloBoxCoroutine(int finalPercent, double scoreBonus) {
 			yield return new WaitForSeconds(1f);
 
+			// Show performance text
 			string resultText = finalPercent switch {
 				>= 100 => "PERFECT\nSOLO!",
 				>= 95  => "AWESOME\nSOLO!",
@@ -96,6 +98,12 @@ namespace YARG.UI {
 
 			yield return new WaitForSeconds(1f);
 
+			// Show point bonus
+			_soloFullText.text = $"{Math.Round(scoreBonus)}\nPOINTS";
+
+			yield return new WaitForSeconds(1f);
+
+			// Fade out the box
 			yield return _soloBoxCanvasGroup
 				.DOFade(0f, 0.25f)
 				.WaitForCompletion();

--- a/Assets/Script/UI/TrackView.cs
+++ b/Assets/Script/UI/TrackView.cs
@@ -106,14 +106,16 @@ namespace YARG.UI {
 
 			// Show performance text
 			string resultText = finalPercent switch {
-				>= 100 => "PERFECT\nSOLO!",
+				>  100 => "HOW!?",
+				   100 => "PERFECT\nSOLO!",
 				>= 95  => "AWESOME\nSOLO!",
 				>= 90  => "GREAT\nSOLO!",
 				>= 80  => "GOOD\nSOLO!",
 				>= 70  => "SOLID\nSOLO",
 				   69  => "<i>NICE</i>\nSOLO",
 				>= 60  => "OKAY\nSOLO",
-				_      => "MESSY\nSOLO",
+				>=  0  => "MESSY\nSOLO",
+				<   0  => "HOW!?",
 			};
 			_soloFullText.text = resultText;
 

--- a/Assets/Script/UI/TrackView.cs
+++ b/Assets/Script/UI/TrackView.cs
@@ -50,34 +50,49 @@ namespace YARG.UI {
 			TrackImage.transform.localScale = new Vector3(scale, scale, scale);
 		}
 
-		public void SetSoloBox(string topText, string bottomText) {
+		public void SetSoloBox(int hitPercent, int notesHit, int totalNotes) {
 			// Stop hide coroutine if we were previously hiding
 			if (_soloBoxHide != null) {
 				StopCoroutine(_soloBoxHide);
 				_soloBoxHide = null;
 			}
 
+			string percentageText = $"{hitPercent}%";
+			string noteCountText = $"{notesHit}/{totalNotes}";
+
 			_soloBox.gameObject.SetActive(true);
 			_soloBoxCanvasGroup.alpha = 1f;
 			_soloBox.sprite = _normalSoloBox;
 
 			_soloFullText.text = string.Empty;
-			_soloTopText.text = topText;
-			_soloBottomText.text = bottomText;
+			_soloTopText.text = percentageText;
+			_soloBottomText.text = noteCountText;
 		}
 
-		public void HideSoloBox(string percent, string fullText) {
+		public void HideSoloBox(int finalPercent) {
+			string percentageText = $"{finalPercent}%";
+
 			_soloTopText.text = string.Empty;
 			_soloBottomText.text = string.Empty;
-			_soloFullText.text = percent;
+			_soloFullText.text = percentageText;
 
-			_soloBoxHide = StartCoroutine(HideSoloBoxCoroutine(fullText));
+			_soloBoxHide = StartCoroutine(HideSoloBoxCoroutine(finalPercent));
 		}
 
-		private IEnumerator HideSoloBoxCoroutine(string fullText) {
+		private IEnumerator HideSoloBoxCoroutine(int finalPercent) {
 			yield return new WaitForSeconds(1f);
 
-			_soloFullText.text = fullText;
+			string resultText = finalPercent switch {
+				>= 100 => "PERFECT\nSOLO!",
+				>= 95  => "AWESOME\nSOLO!",
+				>= 90  => "GREAT\nSOLO!",
+				>= 80  => "GOOD\nSOLO!",
+				>= 70  => "SOLID\nSOLO",
+				   69  => "<i>NICE</i>\nSOLO",
+				>= 60  => "OKAY\nSOLO",
+				_      => "MESSY\nSOLO",
+			};
+			_soloFullText.text = resultText;
 
 			yield return new WaitForSeconds(1f);
 

--- a/Assets/Script/UI/TrackView.cs
+++ b/Assets/Script/UI/TrackView.cs
@@ -34,7 +34,17 @@ namespace YARG.UI {
 
 		[Space]
 		[SerializeField]
-		private Sprite _normalSoloBox;
+		private Sprite _soloSpriteNormal;
+		[SerializeField]
+		private Sprite _soloSpritePerfect;
+		[SerializeField]
+		private Sprite _soloSpriteMessy;
+		[SerializeField]
+		private TMP_ColorGradient _soloGradientNormal;
+		[SerializeField]
+		private TMP_ColorGradient _soloGradientPerfect;
+		[SerializeField]
+		private TMP_ColorGradient _soloGradientMessy;
 
 		private Coroutine _soloBoxHide = null;
 
@@ -61,26 +71,37 @@ namespace YARG.UI {
 			string percentageText = $"{hitPercent}%";
 			string noteCountText = $"{notesHit}/{totalNotes}";
 
+			// Show solo box
 			_soloBox.gameObject.SetActive(true);
+			_soloBox.sprite = _soloSpriteNormal;
 			_soloBoxCanvasGroup.alpha = 1f;
-			_soloBox.sprite = _normalSoloBox;
 
+			// Set solo text
 			_soloFullText.text = string.Empty;
 			_soloTopText.text = percentageText;
 			_soloBottomText.text = noteCountText;
 		}
 
 		public void HideSoloBox(int finalPercent, double scoreBonus) {
-			string percentageText = $"{finalPercent}%";
-
 			_soloTopText.text = string.Empty;
 			_soloBottomText.text = string.Empty;
-			_soloFullText.text = percentageText;
 
 			_soloBoxHide = StartCoroutine(HideSoloBoxCoroutine(finalPercent, scoreBonus));
 		}
 
 		private IEnumerator HideSoloBoxCoroutine(int finalPercent, double scoreBonus) {
+			// Set textbox color
+			var (sprite, gradient) = finalPercent switch {
+				>= 100 => (_soloSpritePerfect, _soloGradientPerfect),
+				>= 60  => (_soloSpriteNormal, _soloGradientNormal),
+				_      => (_soloSpriteMessy, _soloGradientMessy),
+			};
+			_soloBox.sprite = sprite;
+			_soloFullText.colorGradientPreset = gradient;
+
+			// Display final hit percentage
+			_soloFullText.text = $"{finalPercent}%";
+
 			yield return new WaitForSeconds(1f);
 
 			// Show performance text


### PR DESCRIPTION
Summary:

- Solo phrases now have their note counts pre-calculated, and are now excluded if they contain no notes (overdrive phrases are also now excluded if they have no notes).
- All text creation related to the solo box has been moved to TrackView, rather than the methods there accepting strings they take the actual values and turn those into strings themselves.
- The solo score bonus has been re-added, along with displaying it after a solo.
- The solo textbox is now colored again using the vertex colors that were present in the previous implementation. This time they've been turned into asset files, and can now be used on any other textbox if desired.
- The previously commented-out code has been removed now that it's fully reimplemented.
- Solos now wait for their first note to be the current note before starting.
- A special result has been added for anyone who breaks solos again lol