### PR TITLE
Fixed potential enumeration problem in foreach loop

### DIFF
--- a/Assets/Script/Gameplay/BeatEventManager.cs
+++ b/Assets/Script/Gameplay/BeatEventManager.cs
@@ -43,15 +43,17 @@ namespace YARG.Gameplay
         private int _nextTimeSigIndex = 1;
 
         private readonly Dictionary<Action, State> _states = new();
+        private readonly List<Action> _removeStates = new();
+        private readonly List<(Action, State)> _addStates = new();
 
         public void Subscribe(Action action, Info info)
         {
-            _states.Add(action, new State(info));
+            _addStates.Add(action, new State(info));
         }
 
         public void Unsubscribe(Action action)
         {
-            _states.Remove(action);
+            _removeStates.Remove(action);
         }
 
         public void ResetTimers()
@@ -86,6 +88,19 @@ namespace YARG.Gameplay
             // Get the time signature
             var currentTimeSig = timeSigs[_currentTimeSigIndex];
 
+            // Add and remove states from the _state list outside the main loop to prevent enumeration errors. (aka removing things from the list while it loops)
+            foreach (var (action, state) in _addStates)
+            {
+                _states.Add(action, state);
+            }
+            _addStates.Clear();
+
+            foreach (var action in _removeStates)
+            {
+                _states.Remove(action);
+            }
+            _removeStates.Clear();
+            
             // Update per action now
             foreach (var (action, state) in _states)
             {


### PR DESCRIPTION
Add and remove states from the _state list outside the main loop to prevent enumeration errors. (aka removing things from the list while it loops)