### PR TITLE
Refactor how gameplay behaviors are handled

### DIFF
--- a/Assets/Script/Gameplay/BackgroundManager.cs
+++ b/Assets/Script/Gameplay/BackgroundManager.cs
@@ -31,7 +31,7 @@ namespace YARG.Gameplay
         // End time cannot be negative; a negative value means it is not set.
         private double _videoEndTime;
 
-        protected override async UniTask OnSongLoadedAsync()
+        protected override async UniTask GameplayLoadAsync()
         {
             // We don't need to update unless we're using a video
             enabled = false;
@@ -109,7 +109,7 @@ namespace YARG.Gameplay
             }
         }
 
-        protected override void OnSongStarted()
+        protected override void GameplayStart()
         {
             enabled = _videoPlayer.enabled;
         }

--- a/Assets/Script/Gameplay/BackgroundManager.cs
+++ b/Assets/Script/Gameplay/BackgroundManager.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.IO;
 using Cysharp.Threading.Tasks;
 using UnityEngine;
@@ -208,7 +208,7 @@ namespace YARG.Gameplay
             }
         }
 
-        public void SetTime(double songTime)
+        protected override void SeekToTime(double songTime)
         {
             switch (_venueInfo.Type)
             {
@@ -259,7 +259,7 @@ namespace YARG.Gameplay
             _videoSeeking = false;
         }
 
-        public void SetSpeed(float speed)
+        protected override void SetSpeed(float speed)
         {
             switch (_venueInfo.Type)
             {
@@ -269,7 +269,7 @@ namespace YARG.Gameplay
             }
         }
 
-        public void SetPaused(bool paused)
+        protected override void SetPaused(bool paused)
         {
             // Pause/unpause video
             if (_videoPlayer.enabled && _videoStarted && !_videoSeeking)

--- a/Assets/Script/Gameplay/BackgroundManager.cs
+++ b/Assets/Script/Gameplay/BackgroundManager.cs
@@ -9,7 +9,7 @@ using YARG.Venue;
 
 namespace YARG.Gameplay
 {
-    public class BackgroundManager : GameplayBehaviour, IDisposable
+    public class BackgroundManager : GameplayBehaviour
     {
         [SerializeField]
         private VideoPlayer _videoPlayer;
@@ -112,6 +112,15 @@ namespace YARG.Gameplay
         protected override void GameplayStart()
         {
             enabled = _videoPlayer.enabled;
+        }
+
+        protected override void GameplayDestroy()
+        {
+            if (_tempVideoPath != null)
+            {
+                File.Delete(_tempVideoPath);
+                _tempVideoPath = null;
+            }
         }
 
         private void Update()
@@ -276,20 +285,6 @@ namespace YARG.Gameplay
             }
 
             // The venue is dealt with in the GameManager via Time.timeScale
-        }
-
-        public void Dispose()
-        {
-            if (_tempVideoPath != null)
-            {
-                File.Delete(_tempVideoPath);
-                _tempVideoPath = null;
-            }
-        }
-
-        ~BackgroundManager()
-        {
-            Dispose();
         }
     }
 }

--- a/Assets/Script/Gameplay/BackgroundManager.cs
+++ b/Assets/Script/Gameplay/BackgroundManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using Cysharp.Threading.Tasks;
 using UnityEngine;
@@ -123,7 +123,7 @@ namespace YARG.Gameplay
             }
         }
 
-        private void Update()
+        protected override void GameplayUpdate()
         {
             if (_videoSeeking)
                 return;

--- a/Assets/Script/Gameplay/GameManager.cs
+++ b/Assets/Script/Gameplay/GameManager.cs
@@ -276,24 +276,24 @@ namespace YARG.Gameplay
             _songRunner.Update();
             BeatEventHandler.Update(_songRunner.SongTime);
 
-            // Update players
+            // Update players first, so that score is up-to-date before everything else updates
             int totalScore = 0;
             int totalCombo = 0;
+            double totalStarsPercent = 0;
             foreach (var player in _players)
             {
-                player.UpdateWithTimes(_songRunner.InputTime);
+                player.PlayerUpdate();
 
                 totalScore += player.Score;
                 totalCombo += player.Combo;
+                totalStarsPercent += player.GetStarsPercent();
             }
 
             BandScore = totalScore;
             BandCombo = totalCombo;
+            BandStars = totalStarsPercent / _players.Count;
 
-            // Get the band stars
-            BandStars = _players.Sum(player => player.GetStarsPercent()) / _players.Count;
-
-            // Update other gameplay behaviors
+            // Update gameplay behaviors (including players)
             foreach (var behavior in _gameplayBehaviours)
             {
                 behavior.GameplayUpdate();
@@ -552,6 +552,11 @@ namespace YARG.Gameplay
             foreach (var behaviour in _gameplayBehaviours)
             {
                 await behaviour.GameplayStart();
+            }
+
+            foreach (var player in _players)
+            {
+                player.PlayerStart();
             }
         }
 

--- a/Assets/Script/Gameplay/GameManager.cs
+++ b/Assets/Script/Gameplay/GameManager.cs
@@ -165,7 +165,7 @@ namespace YARG.Gameplay
         {
             Navigator.Instance.NavigationEvent -= OnNavigationEvent;
             GlobalVariables.AudioManager.SongEnd -= OnAudioEnd;
-            _songRunner.Dispose();
+            _songRunner?.Dispose();
 
             // Reset the time scale back, as it would be 0 at this point (because of pausing)
             Time.timeScale = 1f;

--- a/Assets/Script/Gameplay/GameManager.cs
+++ b/Assets/Script/Gameplay/GameManager.cs
@@ -243,7 +243,8 @@ namespace YARG.Gameplay
 #endif
 
             // Notify everything that the song's starting
-            LoadingManager.Instance.Queue(FireSongStarted, "Starting song...");
+            IsSongStarted = true;
+            LoadingManager.Instance.Queue(StartBehaviors, "Starting song...");
             await LoadingManager.Instance.StartLoad();
 
             // Loaded, enable updates
@@ -438,11 +439,6 @@ namespace YARG.Gameplay
             if (_loadState != LoadFailureState.None) return;
 
             BeatEventHandler = new(Chart.SyncTrack);
-
-            foreach (var behaviour in _gameplayBehaviours)
-            {
-                await behaviour.OnChartLoaded(Chart);
-            }
         }
 
         private UniTask LoadAudio()
@@ -544,17 +540,15 @@ namespace YARG.Gameplay
         {
             foreach (var behaviour in _gameplayBehaviours)
             {
-                await behaviour.OnSongLoaded();
+                await behaviour.GameplayLoad();
             }
         }
 
-        private async UniTask FireSongStarted()
+        private async UniTask StartBehaviors()
         {
-            IsSongStarted = true;
-
             foreach (var behaviour in _gameplayBehaviours)
             {
-                await behaviour.OnSongStarted();
+                await behaviour.GameplayStart();
             }
         }
 

--- a/Assets/Script/Gameplay/GameManager.cs
+++ b/Assets/Script/Gameplay/GameManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
@@ -243,6 +243,9 @@ namespace YARG.Gameplay
             IsSongStarted = true;
             LoadingManager.Instance.Queue(StartBehaviors, "Starting song...");
             await LoadingManager.Instance.StartLoad();
+
+            // Re-seek song runner to ensure the song doesn't start early
+            _songRunner.Start();
 
             // Loaded, enable updates
             enabled = true;

--- a/Assets/Script/Gameplay/GameManager.cs
+++ b/Assets/Script/Gameplay/GameManager.cs
@@ -242,9 +242,12 @@ namespace YARG.Gameplay
             // Notify everything that the song's starting
             IsSongStarted = true;
             LoadingManager.Instance.Queue(StartBehaviors, "Starting song...");
+            // Wait a frame to make sure the input manager's time is up to date,
+            // initialization can take quite some time
+            LoadingManager.Instance.Queue(UniTask.NextFrame, "Delaying a frame", "to ensure proper initialization");
             await LoadingManager.Instance.StartLoad();
 
-            // Re-seek song runner to ensure the song doesn't start early
+            // Start the song runner
             _songRunner.Start();
 
             // Loaded, enable updates

--- a/Assets/Script/Gameplay/GameManager.cs
+++ b/Assets/Script/Gameplay/GameManager.cs
@@ -293,10 +293,21 @@ namespace YARG.Gameplay
             BandCombo = totalCombo;
             BandStars = totalStarsPercent / _players.Count;
 
-            // Update gameplay behaviors (including players)
-            foreach (var behavior in _gameplayBehaviours)
+            // Update gameplay behaviours (including players)
+            // Manual indexing to prevent enumeration errors if behaviours are added/removed in an update
+            for (int i = 0; i < _gameplayBehaviours.Count; i++)
             {
-                behavior.GameplayUpdate();
+                var behaviour = _gameplayBehaviours[i];
+
+                // Check if the behaviour was removed
+                if (!behaviour.Exists)
+                {
+                    _gameplayBehaviours.RemoveAt(i);
+                    i--;
+                    continue;
+                }
+
+                behaviour.GameplayUpdate();
             }
 
             // Debug text
@@ -541,16 +552,36 @@ namespace YARG.Gameplay
 
         private async UniTask InitializeBehaviours()
         {
-            foreach (var behaviour in _gameplayBehaviours)
+            for (int i = 0; i < _gameplayBehaviours.Count; i++)
             {
+                var behaviour = _gameplayBehaviours[i];
+
+                // Check if the behaviour removed itself in GameplayAwake
+                if (!behaviour.Exists)
+                {
+                    _gameplayBehaviours.RemoveAt(i);
+                    i--;
+                    continue;
+                }
+
                 await behaviour.GameplayLoad();
             }
         }
 
         private async UniTask StartBehaviors()
         {
-            foreach (var behaviour in _gameplayBehaviours)
+            for (int i = 0; i < _gameplayBehaviours.Count; i++)
             {
+                var behaviour = _gameplayBehaviours[i];
+
+                // Check if the behaviour removed itself in GameplayLoad
+                if (!behaviour.Exists)
+                {
+                    _gameplayBehaviours.RemoveAt(i);
+                    i--;
+                    continue;
+                }
+
                 await behaviour.GameplayStart();
             }
 

--- a/Assets/Script/Gameplay/GameManager.cs
+++ b/Assets/Script/Gameplay/GameManager.cs
@@ -295,6 +295,12 @@ namespace YARG.Gameplay
             // Get the band stars
             BandStars = _players.Sum(player => player.GetStarsPercent()) / _players.Count;
 
+            // Update other gameplay behaviors
+            foreach (var behavior in _gameplayBehaviours)
+            {
+                behavior.GameplayUpdate();
+            }
+
             // Debug text
             // Note: this must come last in the update sequence!
             // Any updates happening after this will not reflect until the next frame

--- a/Assets/Script/Gameplay/GameManager.cs
+++ b/Assets/Script/Gameplay/GameManager.cs
@@ -70,7 +70,8 @@ namespace YARG.Gameplay
         // Populated by the GameplayBehaviours themselves as they initialize
         private List<IGameplayBehaviour> _gameplayBehaviours = new();
 
-        public bool IsSongStarted { get; private set; } = false;
+        private bool _behavioursLoaded = false;
+        private bool _behavioursStarted = false;
 
         private enum LoadFailureState
         {
@@ -248,7 +249,6 @@ namespace YARG.Gameplay
 #endif
 
             // Notify everything that the song's starting
-            IsSongStarted = true;
             LoadingManager.Instance.Queue(StartBehaviors, "Starting song...");
             // Wait a frame to make sure the input manager's time is up to date,
             // initialization can take quite some time
@@ -603,6 +603,8 @@ namespace YARG.Gameplay
 #endif
                 }
             }
+
+            _behavioursLoaded = true;
         }
 
         private async UniTask StartBehaviors()
@@ -636,6 +638,8 @@ namespace YARG.Gameplay
 #endif
                 }
             }
+
+            _behavioursStarted = true;
 
             foreach (var player in _players)
             {

--- a/Assets/Script/Gameplay/GameManager.cs
+++ b/Assets/Script/Gameplay/GameManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
@@ -167,7 +167,6 @@ namespace YARG.Gameplay
             Navigator.Instance.NavigationEvent -= OnNavigationEvent;
             GlobalVariables.AudioManager.SongEnd -= OnAudioEnd;
             _songRunner.Dispose();
-            BackgroundManager.Dispose();
 
             // Reset the time scale back, as it would be 0 at this point (because of pausing)
             Time.timeScale = 1f;

--- a/Assets/Script/Gameplay/GameplayBehaviour.cs
+++ b/Assets/Script/Gameplay/GameplayBehaviour.cs
@@ -1,7 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using Cysharp.Threading.Tasks;
 using UnityEngine;
-using YARG.Core.Chart;
 
 namespace YARG.Gameplay
 {
@@ -25,9 +24,8 @@ namespace YARG.Gameplay
         // Private interface for initialization from GameManager
         private interface IGameplayBehaviour
         {
-            UniTask OnChartLoaded(SongChart chart);
-            UniTask OnSongLoaded();
-            UniTask OnSongStarted();
+            UniTask GameplayLoad();
+            UniTask GameplayStart();
         }
 
         public abstract class GameplayBehaviourImpl : MonoBehaviour, IGameplayBehaviour
@@ -58,11 +56,17 @@ namespace YARG.Gameplay
                 // Ensure initialization occurs even if the song manager has already started
                 if (GameManager.IsSongStarted)
                 {
-                    await OnChartLoadedAsync(GameManager.Chart);
-                    await OnSongLoadedAsync();
-                    await OnSongStartedAsync();
+                    await GameplayLoadAsync();
+                    await GameplayStartAsync();
                 }
             }
+
+#if UNITY_EDITOR // Only used for detecting incorrect usages
+            // Protected to warn when hidden by an inheriting class
+            // "The Unity message 'Start' is empty."
+            [SuppressMessage("Performance", "UNT0001", Justification = "Deliberately empty for usage detection.")]
+            protected void Start() { }
+#endif
 
             // Protected to warn when hidden by an inheriting class
             protected void OnDestroy()
@@ -83,50 +87,35 @@ namespace YARG.Gameplay
             }
 
             // Private interface thunks for GameManager initialization
-            UniTask IGameplayBehaviour.OnChartLoaded(SongChart chart)
+            UniTask IGameplayBehaviour.GameplayLoad()
             {
-                return OnChartLoadedAsync(chart);
+                return GameplayLoadAsync();
             }
 
-            UniTask IGameplayBehaviour.OnSongLoaded()
-            {
-                return OnSongLoadedAsync();
-            }
-
-            UniTask IGameplayBehaviour.OnSongStarted()
+            UniTask IGameplayBehaviour.GameplayStart()
             {
                 enabled = true;
-                return OnSongStartedAsync();
+                return GameplayStartAsync();
             }
 
             // Default async implementations which call the synchronous versions
-            protected virtual UniTask OnChartLoadedAsync(SongChart chart)
+            protected virtual UniTask GameplayLoadAsync()
             {
-                OnChartLoaded(chart);
+                GameplayLoad();
                 return UniTask.CompletedTask;
             }
 
-            protected virtual UniTask OnSongLoadedAsync()
+            protected virtual UniTask GameplayStartAsync()
             {
-                OnSongLoaded();
+                GameplayStart();
                 return UniTask.CompletedTask;
             }
 
-            protected virtual UniTask OnSongStartedAsync()
-            {
-                OnSongStarted();
-                return UniTask.CompletedTask;
-            }
-
-            protected virtual void OnChartLoaded(SongChart chart)
+            protected virtual void GameplayLoad()
             {
             }
 
-            protected virtual void OnSongLoaded()
-            {
-            }
-
-            protected virtual void OnSongStarted()
+            protected virtual void GameplayStart()
             {
             }
         }

--- a/Assets/Script/Gameplay/GameplayBehaviour.cs
+++ b/Assets/Script/Gameplay/GameplayBehaviour.cs
@@ -24,6 +24,8 @@ namespace YARG.Gameplay
         // Private interface for interaction from GameManager
         private interface IGameplayBehaviour
         {
+            bool Exists { get; }
+
             UniTask GameplayLoad();
             UniTask GameplayStart();
             void GameplayUpdate();
@@ -85,13 +87,16 @@ namespace YARG.Gameplay
 
                 if (GameManager == null) return;
 
-                GameManager._gameplayBehaviours.Remove(this);
+                // Handled by GameManager to make enumeration simpler
+                // GameManager._gameplayBehaviours.Remove(this);
             }
 
             protected virtual void GameplayAwake() { }
             protected virtual void GameplayDestroy() { }
 
             // Private interface thunks
+            bool IGameplayBehaviour.Exists => this != null;
+
             UniTask IGameplayBehaviour.GameplayLoad() => GameplayLoadAsync();
 
             UniTask IGameplayBehaviour.GameplayStart()

--- a/Assets/Script/Gameplay/GameplayBehaviour.cs
+++ b/Assets/Script/Gameplay/GameplayBehaviour.cs
@@ -62,14 +62,13 @@ namespace YARG.Gameplay
                 GameplayAwake();
 
                 // Disable until the song starts
-                enabled = GameManager.IsSongStarted;
+                enabled = GameManager._behavioursStarted;
 
-                // Ensure initialization occurs even if the song manager has already started
-                if (GameManager.IsSongStarted)
-                {
+                // Ensure initialization occurs if the game manager has already run things
+                if (GameManager._behavioursLoaded)
                     await GameplayLoadAsync();
+                if (GameManager._behavioursStarted)
                     await GameplayStartAsync();
-                }
             }
 
             // Protected to warn when hidden by an inheriting class

--- a/Assets/Script/Gameplay/GameplayBehaviour.cs
+++ b/Assets/Script/Gameplay/GameplayBehaviour.cs
@@ -57,10 +57,12 @@ namespace YARG.Gameplay
 
                 GameManager._gameplayBehaviours.Add(this);
 
+                // Call Awake first to ensure everything is initialized,
+                // otherwise setting `enabled` will call GameplayDisable first
+                GameplayAwake();
+
                 // Disable until the song starts
                 enabled = GameManager.IsSongStarted;
-
-                GameplayAwake();
 
                 // Ensure initialization occurs even if the song manager has already started
                 if (GameManager.IsSongStarted)

--- a/Assets/Script/Gameplay/GameplayBehaviour.cs
+++ b/Assets/Script/Gameplay/GameplayBehaviour.cs
@@ -26,6 +26,7 @@ namespace YARG.Gameplay
         {
             UniTask GameplayLoad();
             UniTask GameplayStart();
+            void GameplayUpdate();
         }
 
         public abstract class GameplayBehaviourImpl : MonoBehaviour, IGameplayBehaviour
@@ -66,6 +67,11 @@ namespace YARG.Gameplay
             // "The Unity message 'Start' is empty."
             [SuppressMessage("Performance", "UNT0001", Justification = "Deliberately empty for usage detection.")]
             protected void Start() { }
+
+            // Protected to warn when hidden by an inheriting class
+            // "The Unity message 'Start' is empty."
+            [SuppressMessage("Performance", "UNT0001", Justification = "Deliberately empty for usage detection.")]
+            protected void Update() { }
 #endif
 
             // Protected to warn when hidden by an inheriting class
@@ -78,24 +84,22 @@ namespace YARG.Gameplay
                 GameManager._gameplayBehaviours.Remove(this);
             }
 
-            protected virtual void GameplayAwake()
-            {
-            }
+            protected virtual void GameplayAwake() { }
+            protected virtual void GameplayDestroy() { }
 
-            protected virtual void GameplayDestroy()
-            {
-            }
-
-            // Private interface thunks for GameManager initialization
-            UniTask IGameplayBehaviour.GameplayLoad()
-            {
-                return GameplayLoadAsync();
-            }
+            // Private interface thunks
+            UniTask IGameplayBehaviour.GameplayLoad() => GameplayLoadAsync();
 
             UniTask IGameplayBehaviour.GameplayStart()
             {
                 enabled = true;
                 return GameplayStartAsync();
+            }
+
+            void IGameplayBehaviour.GameplayUpdate()
+            {
+                if (!enabled) return;
+                GameplayUpdate();
             }
 
             // Default async implementations which call the synchronous versions
@@ -111,13 +115,9 @@ namespace YARG.Gameplay
                 return UniTask.CompletedTask;
             }
 
-            protected virtual void GameplayLoad()
-            {
-            }
-
-            protected virtual void GameplayStart()
-            {
-            }
+            protected virtual void GameplayLoad() { }
+            protected virtual void GameplayStart() { }
+            protected virtual void GameplayUpdate() { }
         }
     }
 }

--- a/Assets/Script/Gameplay/GameplayBehaviour.cs
+++ b/Assets/Script/Gameplay/GameplayBehaviour.cs
@@ -39,6 +39,8 @@ namespace YARG.Gameplay
         {
             protected GameManager GameManager { get; private set; }
 
+            private bool _enabled;
+
             // Protected to warn when hidden by an inheriting class
             // "The Unity message 'Awake' has an incorrect signature."
             [SuppressMessage("Type Safety", "UNT0006", Justification = "UniTaskVoid is a compatible return type.")]
@@ -68,6 +70,20 @@ namespace YARG.Gameplay
                 }
             }
 
+            // Protected to warn when hidden by an inheriting class
+            protected void OnEnable()
+            {
+                _enabled = enabled;
+                GameplayEnable();
+            }
+
+            // Protected to warn when hidden by an inheriting class
+            protected void OnDisable()
+            {
+                _enabled = false;
+                GameplayDisable();
+            }
+
 #if UNITY_EDITOR // Only used for detecting incorrect usages
             // Protected to warn when hidden by an inheriting class
             // "The Unity message 'Start' is empty."
@@ -94,6 +110,9 @@ namespace YARG.Gameplay
             protected virtual void GameplayAwake() { }
             protected virtual void GameplayDestroy() { }
 
+            protected virtual void GameplayEnable() { }
+            protected virtual void GameplayDisable() { }
+
             // Private interface thunks
             bool IGameplayBehaviour.Exists => this != null;
 
@@ -107,7 +126,7 @@ namespace YARG.Gameplay
 
             void IGameplayBehaviour.GameplayUpdate()
             {
-                if (!enabled) return;
+                if (!_enabled) return;
                 GameplayUpdate();
             }
 

--- a/Assets/Script/Gameplay/GameplayBehaviour.cs
+++ b/Assets/Script/Gameplay/GameplayBehaviour.cs
@@ -9,7 +9,7 @@ namespace YARG.Gameplay
     /// </summary>
     /// <remarks>
     /// This class provides guarantees regarding using <see cref="GameManager"/>, such as disabling updates
-    /// until it's finished loading, and also provides hooks for initialization as it loads.
+    /// until it's finished loading, and also provides hooks for various events.
     /// <br/>
     /// When inheriting, do *NOT* use <c>Awake()</c> or <c>OnDestroy()</c>!
     /// Override the <see cref="GameplayAwake"/> and <see cref="GameplayDestroy"/> methods instead.
@@ -21,12 +21,16 @@ namespace YARG.Gameplay
 
     public partial class GameManager
     {
-        // Private interface for initialization from GameManager
+        // Private interface for interaction from GameManager
         private interface IGameplayBehaviour
         {
             UniTask GameplayLoad();
             UniTask GameplayStart();
             void GameplayUpdate();
+
+            void SetPaused(bool paused);
+            void SetSpeed(float speed);
+            void SeekToTime(double songTime);
         }
 
         public abstract class GameplayBehaviourImpl : MonoBehaviour, IGameplayBehaviour
@@ -102,6 +106,10 @@ namespace YARG.Gameplay
                 GameplayUpdate();
             }
 
+            void IGameplayBehaviour.SetPaused(bool paused) => SetPaused(paused);
+            void IGameplayBehaviour.SetSpeed(float speed) => SetSpeed(speed);
+            void IGameplayBehaviour.SeekToTime(double songTime) => SeekToTime(songTime);
+
             // Default async implementations which call the synchronous versions
             protected virtual UniTask GameplayLoadAsync()
             {
@@ -118,6 +126,10 @@ namespace YARG.Gameplay
             protected virtual void GameplayLoad() { }
             protected virtual void GameplayStart() { }
             protected virtual void GameplayUpdate() { }
+
+            protected virtual void SetPaused(bool paused) { }
+            protected virtual void SetSpeed(float speed) { }
+            protected virtual void SeekToTime(double songTime) { }
         }
     }
 }

--- a/Assets/Script/Gameplay/GameplayBehaviour.cs
+++ b/Assets/Script/Gameplay/GameplayBehaviour.cs
@@ -24,7 +24,7 @@ namespace YARG.Gameplay
         // Private interface for interaction from GameManager
         private interface IGameplayBehaviour
         {
-            bool Exists { get; }
+            Object UnityObject { get; } 
 
             UniTask GameplayLoad();
             UniTask GameplayStart();
@@ -116,7 +116,7 @@ namespace YARG.Gameplay
             protected virtual void GameplayDisable() { }
 
             // Private interface thunks
-            bool IGameplayBehaviour.Exists => this != null;
+            Object IGameplayBehaviour.UnityObject => this;
 
             UniTask IGameplayBehaviour.GameplayLoad() => GameplayLoadAsync();
 

--- a/Assets/Script/Gameplay/HUD/HideCursor.cs
+++ b/Assets/Script/Gameplay/HUD/HideCursor.cs
@@ -24,7 +24,7 @@ namespace YARG.Gameplay.HUD
             Cursor.visible = true;
         }
 
-        protected override void OnSongStarted()
+        protected override void GameplayStart()
         {
             Cursor.visible = false;
         }

--- a/Assets/Script/Gameplay/HUD/HideCursor.cs
+++ b/Assets/Script/Gameplay/HUD/HideCursor.cs
@@ -29,7 +29,7 @@ namespace YARG.Gameplay.HUD
             Cursor.visible = false;
         }
 
-        private void Update()
+        private new void Update()
         {
             float showCursorSetting = SettingsManager.Settings.ShowCursorTimer.Data;
 

--- a/Assets/Script/Gameplay/HUD/LyricBar.cs
+++ b/Assets/Script/Gameplay/HUD/LyricBar.cs
@@ -55,9 +55,9 @@ namespace YARG.Gameplay.HUD
             _lyricText.text = string.Empty;
         }
 
-        protected override void OnChartLoaded(SongChart chart)
+        protected override void GameplayLoad()
         {
-            var vocalsPart = chart.Vocals.Parts[0];
+            var vocalsPart = GameManager.Chart.Vocals.Parts[0];
 
             // If not vocals, hide the lyric bar
             if (vocalsPart.NotePhrases.Count <= 0)

--- a/Assets/Script/Gameplay/HUD/LyricBar.cs
+++ b/Assets/Script/Gameplay/HUD/LyricBar.cs
@@ -69,7 +69,7 @@ namespace YARG.Gameplay.HUD
             _vocalPhrases = vocalsPart.NotePhrases;
         }
 
-        private void Update()
+        protected override void GameplayUpdate()
         {
             const double PHRASE_DISTANCE_THRESHOLD = 1.0;
             // If the current phrase ended AND

--- a/Assets/Script/Gameplay/HUD/Pause/GenericPause.cs
+++ b/Assets/Script/Gameplay/HUD/Pause/GenericPause.cs
@@ -12,7 +12,7 @@ namespace YARG.Gameplay.HUD
             PauseMenuManager = FindObjectOfType<PauseMenuManager>();
         }
 
-        protected virtual void OnEnable()
+        protected override void GameplayEnable()
         {
             Navigator.Instance.PushScheme(new NavigationScheme(new()
             {
@@ -23,7 +23,7 @@ namespace YARG.Gameplay.HUD
             }, false));
         }
 
-        private void OnDisable()
+        protected override void GameplayDisable()
         {
             Navigator.Instance.PopScheme();
         }

--- a/Assets/Script/Gameplay/HUD/Pause/PauseMenuManager.cs
+++ b/Assets/Script/Gameplay/HUD/Pause/PauseMenuManager.cs
@@ -47,19 +47,21 @@ namespace YARG.Gameplay.HUD
             _menus = children.ToDictionary(i => i.Menu, i => i);
         }
 
-        private async void Start()
+        protected override async UniTask GameplayLoadAsync()
         {
+            var song = GameManager.Song;
+
             // Set text info
-            _albumText.text = GameManager.Song.Album;
-            _songText.text = GameManager.Song.Name;
-            _artistText.text = GameManager.Song.Artist;
-            _sourceText.text = SongSources.SourceToGameName(GameManager.Song.Source);
+            _albumText.text = song.Album;
+            _songText.text = song.Name;
+            _artistText.text = song.Artist;
+            _sourceText.text = SongSources.SourceToGameName(song.Source);
 
             // Set source icon
-            _sourceIcon.sprite = await SongSources.SourceToIcon(GameManager.Song.Source);
+            _sourceIcon.sprite = await SongSources.SourceToIcon(song.Source);
 
             // Set album cover
-            GameManager.Song.SetRawImageToAlbumCover(_albumCover, CancellationToken.None).Forget();
+            await song.SetRawImageToAlbumCover(_albumCover, CancellationToken.None);
         }
 
         protected override void GameplayDestroy()

--- a/Assets/Script/Gameplay/HUD/Pause/PracticePause.cs
+++ b/Assets/Script/Gameplay/HUD/Pause/PracticePause.cs
@@ -12,9 +12,9 @@ namespace YARG.Gameplay.HUD
         [SerializeField]
         private TextMeshProUGUI _bPositionText;
 
-        protected override void OnEnable()
+        protected override void GameplayEnable()
         {
-            base.OnEnable();
+            base.GameplayEnable();
 
             UpdatePositionText();
         }

--- a/Assets/Script/Gameplay/HUD/Practice/PracticeHud.cs
+++ b/Assets/Script/Gameplay/HUD/Practice/PracticeHud.cs
@@ -44,7 +44,7 @@ namespace YARG.Gameplay.HUD
             _currentSectionIndex = 0;
         }
 
-        private void Update()
+        protected override void GameplayUpdate()
         {
             if (GameManager.Players is null)
             {

--- a/Assets/Script/Gameplay/HUD/Practice/PracticeHud.cs
+++ b/Assets/Script/Gameplay/HUD/Practice/PracticeHud.cs
@@ -51,8 +51,6 @@ namespace YARG.Gameplay.HUD
                 return;
             }
 
-            speedPercentText.text = $"{GameManager.SelectedSongSpeed * 100f:0}%";
-
             int notesHit = 0;
             int totalNotes = 0;
             foreach (var player in GameManager.Players)
@@ -82,6 +80,11 @@ namespace YARG.Gameplay.HUD
                     sectionText.text = $"{_sections[_currentSectionIndex].Name}";
                 }
             }
+        }
+
+        protected override void SetSpeed(float speed)
+        {
+            speedPercentText.text = $"{GameManager.SelectedSongSpeed * 100f:0}%";
         }
 
         public void ResetPractice()

--- a/Assets/Script/Gameplay/HUD/Practice/PracticeHud.cs
+++ b/Assets/Script/Gameplay/HUD/Practice/PracticeHud.cs
@@ -35,16 +35,13 @@ namespace YARG.Gameplay.HUD
 
         protected override void GameplayAwake()
         {
-            _sections = Array.Empty<Section>();
-            _currentSectionIndex = 0;
-        }
-
-        private void Start()
-        {
             if (!GameManager.IsPractice)
             {
                 Destroy(gameObject);
             }
+
+            _sections = Array.Empty<Section>();
+            _currentSectionIndex = 0;
         }
 
         private void Update()

--- a/Assets/Script/Gameplay/HUD/Practice/PracticeSectionMenu.cs
+++ b/Assets/Script/Gameplay/HUD/Practice/PracticeSectionMenu.cs
@@ -103,8 +103,9 @@ namespace YARG.Gameplay.HUD
             }
         }
 
-        protected override void OnChartLoaded(SongChart chart)
+        protected override void GameplayLoad()
         {
+            var chart = GameManager.Chart;
             _sections = chart.Sections;
             _finalTick = chart.GetLastTick();
             _finalChartTime = chart.SyncTrack.TickToTime(_finalTick);

--- a/Assets/Script/Gameplay/HUD/Practice/PracticeSectionMenu.cs
+++ b/Assets/Script/Gameplay/HUD/Practice/PracticeSectionMenu.cs
@@ -86,15 +86,7 @@ namespace YARG.Gameplay.HUD
             }
         }
 
-        private void OnEnable()
-        {
-            // Wait until the chart has been loaded
-            if (_sections is null) return;
-
-            Initialize();
-        }
-
-        private void OnDisable()
+        protected override void GameplayDisable()
         {
             if (_navigationPushed)
             {
@@ -113,7 +105,7 @@ namespace YARG.Gameplay.HUD
             //_pauseMenuManager.PushMenu(PauseMenuManager.Menu.SelectSections);
         }
 
-        private void Initialize()
+        protected override void GameplayStart()
         {
             FirstSelectedIndex = null;
             LastSelectedIndex = null;

--- a/Assets/Script/Gameplay/HUD/Practice/PracticeSectionMenu.cs
+++ b/Assets/Script/Gameplay/HUD/Practice/PracticeSectionMenu.cs
@@ -74,8 +74,6 @@ namespace YARG.Gameplay.HUD
                 return;
             }
 
-            GameManager.ChartLoaded += OnChartLoaded;
-
             // Create all of the section views
             for (int i = 0; i < SECTION_VIEW_EXTRA * 2 + 1; i++)
             {

--- a/Assets/Script/Gameplay/HUD/Practice/PracticeSectionMenu.cs
+++ b/Assets/Script/Gameplay/HUD/Practice/PracticeSectionMenu.cs
@@ -176,7 +176,7 @@ namespace YARG.Gameplay.HUD
             HoveredIndex++;
         }
 
-        private void Update()
+        private new void Update()
         {
             if (_scrollTimer > 0f)
             {

--- a/Assets/Script/Gameplay/HUD/ReplayViewer/ReplayController.cs
+++ b/Assets/Script/Gameplay/HUD/ReplayViewer/ReplayController.cs
@@ -61,7 +61,7 @@ namespace YARG.Gameplay.HUD
             _timeSlider.OnSliderDrag.RemoveAllListeners();
         }
 
-        protected override void OnSongLoaded()
+        protected override void GameplayLoad()
         {
             _songLengthText.text = TimeSpan.FromSeconds(GameManager.SongLength + GameManager.SONG_START_DELAY)
                 .ToString("g");

--- a/Assets/Script/Gameplay/HUD/ReplayViewer/ReplayController.cs
+++ b/Assets/Script/Gameplay/HUD/ReplayViewer/ReplayController.cs
@@ -69,7 +69,7 @@ namespace YARG.Gameplay.HUD
             _replay = GameManager.Replay;
         }
 
-        private void Update()
+        private new void Update()
         {
             if (!GameManager.Paused && _hudVisible)
             {

--- a/Assets/Script/Gameplay/HUD/ScoreBox/ScoreBox.cs
+++ b/Assets/Script/Gameplay/HUD/ScoreBox/ScoreBox.cs
@@ -45,7 +45,7 @@ namespace YARG.Gameplay.HUD
             _songLengthTime = timeSpan.ToString(TimeFormat);
         }
 
-        private void Update()
+        protected override void GameplayUpdate()
         {
             // Update score
             if (GameManager.BandScore != _bandScore)

--- a/Assets/Script/Gameplay/HUD/ScoreBox/ScoreBox.cs
+++ b/Assets/Script/Gameplay/HUD/ScoreBox/ScoreBox.cs
@@ -30,7 +30,7 @@ namespace YARG.Gameplay.HUD
 
         private string TimeFormat => _songHasHours ? TIME_FORMAT_HOURS : TIME_FORMAT;
 
-        private void Start()
+        protected override void GameplayAwake()
         {
             _scoreText.text = SCORE_PREFIX + "0";
             _songTimer.text = string.Empty;
@@ -38,7 +38,7 @@ namespace YARG.Gameplay.HUD
             _songProgressBar.SetProgress(0f);
         }
 
-        protected override void OnSongStarted()
+        protected override void GameplayStart()
         {
             var timeSpan = TimeSpan.FromSeconds(GameManager.SongLength);
             _songHasHours = timeSpan.TotalHours >= 1.0;

--- a/Assets/Script/Gameplay/HUD/ScoreBox/StarDisplay.cs
+++ b/Assets/Script/Gameplay/HUD/ScoreBox/StarDisplay.cs
@@ -44,7 +44,7 @@ namespace YARG.Gameplay.HUD
             _measures.MoveNext();
         }
 
-        private void Update()
+        protected override void GameplayUpdate()
         {
             if (_isGoldAchieved || _measures.Current is null)
             {

--- a/Assets/Script/Gameplay/HUD/ScoreBox/StarDisplay.cs
+++ b/Assets/Script/Gameplay/HUD/ScoreBox/StarDisplay.cs
@@ -38,12 +38,6 @@ namespace YARG.Gameplay.HUD
             _goldMeterHeight = GetComponent<RectTransform>().rect.height;
         }
 
-        private void Start()
-        {
-            enabled = false;
-            GameManager.ChartLoaded += OnChartLoaded;
-        }
-
         protected override void OnChartLoaded(SongChart chart)
         {
             _measures = chart.SyncTrack.Beatlines.Where(b => b.Type == BeatlineType.Measure).GetEnumerator();

--- a/Assets/Script/Gameplay/HUD/ScoreBox/StarDisplay.cs
+++ b/Assets/Script/Gameplay/HUD/ScoreBox/StarDisplay.cs
@@ -38,9 +38,9 @@ namespace YARG.Gameplay.HUD
             _goldMeterHeight = GetComponent<RectTransform>().rect.height;
         }
 
-        protected override void OnChartLoaded(SongChart chart)
+        protected override void GameplayLoad()
         {
-            _measures = chart.SyncTrack.Beatlines.Where(b => b.Type == BeatlineType.Measure).GetEnumerator();
+            _measures = GameManager.Chart.SyncTrack.Beatlines.Where(b => b.Type == BeatlineType.Measure).GetEnumerator();
             _measures.MoveNext();
         }
 

--- a/Assets/Script/Gameplay/HUD/SongInfoText.cs
+++ b/Assets/Script/Gameplay/HUD/SongInfoText.cs
@@ -14,7 +14,7 @@ namespace YARG.Gameplay.HUD
         [SerializeField]
         private TextMeshProUGUI _text;
 
-        private void Start()
+        protected override void GameplayStart()
         {
             // Start fading out
             StartCoroutine(FadeCoroutine());

--- a/Assets/Script/Gameplay/Player/BasePlayer.cs
+++ b/Assets/Script/Gameplay/Player/BasePlayer.cs
@@ -110,11 +110,6 @@ namespace YARG.Gameplay.Player
 
         public virtual void UpdateWithTimes(double inputTime)
         {
-            if (GameManager.Paused)
-            {
-                return;
-            }
-
             UpdateInputs(inputTime);
             UpdateVisualsWithTimes(inputTime);
         }

--- a/Assets/Script/Gameplay/Player/BasePlayer.cs
+++ b/Assets/Script/Gameplay/Player/BasePlayer.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using UnityEngine;
 using YARG.Core.Audio;
 using YARG.Core.Chart;
@@ -76,13 +76,6 @@ namespace YARG.Gameplay.Player
                 Debug.LogWarning($"Player object {gameObject.name} was instantiated outside of the gameplay scene!");
                 Destroy(gameObject);
                 return;
-            }
-
-            // Ensure proper initialization if the song already started
-            // (dunno why that would happen with the players, but just in case)
-            if (GameManager.IsSongStarted)
-            {
-                PlayerStart();
             }
         }
 

--- a/Assets/Script/Gameplay/Player/BasePlayer.cs
+++ b/Assets/Script/Gameplay/Player/BasePlayer.cs
@@ -74,7 +74,7 @@ namespace YARG.Gameplay.Player
             IsFc = true;
         }
 
-        protected void Start()
+        protected override void GameplayStart()
         {
             if (!GameManager.IsReplay)
             {

--- a/Assets/Script/Gameplay/Player/DrumsPlayer.cs
+++ b/Assets/Script/Gameplay/Player/DrumsPlayer.cs
@@ -146,19 +146,6 @@ namespace YARG.Gameplay.Player
                 colors.GetFretInnerColor(0).ToUnityColor());
         }
 
-        public override void UpdateWithTimes(double inputTime)
-        {
-            base.UpdateWithTimes(inputTime);
-
-            Score = Engine.EngineStats.Score;
-            Combo = Engine.EngineStats.Combo;
-        }
-
-        protected override void UpdateVisuals(double songTime)
-        {
-            UpdateBaseVisuals(Engine.EngineStats, songTime);
-        }
-
         protected override void ResetVisuals()
         {
             base.ResetVisuals();

--- a/Assets/Script/Gameplay/Player/FiveFretPlayer.cs
+++ b/Assets/Script/Gameplay/Player/FiveFretPlayer.cs
@@ -110,17 +110,9 @@ namespace YARG.Gameplay.Player
             }
         }
 
-        public override void UpdateWithTimes(double inputTime)
+        protected override void UpdateVisuals(double time)
         {
-            base.UpdateWithTimes(inputTime);
-
-            Score = Engine.EngineStats.Score;
-            Combo = Engine.EngineStats.Combo;
-        }
-
-        protected override void UpdateVisuals(double songTime)
-        {
-            UpdateBaseVisuals(Engine.EngineStats, songTime);
+            base.UpdateVisuals(time);
 
             for (var fret = GuitarAction.GreenFret; fret <= GuitarAction.OrangeFret; fret++)
             {

--- a/Assets/Script/Gameplay/Player/TrackPlayer.cs
+++ b/Assets/Script/Gameplay/Player/TrackPlayer.cs
@@ -85,6 +85,12 @@ namespace YARG.Gameplay.Player
             _hudLocation.position = _hudLocation.position.AddZ(change);
         }
 
+        protected override void OnDestroy()
+        {
+            base.OnDestroy();
+            GameManager.BeatEventHandler.Unsubscribe(StarpowerBar.PulseBarIfAble);
+        }
+
         protected override void ResetVisuals()
         {
             ComboMeter.SetFullCombo(IsFc);
@@ -96,11 +102,11 @@ namespace YARG.Gameplay.Player
             HitWindowDisplay.SetHitWindowSize();
         }
 
-        protected override void UpdateVisualsWithTimes(double time)
+        protected override void UpdateVisuals(double time)
         {
-            base.UpdateVisualsWithTimes(time);
             UpdateNotes(time);
             UpdateBeatlines(time);
+            UpdateTrackVisuals(time);
         }
 
         protected abstract void UpdateNotes(double time);
@@ -129,6 +135,22 @@ namespace YARG.Gameplay.Player
 
                 BeatlineIndex++;
             }
+        }
+
+        private void UpdateTrackVisuals(double time)
+        {
+            int maxMultiplier = Stats.IsStarPowerActive ? 8 : 4;
+            bool groove = Stats.ScoreMultiplier == maxMultiplier;
+
+            TrackMaterial.SetTrackScroll(time, NoteSpeed);
+            TrackMaterial.GrooveMode = groove;
+            TrackMaterial.StarpowerMode = Stats.IsStarPowerActive;
+
+            ComboMeter.SetCombo(Stats.ScoreMultiplier, maxMultiplier, Stats.Combo);
+            StarpowerBar.SetStarpower(Stats.StarPowerAmount, Stats.IsStarPowerActive);
+            SunburstEffects.SetSunburstEffects(groove, Stats.IsStarPowerActive);
+
+            TrackView.UpdateNoteStreak(Stats.Combo);
         }
     }
 
@@ -216,22 +238,6 @@ namespace YARG.Gameplay.Player
             ResetNoteCounters();
 
             ResetVisuals();
-        }
-
-        protected void UpdateBaseVisuals(BaseStats stats, double songTime)
-        {
-            int maxMultiplier = stats.IsStarPowerActive ? 8 : 4;
-            bool groove = stats.ScoreMultiplier == maxMultiplier;
-
-            TrackMaterial.SetTrackScroll(songTime, NoteSpeed);
-            TrackMaterial.GrooveMode = groove;
-            TrackMaterial.StarpowerMode = stats.IsStarPowerActive;
-
-            ComboMeter.SetCombo(stats.ScoreMultiplier, maxMultiplier, stats.Combo);
-            StarpowerBar.SetStarpower(stats.StarPowerAmount, stats.IsStarPowerActive);
-            SunburstEffects.SetSunburstEffects(groove, stats.IsStarPowerActive);
-
-            TrackView.UpdateNoteStreak(stats.Combo);
         }
 
         protected override void UpdateNotes(double songTime)
@@ -344,13 +350,6 @@ namespace YARG.Gameplay.Player
         protected virtual void OnStarPowerPhraseHit(TNote note)
         {
             OnStarPowerPhraseHit();
-        }
-
-        protected override void FinishDestruction()
-        {
-            base.FinishDestruction();
-
-            GameManager.BeatEventHandler.Unsubscribe(StarpowerBar.PulseBarIfAble);
         }
     }
 }

--- a/Assets/Script/Gameplay/Player/Vocals/VocalTrack.cs
+++ b/Assets/Script/Gameplay/Player/Vocals/VocalTrack.cs
@@ -93,7 +93,7 @@ namespace YARG.Gameplay.Player
 
         public bool HarmonyShowing => _vocalsTrack.Instrument == Instrument.Harmony;
 
-        private void Start()
+        protected override void GameplayAwake()
         {
             Assert.AreEqual(_notePools.Length, 3,
                 "Note pools must be of length three (one for each harmony part).");

--- a/Assets/Script/Gameplay/Player/Vocals/VocalTrack.cs
+++ b/Assets/Script/Gameplay/Player/Vocals/VocalTrack.cs
@@ -168,7 +168,7 @@ namespace YARG.Gameplay.Player
             return player;
         }
 
-        private void Update()
+        protected override void GameplayUpdate()
         {
             // Update the range
             if (IsRangeChanging)

--- a/Assets/Script/Gameplay/Player/VocalsPlayer.cs
+++ b/Assets/Script/Gameplay/Player/VocalsPlayer.cs
@@ -75,8 +75,9 @@ namespace YARG.Gameplay.Player
             StarScoreThresholds = PopulateStarScoreThresholds(StarMultiplierThresholds, Engine.BaseScore);
         }
 
-        protected override void FinishDestruction()
+        protected override void OnDestroy()
         {
+            base.OnDestroy();
             _inputContext?.Stop();
         }
 
@@ -326,14 +327,6 @@ namespace YARG.Gameplay.Player
             }
 
             return (closest, octaveShift);
-        }
-
-        public override void UpdateWithTimes(double inputTime)
-        {
-            base.UpdateWithTimes(inputTime);
-
-            Score = Engine.EngineStats.Score;
-            Combo = Engine.EngineStats.Combo;
         }
 
         public override void SetPracticeSection(uint start, uint end)

--- a/Assets/Script/Gameplay/PracticeManager.cs
+++ b/Assets/Script/Gameplay/PracticeManager.cs
@@ -55,10 +55,8 @@ namespace YARG.Gameplay
             Navigator.Instance.NavigationEvent -= OnNavigationEvent;
         }
 
-        private void Update()
+        protected override void GameplayUpdate()
         {
-            if (GameManager.Paused) return;
-
             double endPoint = TimeEnd + (SECTION_RESTART_DELAY * GameManager.SelectedSongSpeed);
             if (GameManager.SongTime >= endPoint) ResetPractice();
         }

--- a/Assets/Script/Gameplay/PracticeManager.cs
+++ b/Assets/Script/Gameplay/PracticeManager.cs
@@ -32,17 +32,10 @@ namespace YARG.Gameplay
         private uint _tickStart;
         private uint _tickEnd;
 
-        private uint _lastTick;
-
         public bool HasSelectedSection    { get; private set; }
         public bool HasUpdatedAbPositions { get; private set; }
 
         protected override void GameplayAwake()
-        {
-            Navigator.Instance.NavigationEvent += OnNavigationEvent;
-        }
-
-        private void Start()
         {
             if (GameManager.IsPractice)
             {
@@ -53,6 +46,8 @@ namespace YARG.Gameplay
             {
                 Destroy(this);
             }
+
+            Navigator.Instance.NavigationEvent += OnNavigationEvent;
         }
 
         protected override void GameplayDestroy()
@@ -66,12 +61,6 @@ namespace YARG.Gameplay
 
             double endPoint = TimeEnd + (SECTION_RESTART_DELAY * GameManager.SelectedSongSpeed);
             if (GameManager.SongTime >= endPoint) ResetPractice();
-        }
-
-        protected override void OnChartLoaded(SongChart chart)
-        {
-            _chart = chart;
-            _lastTick = chart.GetLastTick();
         }
 
         private void OnNavigationEvent(NavigationContext ctx)
@@ -150,8 +139,8 @@ namespace YARG.Gameplay
         public void SetAPosition(double time)
         {
             // We do this because we want to snap to the exact time of a tick, not in between 2 ticks.
-            uint tick = _chart.SyncTrack.TimeToTick(time);
-            double startTime = _chart.SyncTrack.TickToTime(tick);
+            uint tick = GameManager.Chart.SyncTrack.TimeToTick(time);
+            double startTime = GameManager.Chart.SyncTrack.TickToTime(tick);
 
             _tickStart = tick;
             TimeStart = startTime;
@@ -168,8 +157,8 @@ namespace YARG.Gameplay
         public void SetBPosition(double time)
         {
             // We do this because we want to snap to the exact time of a tick, not in between 2 ticks.
-            uint tick = _chart.SyncTrack.TimeToTick(time);
-            double endTime = _chart.SyncTrack.TickToTime(tick);
+            uint tick = GameManager.Chart.SyncTrack.TimeToTick(time);
+            double endTime = GameManager.Chart.SyncTrack.TickToTime(tick);
 
             _tickEnd = tick;
             TimeEnd = endTime;
@@ -217,7 +206,7 @@ namespace YARG.Gameplay
 
         private Section[] GetSectionsInPractice(uint start, uint end)
         {
-            return _chart.Sections.Where(s => s.Tick >= start && s.TickEnd <= end).ToArray();
+            return GameManager.Chart.Sections.Where(s => s.Tick >= start && s.TickEnd <= end).ToArray();
         }
     }
 }

--- a/Assets/Script/Gameplay/Visuals/BaseElement.cs
+++ b/Assets/Script/Gameplay/Visuals/BaseElement.cs
@@ -39,7 +39,7 @@
 
         protected abstract bool UpdateElementPosition();
 
-        protected void Update()
+        protected override void GameplayUpdate()
         {
             // Skip if not initialized
             if (!Initialized) return;

--- a/Assets/Script/Gameplay/Visuals/TrackElements/TrackElement.cs
+++ b/Assets/Script/Gameplay/Visuals/TrackElements/TrackElement.cs
@@ -25,7 +25,7 @@ namespace YARG.Gameplay.Visuals
             base.GameplayAwake();
         }
 
-        private void Start()
+        protected override void GameplayStart()
         {
             // Get fade info
             float fadePos = Player.ZeroFadePosition;

--- a/Assets/Script/Integration/StageKit/StageKitGameplay.cs
+++ b/Assets/Script/Integration/StageKit/StageKitGameplay.cs
@@ -22,9 +22,17 @@ namespace YARG.Integration.StageKit
         private int _drumIndex;
         private StageKitLightingController _controller;
 
-        protected override void OnChartLoaded(SongChart chart)
+        protected override void GameplayAwake()
         {
             _controller = StageKitLightingController.Instance;
+            _controller.CurrentLightingCue = null;
+            _controller.StageKits.ForEach(kit => kit.ResetHaptics());
+        }
+
+        protected override void GameplayLoad()
+        {
+            var chart = GameManager.Chart;
+
             //Should be read from the venue itself eventually but for now, randomize it.
             _controller.LargeVenue = Random.Range(0, 1) == 1;
             _venue = chart.VenueTrack;
@@ -37,9 +45,6 @@ namespace YARG.Integration.StageKit
             _lightingIndex = 0;
             _eventIndex = 0;
             _drumIndex = 0;
-
-            _controller.CurrentLightingCue = null;
-            StageKitLightingController.Instance.StageKits.ForEach(kit => kit.ResetHaptics());
         }
 
         private void Update()

--- a/Assets/Script/Integration/StageKit/StageKitGameplay.cs
+++ b/Assets/Script/Integration/StageKit/StageKitGameplay.cs
@@ -10,17 +10,18 @@ namespace YARG.Integration.StageKit
 {
     public class StageKitGameplay : GameplayBehaviour
     {
+        private StageKitLightingController _controller;
+
         private VenueTrack _venue;
         private SyncTrack _sync;
         private List<VocalsPhrase> _vocals;
         private InstrumentDifficulty<DrumNote> _drums;
-        private bool _onPause = false;
+
         private int _eventIndex;
         private int _lightingIndex;
         private int _syncIndex;
         private int _vocalsIndex;
         private int _drumIndex;
-        private StageKitLightingController _controller;
 
         protected override void GameplayAwake()
         {
@@ -47,28 +48,28 @@ namespace YARG.Integration.StageKit
             _drumIndex = 0;
         }
 
-        private void Update()
+        protected override void SetPaused(bool paused)
         {
-            if (StageKitLightingController.Instance.StageKits.Count == 0)
-            {
-                return;
-            }
-
-            //On Pause, turn off the fog and strobe so people don't die, but leave the leds on, looks nice.
-            //Is there a OnPause/OnResume event? that would simplify this.
-            if (GameManager.Paused && _onPause == false)
+            // On Pause, turn off the fog and strobe so people don't die, but leave the leds on, looks nice.
+            if (paused)
             {
                 _controller.PreviousFogState = _controller.CurrentFogState;
                 _controller.PreviousStrobeState = _controller.CurrentStrobeState;
                 _controller.SetFogMachine(StageKitLightingController.FogState.Off);
                 _controller.SetStrobeSpeed(StageKitStrobeSpeed.Off);
-                _onPause = true;
             }
-            else if (_onPause)
+            else
             {
                 _controller.SetFogMachine(_controller.PreviousFogState);
                 _controller.SetStrobeSpeed(_controller.PreviousStrobeState);
-                _onPause = false;
+            }
+        }
+
+        protected override void GameplayUpdate()
+        {
+            if (StageKitLightingController.Instance.StageKits.Count == 0)
+            {
+                return;
             }
 
             if (_controller.CurrentLightingCue != null)

--- a/Assets/Script/Playback/SongRunner.cs
+++ b/Assets/Script/Playback/SongRunner.cs
@@ -197,14 +197,9 @@ namespace YARG.Playback
             AudioCalibration = (-audioCalibration / 1000.0) - VideoCalibration;
             SongOffset = -songOffset;
 
-            // Initialize times
+            // Initialize times so that they're correct for initial usage
             InitializeSongTime(SongOffset);
             GlobalVariables.AudioManager.SetPosition(0);
-
-            // Start sync thread
-            _runSync = true;
-            _syncThread = new Thread(SyncThread) { IsBackground = true };
-            _syncThread.Start();
         }
 
         ~SongRunner()
@@ -229,6 +224,18 @@ namespace YARG.Playback
                 _syncThread?.Join();
                 _syncThread = null;
             }
+        }
+
+        public void Start()
+        {
+            // Re-initialize times to prevent the song from starting too early
+            InitializeSongTime(SongOffset);
+            GlobalVariables.AudioManager.SetPosition(0);
+
+            // Start sync thread
+            _runSync = true;
+            _syncThread = new Thread(SyncThread) { IsBackground = true };
+            _syncThread.Start();
         }
 
         public void Update()


### PR DESCRIPTION
`GameplayBehaviour`s are now managed directly by `GameManager`, which allows for a number of improvements:
- Initialization methods can now be async where needed, and will be awaited properly while `GameManager` loads.
  - The `SongLoaded`/`ChartLoaded`/etc. events have been removed, as they are no longer necessary after this change.
- Everything is now consistently updated after `GameManager` is, which ensures nothing is potentially a frame behind.
- New hooks for seeking, speed changes, and pausing have been added, which means objects that need these don't have to rely on `GameManager` calling them directly, and don't have to constantly check each update to poll their status.

This fixes the song starting despite loading not actually being finished yet, and should make the system a bit more flexible.

The player classes have also been reworked to *not* use `GameplayBehaviour` (alongside other cleanups), as they are already handled specially by `GameManager`. It also prevents them from being updated twice, since they won't be part of the list of GameplayBehaviour`s.