### PR TITLE
Fix songs not ending in rare cases

### DIFF
--- a/Assets/Scenes/PersistantScene.unity
+++ b/Assets/Scenes/PersistantScene.unity
@@ -1861,6 +1861,7 @@ GameObject:
   m_Component:
   - component: {fileID: 788257160}
   - component: {fileID: 788257161}
+  - component: {fileID: 788257162}
   m_Layer: 0
   m_Name: Game Manager
   m_TagString: Untagged
@@ -1896,6 +1897,18 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   <SettingsMenu>k__BackingField: {fileID: 0}
+--- !u!114 &788257162
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 788257159}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9528aed6905f440386374733309d1614, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &826511794
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Script/Audio/Bass/BassAudioManager.cs
+++ b/Assets/Script/Audio/Bass/BassAudioManager.cs
@@ -31,12 +31,15 @@ namespace YARG.Audio.BASS {
 		public float CurrentPositionF => (float) GetPosition();
 		public float AudioLengthF { get; private set; }
 
+		private IAudioManager.SongEndCallback _songEndCallback;
+
 		private double[] _stemVolumes;
 		private ISampleChannel[] _sfxSamples;
 
 		private int _opusHandle;
 
 		private IStemMixer _mixer;
+
 
 		private void Awake() {
 			SupportedFormats = new[] {
@@ -72,7 +75,10 @@ namespace YARG.Audio.BASS {
 			Bass.Configure(Configuration.UpdateThreads, 2);
 			Bass.Configure(Configuration.FloatDSP, true);
 
+			// Undocumented BASS_CONFIG_MP3_OLDGAPS config.
 			Bass.Configure((Configuration) 68, 1);
+
+			// Disable undocumented BASS_CONFIG_DEV_TIMEOUT config. Prevents pausing audio output if a device times out.
 			Bass.Configure((Configuration) 70, false);
 
 			int deviceCount = Bass.DeviceCount;
@@ -225,6 +231,10 @@ namespace YARG.Audio.BASS {
 			AudioLengthD = _mixer.LeadChannel.LengthD;
 			AudioLengthF = (float) AudioLengthD;
 
+			_mixer.SetSync(SyncFlags.End, () => {
+				UnityMainThreadCallback.QueueEvent(_songEndCallback.Invoke);
+			});
+
 			IsAudioLoaded = true;
 		}
 
@@ -307,6 +317,10 @@ namespace YARG.Audio.BASS {
 			AudioLengthD = _mixer.LeadChannel.LengthD;
 			AudioLengthF = (float) AudioLengthD;
 
+			_mixer.SetSync(SyncFlags.End, () => {
+				UnityMainThreadCallback.QueueEvent(_songEndCallback.Invoke);
+			});
+
 			IsAudioLoaded = true;
 		}
 
@@ -386,6 +400,14 @@ namespace YARG.Audio.BASS {
 			}
 
 			IsPlaying = _mixer.IsPlaying;
+		}
+
+		public void AddSongEndCallback(IAudioManager.SongEndCallback callback) {
+			_songEndCallback += callback;
+		}
+
+		public void RemoveSongEndCallback(IAudioManager.SongEndCallback callback) {
+			_songEndCallback -= callback;
 		}
 
 		public void FadeIn(float maxVolume) {

--- a/Assets/Script/Audio/Bass/BassStemMixer.cs
+++ b/Assets/Script/Audio/Bass/BassStemMixer.cs
@@ -11,9 +11,9 @@ namespace YARG.Audio.BASS {
 	public class BassStemMixer : IStemMixer {
 
 		public int StemsLoaded { get; protected set; }
-		
+
 		public bool IsPlaying { get; protected set; }
-		
+
 		public IReadOnlyDictionary<SongStem, IStemChannel> Channels => _channels;
 
 		public IStemChannel LeadChannel { get; protected set; }
@@ -175,6 +175,12 @@ namespace YARG.Audio.BASS {
 			return !_channels.ContainsKey(stem) ? null : _channels[stem];
 		}
 
+		public void SetSync(SyncFlags sync, Action callback) {
+			BassMix.ChannelSetSync(((BassStemChannel) LeadChannel).StreamHandle, sync, 0, (_, _, _, _) => {
+				UnityMainThreadCallback.QueueEvent(callback);
+			}, IntPtr.Zero);
+		}
+
 		public void Dispose() {
 			Dispose(true);
 			GC.SuppressFinalize(this);
@@ -206,7 +212,7 @@ namespace YARG.Audio.BASS {
 				if (!Bass.StreamFree(_mixerHandle)) {
 					Debug.LogError("Failed to free mixer stream. THIS WILL LEAK MEMORY!");
 				}
-				
+
 				_mixerHandle = 0;
 			}
 		}

--- a/Assets/Script/Audio/Interfaces/IAudioManager.cs
+++ b/Assets/Script/Audio/Interfaces/IAudioManager.cs
@@ -5,6 +5,9 @@ using YARG.Song;
 
 namespace YARG.Audio {
 	public interface IAudioManager {
+
+		public delegate void SongEndCallback();
+
 		public bool UseStarpowerFx { get; set; }
 		public bool IsChipmunkSpeedup { get; set; }
 
@@ -37,6 +40,9 @@ namespace YARG.Audio {
 
 		public void Play();
 		public void Pause();
+
+		public void AddSongEndCallback(SongEndCallback callback);
+		public void RemoveSongEndCallback(SongEndCallback callback);
 
 		public void FadeIn(float maxVolume);
 		public UniTask FadeOut(CancellationToken token = default);

--- a/Assets/Script/Audio/Interfaces/IStemChannel.cs
+++ b/Assets/Script/Audio/Interfaces/IStemChannel.cs
@@ -21,7 +21,7 @@ namespace YARG.Audio {
 
 		public double GetPosition();
 		public void SetPosition(double position);
-		
+
 		public double GetLengthInSeconds();
 
 	}

--- a/Assets/Script/Audio/Interfaces/IStemMixer.cs
+++ b/Assets/Script/Audio/Interfaces/IStemMixer.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading;
 using Cysharp.Threading.Tasks;
+using ManagedBass;
 
 namespace YARG.Audio {
 	public interface IStemMixer : IDisposable {
@@ -28,10 +29,12 @@ namespace YARG.Audio {
 		public void SetPosition(double position);
 
 		public int AddChannel(IStemChannel channel);
-		
+
 		public bool RemoveChannel(IStemChannel channel);
 
 		public IStemChannel GetChannel(SongStem stem);
+
+		public void SetSync(SyncFlags sync, Action callback);
 
 	}
 }

--- a/Assets/Script/PlayMode/Play.cs
+++ b/Assets/Script/PlayMode/Play.cs
@@ -329,6 +329,8 @@ namespace YARG.PlayMode {
 			}
 
 			GameManager.AudioManager.Play();
+
+			GameManager.AudioManager.AddSongEndCallback(OnEndReached);
 			audioStarted = true;
 		}
 
@@ -431,12 +433,11 @@ namespace YARG.PlayMode {
 			if (!playingVocals) {
 				UpdateGenericLyrics();
 			}
+		}
 
-			// End song
-			if (!endReached && realSongTime >= SongLength) {
-				endReached = true;
-				StartCoroutine(EndSong(true));
-			}
+		private void OnEndReached() {
+			endReached = true;
+			StartCoroutine(EndSong(true));
 		}
 
 		private void UpdateGenericLyrics() {

--- a/Assets/Script/UnityMainThreadCallback.cs
+++ b/Assets/Script/UnityMainThreadCallback.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace YARG {
+	public class UnityMainThreadCallback : MonoBehaviour {
+
+		private static readonly Queue<Action> CallbackQueue = new();
+
+		private void Update() {
+			lock (CallbackQueue) {
+				while (CallbackQueue.Count > 0) {
+					CallbackQueue.Dequeue().Invoke();
+				}
+			}
+		}
+
+		public static void QueueEvent(Action action) {
+			lock (CallbackQueue) {
+				CallbackQueue.Enqueue(action);
+			}
+		}
+	}
+}

--- a/Assets/Script/UnityMainThreadCallback.cs.meta
+++ b/Assets/Script/UnityMainThreadCallback.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 9528aed6905f440386374733309d1614
+timeCreated: 1686439596


### PR DESCRIPTION
Some songs (presumably with corrupt audio files) have reported lengths longer than BASS can play. Therefore the song's position never reached the supposed length and the gameplay never ended.

Instead of using the song position, it now uses SYNC events in BASS with callbacks. Probably not done in the nicest way but it did work in quick testing. Might need more testing.