### PR TITLE
Split out song playback and beat event handling into reusable classes

### DIFF
--- a/Assets/Scenes/Gameplay.unity
+++ b/Assets/Scenes/Gameplay.unity
@@ -1262,7 +1262,6 @@ GameObject:
   - component: {fileID: 318454372}
   - component: {fileID: 318454371}
   - component: {fileID: 318454374}
-  - component: {fileID: 318454375}
   - component: {fileID: 318454376}
   - component: {fileID: 318454373}
   - component: {fileID: 318454377}
@@ -1340,18 +1339,6 @@ MonoBehaviour:
   _pauseMenu: {fileID: 1323155442}
   _practiceHud: {fileID: 1316571463}
   _scoreDisplayObject: {fileID: 310620824}
---- !u!114 &318454375
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 318454370}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f3e2924007c5402abc038da7e0d3bb39, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &318454376
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Script/Gameplay/BeatEventManager.cs.meta
+++ b/Assets/Script/Gameplay/BeatEventManager.cs.meta
@@ -1,3 +1,0 @@
-﻿fileFormatVersion: 2
-guid: f3e2924007c5402abc038da7e0d3bb39
-timeCreated: 1692218447

--- a/Assets/Script/Gameplay/GameManager.cs
+++ b/Assets/Script/Gameplay/GameManager.cs
@@ -581,7 +581,10 @@ namespace YARG.Gameplay
         }
 
         public void SetSongTime(double time, double delayTime = SONG_START_DELAY)
-            => _songRunner.SetSongTime(time, delayTime);
+        {
+            _songRunner.SetSongTime(time, delayTime);
+            BeatEventHandler.ResetTimers();
+        }
 
         public void SetSongSpeed(float speed) => _songRunner.SetSongSpeed(speed);
         public void AdjustSongSpeed(float deltaSpeed) => _songRunner.AdjustSongSpeed(deltaSpeed);

--- a/Assets/Script/Gameplay/GameManager.cs
+++ b/Assets/Script/Gameplay/GameManager.cs
@@ -584,7 +584,7 @@ namespace YARG.Gameplay
             => _songRunner.SetSongTime(time, delayTime);
 
         public void SetSongSpeed(float speed) => _songRunner.SetSongSpeed(speed);
-        public void AdjustSongSpeed(float deltaSpeed) => _songRunner.SetSongSpeed(deltaSpeed);
+        public void AdjustSongSpeed(float deltaSpeed) => _songRunner.AdjustSongSpeed(deltaSpeed);
 
         public void Pause(bool showMenu = true)
         {

--- a/Assets/Script/Gameplay/GameManager.cs
+++ b/Assets/Script/Gameplay/GameManager.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
@@ -131,8 +131,9 @@ namespace YARG.Gameplay
 
         private SongRunner _songRunner;
 
+        public BeatEventHandler BeatEventHandler { get; private set; }
+
         public PracticeManager  PracticeManager  { get; private set; }
-        public BeatEventManager BeatEventManager { get; private set; }
         public BackgroundManager BackgroundManager { get; private set; }
 
         public SongMetadata Song  { get; private set; }
@@ -178,7 +179,6 @@ namespace YARG.Gameplay
         {
             // Set references
             PracticeManager = GetComponent<PracticeManager>();
-            BeatEventManager = GetComponent<BeatEventManager>();
             BackgroundManager = GetComponent<BackgroundManager>();
 
             _yargPlayers = PlayerContainer.Players;
@@ -307,8 +307,9 @@ namespace YARG.Gameplay
             // Skip the rest if paused
             if (_songRunner.Paused) return;
 
-            // Update timing info
+            // Update handlers
             _songRunner.Update();
+            BeatEventHandler.Update(_songRunner.SongTime);
 
             // Update players
             int totalScore = 0;
@@ -481,6 +482,7 @@ namespace YARG.Gameplay
             if (_loadState != LoadFailureState.None)
                 return;
 
+            BeatEventHandler = new(Chart.SyncTrack);
             _chartLoaded?.Invoke(Chart);
         }
 

--- a/Assets/Script/Gameplay/GameManager.cs
+++ b/Assets/Script/Gameplay/GameManager.cs
@@ -655,7 +655,7 @@ namespace YARG.Gameplay
             => _songRunner.GetRelativeInputTime(timeFromInputSystem);
 
         public double GetCalibratedRelativeInputTime(double timeFromInputSystem)
-            => _songRunner.GetRelativeInputTime(timeFromInputSystem);
+            => _songRunner.GetCalibratedRelativeInputTime(timeFromInputSystem);
 
         private void EndSong()
         {

--- a/Assets/Script/Gameplay/GameManager.cs
+++ b/Assets/Script/Gameplay/GameManager.cs
@@ -244,11 +244,11 @@ namespace YARG.Gameplay
             }
 
             // Initialize song runner
-            float songSpeed = GlobalVariables.Instance.SongSpeed;
-            double videoCalibration = -SettingsManager.Settings.VideoCalibration.Data / 1000.0;
-            double audioCalibration = (-SettingsManager.Settings.AudioCalibration.Data / 1000.0) - videoCalibration;
-            double songOffset = -Song.SongOffsetSeconds;
-            _songRunner = new SongRunner(songSpeed, videoCalibration, audioCalibration, songOffset);
+            _songRunner = new SongRunner(
+                GlobalVariables.Instance.SongSpeed,
+                SettingsManager.Settings.AudioCalibration.Data,
+                SettingsManager.Settings.VideoCalibration.Data,
+                Song.SongOffsetSeconds);
 
             // Spawn players
             CreatePlayers();
@@ -274,7 +274,7 @@ namespace YARG.Gameplay
 
 #if UNITY_EDITOR
             // Log constant values
-            Debug.Log($"Audio calibration: {audioCalibration}, video calibration: {videoCalibration}, song offset: {songOffset}");
+            Debug.Log($"Audio calibration: {_songRunner.AudioCalibration}, video calibration: {_songRunner.VideoCalibration}, song offset: {_songRunner.SongOffset}");
 #endif
 
             // Loaded, enable updates

--- a/Assets/Script/Gameplay/GameManager.cs
+++ b/Assets/Script/Gameplay/GameManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
@@ -243,15 +243,15 @@ namespace YARG.Gameplay
                 return;
             }
 
-            // Spawn players
-            CreatePlayers();
-
             // Initialize song runner
             float songSpeed = GlobalVariables.Instance.SongSpeed;
             double videoCalibration = -SettingsManager.Settings.VideoCalibration.Data / 1000.0;
             double audioCalibration = (-SettingsManager.Settings.AudioCalibration.Data / 1000.0) - videoCalibration;
             double songOffset = -Song.SongOffsetSeconds;
             _songRunner = new SongRunner(songSpeed, videoCalibration, audioCalibration, songOffset);
+
+            // Spawn players
+            CreatePlayers();
 
             // Listen for menu inputs
             Navigator.Instance.NavigationEvent += OnNavigationEvent;

--- a/Assets/Script/Gameplay/GameManager.cs
+++ b/Assets/Script/Gameplay/GameManager.cs
@@ -619,6 +619,7 @@ namespace YARG.Gameplay
             // Pause the background/venue
             Time.timeScale = 0f;
             BackgroundManager.SetPaused(true);
+            GameStateFetcher.SetPaused(true);
         }
 
         public void Resume(bool inputCompensation = true)
@@ -630,6 +631,7 @@ namespace YARG.Gameplay
             // Unpause the background/venue
             Time.timeScale = 1f;
             BackgroundManager.SetPaused(false);
+            GameStateFetcher.SetPaused(false);
 
             _isReplaySaved = false;
 
@@ -640,6 +642,7 @@ namespace YARG.Gameplay
 
         public void SetPaused(bool paused)
         {
+            // Does not delegate out to _songRunner.SetPaused since we need extra logic
             if (paused)
             {
                 Pause();
@@ -648,8 +651,6 @@ namespace YARG.Gameplay
             {
                 Resume();
             }
-
-            GameStateFetcher.SetPaused(paused);
         }
 
         public void OverridePauseTime(double pauseTime = -1) => _songRunner.OverridePauseTime(pauseTime);

--- a/Assets/Script/Gameplay/GameManager.cs
+++ b/Assets/Script/Gameplay/GameManager.cs
@@ -637,7 +637,15 @@ namespace YARG.Gameplay
 
         public void SetPaused(bool paused)
         {
-            _songRunner.SetPaused(paused);
+            if (paused)
+            {
+                Pause();
+            }
+            else
+            {
+                Resume();
+            }
+
             GameStateFetcher.SetPaused(paused);
         }
 

--- a/Assets/Script/Gameplay/Player/TrackPlayer.cs
+++ b/Assets/Script/Gameplay/Player/TrackPlayer.cs
@@ -154,8 +154,7 @@ namespace YARG.Gameplay.Player
 
         protected virtual void FinishInitialization()
         {
-            GameManager.BeatEventManager.Subscribe(StarpowerBar.PulseBarIfAble,
-                new BeatEventManager.Info(1f / 4f, 0f));
+            GameManager.BeatEventHandler.Subscribe(StarpowerBar.PulseBarIfAble, new(1f / 4f, 0f));
 
             TrackMaterial.Initialize(ZeroFadePosition, FadeSize);
             CameraPositioner.Initialize(Player.CameraPreset);
@@ -318,7 +317,7 @@ namespace YARG.Gameplay.Player
         {
             base.FinishDestruction();
 
-            GameManager.BeatEventManager.Unsubscribe(StarpowerBar.PulseBarIfAble);
+            GameManager.BeatEventHandler.Unsubscribe(StarpowerBar.PulseBarIfAble);
         }
     }
 }

--- a/Assets/Script/Gameplay/Player/TrackPlayer.cs
+++ b/Assets/Script/Gameplay/Player/TrackPlayer.cs
@@ -154,7 +154,7 @@ namespace YARG.Gameplay.Player
 
         protected virtual void FinishInitialization()
         {
-            GameManager.BeatEventHandler.Subscribe(StarpowerBar.PulseBarIfAble, new(1f / 4f, 0f));
+            GameManager.BeatEventHandler.Subscribe(StarpowerBar.PulseBarIfAble, new(1));
 
             TrackMaterial.Initialize(ZeroFadePosition, FadeSize);
             CameraPositioner.Initialize(Player.CameraPreset);

--- a/Assets/Script/Integration/StageKit/StageKitGameplay.cs
+++ b/Assets/Script/Integration/StageKit/StageKitGameplay.cs
@@ -317,7 +317,7 @@ namespace YARG.Integration.StageKit
             foreach (var primitive in _controller.CurrentLightingCue.CuePrimitives)
             {
                 //When a BeatPattern primitive is created, it subscribes its OnBeat to the BeatEventManager.
-                GameManager.BeatEventManager.Unsubscribe(primitive.OnBeat);
+                GameManager.BeatEventHandler.Unsubscribe(primitive.OnBeat);
 
                 primitive.CancellationTokenSource?.Cancel();
             }

--- a/Assets/Script/Integration/StageKit/StageKitLighting.Cues.cs
+++ b/Assets/Script/Integration/StageKit/StageKitLighting.Cues.cs
@@ -42,10 +42,10 @@ namespace YARG.Integration.StageKit
             StageKitLightingController.Instance.SetLed(GREEN, ALL);
             StageKitLightingController.Instance.SetLed(YELLOW, ALL);
 
-            CuePrimitives.Add(new BeatPattern(PatternList1, true, 8.0f));
-            CuePrimitives.Add(new BeatPattern(PatternList2, true, 8.0f));
-            CuePrimitives.Add(new BeatPattern(PatternList3, true, 8.0f));
-            CuePrimitives.Add(new BeatPattern(PatternList4, true, 8.0f));
+            CuePrimitives.Add(new BeatPattern(PatternList1, 0.5f));
+            CuePrimitives.Add(new BeatPattern(PatternList2, 0.5f));
+            CuePrimitives.Add(new BeatPattern(PatternList3, 0.5f));
+            CuePrimitives.Add(new BeatPattern(PatternList4, 0.5f));
         }
     }
 
@@ -76,8 +76,8 @@ namespace YARG.Integration.StageKit
             StageKitLightingController.Instance.SetLed(GREEN, NONE);
             StageKitLightingController.Instance.SetLed(BLUE, NONE);
 
-            CuePrimitives.Add(new BeatPattern(PatternList1));
-            CuePrimitives.Add(new BeatPattern(PatternList2, true, 0.5f));
+            CuePrimitives.Add(new BeatPattern(PatternList1, 4f));
+            CuePrimitives.Add(new BeatPattern(PatternList2, 8f));
         }
     }
 
@@ -108,8 +108,8 @@ namespace YARG.Integration.StageKit
             StageKitLightingController.Instance.SetLed(YELLOW, NONE);
             StageKitLightingController.Instance.SetLed(RED, NONE);
 
-            CuePrimitives.Add(new BeatPattern(PatternList1));
-            CuePrimitives.Add(new BeatPattern(PatternList2, true, 0.5f));
+            CuePrimitives.Add(new BeatPattern(PatternList1, 4f));
+            CuePrimitives.Add(new BeatPattern(PatternList2, 8f));
         }
     }
 
@@ -169,15 +169,15 @@ namespace YARG.Integration.StageKit
             {
                 StageKitLightingController.Instance.SetLed(BLUE, NONE);
                 StageKitLightingController.Instance.SetLed(GREEN, NONE);
-                CuePrimitives.Add(new BeatPattern(LargePatternList1));
-                CuePrimitives.Add(new BeatPattern(LargePatternList2));
+                CuePrimitives.Add(new BeatPattern(LargePatternList1, 4f));
+                CuePrimitives.Add(new BeatPattern(LargePatternList2, 4f));
             }
             else
             {
                 StageKitLightingController.Instance.SetLed(RED, NONE);
                 StageKitLightingController.Instance.SetLed(YELLOW, NONE);
-                CuePrimitives.Add(new BeatPattern(SmallPatternList1));
-                CuePrimitives.Add(new BeatPattern(SmallPatternList2));
+                CuePrimitives.Add(new BeatPattern(SmallPatternList1, 4f));
+                CuePrimitives.Add(new BeatPattern(SmallPatternList2, 4f));
             }
         }
     }
@@ -231,14 +231,14 @@ namespace YARG.Integration.StageKit
                 StageKitLightingController.Instance.SetLed(YELLOW, NONE);
                 StageKitLightingController.Instance.SetLed(BLUE, NONE);
                 StageKitLightingController.Instance.SetLed(GREEN, NONE);
-                CuePrimitives.Add(new BeatPattern(LargePatternList1));
+                CuePrimitives.Add(new BeatPattern(LargePatternList1, 4f));
             }
             else
             {
                 StageKitLightingController.Instance.SetLed(RED, NONE);
-                CuePrimitives.Add(new BeatPattern(SmallPatternList1));
-                CuePrimitives.Add(new BeatPattern(SmallPatternList2));
-                CuePrimitives.Add(new BeatPattern(SmallPatternList3, true, 2.0f));
+                CuePrimitives.Add(new BeatPattern(SmallPatternList1, 4f));
+                CuePrimitives.Add(new BeatPattern(SmallPatternList2, 4f));
+                CuePrimitives.Add(new BeatPattern(SmallPatternList3, 2f));
             }
         }
     }
@@ -302,17 +302,17 @@ namespace YARG.Integration.StageKit
             {
                 StageKitLightingController.Instance.SetLed(GREEN, NONE);
                 //4 times a beats to control on and off because of the 2 different patterns on one color
-                CuePrimitives.Add(new BeatPattern(LargePatternList1, true, 4.0f));
-                CuePrimitives.Add(new BeatPattern(LargePatternList2, true, 4.0f));
-                CuePrimitives.Add(new BeatPattern(LargePatternList3, true, 4.0f));
+                CuePrimitives.Add(new BeatPattern(LargePatternList1, 1f));
+                CuePrimitives.Add(new BeatPattern(LargePatternList2, 1f));
+                CuePrimitives.Add(new BeatPattern(LargePatternList3, 1f));
             }
             else
             {
                 StageKitLightingController.Instance.SetLed(YELLOW, NONE);
                 //4 times a beats to control on and off because of the 2 different patterns on one color
-                CuePrimitives.Add(new BeatPattern(SmallPatternList1, true, 4.0f));
-                CuePrimitives.Add(new BeatPattern(SmallPatternList2, true, 4.0f));
-                CuePrimitives.Add(new BeatPattern(SmallPatternList3, true, 4.0f));
+                CuePrimitives.Add(new BeatPattern(SmallPatternList1, 1f));
+                CuePrimitives.Add(new BeatPattern(SmallPatternList2, 1f));
+                CuePrimitives.Add(new BeatPattern(SmallPatternList3, 1f));
             }
         }
     }
@@ -373,14 +373,14 @@ namespace YARG.Integration.StageKit
             if (StageKitLightingController.Instance.LargeVenue)
             {
                 StageKitLightingController.Instance.SetLed(RED, NONE);
-                CuePrimitives.Add(new BeatPattern(LargePatternList1, true, 2.0f));
-                CuePrimitives.Add(new BeatPattern(LargePatternList2, true, 2.0f));
+                CuePrimitives.Add(new BeatPattern(LargePatternList1, 2f));
+                CuePrimitives.Add(new BeatPattern(LargePatternList2, 2f));
             }
             else
             {
                 StageKitLightingController.Instance.SetLed(BLUE, NONE);
-                CuePrimitives.Add(new BeatPattern(SmallPatternList1, true, 2.0f));
-                CuePrimitives.Add(new BeatPattern(SmallPatternList2, true, 2.0f));
+                CuePrimitives.Add(new BeatPattern(SmallPatternList1, 2f));
+                CuePrimitives.Add(new BeatPattern(SmallPatternList2, 2f));
             }
 
             StageKitLightingController.Instance.SetLed(GREEN, NONE);
@@ -538,8 +538,8 @@ namespace YARG.Integration.StageKit
         {
             StageKitLightingController.Instance.SetLed(GREEN, NONE);
             StageKitLightingController.Instance.SetLed(BLUE, NONE);
-            CuePrimitives.Add(new BeatPattern(PatternList1));
-            CuePrimitives.Add(new BeatPattern(PatternList2, true, 0.5f));
+            CuePrimitives.Add(new BeatPattern(PatternList1, 4f));
+            CuePrimitives.Add(new BeatPattern(PatternList2, 8f));
             // I thought it listens to the next but it doesn't seem to. I'll save this for funky fresh mode
             //new ListenPattern(new List<(int, byte)>(), StageKitLightingPrimitives.ListenTypes.Next);
         }
@@ -571,8 +571,8 @@ namespace YARG.Integration.StageKit
         {
             StageKitLightingController.Instance.SetLed(YELLOW, NONE);
             StageKitLightingController.Instance.SetLed(RED, NONE);
-            CuePrimitives.Add(new BeatPattern(PatternList1));
-            CuePrimitives.Add(new BeatPattern(PatternList2));
+            CuePrimitives.Add(new BeatPattern(PatternList1, 4f));
+            CuePrimitives.Add(new BeatPattern(PatternList2, 4f));
             //new ListenPattern(new List<(int, byte)>(), StageKitLightingPrimitives.ListenTypes.Next);
         }
     }
@@ -664,7 +664,7 @@ namespace YARG.Integration.StageKit
         {
             StageKitLightingController.Instance.SetLed(RED, NONE);
             CuePrimitives.Add(new ListenPattern(PatternList1, ListenTypes.MajorBeat | ListenTypes.MinorBeat));
-            _greenPattern = new BeatPattern(PatternList2, true, 2.0f);
+            _greenPattern = new BeatPattern(PatternList2, 2f);
             CuePrimitives.Add(_greenPattern);
             _greenIsSpinning = true;
             CuePrimitives.Add(new ListenPattern(new (int, byte)[] { (RED, ALL) }, ListenTypes.RedFretDrums, true));
@@ -678,12 +678,12 @@ namespace YARG.Integration.StageKit
             if (_blueOnTwo)
             {
                 CuePrimitives.Add(new BeatPattern(new (int, byte)[] { (BLUE, NONE), (BLUE, ZERO | TWO | FOUR | SIX) },
-                    false));
+                    4f, false));
                 _blueOnTwo = false;
             }
             else
             {
-                CuePrimitives.Add(new BeatPattern(new (int, byte)[] { (BLUE, NONE), (BLUE, TWO | SIX) }, false));
+                CuePrimitives.Add(new BeatPattern(new (int, byte)[] { (BLUE, NONE), (BLUE, TWO | SIX) }, 4f, false));
                 _blueOnTwo = true;
             }
         }
@@ -700,7 +700,7 @@ namespace YARG.Integration.StageKit
             }
             else
             {
-                _greenPattern = new BeatPattern(PatternList2, true, 2.0f);
+                _greenPattern = new BeatPattern(PatternList2, 2f);
                 CuePrimitives.Add(_greenPattern);
             }
 

--- a/Assets/Script/Integration/StageKit/StageKitLighting.Cues.cs
+++ b/Assets/Script/Integration/StageKit/StageKitLighting.Cues.cs
@@ -693,7 +693,7 @@ namespace YARG.Integration.StageKit
             if (StageKitLightingController.Instance.LargeVenue || eventName != BeatlineType.Measure) return;
             if (_greenIsSpinning)
             {
-                _gameManager.BeatEventManager.Unsubscribe(_greenPattern.OnBeat);
+                _gameManager.BeatEventHandler.Unsubscribe(_greenPattern.OnBeat);
                 StageKitLightingController.Instance.CurrentLightingCue.CuePrimitives.Remove(_greenPattern);
 
                 StageKitLightingController.Instance.SetLed(GREEN, ALL);

--- a/Assets/Script/Integration/StageKit/StageKitLighting.Primitives.cs
+++ b/Assets/Script/Integration/StageKit/StageKitLighting.Primitives.cs
@@ -21,8 +21,8 @@ namespace YARG.Integration.StageKit
             _gameManager = Object.FindObjectOfType<GameManager>();
             _continuous = continuous;
             _patternList = patternList;
-            _gameManager.BeatEventManager.Subscribe(OnBeat,
-                new BeatEventManager.Info(1.0f / (timesPerBeat * _patternList.Length), 0f));
+            _gameManager.BeatEventHandler.Subscribe(OnBeat,
+                new(1.0f / (timesPerBeat * _patternList.Length), 0f));
         }
 
         public override void OnBeat()
@@ -35,7 +35,7 @@ namespace YARG.Integration.StageKit
             //they've run once otherwise they pile up.
             if (!_continuous && _patternIndex == _patternList.Length)
             {
-                _gameManager.BeatEventManager.Unsubscribe(OnBeat);
+                _gameManager.BeatEventHandler.Unsubscribe(OnBeat);
                 StageKitLightingController.Instance.CurrentLightingCue.CuePrimitives.Remove(this);
             }
 

--- a/Assets/Script/Integration/StageKit/StageKitLighting.Primitives.cs
+++ b/Assets/Script/Integration/StageKit/StageKitLighting.Primitives.cs
@@ -15,14 +15,14 @@ namespace YARG.Integration.StageKit
         private readonly (int color, byte data)[] _patternList;
         private GameManager _gameManager;
 
-        public BeatPattern((int, byte)[] patternList, bool continuous = true, float timesPerBeat = 1.0f)
+        public BeatPattern((int, byte)[] patternList, float beatsPerCycle, bool continuous = true)
         {
             //Brought to you by Hacky Hack and the Hacktones
             _gameManager = Object.FindObjectOfType<GameManager>();
             _continuous = continuous;
             _patternList = patternList;
-            _gameManager.BeatEventHandler.Subscribe(OnBeat,
-                new(1.0f / (timesPerBeat * _patternList.Length), 0f));
+
+            _gameManager.BeatEventHandler.Subscribe(OnBeat, new(beatsPerCycle / _patternList.Length));
         }
 
         public override void OnBeat()

--- a/Assets/Script/Playback.meta
+++ b/Assets/Script/Playback.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3d6c0f3d0e1dd2641a088ec0743a078a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Script/Playback/BeatEventHandler.cs
+++ b/Assets/Script/Playback/BeatEventHandler.cs
@@ -84,6 +84,20 @@ namespace YARG.Playback
 
         public void Update(double songTime)
         {
+            // Add and remove states from the _state list outside the main loop to prevent enumeration errors.
+            // (aka removing things from the list while it loops)
+            foreach (var (action, state) in _addStates)
+            {
+                _states.Add(action, state);
+            }
+            _addStates.Clear();
+
+            foreach (var action in _removeStates)
+            {
+                _states.Remove(action);
+            }
+            _removeStates.Clear();
+
             // Skip until in the chart
             if (songTime < 0) return;
 
@@ -98,20 +112,6 @@ namespace YARG.Playback
 
             var currentTempo = tempos[_tempoIndex];
             var currentTimeSig = timeSigs[_timeSigIndex];
-
-            // Add and remove states from the _state list outside the main loop to prevent enumeration errors.
-            // (aka removing things from the list while it loops)
-            foreach (var (action, state) in _addStates)
-            {
-                _states.Add(action, state);
-            }
-            _addStates.Clear();
-
-            foreach (var action in _removeStates)
-            {
-                _states.Remove(action);
-            }
-            _removeStates.Clear();
 
             // Update per action now
             foreach (var (action, state) in _states)

--- a/Assets/Script/Playback/BeatEventHandler.cs
+++ b/Assets/Script/Playback/BeatEventHandler.cs
@@ -122,7 +122,7 @@ namespace YARG.Playback
 
                 // Call action
                 bool actionDone = false;
-                while (_sync.TickToTime(state.LastTick + ticksPerEvent, currentTempo) <= songTime + state.Info.Offset)
+                while (_sync.TickToTime(state.LastTick + ticksPerEvent, currentTempo) <= songTime - state.Info.Offset)
                 {
                     state.LastTick += ticksPerEvent;
                     if (!actionDone)

--- a/Assets/Script/Playback/BeatEventHandler.cs.meta
+++ b/Assets/Script/Playback/BeatEventHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9f1bfb58192ec674494628ddb3fde708
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Script/Playback/SongRunner.cs
+++ b/Assets/Script/Playback/SongRunner.cs
@@ -147,13 +147,32 @@ namespace YARG.Playback
         private double _previousInputTime = double.NaN;
         #endregion
 
-        public SongRunner(float songSpeed = 1f, double audioCalibration = 0, double videoCalibration = 0,
+        /// <summary>
+        /// Creates a new song runner with the given speed and calibration values.
+        /// </summary>
+        /// <param name="songSpeed">
+        /// The percentage song speed, where 1f == 100%.
+        /// </param>
+        /// <param name="audioCalibration">
+        /// The audio calibration, in milliseconds.<br/>
+        /// This value is negated and normalized to seconds for more intuitive usage in other code.
+        /// <paramref name="videoCalibration"/> is also applied to keep things visually synced.
+        /// </param>
+        /// <param name="videoCalibration">
+        /// The video calibration, in milliseconds.<br/>
+        /// This value is negated and normalized to seconds for more intuitive usage in other code.
+        /// </param>
+        /// <param name="songOffset">
+        /// The song offset, in seconds.<br/>
+        /// This value is negated for more intuitive usage in other code.
+        /// </param>
+        public SongRunner(float songSpeed = 1f, int audioCalibration = 0, int videoCalibration = 0,
             double songOffset = 0)
         {
             SelectedSongSpeed = songSpeed;
-            AudioCalibration = audioCalibration;
-            VideoCalibration = videoCalibration;
-            SongOffset = songOffset;
+            VideoCalibration = -videoCalibration / 1000.0;
+            AudioCalibration = (-audioCalibration / 1000.0) - VideoCalibration;
+            SongOffset = -songOffset;
 
             // Initialize times
             InitializeSongTime(SongOffset);

--- a/Assets/Script/Playback/SongRunner.cs
+++ b/Assets/Script/Playback/SongRunner.cs
@@ -170,7 +170,12 @@ namespace YARG.Playback
             Dispose(false);
         }
 
-        public void Dispose() => Dispose(true);
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
         private void Dispose(bool disposing)
         {
             // Stop sync thread

--- a/Assets/Script/Playback/SongRunner.cs
+++ b/Assets/Script/Playback/SongRunner.cs
@@ -240,7 +240,7 @@ namespace YARG.Playback
 
             for (; _runSync; _finishedSyncing.Set(), Thread.Sleep(5))
             {
-                if (Paused || _pauseSync)
+                if (!GlobalVariables.AudioManager.IsPlaying || _pauseSync)
                     continue;
 
                 _finishedSyncing.Reset();

--- a/Assets/Script/Playback/SongRunner.cs
+++ b/Assets/Script/Playback/SongRunner.cs
@@ -2,17 +2,17 @@ using System;
 using System.Threading;
 using UnityEngine;
 using YARG.Input;
-using YARG.Settings;
 
-namespace YARG.Gameplay
+namespace YARG.Playback
 {
-    public partial class GameManager
+    public class SongRunner : IDisposable
     {
+        #region Times
         public const double SONG_START_DELAY = 2;
 
         /// <summary>
-        /// The time into the song, accounting for song speed and calibration.<br/>
-        /// This is updated every frame while the game is not paused.
+        /// The time into the song, accounting for song speed and audio calibration.<br/>
+        /// This is updated every frame while not paused.
         /// </summary>
         /// <remarks>
         /// This value should be used for all interactions that are relative to the audio.
@@ -20,18 +20,20 @@ namespace YARG.Gameplay
         public double SongTime => RealSongTime + AudioCalibration;
 
         /// <summary>
-        /// The time into the song, accounting for song speed but <b>not</b> calibration.<br/>
-        /// This is updated every frame while the game is not paused.
+        /// The time into the song, accounting for song speed but <b>not</b> audio calibration.<br/>
+        /// This is updated every frame while not paused.
         /// </summary>
-        /// <remarks>
-        /// This value probably doesn't have any practical use outside of GameManager. It is used
-        /// only for keeping track of the actual audio playback time.
-        /// </remarks>
         public double RealSongTime { get; private set; }
 
         /// <summary>
+        /// The instantaneous current audio time, used for audio synchronization.<br/>
+        /// Accounts for song speed, audio calibration, and song offset.
+        /// </summary>
+        public double SyncSongTime => GlobalVariables.AudioManager.CurrentPositionD + AudioCalibration + SongOffset;
+
+        /// <summary>
         /// The current input time, accounting for song speed and video calibration.<br/>
-        /// This is updated every frame while the game is not paused.
+        /// This is updated every frame while not paused.
         /// </summary>
         /// <remarks>
         /// This value should be used for all interactions with inputs, engines, and replays.
@@ -40,7 +42,7 @@ namespace YARG.Gameplay
 
         /// <summary>
         /// The current input time, accounting for song speed but <b>not</b> video calibration.<br/>
-        /// This is updated every frame while the game is not paused.
+        /// This is updated every frame while not paused.
         /// </summary>
         /// <remarks>
         /// This value should be used for all visual interactions, as video calibration should not delay visuals.
@@ -49,19 +51,25 @@ namespace YARG.Gameplay
         public double RealInputTime { get; private set; }
 
         /// <summary>
+        /// The instantaneous current input time, used for audio synchronization.<br/>
+        /// Accounts for song speed, but <b>not</b> video calibration.
+        /// </summary>
+        public double SyncInputTime => GetRelativeInputTime(InputManager.CurrentInputTime);
+
+        /// <summary>
         /// The input time that is considered to be 0.
         /// Applied before song speed is factored in.
         /// </summary>
-        public static double InputTimeOffset { get; private set; }
+        public double InputTimeOffset { get; private set; }
 
         /// <summary>
         /// The base time added on to relative time to get the real current input time.
         /// Applied after song speed is.
         /// </summary>
-        public static double InputTimeBase { get; private set; }
+        public double InputTimeBase { get; private set; }
+        #endregion
 
-        public double PauseStartTime { get; private set; }
-
+        #region Offsets
         /// <summary>
         /// The audio calibration, in seconds.
         /// </summary>
@@ -70,7 +78,7 @@ namespace YARG.Gameplay
         /// Positive calibration settings will result in a negative number here.
         /// This value also takes video calibration into account, otherwise things will not sync up visually.
         /// </remarks>
-        public double AudioCalibration => (-SettingsManager.Settings.AudioCalibration.Data / 1000.0) - VideoCalibration;
+        public double AudioCalibration { get; }
 
         /// <summary>
         /// The video calibration, in seconds.
@@ -79,7 +87,7 @@ namespace YARG.Gameplay
         /// Be aware that this value is negated!
         /// Positive calibration settings will result in a negative number here.
         /// </remarks>
-        public double VideoCalibration => -SettingsManager.Settings.VideoCalibration.Data / 1000.0;
+        public double VideoCalibration { get; }
 
         /// <summary>
         /// The song offset, in seconds.
@@ -88,25 +96,65 @@ namespace YARG.Gameplay
         /// Be aware that this value is negated!
         /// Positive offsets in the .ini or .chart will result in a negative number here.
         /// </remarks>
-        public double SongOffset => -Song.SongOffsetSeconds;
+        public double SongOffset { get; }
+        #endregion
 
-        // Audio syncing
+        #region Other state
+        /// <summary>
+        /// The song speed as selected by the user.
+        /// </summary>
+        public float SelectedSongSpeed { get; private set; }
+
+        /// <summary>
+        /// The actual current playback speed of the song.
+        /// </summary>
+        /// <remarks>
+        /// The audio may be sped up or slowed down in order to re-synchronize.
+        /// This value takes that speed adjustment into account.
+        /// </remarks>
+        public float ActualSongSpeed => SelectedSongSpeed + _syncSpeedAdjustment;
+
+        /// <summary>
+        /// Whether or not the song is currently paused.
+        /// </summary>
+        public bool Paused { get; private set; }
+
+        /// <summary>
+        /// The input time at which the song was paused.
+        /// </summary>
+        public double PauseStartTime { get; private set; }
+        #endregion
+
+        #region Audio syncing
+        private Thread _syncThread;
+
+        private EventWaitHandle _finishedSyncing = new(true, EventResetMode.ManualReset);
         private volatile bool _runSync;
         private volatile bool _pauseSync;
-        private Thread _syncThread;
-        private EventWaitHandle _finishedSyncing = new(true, EventResetMode.ManualReset);
 
-        private float _syncSpeedAdjustment = 0f;
-        private int _syncSpeedMultiplier = 0;
-        private double _syncStartDelta;
+        private volatile float _syncSpeedAdjustment;
+        private volatile int _syncSpeedMultiplier;
+        private volatile float _syncStartDelta;
 
-        // Seek debugging
+        public float SyncSpeedAdjustment => _syncSpeedAdjustment;
+        public int SyncSpeedMultiplier => _syncSpeedMultiplier;
+        public float SyncStartDelta => _syncStartDelta;
+        #endregion
+
+        #region Seek debugging
         private bool _seeked;
         private double _previousRealSongTime = double.NaN;
         private double _previousInputTime = double.NaN;
+        #endregion
 
-        private void InitializeTime()
+        public SongRunner(float songSpeed = 1f, double audioCalibration = 0, double videoCalibration = 0,
+            double songOffset = 0)
         {
+            SelectedSongSpeed = songSpeed;
+            AudioCalibration = audioCalibration;
+            VideoCalibration = videoCalibration;
+            SongOffset = songOffset;
+
             // Initialize times
             InitializeSongTime(SongOffset);
             GlobalVariables.AudioManager.SetPosition(0);
@@ -117,43 +165,26 @@ namespace YARG.Gameplay
             _syncThread.Start();
         }
 
-        private void UninitializeTime()
+        ~SongRunner()
+        {
+            Dispose(false);
+        }
+
+        public void Dispose() => Dispose(true);
+        private void Dispose(bool disposing)
         {
             // Stop sync thread
             _runSync = false;
-            _syncThread?.Join();
-            _syncThread = null;
+
+            if (disposing)
+            {
+                // Wait for sync thread to stop
+                _syncThread?.Join();
+                _syncThread = null;
+            }
         }
 
-        public double GetRelativeInputTime(double timeFromInputSystem)
-        {
-            return InputTimeBase + ((timeFromInputSystem - InputTimeOffset) * SelectedSongSpeed);
-        }
-
-        public double GetCalibratedRelativeInputTime(double timeFromInputSystem)
-        {
-            return GetRelativeInputTime(timeFromInputSystem) + VideoCalibration;
-        }
-
-        private void SetInputBase(double inputBase)
-        {
-            double previousBase = InputTimeBase;
-            double previousOffset = InputTimeOffset;
-            double previousTime = InputTime;
-
-            InputTimeBase = inputBase;
-            InputTimeOffset = InputManager.CurrentUpdateTime;
-
-            // Update input time
-            RealInputTime = GetRelativeInputTime(InputManager.CurrentUpdateTime);
-
-#if UNITY_EDITOR
-            Debug.Log($"Set input time base. New base: {InputTimeBase:0.000000}, new offset: {InputTimeOffset:0.000000}, new input time: {InputTime:0.000000}\n"
-                + $"Old base: {previousBase:0.000000}, old offset: {previousOffset:0.000000}, old input time: {previousTime:0.000000}");
-#endif
-        }
-
-        private void UpdateTimes()
+        public void Update()
         {
             // Update input time
             RealInputTime = GetRelativeInputTime(InputManager.CurrentUpdateTime);
@@ -209,22 +240,19 @@ namespace YARG.Gameplay
 
                 _finishedSyncing.Reset();
 
-                double inputTime = GetRelativeInputTime(InputManager.CurrentInputTime);
-                double audioTime = GlobalVariables.AudioManager.CurrentPositionD + AudioCalibration + SongOffset;
-
                 // Account for song speed
                 double initialThreshold = INITIAL_SYNC_THRESH * SelectedSongSpeed;
                 double adjustThreshold = ADJUST_SYNC_THRESH * SelectedSongSpeed;
 
                 // Check the difference between input and audio times
-                double delta = inputTime - audioTime;
-                double deltaAbs = Math.Abs(delta);
+                float delta = (float) (SyncInputTime - SyncSongTime);
+                float deltaAbs = Math.Abs(delta);
                 // Don't sync if below the initial sync threshold, and we haven't adjusted the speed
                 if (_syncSpeedMultiplier == 0 && deltaAbs < initialThreshold)
                     continue;
 
                 // We're now syncing, determine how much to adjust the song speed by
-                int speedMultiplier = (int)Math.Round(delta / initialThreshold);
+                int speedMultiplier = (int) Math.Round(delta / initialThreshold);
                 if (speedMultiplier == 0)
                     speedMultiplier = delta > 0 ? 1 : -1;
 
@@ -232,9 +260,7 @@ namespace YARG.Gameplay
                 if (_syncSpeedMultiplier != speedMultiplier)
                 {
                     if (_syncSpeedMultiplier == 0)
-                    {
                         _syncStartDelta = delta;
-                    }
 
                     _syncSpeedMultiplier = speedMultiplier;
 
@@ -263,6 +289,34 @@ namespace YARG.Gameplay
             _syncSpeedMultiplier = 0;
             _syncSpeedAdjustment = 0f;
             GlobalVariables.AudioManager.SetSpeed(ActualSongSpeed);
+        }
+
+        public double GetRelativeInputTime(double timeFromInputSystem)
+        {
+            return InputTimeBase + ((timeFromInputSystem - InputTimeOffset) * SelectedSongSpeed);
+        }
+
+        public double GetCalibratedRelativeInputTime(double timeFromInputSystem)
+        {
+            return GetRelativeInputTime(timeFromInputSystem) + VideoCalibration;
+        }
+
+        private void SetInputBase(double inputBase)
+        {
+            double previousBase = InputTimeBase;
+            double previousOffset = InputTimeOffset;
+            double previousTime = InputTime;
+
+            InputTimeBase = inputBase;
+            InputTimeOffset = InputManager.CurrentUpdateTime;
+
+            // Update input time
+            RealInputTime = GetRelativeInputTime(InputManager.CurrentUpdateTime);
+
+#if UNITY_EDITOR
+            Debug.Log($"Set input time base. New base: {InputTimeBase:0.000000}, new offset: {InputTimeOffset:0.000000}, new input time: {InputTime:0.000000}\n"
+                + $"Old base: {previousBase:0.000000}, old offset: {previousOffset:0.000000}, old input time: {previousTime:0.000000}");
+#endif
         }
 
         private void InitializeSongTime(double time, double delayTime = SONG_START_DELAY)
@@ -314,11 +368,94 @@ namespace YARG.Gameplay
             if (seekTime < 0) seekTime = 0;
             GlobalVariables.AudioManager.SetPosition(seekTime);
 
-            // Reset beat events
-            BeatEventManager.ResetTimers();
-
             _pauseSync = false;
             _seeked = true;
+        }
+
+        public void SetSongSpeed(float speed)
+        {
+            _pauseSync = true;
+            _finishedSyncing.WaitOne();
+
+            // 10% - 4995%, we reserve 5% so that audio syncing can still function
+            speed = Math.Clamp(speed, 10 / 100f, 4995 / 100f);
+
+            // Set speed; save old for input offset compensation
+            SelectedSongSpeed = speed;
+
+            // Set based on the actual song speed, so as to not break resyncing
+            GlobalVariables.AudioManager.SetSpeed(ActualSongSpeed);
+
+            // Adjust input offset, otherwise input time will desync
+            SetInputBase(InputTime);
+
+            _pauseSync = false;
+
+#if UNITY_EDITOR
+            Debug.Log($"Set song speed to {speed:0.00}.\n"
+                + $"Input time: {InputTime:0.000000}, song time: {SongTime:0.000000}");
+#endif
+        }
+
+        public void AdjustSongSpeed(float deltaSpeed) => SetSongSpeed(SelectedSongSpeed + deltaSpeed);
+
+        public void Pause()
+        {
+            if (Paused) return;
+            Paused = true;
+
+            PauseStartTime = RealInputTime;
+            GlobalVariables.AudioManager.Pause();
+
+#if UNITY_EDITOR
+            Debug.Log($"Paused at song time {SongTime:0.000000} (real: {RealSongTime:0.000000}), input time {InputTime:0.000000} (real: {RealInputTime:0.000000}).");
+#endif
+        }
+
+        public void Resume(bool inputCompensation = true)
+        {
+            if (!Paused) return;
+
+            Paused = false;
+
+            if (inputCompensation)
+            {
+                SetInputBase(PauseStartTime);
+            }
+
+            if (RealSongTime >= SongOffset)
+            {
+                GlobalVariables.AudioManager.Play();
+            }
+
+#if UNITY_EDITOR
+            Debug.Log($"Resumed at song time {SongTime:0.000000} (real: {RealSongTime:0.000000}), input time {InputTime:0.000000} (real: {RealInputTime:0.000000}).");
+#endif
+        }
+
+        public void SetPaused(bool paused)
+        {
+            if (paused)
+            {
+                Pause();
+            }
+            else
+            {
+                Resume();
+            }
+        }
+
+        public void OverridePauseTime(double pauseTime = -1)
+        {
+            if (!Paused)
+            {
+                return;
+            }
+
+            if (pauseTime < 0)
+                pauseTime = RealInputTime;
+
+            PauseStartTime = pauseTime;
         }
     }
 }

--- a/Assets/Script/Playback/SongRunner.cs.meta
+++ b/Assets/Script/Playback/SongRunner.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 71cf848fa0d37344dbb1c29b9802088d
+guid: 91293a8c50a4b6742a2beb2869f1fd26
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2


### PR DESCRIPTION
Did this in preparation for the calibrator redo I'm planning, so that no song playback code needs to be duplicated between it and gameplay.

While I was at it, I adjusted the beat event handler a little bit:

- The `BeatEventHandler.Info` struct should be a little more intuitive to set and use, everything is now relative to a single beat instead of four.
- The doc comments now clarify that the beat rate is relative to the current time signature's denominator, rather than absolute.
- The current tempo is now tracked in order to speed up `TickToTime`, as now the binary search can be skipped and the time calculated directly.