### PR TITLE
Fix 404 not found error

### DIFF
--- a/Assets/Script/ThirdParty/UpdateChecker.cs
+++ b/Assets/Script/ThirdParty/UpdateChecker.cs
@@ -42,7 +42,7 @@ namespace YARG
                 // Setup request
                 var request =
                     (HttpWebRequest) WebRequest.Create(
-                        "https://api.github.com/repos/EliteAsian123/YARG/releases/latest");
+                        "https://api.github.com/repos/YARC-Official/YARG/releases/latest");
                 request.UserAgent = "YARG";
 
                 // Sets up a cancellation token to cancel the request if needed (such as menu being hidden)


### PR DESCRIPTION
Fixes 404 not found error when trying to test play in unity when it checks for game updates. If you open the old URL in a browser, itl also do an error 404 not found. Not entirely sure why this hasnt been changed (?)
![image](https://github.com/YARC-Official/YARG/assets/59181698/8ddce9a3-d26b-497d-abef-51e9a6ddac34)
