### PR TITLE
Improve handling of song-specific video backgrounds

### DIFF
--- a/Assets/Script/Gameplay/BackgroundManager.cs
+++ b/Assets/Script/Gameplay/BackgroundManager.cs
@@ -15,6 +15,8 @@ namespace YARG.Gameplay
         [SerializeField]
         private RawImage _backgroundImage;
 
+        private VenueInfo _venueInfo;
+
         private bool _videoShouldBeStarted;
 
         // "The Unity message 'Start' has an incorrect signature."
@@ -27,8 +29,10 @@ namespace YARG.Gameplay
                 return;
             }
 
-            var type = venueInfo.Value.Type;
-            var path = venueInfo.Value.Path;
+            _venueInfo = venueInfo.Value;
+
+            var type = _venueInfo.Type;
+            var path = _venueInfo.Path;
 
             // Set to false (unless we do wanna start the video)
             _videoShouldBeStarted = false;

--- a/Assets/Script/Gameplay/BackgroundManager.cs
+++ b/Assets/Script/Gameplay/BackgroundManager.cs
@@ -23,6 +23,9 @@ namespace YARG.Gameplay
         [SuppressMessage("Type Safety", "UNT0006", Justification = "UniTaskVoid is a compatible return type.")]
         private async UniTaskVoid Start()
         {
+            // We don't need to update unless we're using a video
+            enabled = false;
+
             var venueInfo = VenueLoader.GetVenue(GameManager.Song);
             if (!venueInfo.HasValue)
             {
@@ -72,6 +75,7 @@ namespace YARG.Gameplay
                     _videoPlayer.Prepare();
 
                     _videoShouldBeStarted = true;
+                    enabled = true;
                     break;
                 case VenueType.Image:
                     _backgroundImage.gameObject.SetActive(true);

--- a/Assets/Script/Gameplay/BackgroundManager.cs
+++ b/Assets/Script/Gameplay/BackgroundManager.cs
@@ -128,6 +128,13 @@ namespace YARG.Gameplay
         // it's finished preparing, such as the length
         private void OnVideoPrepared(VideoPlayer player)
         {
+            // Start time is considered set if it is greater than 25 ms in either direction
+            // End time is only set if it is greater than 0
+            // Video will only loop if its length is less than 85% of the song's length
+            const double startTimeThreshold = 0.025;
+            const double endTimeThreshold = 0;
+            const double dontLoopThreshold = 0.85;
+
             if (_venueInfo.Source == VenueSource.Song)
             {
                 _videoStartTime = GameManager.Song.VideoStartTimeSeconds;
@@ -136,12 +143,11 @@ namespace YARG.Gameplay
                 player.time = _videoStartTime;
 
                 // Determine whether or not to loop the video
-                double frameTime = 1 / player.frameRate;
-                if (Math.Abs(_videoStartTime) < frameTime && _videoEndTime < 0)
+                if (Math.Abs(_videoStartTime) <= startTimeThreshold && _videoEndTime <= endTimeThreshold)
                 {
                     // Only loop the video if it's not around the same length as the song
-                    double lengthRatio = (player.length - _videoStartTime) / GameManager.SongLength;
-                    player.isLooping = lengthRatio < 0.85;
+                    double lengthRatio = player.length / GameManager.SongLength;
+                    player.isLooping = lengthRatio < dontLoopThreshold;
                 }
                 else
                 {

--- a/Assets/Script/Gameplay/BackgroundManager.cs
+++ b/Assets/Script/Gameplay/BackgroundManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics.CodeAnalysis;
 using Cysharp.Threading.Tasks;
 using UnityEngine;
@@ -108,7 +108,7 @@ namespace YARG.Gameplay
 
                 // Disable after starting the video if it's not from the song folder
                 // or if video end time is not specified
-                if (_venueInfo.Source != VenueSource.Song || _videoEndTime <= 0)
+                if (_venueInfo.Source != VenueSource.Song || double.IsNaN(_videoEndTime))
                 {
                     enabled = false;
                     return;
@@ -139,6 +139,8 @@ namespace YARG.Gameplay
             {
                 _videoStartTime = GameManager.Song.VideoStartTimeSeconds;
                 _videoEndTime = GameManager.Song.VideoEndTimeSeconds;
+                if (_videoEndTime <= 0)
+                    _videoEndTime = double.NaN;
 
                 player.time = _videoStartTime;
 
@@ -158,7 +160,7 @@ namespace YARG.Gameplay
             else
             {
                 _videoStartTime = 0;
-                _videoEndTime = -1;
+                _videoEndTime = double.NaN;
                 player.isLooping = true;
             }
         }

--- a/Assets/Script/Gameplay/BackgroundManager.cs
+++ b/Assets/Script/Gameplay/BackgroundManager.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.CodeAnalysis;
 using Cysharp.Threading.Tasks;
 using UnityEngine;
 using UnityEngine.UI;
@@ -21,14 +21,14 @@ namespace YARG.Gameplay
         [SuppressMessage("Type Safety", "UNT0006", Justification = "UniTaskVoid is a compatible return type.")]
         private async UniTaskVoid Start()
         {
-            var typePathPair = VenueLoader.GetVenuePath(GameManager.Song);
-            if (typePathPair == null)
+            var venueInfo = VenueLoader.GetVenue(GameManager.Song);
+            if (!venueInfo.HasValue)
             {
                 return;
             }
 
-            var type = typePathPair.Value.Type;
-            var path = typePathPair.Value.Path;
+            var type = venueInfo.Value.Type;
+            var path = venueInfo.Value.Path;
 
             // Set to false (unless we do wanna start the video)
             _videoShouldBeStarted = false;

--- a/Assets/Script/Gameplay/BackgroundManager.cs
+++ b/Assets/Script/Gameplay/BackgroundManager.cs
@@ -1,3 +1,4 @@
+﻿using System;
 using System.Diagnostics.CodeAnalysis;
 using Cysharp.Threading.Tasks;
 using UnityEngine;
@@ -17,7 +18,14 @@ namespace YARG.Gameplay
 
         private VenueInfo _venueInfo;
 
-        private bool _videoShouldBeStarted;
+        private bool _videoStarted = false;
+
+        // These values are relative to the video, not to song time!
+        // A negative start time will delay when the video starts, a positive one will set the video position
+        // to that value when starting playback at the start of a song.
+        private double _videoStartTime;
+        // End time cannot be negative; a negative value means it is not set.
+        private double _videoEndTime;
 
         // "The Unity message 'Start' has an incorrect signature."
         [SuppressMessage("Type Safety", "UNT0006", Justification = "UniTaskVoid is a compatible return type.")]
@@ -36,9 +44,6 @@ namespace YARG.Gameplay
 
             var type = _venueInfo.Type;
             var path = _venueInfo.Path;
-
-            // Set to false (unless we do wanna start the video)
-            _videoShouldBeStarted = false;
 
             switch (type)
             {
@@ -72,9 +77,9 @@ namespace YARG.Gameplay
                 case VenueType.Video:
                     _videoPlayer.url = path;
                     _videoPlayer.enabled = true;
+                    _videoPlayer.prepareCompleted += OnVideoPrepared;
                     _videoPlayer.Prepare();
 
-                    _videoShouldBeStarted = true;
                     enabled = true;
                     break;
                 case VenueType.Image:
@@ -86,11 +91,69 @@ namespace YARG.Gameplay
 
         private void Update()
         {
-            // Start playing the video at 0 seconds
-            if (_videoShouldBeStarted && GameManager.SongTime >= 0.0)
+            // Start video
+            if (!_videoStarted)
             {
-                _videoShouldBeStarted = false;
+                // Don't start playing the video until the start of the song
+                if (GameManager.SongTime < 0.0)
+                    return;
+
+                // Delay until the start time is reached
+                if (_venueInfo.Source == VenueSource.Song &&
+                    _videoStartTime < 0 && GameManager.SongTime < -_videoStartTime)
+                    return;
+
+                _videoStarted = true;
                 _videoPlayer.Play();
+
+                // Disable after starting the video if it's not from the song folder
+                // or if video end time is not specified
+                if (_venueInfo.Source != VenueSource.Song || _videoEndTime <= 0)
+                {
+                    enabled = false;
+                    return;
+                }
+            }
+
+            // End video when reaching the specified end time
+            if (GameManager.SongTime - _videoStartTime >= _videoEndTime)
+            {
+                _videoPlayer.Stop();
+                _videoPlayer.enabled = false;
+                enabled = false;
+            }
+        }
+
+        // Some video player properties don't work correctly until
+        // it's finished preparing, such as the length
+        private void OnVideoPrepared(VideoPlayer player)
+        {
+            if (_venueInfo.Source == VenueSource.Song)
+            {
+                _videoStartTime = GameManager.Song.VideoStartTimeSeconds;
+                _videoEndTime = GameManager.Song.VideoEndTimeSeconds;
+
+                player.time = _videoStartTime;
+
+                // Determine whether or not to loop the video
+                double frameTime = 1 / player.frameRate;
+                if (Math.Abs(_videoStartTime) < frameTime && _videoEndTime < 0)
+                {
+                    // Only loop the video if it's not around the same length as the song
+                    double lengthRatio = (player.length - _videoStartTime) / GameManager.SongLength;
+                    player.isLooping = lengthRatio < 0.85;
+                }
+                else
+                {
+                    // Never loop the video if start/end times are specified
+                    player.isLooping = false;
+                }
+            }
+            else
+            {
+                _videoStartTime = 0;
+                _videoEndTime = -1;
+                player.isLooping = true;
             }
         }
 

--- a/Assets/Script/Gameplay/GameManager.cs
+++ b/Assets/Script/Gameplay/GameManager.cs
@@ -159,6 +159,9 @@ namespace YARG.Gameplay
         /// <inheritdoc cref="SongRunner.Paused"/>
         public bool Paused => _songRunner.Paused;
 
+        /// <inheritdoc cref="SongRunner.PendingPauses"/>
+        public int PendingPauses => _songRunner.PendingPauses;
+
         public double SongLength { get; private set; }
 
         public bool IsReplay   { get; private set; }
@@ -591,7 +594,8 @@ namespace YARG.Gameplay
 
         public void Pause(bool showMenu = true)
         {
-            if (_songRunner.Paused) return;
+            _songRunner.Pause();
+            if (_songRunner.PendingPauses > 1) return;
 
             if (showMenu)
             {
@@ -614,8 +618,6 @@ namespace YARG.Gameplay
                 _debugText.gameObject.SetActive(false);
             }
 
-            _songRunner.Pause();
-
             // Pause the background/venue
             Time.timeScale = 0f;
             BackgroundManager.SetPaused(true);
@@ -624,7 +626,8 @@ namespace YARG.Gameplay
 
         public void Resume(bool inputCompensation = true)
         {
-            if (!_songRunner.Paused) return;
+            _songRunner.Resume(inputCompensation);
+            if (_songRunner.PendingPauses > 1) return;
 
             _pauseMenu.gameObject.SetActive(false);
 
@@ -636,8 +639,6 @@ namespace YARG.Gameplay
             _isReplaySaved = false;
 
             _debugText.gameObject.SetActive(_isShowDebugText);
-
-            _songRunner.Resume(inputCompensation);
         }
 
         public void SetPaused(bool paused)

--- a/Assets/Script/Gameplay/GameManager.cs
+++ b/Assets/Script/Gameplay/GameManager.cs
@@ -586,11 +586,24 @@ namespace YARG.Gameplay
         public void SetSongTime(double time, double delayTime = SONG_START_DELAY)
         {
             _songRunner.SetSongTime(time, delayTime);
+
             BeatEventHandler.ResetTimers();
+            BackgroundManager.SetTime(_songRunner.SongTime);
         }
 
-        public void SetSongSpeed(float speed) => _songRunner.SetSongSpeed(speed);
-        public void AdjustSongSpeed(float deltaSpeed) => _songRunner.AdjustSongSpeed(deltaSpeed);
+        public void SetSongSpeed(float speed)
+        {
+            _songRunner.SetSongSpeed(speed);
+
+            BackgroundManager.SetSpeed(_songRunner.SelectedSongSpeed);
+        }
+
+        public void AdjustSongSpeed(float deltaSpeed)
+        {
+            _songRunner.AdjustSongSpeed(deltaSpeed);
+
+            BackgroundManager.SetSpeed(_songRunner.SelectedSongSpeed);
+        }
 
         public void Pause(bool showMenu = true)
         {

--- a/Assets/Script/Gameplay/HUD/Practice/PracticeSectionMenu.cs
+++ b/Assets/Script/Gameplay/HUD/Practice/PracticeSectionMenu.cs
@@ -160,9 +160,10 @@ namespace YARG.Gameplay.HUD
                 int last = LastSelectedIndex.Value;
 
                 GameManager.PracticeManager.SetPracticeSection(_sections[first], _sections[last]);
+                GameManager.Resume(inputCompensation: false);
 
                 // Hide menu
-                _pauseMenuManager.PopMenu();
+                _pauseMenuManager.PopMenu(resume: false);
             }
         }
 

--- a/Assets/Script/Gameplay/PracticeManager.cs
+++ b/Assets/Script/Gameplay/PracticeManager.cs
@@ -142,7 +142,6 @@ namespace YARG.Gameplay
             GameManager.VocalTrack.SetPracticeSection(tickStart, tickEnd);
 
             GameManager.SetSongTime(timeStart);
-            GameManager.Resume(inputCompensation: false);
 
             _practiceHud.SetSections(GetSectionsInPractice(_sectionStartTick, _sectionEndTick));
             HasSelectedSection = true;
@@ -202,6 +201,7 @@ namespace YARG.Gameplay
             if (HasUpdatedAbPositions)
             {
                 SetPracticeSection(_tickStart, _tickEnd, TimeStart, TimeEnd);
+                GameManager.Resume(inputCompensation: false);
                 HasUpdatedAbPositions = false;
                 return;
             }

--- a/Assets/Script/Venue/VenueLoader.cs
+++ b/Assets/Script/Venue/VenueLoader.cs
@@ -37,7 +37,8 @@ namespace YARG.Venue
 
     public static class VenueLoader
     {
-        public static string VenueFolder => Path.Combine(PathHelper.PersistentDataPath, "venue");
+        private static string _venueFolder = null;
+        public static string VenueFolder => _venueFolder ??= Path.Combine(PathHelper.PersistentDataPath, "venue");
 
         static VenueLoader()
         {


### PR DESCRIPTION
Was very satisfying to load up TWO-TORIAL and have its video background start right on the drop 40 seconds in lol

Notable changes:

- The struct returned by the venue loader has been refactored to both have a better name and indicate where a venue was sourced from, as we don't want to apply video start/end times to a global video.

- BackgroundManager now only `Update()`s when a video is being played, and its update loop has been refactored to implement video start/end time. When it no longer needs to update, it disables itself.

- Song videos will loop if they are notably shorter than the song itself. The threshold is 85% of the song's length: below that it will loop, equal to or above it won't. All other videos will always loop.

- Song videos now follow the song speed and are seeked when setting song position. Music videos and modcharts will now match up in practice mode.