### PR TITLE
Headers are added for the different sections, merged results, filter for songs without certain instruments

### DIFF
--- a/Assets/Art/UI/MusicLibrary/Chevron_Down.png
+++ b/Assets/Art/UI/MusicLibrary/Chevron_Down.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4281d50136b868d0aa2c5ccf76ae7a063488e3614e616516a8c2c857b23dfbbc
+size 387

--- a/Assets/Art/UI/MusicLibrary/Chevron_Down.png.meta
+++ b/Assets/Art/UI/MusicLibrary/Chevron_Down.png.meta
@@ -1,0 +1,123 @@
+fileFormatVersion: 2
+guid: 4a4ba0f5f6fbdff4ca0556b981ef1d61
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 12
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMasterTextureLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 1
+    wrapV: 1
+    wrapW: 0
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  cookieLightType: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Server
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    nameFileIdTable: {}
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Script/Song/SongSearching.cs
+++ b/Assets/Script/Song/SongSearching.cs
@@ -28,8 +28,8 @@ namespace YARG.Song {
 			}
 		}
 
-		private readonly static List<Tuple<string, string>> troublesomeCharacters = new List<Tuple<string, string>>{
-			Tuple.Create("Æ", "AE") // Tool - Ænema
+		private readonly static List<(string, string)> troublesomeCharacters = new List<(string, string)>{
+			("Æ", "AE") // Tool - Ænema
 		};
 
 		public IEnumerable<SongEntry> Search(string value){

--- a/Assets/Script/Song/SongSearching.cs
+++ b/Assets/Script/Song/SongSearching.cs
@@ -1,0 +1,207 @@
+using System;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Globalization;
+using System.Collections.Generic;
+using System.Linq;
+using Cysharp.Threading.Tasks;
+using TMPro;
+using UnityEngine;
+using UnityEngine.InputSystem;
+using UnityEngine.UI;
+using YARG.Audio;
+using YARG.Data;
+using YARG.Input;
+using YARG.Song;
+using YARG.UI.MusicLibrary.ViewTypes;
+using Random = UnityEngine.Random;
+
+namespace YARG.Song {
+	public class SongSearching {
+
+		private readonly static SongSearching _instance = new SongSearching();
+
+		public static SongSearching Instance {
+			get
+			{
+				return _instance;
+			}
+		}
+
+		private readonly static List<Tuple<string, string>> troublesomeCharacters = new List<Tuple<string, string>>{
+			Tuple.Create("Æ", "AE") // Tool - Ænema
+		};
+
+		public IEnumerable<SongEntry> Search(string value){
+			var split = value.Split(';');
+			IEnumerable<SongEntry> songsOut = Enumerable.Empty<SongEntry>();
+
+			foreach (var arg in split) {
+				// songsOut = SearchSongs(arg);
+				songsOut = songsOut.Union(SearchSongs(arg));
+			}
+
+			return songsOut.OrderBy(OrderBy());
+		}
+
+		private IEnumerable<SongEntry> SearchSongs(string arg){
+			if (arg.StartsWith("artist:")) {
+				var artist = arg[7..];
+				return SearchByArtist(artist);
+			}
+
+			if (arg.StartsWith("source:")) {
+				var source = arg[7..];
+				return SearchBySource(source);
+			}
+
+			if (arg.StartsWith("album:")) {
+				var album = arg[6..];
+				return SearchByAlbum(album);
+			}
+
+			if (arg.StartsWith("charter:")) {
+				var charter = arg[8..];
+				return SearchByCharter(charter);
+			}
+
+			if (arg.StartsWith("year:")) {
+				var year = arg[5..];
+				return SearchByYear(year);
+			}
+
+			if (arg.StartsWith("genre:")) {
+				var genre = arg[6..];
+				return SearchByGenre(genre);
+			}
+
+			if (arg.StartsWith("instrument:")) {
+				var instrument = arg[11..];
+
+				if(!string.IsNullOrEmpty(instrument) && instrument.Length > 1 && instrument.StartsWith("-")){
+					return SearchByMissingInstrument(instrument.Substring(1));
+				}
+				return SearchByInstrument(instrument);
+			}
+
+			return SongContainer.Songs
+					.Select(i => new { score = Search(arg, i), songInfo = i })
+					.Where(i => i.score >= 0)
+					.OrderBy(i => i.score)
+					.Select(i => i.songInfo);
+		}
+
+		private IEnumerable<SongEntry> SearchByArtist(string artist){
+			return SongContainer.Songs
+				.Where(i => RemoveDiacriticsAndArticle(i.Artist) == RemoveDiacriticsAndArticle(artist));
+		}
+
+		private IEnumerable<SongEntry> SearchBySource(string source){
+			return SongContainer.Songs
+				.Where(i => i.Source?.ToLower() == source.ToLower());
+		}
+		
+		private IEnumerable<SongEntry> SearchByAlbum(string album){
+			return SongContainer.Songs
+				.Where(i => RemoveDiacritics(i.Album) == RemoveDiacritics(album));
+		}
+
+		private IEnumerable<SongEntry> SearchByCharter(string charter){
+			return SongContainer.Songs
+				.Where(i => i.Charter?.ToLower() == charter.ToLower());
+		}
+
+		private IEnumerable<SongEntry> SearchByYear(string year){
+			return SongContainer.Songs
+				.Where(i => i.Year?.ToLower() == year.ToLower());
+		}
+
+		private IEnumerable<SongEntry> SearchByGenre(string genre){
+			return SongContainer.Songs
+				.Where(i => i.Genre?.ToLower() == genre.ToLower());
+		}
+
+		private IEnumerable<SongEntry> SearchByInstrument(string instrument){
+			return instrument switch {
+				"band" => SongContainer.Songs.Where(i => i.BandDifficulty >= 0),
+				"vocals" => SongContainer.Songs.Where(i => i.VocalParts < 2),
+				"harmVocals" => SongContainer.Songs.Where(i => i.VocalParts >= 2),
+				_ => SongContainer.Songs.Where(i =>
+					i.HasInstrument(InstrumentHelper.FromStringName(instrument))),
+			};
+		}
+
+		private IEnumerable<SongEntry> SearchByMissingInstrument(string instrument){
+			return instrument switch {
+				"band" => SongContainer.Songs.Where(i => i.BandDifficulty < 0),
+				"vocals" => SongContainer.Songs.Where(i => i.VocalParts <= 0),
+				// string s when s.StartsWith("-") => SongContainer.Songs.Where(SongIsMissing(instrument)),
+				_ => SongContainer.Songs.Where(SongIsMissing(instrument)),
+			};
+		}
+
+		private Func<SongEntry, bool> SongIsMissing(string instrument){
+			return s => !s.HasInstrument(InstrumentHelper.FromStringName(instrument));
+		}
+
+		public static string RemoveDiacritics(string text) {
+			if (text == null) {
+				return null;
+			}
+
+			foreach(var c in troublesomeCharacters){
+				text = text.Replace(c.Item1, c.Item2);
+			}
+
+			var normalizedString = text.ToLowerInvariant().Normalize(NormalizationForm.FormD);
+			var stringBuilder = new StringBuilder(capacity: normalizedString.Length);
+
+			for (int i = 0; i < normalizedString.Length; i++) {
+				char c = normalizedString[i];
+				var unicodeCategory = CharUnicodeInfo.GetUnicodeCategory(c);
+				if (unicodeCategory != UnicodeCategory.NonSpacingMark) {
+					stringBuilder.Append(c);
+				}
+			}
+
+			return stringBuilder
+				.ToString()
+				.Normalize(NormalizationForm.FormC);
+		}
+
+		public static string RemoveDiacriticsAndArticle(string text){
+			var textWithoutDiacretics = RemoveDiacritics(text);
+			return SongSorting.RemoveArticle(textWithoutDiacretics);
+		}
+
+		private int Search(string input, SongEntry songInfo) {
+			string normalizedInput = RemoveDiacritics(input);
+
+			// Get name index
+			string name = songInfo.NameNoParenthesis;
+			int nameIndex = RemoveDiacritics(name).IndexOf(normalizedInput);
+
+			// Get artist index
+			string artist = songInfo.Artist;
+			int artistIndex = RemoveDiacritics(artist).IndexOf(normalizedInput, StringComparison.Ordinal);
+
+			// Return the best search
+			if (nameIndex == -1 && artistIndex == -1) {
+				return -1;
+			}
+
+			if (nameIndex == -1) {
+				return artistIndex;
+			}
+
+			if (artistIndex == -1) {
+				return nameIndex;
+			}
+			return Mathf.Min(nameIndex, artistIndex);
+		}
+
+		private Func<SongEntry, string> OrderBy(){
+			return SongSorting.Instance.SortBy();
+		}
+	}
+}

--- a/Assets/Script/Song/SongSearching.cs.meta
+++ b/Assets/Script/Song/SongSearching.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fd9d119804448434aab29f3fd3a49445
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Script/Song/SongSorting.cs
+++ b/Assets/Script/Song/SongSorting.cs
@@ -90,7 +90,7 @@ namespace YARG.Song {
 
 			sortBy = song => {
 				string name = song.NameNoParenthesis.ToUpper();
-				return RemoveArticle(name);
+				return SongSearching.RemoveDiacriticsAndArticle(name);
 			};
 
 			return true;
@@ -207,10 +207,13 @@ namespace YARG.Song {
 				return EMPTY_VALUE;
 			}
 
-			var name = RemoveArticle(value);
+			var name = SongSearching.RemoveDiacriticsAndArticle(value);
+
 			if(Regex.IsMatch(name, @"^\W")){
 				return EMPTY_VALUE;
-			} else if (Regex.IsMatch(name, @"^\d")){
+			}
+
+			if(Regex.IsMatch(name, @"^\d")){
 				return "0-9";
 			}
 			return name.Substring(0,1).ToUpper();
@@ -246,6 +249,18 @@ namespace YARG.Song {
 				.Distinct()
 				.OrderBy(ch => ch)
 				.ToList();
+		}
+
+		public List<string> GetSongsFirstLetter(){
+			return songsFirstLetter;
+		}
+
+		public int GetSectionsSize(){
+			return songsFirstLetter.Count;
+		}
+
+		public string GetLastSection(){
+			return songsFirstLetter[songsFirstLetter.Count - 1];
 		}
 
 		public Func<SongEntry, string> SortBy(){
@@ -332,6 +347,17 @@ namespace YARG.Song {
 				);
 
 			return _index;
+		}
+
+		public int GetIndexOfLetter(List<ViewType> songs, string value, int skip){
+			return songs.FindIndex(skip, song =>
+				song is SongViewType songType &&
+					String.Equals(
+						index(songType),
+						value,
+						StringComparison.OrdinalIgnoreCase
+					)
+			);
 		}
 	}
 }

--- a/Assets/Script/UI/MusicLibrary/SongSelection.cs
+++ b/Assets/Script/UI/MusicLibrary/SongSelection.cs
@@ -89,7 +89,8 @@ namespace YARG.UI.MusicLibrary {
 		private List<SongView> _songViews = new();
 		private float _scrollTimer = 0f;
 		private bool searchBoxShouldBeEnabled = false;
-		private readonly int numberOfDivisions = 3; //RANDOM SONG, RECOMMENDEND SONGS, ALL SONGS
+		private readonly int NUMBER_OF_DIVISIONS = 3; //RANDOM SONG, RECOMMENDEND SONGS, ALL SONGS
+		private readonly int MIN_SONGS_FOR_SECTION_HEADERS = 30;
 
 		private void Awake() {
 			refreshFlag = true;
@@ -213,6 +214,10 @@ namespace YARG.UI.MusicLibrary {
 		}
 
 		private void ChangeFilter() {
+			if (CurrentSelection is not SongViewType view) {
+				return;
+			}
+
 			UpdateFilter();
 			UpdateFilterButtonName();
 			UpdateNavigationScheme();
@@ -288,128 +293,129 @@ namespace YARG.UI.MusicLibrary {
 		}
 
 		public void UpdateSearch() {
-			// Get recommended songs
-			if (_recommendedSongs == null) {
-				_recommendedSongs = new();
+			SetRecommendedSongs();
 
-				if (SongContainer.Songs.Count > 0) {
-					FillRecommendedSongs();
-				}
-			}
+			bool searchBoxHasContent = !string.IsNullOrEmpty(searchField.text);
 
-			if (string.IsNullOrEmpty(searchField.text)) {
-				// Add all songs
-				_songs = SongContainer.Songs
-					.OrderBy(OrderBy())
-					.Select(i => new SongViewType(i))
-					.Cast<ViewType>()
-					.ToList();
-				_songs.Insert(0, new CategoryViewType(
-					"ALL SONGS",
-					$"<#00B6F5><b>{_songs.Count}</b> <#006488>{(_songs.Count == 1 ? "SONG" : "SONGS")}",
-					SongContainer.Songs
-				));
-
-				// Add recommended songs
-				foreach (var song in _recommendedSongs) {
-					_songs.Insert(0, new SongViewType(song));
-				}
-				_songs.Insert(0, new CategoryViewType(
-					_recommendedSongs.Count == 1 ? "RECOMMENDED SONG" : "RECOMMENDED SONGS",
-					$"<#00B6F5><b>{_recommendedSongs.Count}</b> <#006488>{(_recommendedSongs.Count == 1 ? "SONG" : "SONGS")}",
-					_recommendedSongs
-				));
-
-				// Add buttons
-				_songs.Insert(0, new ButtonViewType(
-					"RANDOM SONG",
-					"Icon/Random",
-					() => {
-						SelectRandomSong();
-					}
-				));
+			if (searchBoxHasContent) {
+				IEnumerable<SongEntry> songsOut = SongSearching.Instance.Search(searchField.text);
+				AddFilteredSongs(songsOut);
+				AddSearchResultsHeader();
 			} else {
-				// Split up args
-				var split = searchField.text.Split(';');
-				IEnumerable<SongEntry> songsOut = SongContainer.Songs;
-
-				// Go through them all
-				bool searched = false;
-				foreach (var arg in split) {
-					if (arg.StartsWith("artist:")) {
-						// Artist filter
-						var artist = arg[7..];
-						songsOut = SongContainer.Songs
-							.Where(i => RemoveDiacriticsAndArticle(i.Artist) == RemoveDiacriticsAndArticle(artist));
-					} else if (arg.StartsWith("source:")) {
-						// Source filter
-						var source = arg[7..];
-						songsOut = SongContainer.Songs
-							.Where(i => i.Source?.ToLower() == source.ToLower());
-					} else if (arg.StartsWith("album:")) {
-						// Album filter
-						var album = arg[6..];
-						songsOut = SongContainer.Songs
-							.Where(i => RemoveDiacritics(i.Album) == RemoveDiacritics(album));
-					} else if (arg.StartsWith("charter:")) {
-						// Charter filter
-						var charter = arg[8..];
-						songsOut = SongContainer.Songs
-							.Where(i => i.Charter?.ToLower() == charter.ToLower());
-					} else if (arg.StartsWith("year:")) {
-						// Year filter
-						var year = arg[5..];
-						songsOut = SongContainer.Songs
-							.Where(i => i.Year?.ToLower() == year.ToLower());
-					} else if (arg.StartsWith("genre:")) {
-						// Genre filter
-						var genre = arg[6..];
-						songsOut = SongContainer.Songs
-							.Where(i => i.Genre?.ToLower() == genre.ToLower());
-					} else if (arg.StartsWith("instrument:")) {
-						// Instrument filter
-						var instrument = arg[11..];
-						/*f (instrument == "band") {
-							songsOut = SongContainer.Songs
-								.Where(i => i.BandDifficulty >= 0);
-						} else {
-							songsOut = SongContainer.Songs
-								.Where(i => i.HasInstrument(InstrumentHelper.FromStringName(instrument)));
-						}*/
-						songsOut = instrument switch {
-							"band" => SongContainer.Songs.Where(i => i.BandDifficulty >= 0),
-							"vocals" => SongContainer.Songs.Where(i => i.VocalParts < 2),
-							"harmVocals" => SongContainer.Songs.Where(i => i.VocalParts >= 2),
-							_ => SongContainer.Songs.Where(i =>
-								i.HasInstrument(InstrumentHelper.FromStringName(instrument))),
-						};
-					} else if (!searched) {
-						// Search
-						searched = true;
-						songsOut = songsOut
-							.Select(i => new { score = Search(arg, i), songInfo = i })
-							.Where(i => i.score >= 0)
-							.OrderBy(i => i.score)
-							.Select(i => i.songInfo);
-					}
-				}
-
-				// Sort
-				if (!searched) {
-					// songsOut = songsOut.OrderBy(song => GetSortName(song));
-					songsOut = songsOut.OrderBy(OrderBy());
-				}
-
-				// Add header
-				_songs = songsOut.Select(i => new SongViewType(i)).Cast<ViewType>().ToList();
-				_songs.Insert(0, new CategoryViewType(
-					"SEARCH RESULTS",
-					$"<#00B6F5><b>{_songs.Count}</b> <#006488>{(_songs.Count == 1 ? "SONG" : "SONGS")}"
-				));
+				AddAllSongs();
+				AddSongsCount();
+				AddAllReccomendedSongs();
+				AddReccommendendSongsHeader();
+				AddRandomSongHeader();
 			}
 
+			TryToRemoveHeaders();
+			SetSelectedIndex();
+			UpdateIndex();
+			UpdateSongViews();
+			UpdateScrollbar();
+			AddSectionHeaders();
+		}
+
+		private void SetRecommendedSongs(){
+			if (_recommendedSongs != null){
+				return;
+			}
+
+			_recommendedSongs = new();
+			
+			if (SongContainer.Songs.Count > 0) {
+				FillRecommendedSongs();
+			}
+		}
+
+		private void AddAllSongs(){
+			_songs = SongContainer.Songs
+				.OrderBy(OrderBy())
+				.Select(i => new SongViewType(i))
+				.Cast<ViewType>()
+				.ToList();
+		}
+
+		private void AddSongsCount(){
+			var count = _songs.Count;
+
+			_songs.Insert(0, new CategoryViewType(
+				"ALL SONGS",
+				$"<#00B6F5><b>{count}</b> <#006488>{(count == 1 ? "SONG" : "SONGS")}",
+				SongContainer.Songs
+			));
+		}
+
+		private void AddAllReccomendedSongs(){
+			foreach (var song in _recommendedSongs) {
+				_songs.Insert(0, new SongViewType(song));
+			}
+		}
+
+		private void AddReccommendendSongsHeader(){
+			_songs.Insert(0, new CategoryViewType(
+				_recommendedSongs.Count == 1 ? "RECOMMENDED SONG" : "RECOMMENDED SONGS",
+				$"<#00B6F5><b>{_recommendedSongs.Count}</b> <#006488>{(_recommendedSongs.Count == 1 ? "SONG" : "SONGS")}",
+				_recommendedSongs
+			));
+		}
+
+		private void AddRandomSongHeader(){
+			_songs.Insert(0, new ButtonViewType(
+				"RANDOM SONG",
+				"Icon/Random",
+				() => {
+					SelectRandomSong();
+				}
+			));
+		}
+
+		private void AddSectionHeaders() {
+			bool sectionHeadersAreVisible = SectionHeadersAreVisible();
+
+			if(!sectionHeadersAreVisible){
+				return;
+			}
+
+			List<string> sections = SongSorting.Instance.GetSongsFirstLetter();
+			int skip = GetSkip();
+
+			foreach (var section in sections) {
+				AddSectionHeader(section, skip);
+			}
+		}
+
+		private bool SectionHeadersAreVisible(){
+			return _songs.Count >= MIN_SONGS_FOR_SECTION_HEADERS;
+		}
+
+		private void AddSectionHeader(string section, int skip) {
+			var index = SongSorting.Instance.GetIndexOfLetter(_songs, section, skip);
+			
+			_songs.Insert(index, new ButtonViewType(
+				$"<#00B6F5><b>{section}</b><#006488>",
+				"Icon/ChevronDown",
+				() => { }
+			));
+		}
+
+		private void AddFilteredSongs(IEnumerable<SongEntry> songsOut){
+			_songs = songsOut.Select(i => new SongViewType(i)).Cast<ViewType>().ToList();
+		}
+
+		private void AddSearchResultsHeader(){
+			var count = _songs.Count;
+			_songs.Insert(0, new CategoryViewType(
+				"SEARCH RESULTS",
+				$"<#00B6F5><b>{count}</b> <#006488>{(count == 1 ? "SONG" : "SONGS")}"
+			));
+		}
+
+		private void TryToRemoveHeaders(){
 			// Count songs
 			int songCount = 0;
+
 			foreach (var viewType in _songs) {
 				if (viewType is SongViewType) {
 					songCount++;
@@ -420,77 +426,29 @@ namespace YARG.UI.MusicLibrary {
 			if (songCount <= 0) {
 				_songs.Clear();
 			}
+		}
 
-			if (GameManager.Instance.SelectedSong == null) {
-				if (string.IsNullOrEmpty(searchField.text)) {
-					SelectedIndex = 2;
-				} else {
-					SelectedIndex = 1;
-				}
-			} else {
+		private void SetSelectedIndex(){
+			if (GameManager.Instance.SelectedSong != null) {
 				var index = _songs.FindIndex(song => {
 					return song is SongViewType songType && songType.SongEntry == GameManager.Instance.SelectedSong;
 				});
 
 				SelectedIndex = Mathf.Max(1, index);
+				return;
 			}
 
-			UpdateIndex();
-			UpdateSongViews();
-			UpdateScrollbar();
+			var searchBoxHasContent = !string.IsNullOrEmpty(searchField.text);
+
+			if (searchBoxHasContent) {
+					SelectedIndex = 1;
+			} else {
+				SelectedIndex = 2;
+			}
 		}
 
 		private void UpdateIndex(){
 			SongSorting.Instance.UpdateIndex(_songs);
-		}
-
-		private static string RemoveDiacriticsAndArticle(string text){
-			var textWithoutDiacretics = RemoveDiacritics(text);
-			return SongSorting.RemoveArticle(textWithoutDiacretics);
-		}
-
-		private static string RemoveDiacritics(string text) {
-			if (text == null) {
-				return null;
-			}
-
-			var normalizedString = text.ToLowerInvariant().Normalize(NormalizationForm.FormD);
-			var stringBuilder = new StringBuilder(capacity: normalizedString.Length);
-
-			for (int i = 0; i < normalizedString.Length; i++) {
-				char c = normalizedString[i];
-				var unicodeCategory = CharUnicodeInfo.GetUnicodeCategory(c);
-				if (unicodeCategory != UnicodeCategory.NonSpacingMark) {
-					stringBuilder.Append(c);
-				}
-			}
-
-			return stringBuilder
-				.ToString()
-				.Normalize(NormalizationForm.FormC);
-		}
-
-		private int Search(string input, SongEntry songInfo) {
-			string normalizedInput = RemoveDiacritics(input);
-
-			// Get name index
-			string name = songInfo.NameNoParenthesis;
-			int nameIndex = RemoveDiacritics(name).IndexOf(normalizedInput);
-
-			// Get artist index
-			string artist = songInfo.Artist;
-			int artistIndex = RemoveDiacritics(artist).IndexOf(normalizedInput, StringComparison.Ordinal);
-
-			// Return the best search
-			if (nameIndex == -1 && artistIndex == -1) {
-				return -1;
-			} else if (nameIndex == -1) {
-				return artistIndex;
-			} else if (artistIndex == -1) {
-				return nameIndex;
-			} else {
-				return Mathf.Min(nameIndex, artistIndex);
-			}
 		}
 
 		private void FillRecommendedSongs() {
@@ -558,16 +516,22 @@ namespace YARG.UI.MusicLibrary {
 		}
 
 		public void Back() {
-			if (string.IsNullOrEmpty(searchField.text)) {
-				if (SelectedIndex > 2) {
-					SelectedIndex = 2;
-				} else {
-					MainMenu.Instance.ShowMainMenu();
-				}
-			} else {
+			bool searchBoxHasContent = !string.IsNullOrEmpty(searchField.text);
+
+			if (searchBoxHasContent) {
 				ClearSearchBox();
 				UpdateSearch();
+				ResetSearchButton();
+				UpdateNavigationScheme();
+				return;
 			}
+
+			if (SelectedIndex > 2) {
+				SelectedIndex = 2;
+				return;
+			}
+
+			MainMenu.Instance.ShowMainMenu();
 		}
 
 		private void ClearSearchBox() {
@@ -575,49 +539,64 @@ namespace YARG.UI.MusicLibrary {
 			searchField.ActivateInputField();
 		}
 
+		private void ResetSearchButton(){
+			_nextFilter = "Search artist";
+		}
+
 		private void SelectRandomSong(){
-			// Get how many non-song things there are
-			int skip = _songs.Count - SongContainer.Songs.Count;
+			int skip = GetSkip();
 			// Select random between all of the songs
 			SelectedIndex = Random.Range(skip, SongContainer.Songs.Count);
 		}
 
 		private void SelectPreviousSection(){
 			if (CurrentSelection is not SongViewType song) {
+				SelectedIndex--;
 				return;
 			}
 
-			int skip = GetSkip();
+			int firstSongIndex = GetFirstSongIndex();
 
-			if(SongIsRecommendedOrDivision(skip)){
-				SelectedIndex = 1;
+			if(SongIsRecommendedOrDivision(firstSongIndex)){
+				SelectedIndex = GetLastSongIndex(firstSongIndex);
 				return;
 			}
 
-			SelectedIndex = SongSorting.Instance.SelectNewSection(_songs, SelectedIndex, song, skip, SongSorting.PreviousNext.PREVIOUS);
+			SelectedIndex = SongSorting.Instance.SelectNewSection(_songs, SelectedIndex, song, firstSongIndex, SongSorting.PreviousNext.PREVIOUS);
 		}
 
 		private void SelectNextSection(){
 			if (CurrentSelection is not SongViewType song) {
+				SelectedIndex++;
 				return;
 			}
 
-			int skip = GetSkip();
+			int firstSongIndex = GetFirstSongIndex();
 
-			if(SongIsRecommendedOrDivision(skip)){
-				SelectedIndex = skip;
+			if(SongIsRecommendedOrDivision(firstSongIndex)){
+				SelectedIndex = firstSongIndex + 1;//Ad first header
 				return;
 			}
 
-			SelectedIndex = SongSorting.Instance.SelectNewSection(_songs, SelectedIndex, song, skip, SongSorting.PreviousNext.NEXT);
+			SelectedIndex = SongSorting.Instance.SelectNewSection(_songs, SelectedIndex, song, firstSongIndex, SongSorting.PreviousNext.NEXT);
 		}
 
 		private bool SongIsRecommendedOrDivision(int skip){
-			bool recommendedSongsAreVisible = skip == _recommendedSongs.Count + numberOfDivisions;
+			bool recommendedSongsAreVisible = skip == _recommendedSongs.Count + NUMBER_OF_DIVISIONS;
 			return recommendedSongsAreVisible && SelectedIndex < skip;
 		}
 
+		private int GetFirstSongIndex(){
+			return Mathf.Max(1, _songs.Count - SongContainer.Songs.Count - SongSorting.Instance.GetSectionsSize());
+		}
+
+		private int GetLastSongIndex(int skip){
+			string lastSection = SongSorting.Instance.GetLastSection();
+			return SongSorting.Instance.GetIndexOfLetter(_songs, lastSection, skip);
+		}
+
 		private int GetSkip(){
+			// Get how many non-song things there are
 			return Mathf.Max(1, _songs.Count - SongContainer.Songs.Count);
 		}
 

--- a/Assets/Settings/AddressableAssetsData/AssetGroups/Default Local Group.asset
+++ b/Assets/Settings/AddressableAssetsData/AssetGroups/Default Local Group.asset
@@ -92,6 +92,11 @@ MonoBehaviour:
     m_ReadOnly: 0
     m_SerializedLabels: []
     FlaggedDuringContentUpdateRestriction: 0
+  - m_GUID: 4a4ba0f5f6fbdff4ca0556b981ef1d61
+    m_Address: Icon/ChevronDown
+    m_ReadOnly: 0
+    m_SerializedLabels: []
+    FlaggedDuringContentUpdateRestriction: 0
   m_ReadOnly: 0
   m_Settings: {fileID: 11400000, guid: e05274e5aee7ff54bb550557e8a635f2, type: 2}
   m_SchemaSet:


### PR DESCRIPTION
* Headers are only shown if the song list is greater than 30 songs (arbritrary number)
    + TODO: Tweak constant MIN_SONGS_FOR_SECTION_HEADERS

* Added filters to search for songs without a specific instrument 
    + instrument:-guitar 
    + instrument:-bass 
    + instrument:-drums 
    + instrument:-keys 
    + instrument:-vocals 
    + instrument:-band

* The search results are merged
    + source:rb1dlc;source:rb2dlc

* Fixed bug that displayed the following filter incorrectly if the back button was pressed

* SongSelection.cs class refactored
    + SongSearching.cs created