### PR TITLE
Fix idle mouse causing wrong initial selection of menu options

### DIFF
--- a/Assets/Script/Menu/Navigation/NavigatableBehaviour.cs
+++ b/Assets/Script/Menu/Navigation/NavigatableBehaviour.cs
@@ -4,7 +4,7 @@ using UnityEngine.EventSystems;
 
 namespace YARG.Menu.Navigation
 {
-    public abstract class NavigatableBehaviour : MonoBehaviour, IPointerEnterHandler, IPointerExitHandler, IPointerDownHandler
+    public abstract class NavigatableBehaviour : MonoBehaviour, IPointerMoveHandler, IPointerDownHandler
     {
         [SerializeField]
         private bool _selectOnHover;
@@ -60,18 +60,6 @@ namespace YARG.Menu.Navigation
             _selectedVisual.SetActive(selected);
         }
 
-        public virtual void OnPointerEnter(PointerEventData eventData)
-        {
-            if (_selectOnHover)
-            {
-                SetSelected(true, SelectionOrigin.Mouse);
-            }
-        }
-
-        public virtual void OnPointerExit(PointerEventData eventData)
-        {
-        }
-
         public virtual void OnPointerDown(PointerEventData eventData)
         {
             SetSelected(true, SelectionOrigin.Mouse);
@@ -79,6 +67,14 @@ namespace YARG.Menu.Navigation
 
         public virtual void Confirm()
         {
+        }
+
+        public void OnPointerMove(PointerEventData eventData)
+        {
+            if (_selectOnHover)
+            {
+                SetSelected(true, SelectionOrigin.Mouse);
+            }
         }
     }
 }


### PR DESCRIPTION
When the mouse was positioned on top of a menu option that appeared, it was automatically selected, which is annoying when using an instrument as the main input device