### PR TITLE
No Overstrum Before/After Chart. Drum Freestyle soon to come.

### DIFF
--- a/Assets/Script/PlayMode/AbstractTrack.cs
+++ b/Assets/Script/PlayMode/AbstractTrack.cs
@@ -49,6 +49,7 @@ namespace YARG.PlayMode {
 		protected int hitChartIndex = 0;
 		public NoteInfo CurrentNote => 
 			hitChartIndex < Chart.Count ? Chart[hitChartIndex] : null;
+		public bool CurrentlyInChart => Chart.Count >= 0 && HitMarginStartTime >= Chart[0].time && HitMarginEndTime < Chart[^1].time;
 
 		protected int currentBeatIndex = 0;
 

--- a/Assets/Script/PlayMode/DrumsTrack.cs
+++ b/Assets/Script/PlayMode/DrumsTrack.cs
@@ -221,26 +221,33 @@ namespace YARG.PlayMode {
 		}
 
 		private void UpdateInput() {
+			
+			//Disables overstrums if chart ended/hasn't started
+			if(!CurrentlyInChart) {
+				return;
+			}
+			
 			// Handle misses (multiple a frame in case of lag)
 			while (HitMarginEndTime > expectedHits.PeekOrNull()?[0].time) {
-				var missedChord = expectedHits.Dequeue();
+					var missedChord = expectedHits.Dequeue();
 
-				// Call miss for each component
-				foreach (var hit in missedChord) {
-					hitChartIndex++;
+					// Call miss for each component
+					foreach (var hit in missedChord) {
+						hitChartIndex++;
 
-					// The player should not be penalized for missing activator notes
-					if (hit.isActivator) {
-						continue;
+						// The player should not be penalized for missing activator notes
+						if (hit.isActivator) {
+							continue;
+						}
+
+						Combo = 0;
+						missedAnyNote = true;
+						notePool.MissNote(hit);
+						StopAudio = true;
 					}
-
-					Combo = 0;
-					missedAnyNote = true;
-					notePool.MissNote(hit);
-					StopAudio = true;
-				}
 			}
 		}
+		
 
 		protected override void PauseToggled(bool pause) {
 			if (!pause) {
@@ -306,6 +313,11 @@ namespace YARG.PlayMode {
 				}
 			}
 
+			//Disables overstrums if chart ended/hasn't started
+			if(!CurrentlyInChart) {
+				return;
+			}
+			
 			// Overstrum if no expected
 			if (expectedHits.Count <= 0) {
 				Combo = 0;

--- a/Assets/Script/PlayMode/DrumsTrack.cs
+++ b/Assets/Script/PlayMode/DrumsTrack.cs
@@ -221,11 +221,11 @@ namespace YARG.PlayMode {
 		}
 
 		private void UpdateInput() {
-			//Disables overstrums if chart ended/hasn't started
-			if(!CurrentlyInChart) {
+			// Ignore inputs until the first note enters the hit window
+			if (!CurrentlyInChart) {
 				return;
 			}
-			
+
 			// Handle misses (multiple a frame in case of lag)
 			while (HitMarginEndTime > expectedHits.PeekOrNull()?[0].time) {
 				var missedChord = expectedHits.Dequeue();
@@ -311,11 +311,11 @@ namespace YARG.PlayMode {
 				}
 			}
 
-			//Disables overstrums if chart ended/hasn't started
-			if(!CurrentlyInChart) {
+			// Ignore inputs until the first note enters the hit window
+			if (!CurrentlyInChart) {
 				return;
 			}
-			
+
 			// Overstrum if no expected
 			if (expectedHits.Count <= 0) {
 				Combo = 0;

--- a/Assets/Script/PlayMode/DrumsTrack.cs
+++ b/Assets/Script/PlayMode/DrumsTrack.cs
@@ -221,7 +221,6 @@ namespace YARG.PlayMode {
 		}
 
 		private void UpdateInput() {
-			
 			//Disables overstrums if chart ended/hasn't started
 			if(!CurrentlyInChart) {
 				return;
@@ -229,25 +228,24 @@ namespace YARG.PlayMode {
 			
 			// Handle misses (multiple a frame in case of lag)
 			while (HitMarginEndTime > expectedHits.PeekOrNull()?[0].time) {
-					var missedChord = expectedHits.Dequeue();
+				var missedChord = expectedHits.Dequeue();
 
-					// Call miss for each component
-					foreach (var hit in missedChord) {
-						hitChartIndex++;
+				// Call miss for each component
+				foreach (var hit in missedChord) {
+					hitChartIndex++;
 
-						// The player should not be penalized for missing activator notes
-						if (hit.isActivator) {
-							continue;
-						}
-
-						Combo = 0;
-						missedAnyNote = true;
-						notePool.MissNote(hit);
-						StopAudio = true;
+					// The player should not be penalized for missing activator notes
+					if (hit.isActivator) {
+						continue;
 					}
+
+					Combo = 0;
+					missedAnyNote = true;
+					notePool.MissNote(hit);
+					StopAudio = true;
+				}
 			}
 		}
-		
 
 		protected override void PauseToggled(bool pause) {
 			if (!pause) {

--- a/Assets/Script/PlayMode/FiveFretTrack.cs
+++ b/Assets/Script/PlayMode/FiveFretTrack.cs
@@ -195,6 +195,11 @@ namespace YARG.PlayMode {
 		}
 
 		private void UpdateInput() {
+			//Disables overstrums if chart ended/hasn't started
+			if(!CurrentlyInChart) {
+				return;
+			}
+
 			// Only want to decrease strum leniency on frames where we didn't strum
 			bool strummedCurrentNote = false;
 			bool strumLeniencyEnded = false;
@@ -216,20 +221,20 @@ namespace YARG.PlayMode {
 
 
 			// Handle misses (multiple a frame in case of lag)
-			while (HitMarginEndTime > expectedHits.PeekOrNull()?[0].time) {
-				var missedChord = expectedHits.Dequeue();
-				ResetAllowedChordGhosts();
-				// Call miss for each component
-				Combo = 0;
-				missedAnyNote = true;
-				StopAudio = true;
-				lastHitNote = null;
-				foreach (var hit in missedChord) {
-					hitChartIndex++;
-					notePool.MissNote(hit);
-					if (hit.fret < 5) extendedSustain[hit.fret] = false;
-				}
-				allowedOverstrums.Clear(); // Disallow all overstrums upon missing
+			while (HitMarginEndTime > expectedHits.PeekOrNull()?[0].time) {	
+					var missedChord = expectedHits.Dequeue();
+					ResetAllowedChordGhosts();
+					// Call miss for each component
+					Combo = 0;
+					missedAnyNote = true;
+					StopAudio = true;
+					lastHitNote = null;
+					foreach (var hit in missedChord) {
+						hitChartIndex++;
+						notePool.MissNote(hit);
+						if (hit.fret < 5) extendedSustain[hit.fret] = false;
+					}
+					allowedOverstrums.Clear(); // Disallow all overstrums upon missing
 			}
 
 			if (expectedHits.Count <= 0) {
@@ -429,6 +434,7 @@ namespace YARG.PlayMode {
 				}
 			}
 		}
+		
 
 		private void RemoveOldAllowedOverstrums() {
 			// Remove all old allowed overstrums
@@ -612,6 +618,11 @@ namespace YARG.PlayMode {
 
 			frets[fret].SetPressed(pressed);
 
+			//Disables overstrums if chart ended/hasn't started
+			if(!CurrentlyInChart) {
+				return;
+			}
+			
 			if (pressed) {
 				// Let go of held notes if wrong note pressed
 				if (!IsExtendedSustain()) { // Unless it's extended sustains

--- a/Assets/Script/PlayMode/FiveFretTrack.cs
+++ b/Assets/Script/PlayMode/FiveFretTrack.cs
@@ -689,6 +689,11 @@ namespace YARG.PlayMode {
 			latestInput = CurrentTime;
 			latestInputIsStrum = true;
 
+			// Ignore inputs until the first note enters the hit window
+			if (!CurrentlyInChart) {
+				return;
+			}
+
 			// Strum leniency already active and another strum inputted, a double strum occurred (must overstrum)
 			if (strumLeniency > 0f) {
 				UpdateOverstrums();

--- a/Assets/Script/PlayMode/FiveFretTrack.cs
+++ b/Assets/Script/PlayMode/FiveFretTrack.cs
@@ -578,6 +578,13 @@ namespace YARG.PlayMode {
 			latestInput = CurrentTime;
 			latestInputIsStrum = false;
 
+			frets[fret].SetPressed(pressed);
+
+			// Ignore inputs until the first note enters the hit window
+			if (!CurrentlyInChart) {
+				return;
+			}
+
 			// Should it check ghosting?
 			if (SettingsManager.Settings.AntiGhosting.Data && allowedGhosts > 0 && pressed && hitChartIndex > 0) {
 				bool checkGhosting = true;
@@ -613,13 +620,6 @@ namespace YARG.PlayMode {
 						}
 					}
 				}
-			}
-
-			frets[fret].SetPressed(pressed);
-
-			//Disables overstrums if chart ended/hasn't started
-			if(!CurrentlyInChart) {
-				return;
 			}
 			
 			if (pressed) {

--- a/Assets/Script/PlayMode/FiveFretTrack.cs
+++ b/Assets/Script/PlayMode/FiveFretTrack.cs
@@ -221,20 +221,20 @@ namespace YARG.PlayMode {
 
 
 			// Handle misses (multiple a frame in case of lag)
-			while (HitMarginEndTime > expectedHits.PeekOrNull()?[0].time) {	
-					var missedChord = expectedHits.Dequeue();
-					ResetAllowedChordGhosts();
-					// Call miss for each component
-					Combo = 0;
-					missedAnyNote = true;
-					StopAudio = true;
-					lastHitNote = null;
-					foreach (var hit in missedChord) {
-						hitChartIndex++;
-						notePool.MissNote(hit);
-						if (hit.fret < 5) extendedSustain[hit.fret] = false;
-					}
-					allowedOverstrums.Clear(); // Disallow all overstrums upon missing
+			while (HitMarginEndTime > expectedHits.PeekOrNull()?[0].time) {
+				var missedChord = expectedHits.Dequeue();
+				ResetAllowedChordGhosts();
+				// Call miss for each component
+				Combo = 0;
+				missedAnyNote = true;
+				StopAudio = true;
+				lastHitNote = null;
+				foreach (var hit in missedChord) {
+					hitChartIndex++;
+					notePool.MissNote(hit);
+					if (hit.fret < 5) extendedSustain[hit.fret] = false;
+				}
+				allowedOverstrums.Clear(); // Disallow all overstrums upon missing
 			}
 
 			if (expectedHits.Count <= 0) {
@@ -434,7 +434,6 @@ namespace YARG.PlayMode {
 				}
 			}
 		}
-		
 
 		private void RemoveOldAllowedOverstrums() {
 			// Remove all old allowed overstrums


### PR DESCRIPTION
New code stops combo breaks before the chart starts and after the code ends. (All credit for that goes to TheNathannator/drumbs, I just kinda put it together)

Works for both 5 Fret Guitar and Drums, hasn't yet been implemented into Real Guitar.

This code will be reused later for Freestyle Drums, however I haven't yet committed any of that since it's using non-original sound effects for the time being. Once I can get original samples, either by myself or through someone on the server, I'll start pushing the code for that.