### PR TITLE
Fix infinite loop generating beatlines in 1/x time signatures

### DIFF
--- a/Assets/Script/Chart/BeatHandler.cs
+++ b/Assets/Script/Chart/BeatHandler.cs
@@ -92,8 +92,8 @@ namespace YARG.Chart {
 					}
 				}
 
-				// Last beat should never be a strong beat if denominator is bigger than 4.
-				if (currentBeatInMeasure == currentTS.numerator - 1 && currentTS.denominator > 4) {
+				// Last beat of measure should never be a strong beat if denominator is bigger than 4.
+				if (currentBeatInMeasure == currentTS.numerator - 1 && currentTS.denominator > 4 && currentTick < lastTick + forwardStep) {
 					style = BeatStyle.WEAK;
 				}
 
@@ -142,7 +142,7 @@ namespace YARG.Chart {
 			{
 				foreach (var songObject in chart.chartObjects) {
 					if (songObject.tick <= lastTick) continue;
-					
+
 					lastTick = songObject.tick;
 
 					if (songObject is MoonNote note)


### PR DESCRIPTION
In cases where charts finish with in a 1/x time signature (where x > 4) the beat generation code falls into an infinite loop trying to finish the song on a measure. This was impossible though as 1/x time signatures are forced to only generate the first measure as a measure line, while the rest are standard strong/weak beats.

This caused an infinite loop and generated beats until memory ran out causing the game to hang forever.

Thanks to JasonParadise for finding this bug on stream and sending me the chart to diagnose the problem.