### PR TITLE
Fix drums hit window visual not being centered correctly

### DIFF
--- a/Assets/Prefabs/DrumsTrack.prefab
+++ b/Assets/Prefabs/DrumsTrack.prefab
@@ -400,16 +400,6 @@ PrefabInstance:
       propertyPath: m_LocalPosition.z
       value: 1.296
       objectReference: {fileID: 0}
-    - target: {fileID: 4405145901572709445, guid: ba68df35237e09f4abcf788160c15375,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -0.007
-      objectReference: {fileID: 0}
-    - target: {fileID: 4405145901572709445, guid: ba68df35237e09f4abcf788160c15375,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -2.179
-      objectReference: {fileID: 0}
     - target: {fileID: 4431318561618230466, guid: ba68df35237e09f4abcf788160c15375,
         type: 3}
       propertyPath: m_RootOrder


### PR DESCRIPTION
At some point the hit window object on the drums track got moved a little ways behind where it was supposed to be, resulting in the hit window visually being longer in the back and shorter in the front despite not actually functioning that way.

![image](https://github.com/YARC-Official/YARG/assets/29052821/d33fd949-4cf4-4642-9441-e03fb8ca6d8f)
