### PR TITLE
Fixed race condition on beat subscribe

### DIFF
--- a/Assets/Script/Gameplay/BeatEventManager.cs
+++ b/Assets/Script/Gameplay/BeatEventManager.cs
@@ -100,9 +100,11 @@ namespace YARG.Gameplay
                 while (_sync.TickToTime(state.LastTick + ticksPerNote) <= GameManager.SongTime + state.Info.Offset)
                 {
                     state.LastTick += ticksPerNote;
-                    if (actionDone) continue;
-                    action();
-                    actionDone = true;
+                    if (!actionDone)
+                    {
+                        action();
+                        actionDone = true;
+                    }
                 }
             }
         }

--- a/Assets/Script/Gameplay/BeatEventManager.cs
+++ b/Assets/Script/Gameplay/BeatEventManager.cs
@@ -46,7 +46,7 @@ namespace YARG.Gameplay
 
         public void Subscribe(Action action, Info info)
         {
-            _states.Add(new State(info), state);
+            _states.Add(action, new State(info));
         }
 
         public void Unsubscribe(Action action)

--- a/Assets/Script/Gameplay/BeatEventManager.cs
+++ b/Assets/Script/Gameplay/BeatEventManager.cs
@@ -46,7 +46,22 @@ namespace YARG.Gameplay
 
         public void Subscribe(Action action, Info info)
         {
-            _states.Add(action, new State(info));
+            var thing = new State(info);
+            var timeSigs = _sync.TimeSignatures;
+            var currentTimeSig = timeSigs[_currentTimeSigIndex];
+
+            //I just lifted this part from Update()
+            while (_nextTimeSigIndex < timeSigs.Count && timeSigs[_nextTimeSigIndex].Time < GameManager.InputTime)
+            {
+                _currentTimeSigIndex++;
+                _nextTimeSigIndex++;
+            }           
+            uint ticksPerWholeNote = (uint) (_sync.Resolution * ((double) 4 / currentTimeSig.Denominator) * 4);
+            uint ticksPerNote = (uint) (ticksPerWholeNote * thing.Info.Note);
+
+            //calculates and adds the number of missed ticks 
+            thing.LastTick =  (uint)(GameManager.SongTime / _sync.TickToTime(ticksPerNote + (uint)thing.Info.Offset) )* ticksPerNote;
+            _states.Add(action, thing);
         }
 
         public void Unsubscribe(Action action)


### PR DESCRIPTION
Previously, when subscribing to BeatEventManger after the song started, the action would fire a billion times in a second to catch up to the current song tick, now it calculates and adds whatever was missed before subscribing.