### PR TITLE
Properly fix solos, and fix Pro Drums/5-lane drums SP/solos/activations not showing up

### DIFF
--- a/Assets/Script/Obsolete/Data/YargChart.cs
+++ b/Assets/Script/Obsolete/Data/YargChart.cs
@@ -124,7 +124,7 @@ namespace YARG.Data
 
 #pragma warning restore format
 
-        private List<MoonSong.MoonInstrument> _loadedEvents = new();
+        private List<string> _loadedEvents = new();
 
         public List<EventInfo> events = new();
         public List<Beat> beats = new();
@@ -251,14 +251,14 @@ namespace YARG.Data
                 notes[(int) diff] = loader.GetNotesFromChart(_song, diff);
             }
 
-            if (_loadedEvents.Contains(instrument))
+            if (_loadedEvents.Contains(instrumentName))
             {
                 return notes;
             }
 
             events.AddRange(loader.GetEventsFromChart(_song));
             events.Sort((e1, e2) => e1.time.CompareTo(e2.time));
-            _loadedEvents.Add(instrument);
+            _loadedEvents.Add(instrumentName);
 
             return notes;
         }

--- a/Assets/Script/Track/AbstractTrack.cs
+++ b/Assets/Script/Track/AbstractTrack.cs
@@ -271,7 +271,7 @@ namespace YARG.PlayMode
             // Solos and SP cannot share notes, so we can save some iteration time and only go start-to-end once overall
             int spNoteIndex = 0;
             int soloNoteIndex = 0;
-            bool chordsAreSingleNote = player.chosenInstrument is "drums" or "realDrums" or "ghDrums";
+            bool chordsAreSingleNote = player.chosenInstrument is not ("drums" or "realDrums" or "ghDrums");
             foreach (var eventInfo in Play.Instance.chart.events)
             {
                 if (eventInfo.name == spName)

--- a/Assets/Script/Track/DrumsTrack.cs
+++ b/Assets/Script/Track/DrumsTrack.cs
@@ -464,6 +464,12 @@ namespace YARG.PlayMode
             notePool.HitNote(hit);
             StopAudio = false;
 
+            // Solo stuff
+            if (soloInProgress)
+            {
+                soloNotesHit++;
+            }
+
             // Play particles
             if (hit.fret != kickIndex)
             {

--- a/Assets/Script/Track/FiveFretTrack.cs
+++ b/Assets/Script/Track/FiveFretTrack.cs
@@ -464,14 +464,14 @@ namespace YARG.PlayMode
             StopAudio = false;
             lastHitNote = chord;
 
+            // Solo stuff
+            if (soloInProgress)
+            {
+                soloNotesHit++;
+            }
+
             foreach (var hit in chord)
             {
-                // Solo stuff
-                if (soloInProgress)
-                {
-                    soloNotesHit++;
-                }
-
                 hitChartIndex++;
                 // Hit notes
                 notePool.HitNote(hit);


### PR DESCRIPTION
Solos not having their note count set correctly was an error on my part lol, got the track check inverted. Drums also just did not keep track of how many notes were hit during solos, so I threw that in too.

SP/solos/activations not showing up was an oversight from a check that prevents events from being loaded for the same track twice, this has been addressed.