### PR TITLE
Info Container Fix

### DIFF
--- a/Assets/Scenes/PersistantScene.unity
+++ b/Assets/Scenes/PersistantScene.unity
@@ -762,7 +762,7 @@ MonoBehaviour:
   m_fontColor32:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColor: {r: 1, g: 1, b: 1, a: 0.5882353}
   m_enableVertexGradient: 0
   m_colorMode: 3
   m_fontColorGradient:
@@ -779,8 +779,8 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 36
-  m_fontSizeBase: 36
+  m_fontSize: 25
+  m_fontSizeBase: 25
   m_fontWeight: 400
   m_enableAutoSizing: 0
   m_fontSizeMin: 18
@@ -1251,10 +1251,10 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: 'FPS: 99999'
+  m_text: <b>FPS:</b> 99999
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 19b7115073766a24aa48ceca884dcbf5, type: 2}
-  m_sharedMaterial: {fileID: 4249517445589659644, guid: 19b7115073766a24aa48ceca884dcbf5,
+  m_fontAsset: {fileID: 11400000, guid: ae170e91fd29a90479e906ddffb1d8ee, type: 2}
+  m_sharedMaterial: {fileID: -5480317595949376055, guid: ae170e91fd29a90479e906ddffb1d8ee,
     type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
@@ -1279,8 +1279,8 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 36
-  m_fontSizeBase: 36
+  m_fontSize: 25
+  m_fontSizeBase: 25
   m_fontWeight: 400
   m_enableAutoSizing: 0
   m_fontSizeMin: 18
@@ -1366,7 +1366,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 86}
+  m_SizeDelta: {x: 0, y: 50}
   m_Pivot: {x: 0.5, y: 0.99999964}
 --- !u!114 &651382556
 MonoBehaviour:

--- a/Assets/Script/UI/FpsCounter.cs
+++ b/Assets/Script/UI/FpsCounter.cs
@@ -23,9 +23,11 @@ namespace YARG.UI {
 		private float fpsUpdateRate;
 
 		private float nextUpdateTime;
+		int screenRate;
 
 		private void Awake() {
 			Instance = this;
+			screenRate = Screen.currentResolution.refreshRate;
 		}
 
 		public void SetVisible(bool value) {
@@ -44,22 +46,24 @@ namespace YARG.UI {
 			}
 
 			int fps = (int)(1f / Time.unscaledDeltaTime);
+			
 
 			// Color the circle sprite based on the FPS
+			// red if lower than 30, yellow if lower than screen refresh rate, green otherwise
 			if (fps < 30) {
 				fpsCircle.color = fpsCircleRed;
-			} else if (fps < 60) {
+			} else if (fps < screenRate) {
 				fpsCircle.color = fpsCircleYellow;
 			} else {
 				fpsCircle.color = fpsCircleGreen;
 			}
 
 			// Display the FPS
-			fpsText.text = $"FPS: {fps}";
+			fpsText.text = $"<b>FPS:</b> {fps}";
 
 #if UNITY_EDITOR
 			// Display the memory usage
-			fpsText.text += $"\nMemory: {Profiler.GetTotalAllocatedMemoryLong() / 1024 / 1024} MB";
+			fpsText.text += $"   •   <b>Memory:</b> {Profiler.GetTotalAllocatedMemoryLong() / 1024 / 1024} MB";
 #endif
 
 			// reset the update time


### PR DESCRIPTION
[FPS Counter]
- The Memory Text is in one line now:  
**FPS:** 12345   •   **Memory:** 12345mb
- Red dot if FPS lower than 30, yellow if lower than screen refresh rate, green otherwise

[PersistantScene]
- Fix the Position of Info Container and height
- Lower the text size since the Scene is render at 1080p now
- add transparency to the Watermark