### PR TITLE
Clean up navigation group selection handling and fix various issues

### DIFF
--- a/Assets/Prefabs/Menu/DifficultySelect/DifficultySelectMenu.prefab
+++ b/Assets/Prefabs/Menu/DifficultySelect/DifficultySelectMenu.prefab
@@ -1809,8 +1809,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _defaultGroup: 1
   _canBeCurrent: 1
-  _addAllChildrenOnAwake: 1
-  _selectFirst: 1
+  _addAllChildrenOnAwake: 0
+  _selectFirst: 0
 --- !u!224 &7507340441076923383 stripped
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 375337769934742335, guid: 81863a63e0d96cf459c263ee0ea6f98e,

--- a/Assets/Script/Helpers/LocaleHelper.cs
+++ b/Assets/Script/Helpers/LocaleHelper.cs
@@ -8,6 +8,8 @@ namespace YARG.Helpers
 {
     public static class LocaleHelper
     {
+        public static readonly LocalizedString EmptyString = new();
+
         public static string LocalizeString(string table, string key)
         {
             return LocalizationSettings.StringDatabase.GetLocalizedString(table, key);

--- a/Assets/Script/Menu/Common/Header/HeaderTabs.cs
+++ b/Assets/Script/Menu/Common/Header/HeaderTabs.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using UnityEngine;
 using YARG.Core.Input;
@@ -69,8 +69,14 @@ namespace YARG.Menu
             RefreshTabs();
         }
 
-        private void OnSelectionChanged(NavigatableBehaviour nav, SelectionOrigin selectionOrigin)
+        private void OnSelectionChanged(NavigatableBehaviour selected, SelectionOrigin selectionOrigin)
         {
+            if (selected == null)
+            {
+                SelectedTabId = null;
+                return;
+            }
+
             TabChanged?.Invoke(SelectedTabId);
         }
 

--- a/Assets/Script/Menu/Navigation/NavigatableBehaviour.cs
+++ b/Assets/Script/Menu/Navigation/NavigatableBehaviour.cs
@@ -39,11 +39,6 @@ namespace YARG.Menu.Navigation
         {
             if (Selected == selected) return;
 
-            if (selected)
-            {
-                NavigationGroup.DeselectAll();
-            }
-
             Selected = selected;
             OnSelectionChanged(selected);
 

--- a/Assets/Script/Menu/Navigation/NavigatableBehaviour.cs
+++ b/Assets/Script/Menu/Navigation/NavigatableBehaviour.cs
@@ -15,18 +15,9 @@ namespace YARG.Menu.Navigation
 
         public NavigationGroup NavigationGroup { get; set; }
 
-        private bool _selected;
-        public bool Selected
-        {
-            get => _selected;
-            private set
-            {
-                _selected = value;
-                SelectionStateChanged?.Invoke(value);
-            }
-        }
+        public bool Selected { get; private set; }
 
-        public event Action<bool> SelectionStateChanged;
+        public event Action<NavigatableBehaviour, bool, SelectionOrigin> SelectionStateChanged;
 
         protected virtual void Awake()
         {
@@ -35,19 +26,18 @@ namespace YARG.Menu.Navigation
             _selectedVisual.SetActive(Selected);
         }
 
+        protected virtual void OnDestroy()
+        {
+            SelectionStateChanged?.Invoke(this, false, SelectionOrigin.Programmatically);
+        }
+
         public void SetSelected(bool selected, SelectionOrigin selectionOrigin)
         {
             if (Selected == selected) return;
 
             Selected = selected;
             OnSelectionChanged(selected);
-
-            // Make sure these happen after, because they call events that rely on the above.
-            if (selected)
-            {
-                NavigationGroup.SetSelectedFromNavigatable(this, selectionOrigin);
-                NavigationGroup.SetAsCurrent();
-            }
+            SelectionStateChanged?.Invoke(this, selected, selectionOrigin);
         }
 
         protected virtual void OnSelectionChanged(bool selected)

--- a/Assets/Script/Menu/Navigation/NavigationGroup.cs
+++ b/Assets/Script/Menu/Navigation/NavigationGroup.cs
@@ -72,6 +72,7 @@ namespace YARG.Menu.Navigation
 
             _navigatables.Add(navigatable);
             navigatable.NavigationGroup = this;
+            navigatable.SelectionStateChanged += OnSelectionStateChanged;
         }
 
         public void AddNavigatable(GameObject gameObj)
@@ -142,11 +143,11 @@ namespace YARG.Menu.Navigation
             SelectionChanged?.Invoke(SelectedBehaviour, selectionOrigin);
         }
 
-        // Called from NavigatableBehaviours when they get selected
-        public void SetSelectedFromNavigatable(NavigatableBehaviour navigatableBehaviour, SelectionOrigin selectionOrigin)
+        private void OnSelectionStateChanged(NavigatableBehaviour navigatableBehaviour, bool selected,
+            SelectionOrigin selectionOrigin)
         {
             int index;
-            if (navigatableBehaviour != null)
+            if (selected)
             {
                 index = _navigatables.IndexOf(navigatableBehaviour);
                 if (index < 0)
@@ -165,6 +166,8 @@ namespace YARG.Menu.Navigation
 
             SelectedIndex = index;
             SelectionChanged?.Invoke(SelectedBehaviour, selectionOrigin);
+            if (selected)
+                SetAsCurrent();
         }
 
         public void DeselectCurrent()

--- a/Assets/Script/Menu/Navigation/NavigationGroup.cs
+++ b/Assets/Script/Menu/Navigation/NavigationGroup.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -20,6 +20,8 @@ namespace YARG.Menu.Navigation
         private bool _addAllChildrenOnAwake;
         [SerializeField]
         private bool _selectFirst;
+
+        public int Count => _navigatables.Count;
 
         public int SelectedIndex { get; private set; }
 
@@ -120,7 +122,10 @@ namespace YARG.Menu.Navigation
 
         public void SelectAt(int index, SelectionOrigin selectionOrigin = SelectionOrigin.Programmatically)
         {
-            if (index == SelectedIndex || index >= _navigatables.Count || index < 0)
+            if (index >= _navigatables.Count || index < 0)
+                throw new ArgumentOutOfRangeException(nameof(index), index, $"Index must be less than the count of navigatables ({_navigatables.Count})!");
+
+            if (index == SelectedIndex)
                 return;
 
             if (SelectedBehaviour != null)

--- a/Assets/Script/Menu/Navigation/NavigationGroup.cs
+++ b/Assets/Script/Menu/Navigation/NavigationGroup.cs
@@ -23,7 +23,7 @@ namespace YARG.Menu.Navigation
 
         public int Count => _navigatables.Count;
 
-        public int SelectedIndex { get; private set; }
+        public int SelectedIndex { get; private set; } = -1;
 
         public NavigatableBehaviour SelectedBehaviour
         {
@@ -47,8 +47,7 @@ namespace YARG.Menu.Navigation
             {
                 foreach (var navigatable in GetComponentsInChildren<NavigatableBehaviour>())
                 {
-                    navigatable.NavigationGroup = this;
-                    _navigatables.Add(navigatable);
+                    AddNavigatable(navigatable);
                 }
             }
         }
@@ -68,6 +67,9 @@ namespace YARG.Menu.Navigation
 
         public void AddNavigatable(NavigatableBehaviour navigatable)
         {
+            if (_navigatables.Contains(navigatable))
+                throw new InvalidOperationException($"Navigation group {this} already contains navigatable {navigatable}!");
+
             _navigatables.Add(navigatable);
             navigatable.NavigationGroup = this;
         }
@@ -90,6 +92,7 @@ namespace YARG.Menu.Navigation
 
         public void ClearNavigatables()
         {
+            DeselectAll();
             _navigatables.Clear();
         }
 

--- a/Assets/Script/Menu/Navigation/NavigationGroup.cs
+++ b/Assets/Script/Menu/Navigation/NavigationGroup.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -106,7 +106,8 @@ namespace YARG.Menu.Navigation
         public void SelectNext()
         {
             int selected = SelectedIndex;
-            if (selected < 0) return;
+            if (selected < 0 || selected >= _navigatables.Count - 1)
+                return;
 
             SelectAt(selected + 1, SelectionOrigin.Navigation);
         }
@@ -114,7 +115,8 @@ namespace YARG.Menu.Navigation
         public void SelectPrevious()
         {
             int selected = SelectedIndex;
-            if (selected < 0) return;
+            if (selected <= 0)
+                return;
 
             SelectAt(selected - 1, SelectionOrigin.Navigation);
         }
@@ -122,7 +124,7 @@ namespace YARG.Menu.Navigation
 
         public void SelectAt(int index, SelectionOrigin selectionOrigin = SelectionOrigin.Programmatically)
         {
-            if (index >= _navigatables.Count || index < 0)
+            if (index >= _navigatables.Count)
                 throw new ArgumentOutOfRangeException(nameof(index), index, $"Index must be less than the count of navigatables ({_navigatables.Count})!");
 
             if (index == SelectedIndex)
@@ -132,16 +134,26 @@ namespace YARG.Menu.Navigation
                 SelectedBehaviour.SetSelected(false, selectionOrigin);
 
             SelectedIndex = index;
-            SelectedBehaviour.SetSelected(true, selectionOrigin);
+            if (SelectedBehaviour != null)
+                SelectedBehaviour.SetSelected(true, selectionOrigin);
+
             SelectionChanged?.Invoke(SelectedBehaviour, selectionOrigin);
         }
 
         // Called from NavigatableBehaviours when they get selected
         public void SetSelectedFromNavigatable(NavigatableBehaviour navigatableBehaviour, SelectionOrigin selectionOrigin)
         {
-            int index = _navigatables.IndexOf(navigatableBehaviour);
-            if (index < 0)
-                throw new InvalidOperationException("The navigation item being selected is not present in the list!");
+            int index;
+            if (navigatableBehaviour != null)
+            {
+                index = _navigatables.IndexOf(navigatableBehaviour);
+                if (index < 0)
+                    throw new ArgumentException("The navigation item being selected is not present in the list!");
+            }
+            else
+            {
+                index = -1;
+            }
 
             if (index == SelectedIndex)
                 return;

--- a/Assets/Script/Menu/Navigation/NavigationGroup.cs
+++ b/Assets/Script/Menu/Navigation/NavigationGroup.cs
@@ -23,18 +23,16 @@ namespace YARG.Menu.Navigation
 
         public int Count => _navigatables.Count;
 
-        public int SelectedIndex { get; private set; } = -1;
+        public int? SelectedIndex { get; private set; } = null;
 
         public NavigatableBehaviour SelectedBehaviour
         {
             get
             {
-                if (_navigatables.Count < 1 || SelectedIndex < 0)
+                if (SelectedIndex is not {} index || index < 0 || index >= _navigatables.Count)
                     return null;
 
-                // Ensure selected index stays within bounds
-                SelectedIndex = Math.Clamp(SelectedIndex, 0, _navigatables.Count - 1);
-                return _navigatables[SelectedIndex];
+                return _navigatables[index];
             }
         }
 
@@ -59,7 +57,7 @@ namespace YARG.Menu.Navigation
                 CurrentNavigationGroup = this;
             }
 
-            if (_selectFirst && SelectedIndex < 0)
+            if (_selectFirst && SelectedBehaviour == null)
             {
                 SelectFirst();
             }
@@ -109,8 +107,7 @@ namespace YARG.Menu.Navigation
 
         public void SelectNext()
         {
-            int selected = SelectedIndex;
-            if (selected < 0 || selected >= _navigatables.Count - 1)
+            if (SelectedIndex is not {} selected || selected < 0 || selected >= _navigatables.Count - 1)
                 return;
 
             SelectAt(selected + 1, SelectionOrigin.Navigation);
@@ -118,20 +115,19 @@ namespace YARG.Menu.Navigation
 
         public void SelectPrevious()
         {
-            int selected = SelectedIndex;
-            if (selected <= 0)
+            if (SelectedIndex is not {} selected || selected <= 0)
                 return;
 
             SelectAt(selected - 1, SelectionOrigin.Navigation);
         }
 
-        public void SelectAt(int index, SelectionOrigin selectionOrigin = SelectionOrigin.Programmatically)
+        public void SelectAt(int? index, SelectionOrigin selectionOrigin = SelectionOrigin.Programmatically)
         {
             if (index == SelectedIndex || _navigatables.Count < 1)
                 return;
 
-            if (index >= _navigatables.Count)
-                throw new ArgumentOutOfRangeException(nameof(index), index, $"Index must be less than the count of navigatables ({_navigatables.Count})!");
+            if (index < 0 || index >= _navigatables.Count)
+                throw new ArgumentOutOfRangeException(nameof(index), index, $"Index must be between 0 and the count of navigatables ({_navigatables.Count})!");
 
             if (SelectedBehaviour != null)
                 SelectedBehaviour.SetSelected(false, selectionOrigin);
@@ -146,7 +142,7 @@ namespace YARG.Menu.Navigation
         private void OnSelectionStateChanged(NavigatableBehaviour navigatableBehaviour, bool selected,
             SelectionOrigin selectionOrigin)
         {
-            int index;
+            int? index;
             if (selected)
             {
                 index = _navigatables.IndexOf(navigatableBehaviour);
@@ -155,7 +151,7 @@ namespace YARG.Menu.Navigation
             }
             else
             {
-                index = -1;
+                index = null;
             }
 
             if (index == SelectedIndex)
@@ -175,7 +171,7 @@ namespace YARG.Menu.Navigation
             if (SelectedBehaviour != null)
                 SelectedBehaviour.SetSelected(false, SelectionOrigin.Programmatically);
 
-            SelectedIndex = -1;
+            SelectedIndex = null;
             SelectionChanged?.Invoke(null, SelectionOrigin.Programmatically);
         }
 
@@ -186,7 +182,7 @@ namespace YARG.Menu.Navigation
                 navigatable.SetSelected(false, SelectionOrigin.Programmatically);
             }
 
-            SelectedIndex = -1;
+            SelectedIndex = null;
             SelectionChanged?.Invoke(null, SelectionOrigin.Programmatically);
         }
 

--- a/Assets/Script/Menu/Navigation/NavigationGroup.cs
+++ b/Assets/Script/Menu/Navigation/NavigationGroup.cs
@@ -121,14 +121,13 @@ namespace YARG.Menu.Navigation
             SelectAt(selected - 1, SelectionOrigin.Navigation);
         }
 
-
         public void SelectAt(int index, SelectionOrigin selectionOrigin = SelectionOrigin.Programmatically)
         {
+            if (index == SelectedIndex || _navigatables.Count < 1)
+                return;
+
             if (index >= _navigatables.Count)
                 throw new ArgumentOutOfRangeException(nameof(index), index, $"Index must be less than the count of navigatables ({_navigatables.Count})!");
-
-            if (index == SelectedIndex)
-                return;
 
             if (SelectedBehaviour != null)
                 SelectedBehaviour.SetSelected(false, selectionOrigin);

--- a/Assets/Script/Menu/Navigation/NavigationTextColorizer.cs
+++ b/Assets/Script/Menu/Navigation/NavigationTextColorizer.cs
@@ -33,6 +33,11 @@ namespace YARG.Menu.Navigation
             OnSelectionStateChanged(_navigatableBehaviour.Selected);
         }
 
+        private void OnSelectionStateChanged(NavigatableBehaviour navigatable, bool selected, SelectionOrigin selectionOrigin)
+        {
+            OnSelectionStateChanged(selected);
+        }
+
         private void OnSelectionStateChanged(bool selected)
         {
             for (int i = 0; i < _texts.Length; i++)

--- a/Assets/Script/Menu/Navigation/ScrollViewNavigationUpdater.cs
+++ b/Assets/Script/Menu/Navigation/ScrollViewNavigationUpdater.cs
@@ -22,16 +22,17 @@ namespace YARG.Menu.Navigation
             _navigationGroup.SelectionChanged += OnSelectionChanged;
         }
 
-        private void OnSelectionChanged(NavigatableBehaviour nav, SelectionOrigin selectionOrigin)
+        private void OnSelectionChanged(NavigatableBehaviour selected, SelectionOrigin selectionOrigin)
         {
             // Only scroll it automatically if it's a navigation selection type
-            if (selectionOrigin != SelectionOrigin.Navigation) return;
+            if (selectionOrigin != SelectionOrigin.Navigation || selected == null)
+                return;
 
             Canvas.ForceUpdateCanvases();
 
             var newPos =
                 _scrollRect.transform.InverseTransformPoint(_contentTransform.position).y -
-                _scrollRect.transform.InverseTransformPoint(nav.transform.position).y -
+                _scrollRect.transform.InverseTransformPoint(selected.transform.position).y -
                 _rectTransform.rect.height / 2f;
 
             _contentTransform.anchoredPosition = _contentTransform.anchoredPosition.WithY(newPos);

--- a/Assets/Script/Menu/ProfileList/ProfileView.cs
+++ b/Assets/Script/Menu/ProfileList/ProfileView.cs
@@ -100,6 +100,7 @@ namespace YARG.Menu.ProfileList
             {
                 Destroy(gameObject);
                 NavigationGroup.RemoveNavigatable(this);
+                NavigationGroup = null;
             }
         }
 

--- a/Assets/Script/Menu/Settings/SettingsMenu.cs
+++ b/Assets/Script/Menu/Settings/SettingsMenu.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Cysharp.Threading.Tasks;
 using UnityEngine;
@@ -115,11 +115,18 @@ namespace YARG.Menu.Settings
         {
             CurrentTab?.OnTabExit();
             CurrentTab = SettingsManager.GetTabByName(tab);
-            CurrentTab.OnTabEnter();
+            CurrentTab?.OnTabEnter();
         }
 
         private void OnSelectionChanged(NavigatableBehaviour selected, SelectionOrigin selectionOrigin)
         {
+            if (selected == null || CurrentTab == null)
+            {
+                _settingName.StringReference = LocaleHelper.EmptyString;
+                _settingDescription.StringReference = LocaleHelper.EmptyString;
+                return;
+            }
+
             var settingNav = selected.GetComponent<BaseSettingNavigatable>();
 
             _settingName.StringReference = LocaleHelper.StringReference(
@@ -163,7 +170,7 @@ namespace YARG.Menu.Settings
             _settingsContainer.DestroyChildren();
 
             // Build the settings tab
-            CurrentTab.BuildSettingTab(_settingsContainer, _settingsNavGroup);
+            CurrentTab?.BuildSettingTab(_settingsContainer, _settingsNavGroup);
 
             if (resetScroll)
             {
@@ -185,6 +192,9 @@ namespace YARG.Menu.Settings
             }
 
             DestroyPreview();
+
+            if (CurrentTab == null)
+                return;
 
             // Spawn world preview
             _previewContainerWorld.gameObject.SetActive(true);


### PR DESCRIPTION
Navigatables are now selected using an index instead of a direct reference, which helps to ensure various things about how selections are handled. Deselections are also now reported via the selection changed event, and more error checking/reporting has been added to detect issues such as out-of-range indexes and duplicate entries.

In addition, this PR fixes the song path manager throwing an out-of-range exception when refreshing the settings menu, as well as the unintentional wraparound that would happen in the difficulty menu when scrolling down on Ready.