### PR TITLE
Various Microphone/Vocals fixes

### DIFF
--- a/Assets/Script/Audio/Bass/BassAudioManager.cs
+++ b/Assets/Script/Audio/Bass/BassAudioManager.cs
@@ -86,6 +86,8 @@ namespace YARG.Audio.BASS {
 			Bass.PlaybackBufferLength = 75;
 			Bass.DeviceNonStop = true;
 
+			// Affects Windows only. Forces device names to be in UTF-8 on Windows rather than ANSI.
+			Bass.Configure(Configuration.UnicodeDeviceInformation, true);
 			Bass.Configure(Configuration.TruePlayPosition, 0);
 			Bass.Configure(Configuration.UpdateThreads, 2);
 			Bass.Configure(Configuration.FloatDSP, true);
@@ -138,15 +140,24 @@ namespace YARG.Audio.BASS {
 		public IList<IMicDevice> GetAllInputDevices() {
 			var mics = new List<IMicDevice>();
 
+			var typeWhitelist = new List<DeviceType> {
+				DeviceType.Headset,
+				DeviceType.Digital,
+				DeviceType.Line,
+				DeviceType.Headphones,
+				DeviceType.Microphone,
+			};
+
 			for (int deviceIndex = 0; Bass.RecordGetDeviceInfo(deviceIndex, out var info); deviceIndex++) {
 				if (!info.IsEnabled) {
 					continue;
 				}
 
-				// We do not check the device type since there are too many that a recording device can be,
-				// instead we only exclude loopback devices
+				//Debug.Log($"Device {deviceIndex}: Name: {info.Name}. Type: {info.Type}. IsLoopback: {info.IsLoopback}.");
+
+				// Check if type is in whitelist
 				// The "Default" device is also excluded here since we want the user to explicitly pick which microphone to use
-				if (info.IsLoopback || info.Name == "Default") {
+				if (!typeWhitelist.Contains(info.Type) || info.Name == "Default") {
 					continue;
 				}
 

--- a/Assets/Script/Audio/Bass/BassMicDevice.cs
+++ b/Assets/Script/Audio/Bass/BassMicDevice.cs
@@ -61,7 +61,7 @@ namespace YARG.Audio {
 			Bass.RecordInit(_deviceId);
 			Bass.RecordGetInfo(out var info);
 
-			const BassFlags flags = BassFlags.Float;
+			const BassFlags flags = BassFlags.Default;
 
 			// We want to start recording immediately because of device context switching and device numbers.
 			// If we initialize the device but don't record immediately, the device number might change and we'll be recording from the wrong device.
@@ -71,7 +71,7 @@ namespace YARG.Audio {
 				// If we failed to start recording, we need to return the error code.
 				_initialized = false;
 				Debug.LogError($"Failed to start recording: {Bass.LastError}");
-				return (int) Bass.LastError;;
+				return (int) Bass.LastError;
 			}
 
 			int lowEqHandle = Bass.ChannelSetFX(_processedRecordHandle, EffectType.PeakEQ, 0);
@@ -87,7 +87,7 @@ namespace YARG.Audio {
 				fGain = -10f
 			});
 
-			_monitorPlaybackHandle = Bass.CreateStream(44100, info.Channels, BassFlags.Float, StreamProcedureType.Push);
+			_monitorPlaybackHandle = Bass.CreateStream(44100, info.Channels, flags, StreamProcedureType.Push);
 			if(_monitorPlaybackHandle == 0) {
 				_initialized = false;
 				Debug.LogError($"Failed to create monitor stream: {Bass.LastError}");
@@ -153,13 +153,22 @@ namespace YARG.Audio {
 		}
 
 		private unsafe void CalculatePitchAndAmplitude(IntPtr buffer, int byteLength) {
-			int length = byteLength / sizeof(float);
-			var bufferSpan = new ReadOnlySpan<float>((float*) buffer, length);
+			int sampleCount = byteLength / sizeof(short);
+			float* floatBuffer = stackalloc float[sampleCount];
+
+			// Convert 16 bit buffer to floats
+			// If this isn't 16 bit god knows what device they're using.
+			var shortBufferSpan = new ReadOnlySpan<short>((short*) buffer, sampleCount);
+			for (int i = 0; i < sampleCount; i++) {
+				floatBuffer[i] = shortBufferSpan[i] / 32768f;
+			}
+
+			var bufferSpan = new ReadOnlySpan<float>(floatBuffer, sampleCount);
 
 			// Calculate the root mean square
 			float sum = 0f;
 			int count = 0;
-			for (int i = 0; i < length; i += 4, count++) {
+			for (int i = 0; i < sampleCount; i += 4, count++) {
 				sum += bufferSpan[i] * bufferSpan[i];
 			}
 			sum = Mathf.Sqrt(sum / count);


### PR DESCRIPTION
Fixes the `ExecutionEngineException: String conversion error: Illegal byte sequence encounted in the input.` exception. By default on Windows, BASS will retrieve device names in ANSI, even if they are Unicode names (other platforms always use Unicode). BASS has a config option to use Unicode on Windows so I enabled that.

Changed the device list to use a whitelist of types instead of including all non-loopback devices. The list may not be completely exhaustive yet but it excludes most devices which aren't recording devices.

Fixed the `SampleFormat` error when trying to initialise a microphone (particularly on Linux). I believe this is caused by Linux/devices on Linux not supporting floating point sample recording. Instead it now uses standard 16-bit samples and does the floating point conversion manually for pitch detection logic