### PR TITLE
Adds "Album Art as Background" settings

### DIFF
--- a/Assets/Art/Reference/oneplayer.png
+++ b/Assets/Art/Reference/oneplayer.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:452cc0191f400a535843226397c5f1e0097787af68eb5165ef5ddd7cb5fc524d
+size 507476

--- a/Assets/Art/Reference/oneplayer.png.meta
+++ b/Assets/Art/Reference/oneplayer.png.meta
@@ -1,0 +1,123 @@
+fileFormatVersion: 2
+guid: 2af07dbc4acb87443a2c7df27ceab6e6
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 12
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 1
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMasterTextureLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 0
+    wrapV: 0
+    wrapW: 0
+  nPOTScale: 1
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 0
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 0
+  spriteTessellationDetail: -1
+  textureType: 0
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  cookieLightType: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Server
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    nameFileIdTable: {}
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Art/Reference/threeplayer.png
+++ b/Assets/Art/Reference/threeplayer.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6ae88a723232e9370c71a6a2f4a0220f092eaed34e817bb7b5c28db5c76676b7
+size 1038075

--- a/Assets/Art/Reference/threeplayer.png.meta
+++ b/Assets/Art/Reference/threeplayer.png.meta
@@ -1,0 +1,123 @@
+fileFormatVersion: 2
+guid: 857fdde8a21729a47a3ff38c7e9e4ff8
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 12
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 1
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMasterTextureLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 0
+    wrapV: 0
+    wrapW: 0
+  nPOTScale: 1
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 0
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 0
+  spriteTessellationDetail: -1
+  textureType: 0
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  cookieLightType: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Server
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    nameFileIdTable: {}
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Art/Reference/twoplayer.png
+++ b/Assets/Art/Reference/twoplayer.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5fd3b25e3831b816847156afeb1dbd3e0eb71f9fd756501e8c228177c17f2a26
+size 946824

--- a/Assets/Art/Reference/twoplayer.png.meta
+++ b/Assets/Art/Reference/twoplayer.png.meta
@@ -1,0 +1,123 @@
+fileFormatVersion: 2
+guid: acfecf242521b21419d147239543292a
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 12
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 1
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMasterTextureLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 0
+    wrapV: 0
+    wrapW: 0
+  nPOTScale: 1
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 0
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 0
+  spriteTessellationDetail: -1
+  textureType: 0
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  cookieLightType: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Server
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    nameFileIdTable: {}
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Art/Textures/Gameplay/AlbumBackgroundDarkener.png
+++ b/Assets/Art/Textures/Gameplay/AlbumBackgroundDarkener.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7bb53364365d911337ca67dae76f475cf1f0b4adde4a94ec1a95e65e2dbca146
+size 22412

--- a/Assets/Art/Textures/Gameplay/AlbumBackgroundDarkener.png.meta
+++ b/Assets/Art/Textures/Gameplay/AlbumBackgroundDarkener.png.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: e228f2a3e7ac9fe46a20f9519094799c
+guid: 56114b28f727dbe4283db8aa92a37d2f
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}
@@ -61,7 +61,7 @@ TextureImporter:
   maxTextureSizeSet: 0
   compressionQualitySet: 0
   textureFormatSet: 0
-  ignorePngGamma: 0
+  ignorePngGamma: 1
   applyGammaDecoding: 0
   cookieLightType: 0
   platformSettings:

--- a/Assets/Art/Textures/Gameplay/AlbumBgTransparency.png
+++ b/Assets/Art/Textures/Gameplay/AlbumBgTransparency.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bcba9e46245edd9cd191294132d5e61b27488458ed2bce703e93e9cdcf2f7d6d
-size 18718

--- a/Assets/Art/Textures/Gameplay/AlbumBgTransparency.png
+++ b/Assets/Art/Textures/Gameplay/AlbumBgTransparency.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:bcba9e46245edd9cd191294132d5e61b27488458ed2bce703e93e9cdcf2f7d6d
+size 18718

--- a/Assets/Art/Textures/Gameplay/AlbumBgTransparency.png.meta
+++ b/Assets/Art/Textures/Gameplay/AlbumBgTransparency.png.meta
@@ -1,0 +1,123 @@
+fileFormatVersion: 2
+guid: e228f2a3e7ac9fe46a20f9519094799c
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 12
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 1
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMasterTextureLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 0
+    wrapV: 0
+    wrapW: 0
+  nPOTScale: 1
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 0
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 0
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  cookieLightType: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Server
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    nameFileIdTable: {}
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/Gameplay.unity
+++ b/Assets/Scenes/Gameplay.unity
@@ -425,12 +425,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _canvasGroup: {fileID: 103030105}
   _text: {fileID: 103030102}
-  _albumCanvasOnePlayer: {fileID: 330108490}
-  _albumTextOnePlayer: {fileID: 330108491}
-  _albumCanvasTwoPlayer: {fileID: 1603842093}
-  _albumTextTwoPlayer: {fileID: 1603842094}
-  _albumCanvasThreePlayer: {fileID: 812823480}
-  _albumTextThreePlayer: {fileID: 812823481}
+  _albumText: {fileID: 330108491}
 --- !u!225 &103030105
 CanvasGroup:
   m_ObjectHideFlags: 0
@@ -1272,7 +1267,7 @@ PrefabInstance:
     - target: {fileID: 227366190812778480, guid: 039fee0ec42345d4f88c0625255415d4,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 2.515854
+      value: -187.3
       objectReference: {fileID: 0}
     - target: {fileID: 1682100932476655723, guid: 039fee0ec42345d4f88c0625255415d4,
         type: 3}
@@ -1407,7 +1402,7 @@ PrefabInstance:
     - target: {fileID: 2517693471320601084, guid: 039fee0ec42345d4f88c0625255415d4,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: -2.515854
+      value: 187.3
       objectReference: {fileID: 0}
     - target: {fileID: 6897601373631971078, guid: 039fee0ec42345d4f88c0625255415d4,
         type: 3}
@@ -1605,9 +1600,7 @@ MonoBehaviour:
   _videoPlayer: {fileID: 218824352}
   _backgroundImage: {fileID: 1773048783}
   _coverBackgroundImage: {fileID: 1919331475}
-  _coverImageOnePlayer: {fileID: 615696804}
-  _coverImageTwoPlayer: {fileID: 2052216687}
-  _coverImageThreePlayer: {fileID: 490605249}
+  _coverImage: {fileID: 615696804}
   _blackTransparency: {fileID: 1742166852}
 --- !u!114 &318454377
 MonoBehaviour:
@@ -1635,7 +1628,7 @@ GameObject:
   - component: {fileID: 330108491}
   - component: {fileID: 330108490}
   m_Layer: 5
-  m_Name: 1p Album Display
+  m_Name: Song Info Album
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -1649,16 +1642,16 @@ RectTransform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 330108488}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -2.5}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 571602432}
-  m_RootOrder: 1
+  m_Father: {fileID: 851048040}
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 1025, y: -280}
+  m_AnchoredPosition: {x: 440.5202, y: -570.0001}
   m_SizeDelta: {x: 600, y: 300}
   m_Pivot: {x: 0, y: 0.9999999}
 --- !u!225 &330108490
@@ -1784,12 +1777,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _canvasGroup: {fileID: 103030105}
   _text: {fileID: 103030102}
-  _albumCanvasOnePlayer: {fileID: 330108490}
-  _albumTextOnePlayer: {fileID: 330108491}
-  _albumCanvasTwoPlayer: {fileID: 1603842093}
-  _albumTextTwoPlayer: {fileID: 1603842094}
-  _albumCanvasThreePlayer: {fileID: 812823480}
-  _albumTextThreePlayer: {fileID: 812823481}
+  _albumText: {fileID: 330108491}
 --- !u!222 &330108493
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -1798,44 +1786,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 330108488}
   m_CullTransparentMesh: 1
---- !u!1 &391430506
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 391430507}
-  m_Layer: 5
-  m_Name: 2 Player
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &391430507
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 391430506}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 2.5}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 2052216686}
-  - {fileID: 1603842092}
-  m_Father: {fileID: 851048040}
-  m_RootOrder: 3
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -61.51013, y: 217.26762}
-  m_SizeDelta: {x: 1234.4797, y: 311.51175}
-  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1001 &396166999
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -3011,79 +2961,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 477816501}
   m_CullTransparentMesh: 1
---- !u!1 &490605247
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 490605248}
-  - component: {fileID: 490605250}
-  - component: {fileID: 490605249}
-  m_Layer: 5
-  m_Name: 3p Cover
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!224 &490605248
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 490605247}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 2.5000005}
-  m_LocalScale: {x: 0.5, y: 0.5, z: 0.5}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1913327001}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -266, y: -258}
-  m_SizeDelta: {x: -54.93921, y: 768.4883}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &490605249
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 490605247}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1344c3c82d62a2a41a3576d8abb8e3ea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Texture: {fileID: 0}
-  m_UVRect:
-    serializedVersion: 2
-    x: 0
-    y: 0
-    width: 1
-    height: 1
---- !u!222 &490605250
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 490605247}
-  m_CullTransparentMesh: 1
 --- !u!1 &523103389
 GameObject:
   m_ObjectHideFlags: 0
@@ -3285,44 +3162,6 @@ MonoBehaviour:
   m_ChildScaleWidth: 0
   m_ChildScaleHeight: 0
   m_ReverseArrangement: 0
---- !u!1 &571602431
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 571602432}
-  m_Layer: 5
-  m_Name: 1 Player
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &571602432
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 571602431}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 2.5}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 615696803}
-  - {fileID: 330108489}
-  m_Father: {fileID: 851048040}
-  m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -61.51013, y: 217.26762}
-  m_SizeDelta: {x: 1234.4797, y: 311.51175}
-  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &615696802
 GameObject:
   m_ObjectHideFlags: 0
@@ -3335,7 +3174,7 @@ GameObject:
   - component: {fileID: 615696805}
   - component: {fileID: 615696804}
   m_Layer: 5
-  m_Name: 1p Cover
+  m_Name: Album Cover
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -3349,17 +3188,17 @@ RectTransform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 615696802}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 2.5000005}
+  m_LocalPosition: {x: 0, y: 0, z: 5}
   m_LocalScale: {x: 0.5, y: 0.5, z: 0.5}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 571602432}
-  m_RootOrder: 0
+  m_Father: {fileID: 851048040}
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -518, y: -269}
-  m_SizeDelta: {x: -54.93921, y: 768.4883}
+  m_AnchoredPosition: {x: -579.51013, y: -51.732346}
+  m_SizeDelta: {x: 991, y: -246.04688}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &615696804
 MonoBehaviour:
@@ -4046,183 +3885,6 @@ RectTransform:
     type: 3}
   m_PrefabInstance: {fileID: 396166999}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &812823478
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 812823479}
-  - component: {fileID: 812823483}
-  - component: {fileID: 812823482}
-  - component: {fileID: 812823481}
-  - component: {fileID: 812823480}
-  m_Layer: 5
-  m_Name: 3p Album Display
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!224 &812823479
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 812823478}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -2.5}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1913327001}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 875, y: -165}
-  m_SizeDelta: {x: 600, y: 300}
-  m_Pivot: {x: 0, y: 0.9999999}
---- !u!225 &812823480
-CanvasGroup:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 812823478}
-  m_Enabled: 1
-  m_Alpha: 1
-  m_Interactable: 1
-  m_BlocksRaycasts: 1
-  m_IgnoreParentGroups: 0
---- !u!114 &812823481
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 812823478}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_text: 'Buddy Holly
-
-    Weezer
-
-    Weezer (The Blue Album), 1994
-
-    Charter:
-    Harmonix'
-  m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: ae170e91fd29a90479e906ddffb1d8ee, type: 2}
-  m_sharedMaterial: {fileID: -5480317595949376055, guid: ae170e91fd29a90479e906ddffb1d8ee,
-    type: 2}
-  m_fontSharedMaterials: []
-  m_fontMaterial: {fileID: 0}
-  m_fontMaterials: []
-  m_fontColor32:
-    serializedVersion: 2
-    rgba: 4294967295
-  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
-  m_enableVertexGradient: 0
-  m_colorMode: 3
-  m_fontColorGradient:
-    topLeft: {r: 1, g: 1, b: 1, a: 1}
-    topRight: {r: 1, g: 1, b: 1, a: 1}
-    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
-    bottomRight: {r: 1, g: 1, b: 1, a: 1}
-  m_fontColorGradientPreset: {fileID: 0}
-  m_spriteAsset: {fileID: 0}
-  m_tintAllSprites: 0
-  m_StyleSheet: {fileID: 0}
-  m_TextStyleHashCode: -1183493901
-  m_overrideHtmlColors: 0
-  m_faceColor:
-    serializedVersion: 2
-    rgba: 4294967295
-  m_fontSize: 38
-  m_fontSizeBase: 38
-  m_fontWeight: 400
-  m_enableAutoSizing: 0
-  m_fontSizeMin: 18
-  m_fontSizeMax: 72
-  m_fontStyle: 0
-  m_HorizontalAlignment: 1
-  m_VerticalAlignment: 256
-  m_textAlignment: 65535
-  m_characterSpacing: 0
-  m_wordSpacing: 0
-  m_lineSpacing: 0
-  m_lineSpacingMax: 0
-  m_paragraphSpacing: 0
-  m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
-  m_wordWrappingRatios: 0.4
-  m_overflowMode: 0
-  m_linkedTextComponent: {fileID: 0}
-  parentLinkedComponent: {fileID: 0}
-  m_enableKerning: 1
-  m_enableExtraPadding: 0
-  checkPaddingRequired: 0
-  m_isRichText: 1
-  m_parseCtrlCharacters: 1
-  m_isOrthographic: 1
-  m_isCullingEnabled: 0
-  m_horizontalMapping: 0
-  m_verticalMapping: 0
-  m_uvLineOffset: 0
-  m_geometrySortingOrder: 0
-  m_IsTextObjectScaleStatic: 0
-  m_VertexBufferAutoSizeReduction: 0
-  m_useMaxVisibleDescender: 1
-  m_pageToDisplay: 1
-  m_margin: {x: 0, y: 0, z: 0, w: 0}
-  m_isUsingLegacyAnimationComponent: 0
-  m_isVolumetricText: 0
-  m_hasFontAssetChanged: 0
-  m_baseMaterial: {fileID: 0}
-  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
---- !u!114 &812823482
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 812823478}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8e5de85e872a41eda7f9e32a94dd1cdf, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _canvasGroup: {fileID: 103030105}
-  _text: {fileID: 103030102}
-  _albumCanvasOnePlayer: {fileID: 330108490}
-  _albumTextOnePlayer: {fileID: 330108491}
-  _albumCanvasTwoPlayer: {fileID: 1603842093}
-  _albumTextTwoPlayer: {fileID: 1603842094}
-  _albumCanvasThreePlayer: {fileID: 812823480}
-  _albumTextThreePlayer: {fileID: 812823481}
---- !u!222 &812823483
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 812823478}
-  m_CullTransparentMesh: 1
 --- !u!1 &820110413
 GameObject:
   m_ObjectHideFlags: 0
@@ -4383,9 +4045,8 @@ RectTransform:
   m_Children:
   - {fileID: 1919331474}
   - {fileID: 1742166850}
-  - {fileID: 571602432}
-  - {fileID: 391430507}
-  - {fileID: 1913327001}
+  - {fileID: 615696803}
+  - {fileID: 330108489}
   m_Father: {fileID: 1650395555}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -6041,183 +5702,6 @@ MonoBehaviour:
   m_ChildScaleWidth: 0
   m_ChildScaleHeight: 0
   m_ReverseArrangement: 0
---- !u!1 &1603842091
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1603842092}
-  - component: {fileID: 1603842096}
-  - component: {fileID: 1603842095}
-  - component: {fileID: 1603842094}
-  - component: {fileID: 1603842093}
-  m_Layer: 5
-  m_Name: 2p Album Display
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!224 &1603842092
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1603842091}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -2.5}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 391430507}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 423.01794, y: -493.0235}
-  m_SizeDelta: {x: 600, y: 300}
-  m_Pivot: {x: 0, y: 0.9999999}
---- !u!225 &1603842093
-CanvasGroup:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1603842091}
-  m_Enabled: 1
-  m_Alpha: 1
-  m_Interactable: 1
-  m_BlocksRaycasts: 1
-  m_IgnoreParentGroups: 0
---- !u!114 &1603842094
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1603842091}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_text: 'Buddy Holly
-
-    Weezer
-
-    Weezer (The Blue Album), 1994
-
-    Charter:
-    Harmonix'
-  m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: ae170e91fd29a90479e906ddffb1d8ee, type: 2}
-  m_sharedMaterial: {fileID: -5480317595949376055, guid: ae170e91fd29a90479e906ddffb1d8ee,
-    type: 2}
-  m_fontSharedMaterials: []
-  m_fontMaterial: {fileID: 0}
-  m_fontMaterials: []
-  m_fontColor32:
-    serializedVersion: 2
-    rgba: 4294967295
-  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
-  m_enableVertexGradient: 0
-  m_colorMode: 3
-  m_fontColorGradient:
-    topLeft: {r: 1, g: 1, b: 1, a: 1}
-    topRight: {r: 1, g: 1, b: 1, a: 1}
-    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
-    bottomRight: {r: 1, g: 1, b: 1, a: 1}
-  m_fontColorGradientPreset: {fileID: 0}
-  m_spriteAsset: {fileID: 0}
-  m_tintAllSprites: 0
-  m_StyleSheet: {fileID: 0}
-  m_TextStyleHashCode: -1183493901
-  m_overrideHtmlColors: 0
-  m_faceColor:
-    serializedVersion: 2
-    rgba: 4294967295
-  m_fontSize: 38
-  m_fontSizeBase: 38
-  m_fontWeight: 400
-  m_enableAutoSizing: 0
-  m_fontSizeMin: 18
-  m_fontSizeMax: 72
-  m_fontStyle: 0
-  m_HorizontalAlignment: 2
-  m_VerticalAlignment: 256
-  m_textAlignment: 65535
-  m_characterSpacing: 0
-  m_wordSpacing: 0
-  m_lineSpacing: 0
-  m_lineSpacingMax: 0
-  m_paragraphSpacing: 0
-  m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
-  m_wordWrappingRatios: 0.4
-  m_overflowMode: 0
-  m_linkedTextComponent: {fileID: 0}
-  parentLinkedComponent: {fileID: 0}
-  m_enableKerning: 1
-  m_enableExtraPadding: 0
-  checkPaddingRequired: 0
-  m_isRichText: 1
-  m_parseCtrlCharacters: 1
-  m_isOrthographic: 1
-  m_isCullingEnabled: 0
-  m_horizontalMapping: 0
-  m_verticalMapping: 0
-  m_uvLineOffset: 0
-  m_geometrySortingOrder: 0
-  m_IsTextObjectScaleStatic: 0
-  m_VertexBufferAutoSizeReduction: 0
-  m_useMaxVisibleDescender: 1
-  m_pageToDisplay: 1
-  m_margin: {x: 0, y: 0, z: 0, w: 0}
-  m_isUsingLegacyAnimationComponent: 0
-  m_isVolumetricText: 0
-  m_hasFontAssetChanged: 0
-  m_baseMaterial: {fileID: 0}
-  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
---- !u!114 &1603842095
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1603842091}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8e5de85e872a41eda7f9e32a94dd1cdf, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _canvasGroup: {fileID: 103030105}
-  _text: {fileID: 103030102}
-  _albumCanvasOnePlayer: {fileID: 330108490}
-  _albumTextOnePlayer: {fileID: 330108491}
-  _albumCanvasTwoPlayer: {fileID: 1603842093}
-  _albumTextTwoPlayer: {fileID: 1603842094}
-  _albumCanvasThreePlayer: {fileID: 812823480}
-  _albumTextThreePlayer: {fileID: 812823481}
---- !u!222 &1603842096
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1603842091}
-  m_CullTransparentMesh: 1
 --- !u!1 &1650395551
 GameObject:
   m_ObjectHideFlags: 0
@@ -6806,7 +6290,7 @@ RectTransform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1742166849}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 9}
+  m_LocalPosition: {x: 0, y: 0, z: 8}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -6859,7 +6343,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Texture: {fileID: 2800000, guid: e228f2a3e7ac9fe46a20f9519094799c, type: 3}
+  m_Texture: {fileID: 2800000, guid: 56114b28f727dbe4283db8aa92a37d2f, type: 3}
   m_UVRect:
     serializedVersion: 2
     x: 0
@@ -7490,44 +6974,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1888549643}
   m_CullTransparentMesh: 1
---- !u!1 &1913327000
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1913327001}
-  m_Layer: 5
-  m_Name: 3+ Player
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &1913327001
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1913327000}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 2.5}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 490605248}
-  - {fileID: 812823479}
-  m_Father: {fileID: 851048040}
-  m_RootOrder: 4
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -61.51013, y: 217.26762}
-  m_SizeDelta: {x: 1234.4797, y: 311.51175}
-  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &1919331473
 GameObject:
   m_ObjectHideFlags: 0
@@ -7541,7 +6987,7 @@ GameObject:
   - component: {fileID: 1919331475}
   - component: {fileID: 1919331477}
   m_Layer: 5
-  m_Name: Cover Background
+  m_Name: Album Background
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -7885,79 +7331,6 @@ RectTransform:
     type: 3}
   m_PrefabInstance: {fileID: 1985479404}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &2052216685
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2052216686}
-  - component: {fileID: 2052216688}
-  - component: {fileID: 2052216687}
-  m_Layer: 5
-  m_Name: 2p Cover
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!224 &2052216686
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2052216685}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 2.5000005}
-  m_LocalScale: {x: 0.5, y: 0.5, z: 0.5}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 391430507}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 105.78027, y: -23}
-  m_SizeDelta: {x: -54.93921, y: 768.4883}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &2052216687
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2052216685}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1344c3c82d62a2a41a3576d8abb8e3ea, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Texture: {fileID: 0}
-  m_UVRect:
-    serializedVersion: 2
-    x: 0
-    y: 0
-    width: 1
-    height: 1
---- !u!222 &2052216688
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2052216685}
-  m_CullTransparentMesh: 1
 --- !u!1 &2075200648
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Gameplay.unity
+++ b/Assets/Scenes/Gameplay.unity
@@ -326,11 +326,14 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: 'Song Info Here
+  m_text: 'Buddy Holly
 
-    Wow
+    Weezer
 
-    Very Nice.'
+    Weezer (The Blue Album), 1994
+
+    Charter:
+    Harmonix'
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: ae170e91fd29a90479e906ddffb1d8ee, type: 2}
   m_sharedMaterial: {fileID: -5480317595949376055, guid: ae170e91fd29a90479e906ddffb1d8ee,
@@ -422,6 +425,12 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _canvasGroup: {fileID: 103030105}
   _text: {fileID: 103030102}
+  _albumCanvasOnePlayer: {fileID: 330108490}
+  _albumTextOnePlayer: {fileID: 330108491}
+  _albumCanvasTwoPlayer: {fileID: 1603842093}
+  _albumTextTwoPlayer: {fileID: 1603842094}
+  _albumCanvasThreePlayer: {fileID: 812823480}
+  _albumTextThreePlayer: {fileID: 812823481}
 --- !u!225 &103030105
 CanvasGroup:
   m_ObjectHideFlags: 0
@@ -1419,6 +1428,79 @@ GameObject:
     type: 3}
   m_PrefabInstance: {fileID: 310620822}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &312302476
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 312302477}
+  - component: {fileID: 312302479}
+  - component: {fileID: 312302478}
+  m_Layer: 5
+  m_Name: Three player + Vocalist
+  m_TagString: EditorOnly
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &312302477
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 312302476}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1068939578}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 2204.1245, y: 1080}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &312302478
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 312302476}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1344c3c82d62a2a41a3576d8abb8e3ea, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Texture: {fileID: 2800000, guid: 857fdde8a21729a47a3ff38c7e9e4ff8, type: 3}
+  m_UVRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+--- !u!222 &312302479
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 312302476}
+  m_CullTransparentMesh: 1
 --- !u!1 &318454370
 GameObject:
   m_ObjectHideFlags: 0
@@ -1522,6 +1604,11 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _videoPlayer: {fileID: 218824352}
   _backgroundImage: {fileID: 1773048783}
+  _coverBackgroundImage: {fileID: 1919331475}
+  _coverImageOnePlayer: {fileID: 615696804}
+  _coverImageTwoPlayer: {fileID: 2052216687}
+  _coverImageThreePlayer: {fileID: 490605249}
+  _blackTransparency: {fileID: 1742166852}
 --- !u!114 &318454377
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1534,6 +1621,221 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ff8084e0e7e64cf4d965e697cc8deee6, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &330108488
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 330108489}
+  - component: {fileID: 330108493}
+  - component: {fileID: 330108492}
+  - component: {fileID: 330108491}
+  - component: {fileID: 330108490}
+  m_Layer: 5
+  m_Name: 1p Album Display
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &330108489
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 330108488}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -2.5}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 571602432}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 1025, y: -280}
+  m_SizeDelta: {x: 600, y: 300}
+  m_Pivot: {x: 0, y: 0.9999999}
+--- !u!225 &330108490
+CanvasGroup:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 330108488}
+  m_Enabled: 1
+  m_Alpha: 1
+  m_Interactable: 1
+  m_BlocksRaycasts: 1
+  m_IgnoreParentGroups: 0
+--- !u!114 &330108491
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 330108488}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 'Buddy Holly
+
+    Weezer
+
+    Weezer (The Blue Album), 1994
+
+    Charter:
+    Harmonix'
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: ae170e91fd29a90479e906ddffb1d8ee, type: 2}
+  m_sharedMaterial: {fileID: -5480317595949376055, guid: ae170e91fd29a90479e906ddffb1d8ee,
+    type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 38
+  m_fontSizeBase: 38
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!114 &330108492
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 330108488}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8e5de85e872a41eda7f9e32a94dd1cdf, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _canvasGroup: {fileID: 103030105}
+  _text: {fileID: 103030102}
+  _albumCanvasOnePlayer: {fileID: 330108490}
+  _albumTextOnePlayer: {fileID: 330108491}
+  _albumCanvasTwoPlayer: {fileID: 1603842093}
+  _albumTextTwoPlayer: {fileID: 1603842094}
+  _albumCanvasThreePlayer: {fileID: 812823480}
+  _albumTextThreePlayer: {fileID: 812823481}
+--- !u!222 &330108493
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 330108488}
+  m_CullTransparentMesh: 1
+--- !u!1 &391430506
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 391430507}
+  m_Layer: 5
+  m_Name: 2 Player
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &391430507
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 391430506}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 2.5}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2052216686}
+  - {fileID: 1603842092}
+  m_Father: {fileID: 851048040}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -61.51013, y: 217.26762}
+  m_SizeDelta: {x: 1234.4797, y: 311.51175}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1001 &396166999
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2287,7 +2589,7 @@ RectTransform:
   - {fileID: 1316571461}
   - {fileID: 103030101}
   m_Father: {fileID: 1650395555}
-  m_RootOrder: 3
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -2709,6 +3011,79 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 477816501}
   m_CullTransparentMesh: 1
+--- !u!1 &490605247
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 490605248}
+  - component: {fileID: 490605250}
+  - component: {fileID: 490605249}
+  m_Layer: 5
+  m_Name: 3p Cover
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &490605248
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 490605247}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 2.5000005}
+  m_LocalScale: {x: 0.5, y: 0.5, z: 0.5}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1913327001}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -266, y: -258}
+  m_SizeDelta: {x: -54.93921, y: 768.4883}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &490605249
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 490605247}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1344c3c82d62a2a41a3576d8abb8e3ea, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Texture: {fileID: 0}
+  m_UVRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+--- !u!222 &490605250
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 490605247}
+  m_CullTransparentMesh: 1
 --- !u!1 &523103389
 GameObject:
   m_ObjectHideFlags: 0
@@ -2910,6 +3285,117 @@ MonoBehaviour:
   m_ChildScaleWidth: 0
   m_ChildScaleHeight: 0
   m_ReverseArrangement: 0
+--- !u!1 &571602431
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 571602432}
+  m_Layer: 5
+  m_Name: 1 Player
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &571602432
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 571602431}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 2.5}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 615696803}
+  - {fileID: 330108489}
+  m_Father: {fileID: 851048040}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -61.51013, y: 217.26762}
+  m_SizeDelta: {x: 1234.4797, y: 311.51175}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &615696802
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 615696803}
+  - component: {fileID: 615696805}
+  - component: {fileID: 615696804}
+  m_Layer: 5
+  m_Name: 1p Cover
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &615696803
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 615696802}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 2.5000005}
+  m_LocalScale: {x: 0.5, y: 0.5, z: 0.5}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 571602432}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -518, y: -269}
+  m_SizeDelta: {x: -54.93921, y: 768.4883}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &615696804
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 615696802}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1344c3c82d62a2a41a3576d8abb8e3ea, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Texture: {fileID: 0}
+  m_UVRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+--- !u!222 &615696805
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 615696802}
+  m_CullTransparentMesh: 1
 --- !u!1 &626807277
 GameObject:
   m_ObjectHideFlags: 0
@@ -3560,6 +4046,183 @@ RectTransform:
     type: 3}
   m_PrefabInstance: {fileID: 396166999}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &812823478
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 812823479}
+  - component: {fileID: 812823483}
+  - component: {fileID: 812823482}
+  - component: {fileID: 812823481}
+  - component: {fileID: 812823480}
+  m_Layer: 5
+  m_Name: 3p Album Display
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &812823479
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 812823478}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -2.5}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1913327001}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 875, y: -165}
+  m_SizeDelta: {x: 600, y: 300}
+  m_Pivot: {x: 0, y: 0.9999999}
+--- !u!225 &812823480
+CanvasGroup:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 812823478}
+  m_Enabled: 1
+  m_Alpha: 1
+  m_Interactable: 1
+  m_BlocksRaycasts: 1
+  m_IgnoreParentGroups: 0
+--- !u!114 &812823481
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 812823478}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 'Buddy Holly
+
+    Weezer
+
+    Weezer (The Blue Album), 1994
+
+    Charter:
+    Harmonix'
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: ae170e91fd29a90479e906ddffb1d8ee, type: 2}
+  m_sharedMaterial: {fileID: -5480317595949376055, guid: ae170e91fd29a90479e906ddffb1d8ee,
+    type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 38
+  m_fontSizeBase: 38
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!114 &812823482
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 812823478}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8e5de85e872a41eda7f9e32a94dd1cdf, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _canvasGroup: {fileID: 103030105}
+  _text: {fileID: 103030102}
+  _albumCanvasOnePlayer: {fileID: 330108490}
+  _albumTextOnePlayer: {fileID: 330108491}
+  _albumCanvasTwoPlayer: {fileID: 1603842093}
+  _albumTextTwoPlayer: {fileID: 1603842094}
+  _albumCanvasThreePlayer: {fileID: 812823480}
+  _albumTextThreePlayer: {fileID: 812823481}
+--- !u!222 &812823483
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 812823478}
+  m_CullTransparentMesh: 1
 --- !u!1 &820110413
 GameObject:
   m_ObjectHideFlags: 0
@@ -3690,6 +4353,47 @@ MonoBehaviour:
   m_ChildScaleWidth: 0
   m_ChildScaleHeight: 0
   m_ReverseArrangement: 0
+--- !u!1 &851048039
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 851048040}
+  m_Layer: 5
+  m_Name: Album BG
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &851048040
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 851048039}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1919331474}
+  - {fileID: 1742166850}
+  - {fileID: 571602432}
+  - {fileID: 391430507}
+  - {fileID: 1913327001}
+  m_Father: {fileID: 1650395555}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -44.270233, y: 0}
+  m_SizeDelta: {x: 188.54047, y: 1326.047}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1001 &922548496
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -3830,7 +4534,7 @@ PrefabInstance:
     - target: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0,
         type: 3}
       propertyPath: m_RootOrder
-      value: 7
+      value: 8
       objectReference: {fileID: 0}
     - target: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0,
         type: 3}
@@ -4047,7 +4751,7 @@ RectTransform:
   - {fileID: 658438232}
   - {fileID: 1651499654}
   m_Father: {fileID: 1650395555}
-  m_RootOrder: 4
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
@@ -4205,6 +4909,46 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1061222912}
   m_CullTransparentMesh: 1
+--- !u!1 &1068939577
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1068939578}
+  m_Layer: 5
+  m_Name: References
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &1068939578
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1068939577}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1943762375}
+  - {fileID: 1290139439}
+  - {fileID: 312302477}
+  - {fileID: 1327505391}
+  m_Father: {fileID: 1650395555}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &1085040316
 GameObject:
   m_ObjectHideFlags: 0
@@ -4518,6 +5262,79 @@ RectTransform:
     type: 3}
   m_PrefabInstance: {fileID: 1279855062}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1290139438
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1290139439}
+  - component: {fileID: 1290139441}
+  - component: {fileID: 1290139440}
+  m_Layer: 5
+  m_Name: Two player + Vocalist
+  m_TagString: EditorOnly
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &1290139439
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1290139438}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1068939578}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 2204.1245, y: 1080}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1290139440
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1290139438}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1344c3c82d62a2a41a3576d8abb8e3ea, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Texture: {fileID: 2800000, guid: acfecf242521b21419d147239543292a, type: 3}
+  m_UVRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+--- !u!222 &1290139441
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1290139438}
+  m_CullTransparentMesh: 1
 --- !u!114 &1312797156 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 5801866611232935394, guid: f09d7030713b2e34dbc210e5e014add2,
@@ -4623,7 +5440,7 @@ RectTransform:
   - {fileID: 459816309}
   - {fileID: 1985479405}
   m_Father: {fileID: 1650395555}
-  m_RootOrder: 5
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -4660,7 +5477,7 @@ GameObject:
   - component: {fileID: 1327505393}
   - component: {fileID: 1327505392}
   m_Layer: 5
-  m_Name: Reference
+  m_Name: Interface
   m_TagString: EditorOnly
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -4673,18 +5490,18 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1327505390}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 1650395555}
-  m_RootOrder: 1
+  m_Father: {fileID: 1068939578}
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_SizeDelta: {x: 2204.1245, y: 1080}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1327505392
 MonoBehaviour:
@@ -4753,7 +5570,7 @@ RectTransform:
   m_Children:
   - {fileID: 626807278}
   m_Father: {fileID: 1650395555}
-  m_RootOrder: 2
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -4838,7 +5655,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 0}
-  m_AnchoredPosition: {x: -27.5, y: 40}
+  m_AnchoredPosition: {x: -27.500122, y: 40}
   m_SizeDelta: {x: -845, y: 150}
   m_Pivot: {x: 0.5, y: 1}
 --- !u!114 &1338572398
@@ -5224,6 +6041,183 @@ MonoBehaviour:
   m_ChildScaleWidth: 0
   m_ChildScaleHeight: 0
   m_ReverseArrangement: 0
+--- !u!1 &1603842091
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1603842092}
+  - component: {fileID: 1603842096}
+  - component: {fileID: 1603842095}
+  - component: {fileID: 1603842094}
+  - component: {fileID: 1603842093}
+  m_Layer: 5
+  m_Name: 2p Album Display
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &1603842092
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1603842091}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -2.5}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 391430507}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 423.01794, y: -493.0235}
+  m_SizeDelta: {x: 600, y: 300}
+  m_Pivot: {x: 0, y: 0.9999999}
+--- !u!225 &1603842093
+CanvasGroup:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1603842091}
+  m_Enabled: 1
+  m_Alpha: 1
+  m_Interactable: 1
+  m_BlocksRaycasts: 1
+  m_IgnoreParentGroups: 0
+--- !u!114 &1603842094
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1603842091}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 'Buddy Holly
+
+    Weezer
+
+    Weezer (The Blue Album), 1994
+
+    Charter:
+    Harmonix'
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: ae170e91fd29a90479e906ddffb1d8ee, type: 2}
+  m_sharedMaterial: {fileID: -5480317595949376055, guid: ae170e91fd29a90479e906ddffb1d8ee,
+    type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 38
+  m_fontSizeBase: 38
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!114 &1603842095
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1603842091}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8e5de85e872a41eda7f9e32a94dd1cdf, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _canvasGroup: {fileID: 103030105}
+  _text: {fileID: 103030102}
+  _albumCanvasOnePlayer: {fileID: 330108490}
+  _albumTextOnePlayer: {fileID: 330108491}
+  _albumCanvasTwoPlayer: {fileID: 1603842093}
+  _albumTextTwoPlayer: {fileID: 1603842094}
+  _albumCanvasThreePlayer: {fileID: 812823480}
+  _albumTextThreePlayer: {fileID: 812823481}
+--- !u!222 &1603842096
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1603842091}
+  m_CullTransparentMesh: 1
 --- !u!1 &1650395551
 GameObject:
   m_ObjectHideFlags: 0
@@ -5316,8 +6310,9 @@ RectTransform:
   m_LocalScale: {x: 0, y: 0, z: 0}
   m_ConstrainProportionsScale: 0
   m_Children:
+  - {fileID: 851048040}
   - {fileID: 1773048782}
-  - {fileID: 1327505391}
+  - {fileID: 1068939578}
   - {fileID: 1330928976}
   - {fileID: 397042284}
   - {fileID: 1047079481}
@@ -5784,6 +6779,101 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!1 &1742166849
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1742166850}
+  - component: {fileID: 1742166853}
+  - component: {fileID: 1742166852}
+  - component: {fileID: 1742166851}
+  m_Layer: 5
+  m_Name: Black Transparency
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &1742166850
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1742166849}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 9}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 851048040}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 44.270203, y: 0}
+  m_SizeDelta: {x: 2500, y: 2000}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!223 &1742166851
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1742166849}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 2
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_AdditionalShaderChannelsFlag: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!114 &1742166852
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1742166849}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1344c3c82d62a2a41a3576d8abb8e3ea, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Texture: {fileID: 2800000, guid: e228f2a3e7ac9fe46a20f9519094799c, type: 3}
+  m_UVRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+--- !u!222 &1742166853
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1742166849}
+  m_CullTransparentMesh: 1
 --- !u!1 &1757985208
 GameObject:
   m_ObjectHideFlags: 0
@@ -5864,7 +6954,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1650395555}
-  m_RootOrder: 0
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -6400,6 +7490,206 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1888549643}
   m_CullTransparentMesh: 1
+--- !u!1 &1913327000
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1913327001}
+  m_Layer: 5
+  m_Name: 3+ Player
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1913327001
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1913327000}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 2.5}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 490605248}
+  - {fileID: 812823479}
+  m_Father: {fileID: 851048040}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -61.51013, y: 217.26762}
+  m_SizeDelta: {x: 1234.4797, y: 311.51175}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &1919331473
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1919331474}
+  - component: {fileID: 1919331476}
+  - component: {fileID: 1919331475}
+  - component: {fileID: 1919331477}
+  m_Layer: 5
+  m_Name: Cover Background
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &1919331474
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1919331473}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 851048040}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 44.27014, y: 0}
+  m_SizeDelta: {x: 2217.2961, y: 1079.9999}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1919331475
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1919331473}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1344c3c82d62a2a41a3576d8abb8e3ea, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 2100000, guid: 3b5eade2dc49a2748ad794a2c503c808, type: 2}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Texture: {fileID: 0}
+  m_UVRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+--- !u!222 &1919331476
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1919331473}
+  m_CullTransparentMesh: 1
+--- !u!114 &1919331477
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1919331473}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cfabb0440166ab443bba8876756fdfa9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_EffectColor: {r: 0, g: 0, b: 0, a: 0.5}
+  m_EffectDistance: {x: 20, y: 20}
+  m_UseGraphicAlpha: 1
+--- !u!1 &1943762374
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1943762375}
+  - component: {fileID: 1943762377}
+  - component: {fileID: 1943762376}
+  m_Layer: 5
+  m_Name: One player + Vocalist
+  m_TagString: EditorOnly
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &1943762375
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1943762374}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1068939578}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 2204.1245, y: 1080}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1943762376
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1943762374}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1344c3c82d62a2a41a3576d8abb8e3ea, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Texture: {fileID: 2800000, guid: 2af07dbc4acb87443a2c7df27ceab6e6, type: 3}
+  m_UVRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+--- !u!222 &1943762377
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1943762374}
+  m_CullTransparentMesh: 1
 --- !u!1 &1954655096
 GameObject:
   m_ObjectHideFlags: 0
@@ -6595,6 +7885,79 @@ RectTransform:
     type: 3}
   m_PrefabInstance: {fileID: 1985479404}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &2052216685
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2052216686}
+  - component: {fileID: 2052216688}
+  - component: {fileID: 2052216687}
+  m_Layer: 5
+  m_Name: 2p Cover
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &2052216686
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2052216685}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 2.5000005}
+  m_LocalScale: {x: 0.5, y: 0.5, z: 0.5}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 391430507}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 105.78027, y: -23}
+  m_SizeDelta: {x: -54.93921, y: 768.4883}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &2052216687
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2052216685}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1344c3c82d62a2a41a3576d8abb8e3ea, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Texture: {fileID: 0}
+  m_UVRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+--- !u!222 &2052216688
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2052216685}
+  m_CullTransparentMesh: 1
 --- !u!1 &2075200648
 GameObject:
   m_ObjectHideFlags: 0
@@ -6820,7 +8183,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1650395555}
-  m_RootOrder: 6
+  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}

--- a/Assets/Scenes/Gameplay.unity
+++ b/Assets/Scenes/Gameplay.unity
@@ -4095,22 +4095,22 @@ PrefabInstance:
     - target: {fileID: 2933889975780695480, guid: f8c143f8514898b4fb85fbadc18550c0,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2933889975780695480, guid: f8c143f8514898b4fb85fbadc18550c0,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2933889975780695480, guid: f8c143f8514898b4fb85fbadc18550c0,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 30.000036
       objectReference: {fileID: 0}
     - target: {fileID: 2933889975780695480, guid: f8c143f8514898b4fb85fbadc18550c0,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -32
       objectReference: {fileID: 0}
     - target: {fileID: 5322898957872382039, guid: f8c143f8514898b4fb85fbadc18550c0,
         type: 3}
@@ -6985,7 +6985,6 @@ GameObject:
   - component: {fileID: 1919331474}
   - component: {fileID: 1919331476}
   - component: {fileID: 1919331475}
-  - component: {fileID: 1919331477}
   m_Layer: 5
   m_Name: Album Background
   m_TagString: Untagged
@@ -7048,21 +7047,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1919331473}
   m_CullTransparentMesh: 1
---- !u!114 &1919331477
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1919331473}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: cfabb0440166ab443bba8876756fdfa9, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_EffectColor: {r: 0, g: 0, b: 0, a: 0.5}
-  m_EffectDistance: {x: 20, y: 20}
-  m_UseGraphicAlpha: 1
 --- !u!1 &1943762374
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Script/Gameplay/BackgroundManager.cs
+++ b/Assets/Script/Gameplay/BackgroundManager.cs
@@ -31,11 +31,7 @@ namespace YARG.Gameplay
         [SerializeField]
         private RawImage _coverBackgroundImage;
         [SerializeField]
-        private RawImage _coverImageOnePlayer;
-        [SerializeField]
-        private RawImage _coverImageTwoPlayer;
-        [SerializeField]
-        private RawImage _coverImageThreePlayer;
+        private RawImage _coverImage;
         [SerializeField]
         private RawImage _blackTransparency;
 
@@ -132,12 +128,11 @@ namespace YARG.Gameplay
                 case BackgroundType.Album:
                     await GameManager.Song.SetRawImageToAlbumCover(_coverBackgroundImage, CancellationToken.None); // Grabs album cover and applies it to the objects
                         
-                    _coverImageOnePlayer.texture = _coverBackgroundImage.texture;
-                    _coverImageTwoPlayer.texture = _coverBackgroundImage.texture;
-                    _coverImageThreePlayer.texture = _coverBackgroundImage.texture;
-                        
+                    _coverImage.texture = _coverBackgroundImage.texture;
+                    
                     _coverBackgroundImage.gameObject.SetActive(true);
                     _blackTransparency.gameObject.SetActive(true); // Really dumb way of darkening the background image, just a big semi-transparent black box that fills the screen
+                    _coverImage.gameObject.SetActive(true);
 
                     int playerCount = 0;
                     foreach (var player in GameManager.Players)
@@ -148,21 +143,18 @@ namespace YARG.Gameplay
 
                     if (playerCount == 1)
                     {
-                        _coverImageOnePlayer.gameObject.SetActive(true);
-                        _coverImageTwoPlayer.gameObject.SetActive(false);
-                        _coverImageThreePlayer.gameObject.SetActive(false);
+                        RectTransform _albumCoverRt = _coverImage.GetComponent<RectTransform>(); 
+                        _albumCoverRt.anchoredPosition = new Vector3(-555, -0, 5);
                     }
                     if (playerCount == 2)
                     {
-                        _coverImageOnePlayer.gameObject.SetActive(false);
-                        _coverImageTwoPlayer.gameObject.SetActive(true);
-                        _coverImageThreePlayer.gameObject.SetActive(false);
+                        RectTransform _albumCoverRt = _coverImage.GetComponent<RectTransform>(); 
+                        _albumCoverRt.anchoredPosition = new Vector3(40, 175, 5);
                     }
                     if (playerCount >= 3)
                     {
-                        _coverImageOnePlayer.gameObject.SetActive(false);
-                        _coverImageTwoPlayer.gameObject.SetActive(false);
-                        _coverImageThreePlayer.gameObject.SetActive(true);
+                        RectTransform _albumCoverRt = _coverImage.GetComponent<RectTransform>(); 
+                        _albumCoverRt.anchoredPosition = new Vector3 (-340, 0, 5);
                     }
                     break;
             }

--- a/Assets/Script/Gameplay/BackgroundManager.cs
+++ b/Assets/Script/Gameplay/BackgroundManager.cs
@@ -1,14 +1,22 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
+using System.Threading;
 using Cysharp.Threading.Tasks;
 using UnityEngine;
 using UnityEngine.UI;
 using UnityEngine.Video;
+using YARG.Core.Song;
 using YARG.Core.Extensions;
 using YARG.Core.Venue;
 using YARG.Helpers;
+using YARG.Helpers.Extensions;
 using YARG.Venue;
+using System.Text.RegularExpressions;
+using TMPro;
+using JetBrains.Annotations;
+using YARG.Gameplay.HUD;
+using YARG.Gameplay.Player;
 
 namespace YARG.Gameplay
 {
@@ -19,6 +27,19 @@ namespace YARG.Gameplay
         private VideoPlayer _videoPlayer;
         [SerializeField]
         private RawImage _backgroundImage;
+
+        [SerializeField]
+        private RawImage _coverBackgroundImage;
+        [SerializeField]
+        private RawImage _coverImageOnePlayer;
+        [SerializeField]
+        private RawImage _coverImageTwoPlayer;
+        [SerializeField]
+        private RawImage _coverImageThreePlayer;
+        [SerializeField]
+        private RawImage _blackTransparency;
+
+        public SongMetadata Song { get; }
 
         private VenueInfo _venueInfo;
 
@@ -106,6 +127,42 @@ namespace YARG.Gameplay
                     {
                         _backgroundImage.gameObject.SetActive(true);
                         _backgroundImage.texture = texture;
+                    }
+                    break;
+                case BackgroundType.Album:
+                    await GameManager.Song.SetRawImageToAlbumCover(_coverBackgroundImage, CancellationToken.None); // Grabs album cover and applies it to the objects
+                        
+                    _coverImageOnePlayer.texture = _coverBackgroundImage.texture;
+                    _coverImageTwoPlayer.texture = _coverBackgroundImage.texture;
+                    _coverImageThreePlayer.texture = _coverBackgroundImage.texture;
+                        
+                    _coverBackgroundImage.gameObject.SetActive(true);
+                    _blackTransparency.gameObject.SetActive(true); // Really dumb way of darkening the background image, just a big semi-transparent black box that fills the screen
+
+                    int playerCount = 0;
+                    foreach (var player in GameManager.Players)
+                    {
+                        if (player is not Gameplay.Player.VocalsPlayer)
+                            playerCount++;
+                    }
+
+                    if (playerCount == 1)
+                    {
+                        _coverImageOnePlayer.gameObject.SetActive(true);
+                        _coverImageTwoPlayer.gameObject.SetActive(false);
+                        _coverImageThreePlayer.gameObject.SetActive(false);
+                    }
+                    if (playerCount == 2)
+                    {
+                        _coverImageOnePlayer.gameObject.SetActive(false);
+                        _coverImageTwoPlayer.gameObject.SetActive(true);
+                        _coverImageThreePlayer.gameObject.SetActive(false);
+                    }
+                    if (playerCount >= 3)
+                    {
+                        _coverImageOnePlayer.gameObject.SetActive(false);
+                        _coverImageTwoPlayer.gameObject.SetActive(false);
+                        _coverImageThreePlayer.gameObject.SetActive(true);
                     }
                     break;
             }

--- a/Assets/Script/Gameplay/BackgroundManager.cs
+++ b/Assets/Script/Gameplay/BackgroundManager.cs
@@ -144,12 +144,12 @@ namespace YARG.Gameplay
                     if (playerCount == 1)
                     {
                         RectTransform _albumCoverRt = _coverImage.GetComponent<RectTransform>(); 
-                        _albumCoverRt.anchoredPosition = new Vector3(-555, -0, 5);
+                        _albumCoverRt.anchoredPosition = new Vector3(-555, -55, 5);
                     }
                     if (playerCount == 2)
                     {
                         RectTransform _albumCoverRt = _coverImage.GetComponent<RectTransform>(); 
-                        _albumCoverRt.anchoredPosition = new Vector3(40, 175, 5);
+                        _albumCoverRt.anchoredPosition = new Vector3(40, 170, 5);
                     }
                     if (playerCount >= 3)
                     {

--- a/Assets/Script/Gameplay/HUD/SongInfoText.cs
+++ b/Assets/Script/Gameplay/HUD/SongInfoText.cs
@@ -1,7 +1,11 @@
 ﻿using System.Collections;
+using Cysharp.Threading.Tasks.Triggers;
 using DG.Tweening;
+using DG.Tweening.Core.Easing;
 using TMPro;
+using UnityEditorInternal;
 using UnityEngine;
+using YARG.Gameplay.Player;
 using YARG.Helpers;
 using YARG.Settings;
 
@@ -15,8 +19,85 @@ namespace YARG.Gameplay.HUD
         [SerializeField]
         private TextMeshProUGUI _text;
 
+        [SerializeField]
+        private CanvasGroup _albumCanvasOnePlayer;
+        [SerializeField]
+        private TextMeshProUGUI _albumTextOnePlayer;
+        [SerializeField]
+        private CanvasGroup _albumCanvasTwoPlayer;
+        [SerializeField]
+        private TextMeshProUGUI _albumTextTwoPlayer;
+        [SerializeField]
+        private CanvasGroup _albumCanvasThreePlayer;
+        [SerializeField]
+        private TextMeshProUGUI _albumTextThreePlayer;
+
         private void Start()
+        {   
+            
+            if (!SettingsManager.Settings.DisablePerSongBackgrounds.Value)
         {
+            // Album Bg has different font parameters
+            if (SettingsManager.Settings.AlbumArtBackground.Value)
+        {   
+            
+            {
+                _text.gameObject.SetActive(false);
+                
+                int playerCount = 0;
+                foreach (var player in GameManager.Players)
+                {
+                    if (player is not Gameplay.Player.VocalsPlayer)
+                       playerCount++;
+                } 
+
+                var aLines = SongToText.ToStyled(SongToText.FORMAT_LONG, GameManager.Song);
+
+            string aFinalText = "";
+            foreach (var aLine in aLines)
+            {
+                // Add styles to each styling
+                aFinalText += aLine.Style switch
+                {
+                    SongToText.Style.Header =>
+                        $"<size=100%><font-weight=800>{aLine.Text}</font-weight></size>",
+                    SongToText.Style.SubHeader =>
+                        $"<size=95%><alpha=#95><i><font-weight=650>{aLine.Text}</font-weight></i></size>",
+                    _ =>
+                        $"<size=90%><alpha=#80><font-weight=650>{aLine.Text}</font-weight></size>"
+                } + "\n";
+            }
+            _albumTextOnePlayer.text = aFinalText;
+            _albumTextTwoPlayer.text = aFinalText;
+            _albumTextThreePlayer.text = aFinalText;
+
+            if (playerCount == 1)
+            {
+                _albumTextOnePlayer.gameObject.SetActive(true);
+                _albumTextTwoPlayer.gameObject.SetActive(false);
+                _albumTextThreePlayer.gameObject.SetActive(false);
+                
+            }
+            if (playerCount == 2)
+            {
+                _albumTextOnePlayer.gameObject.SetActive(false);
+                _albumTextTwoPlayer.gameObject.SetActive(true);
+                _albumTextThreePlayer.gameObject.SetActive(false);
+                
+            }
+            if (playerCount >= 3)
+            {
+                _albumTextOnePlayer.gameObject.SetActive(false);
+                _albumTextTwoPlayer.gameObject.SetActive(false);
+                _albumTextThreePlayer.gameObject.SetActive(true);
+                
+            }
+            }
+        }
+        }
+        else
+        {
+            
             if (!SettingsManager.Settings.KeepSongInfoVisible.Value)
             {
                 // Start fading out
@@ -39,9 +120,14 @@ namespace YARG.Gameplay.HUD
                         $"<size=80%><alpha=#66><i><font-weight=600>{line.Text}</font-weight></i></size>"
                 } + "\n";
             }
+            _albumTextOnePlayer.gameObject.SetActive(false);
+            _albumTextTwoPlayer.gameObject.SetActive(false);
+            _albumTextThreePlayer.gameObject.SetActive(false);
 
             _text.text = finalText;
         }
+        }
+    
 
         private IEnumerator FadeCoroutine()
         {

--- a/Assets/Script/Gameplay/HUD/SongInfoText.cs
+++ b/Assets/Script/Gameplay/HUD/SongInfoText.cs
@@ -1,13 +1,18 @@
 ﻿using System.Collections;
+using System.Collections.Generic;
 using Cysharp.Threading.Tasks.Triggers;
 using DG.Tweening;
 using DG.Tweening.Core.Easing;
 using TMPro;
+using UnityEditor.Localization.Plugins.XLIFF.V20;
 using UnityEditorInternal;
 using UnityEngine;
+using UnityEngine.UI;
+using UnityEngine.UIElements;
 using YARG.Gameplay.Player;
 using YARG.Helpers;
 using YARG.Settings;
+using YARG.Venue;
 
 namespace YARG.Gameplay.HUD
 {
@@ -19,116 +24,93 @@ namespace YARG.Gameplay.HUD
         [SerializeField]
         private TextMeshProUGUI _text;
 
-        [SerializeField]
-        private CanvasGroup _albumCanvasOnePlayer;
-        [SerializeField]
-        private TextMeshProUGUI _albumTextOnePlayer;
-        [SerializeField]
-        private CanvasGroup _albumCanvasTwoPlayer;
-        [SerializeField]
-        private TextMeshProUGUI _albumTextTwoPlayer;
-        [SerializeField]
-        private CanvasGroup _albumCanvasThreePlayer;
-        [SerializeField]
-        private TextMeshProUGUI _albumTextThreePlayer;
+        [SerializeField] 
+        private TextMeshProUGUI _albumText;
 
         private void Start()
         {   
             
-            if (!SettingsManager.Settings.DisablePerSongBackgrounds.Value)
-        {
-            // Album Bg has different font parameters
-            if (SettingsManager.Settings.AlbumArtBackground.Value)
-        {   
+                // Album Bg has different font parameters
+                if (SettingsManager.Settings.BackgroundMode.Value == VenueMode.AlbumAsBackground || SettingsManager.Settings.BackgroundMode.Value == VenueMode.OverrideToAlbumAsBackground)
+                {   
+                    int playerCount = 0;
+                    foreach (var player in GameManager.Players)
+                    {
+                        if (player is not VocalsPlayer)
+                            playerCount++;
+                    } 
+
+                    var aLines = SongToText.ToStyled(SongToText.FORMAT_LONG, GameManager.Song);
+
+                    string aFinalText = "";
+                    foreach (var aLine in aLines)
+                    {
+                        // Add styles to each styling
+                        aFinalText += aLine.Style switch
+                        {
+                            SongToText.Style.Header =>
+                                $"<size=110%><font-weight=800>{aLine.Text}</font-weight></size>",
+                            SongToText.Style.SubHeader =>
+                                $"<size=105%><alpha=#95><i><font-weight=700>{aLine.Text}</font-weight></i></size>",
+                            _ =>
+                                $"<size=100%><alpha=#80><font-weight=650>{aLine.Text}</font-weight></size>"
+                        } + "\n";
+                    }
+
+                    _text.gameObject.SetActive(false);
+                    _albumText.text = aFinalText;
             
-            {
-                _text.gameObject.SetActive(false);
-                
-                int playerCount = 0;
-                foreach (var player in GameManager.Players)
+                    if (playerCount == 1)
+                    {
+                        RectTransform _albumTextRt = _albumText.GetComponent<RectTransform>(); 
+                        _albumTextRt.anchoredPosition = new Vector3(400, -500, -2);
+                    }
+                    if (playerCount == 2)
+                    {
+                        RectTransform _albumTextRt = _albumText.GetComponent<RectTransform>(); 
+                        _albumTextRt.anchoredPosition = new Vector3(-160, -800, -2);
+                        string realign = "<align=center>";
+                        _albumText.text = $"{realign}{aFinalText}";
+                    }
+                    if (playerCount >= 3)
+                    {
+                        RectTransform _albumTextRt = _albumText.GetComponent<RectTransform>(); 
+                        _albumTextRt.anchoredPosition = new Vector3 (300, -480, -2);
+                    }
+
+                    _albumText.gameObject.SetActive(true);
+                }
+                else
                 {
-                    if (player is not Gameplay.Player.VocalsPlayer)
-                       playerCount++;
-                } 
+                    if (!SettingsManager.Settings.KeepSongInfoVisible.Value)
+                    {
+                        // Start fading out
+                        StartCoroutine(FadeCoroutine());
+                    }
 
-                var aLines = SongToText.ToStyled(SongToText.FORMAT_LONG, GameManager.Song);
+                    var lines = SongToText.ToStyled(SongToText.FORMAT_LONG, GameManager.Song);
 
-            string aFinalText = "";
-            foreach (var aLine in aLines)
-            {
-                // Add styles to each styling
-                aFinalText += aLine.Style switch
-                {
-                    SongToText.Style.Header =>
-                        $"<size=100%><font-weight=800>{aLine.Text}</font-weight></size>",
-                    SongToText.Style.SubHeader =>
-                        $"<size=95%><alpha=#95><i><font-weight=650>{aLine.Text}</font-weight></i></size>",
-                    _ =>
-                        $"<size=90%><alpha=#80><font-weight=650>{aLine.Text}</font-weight></size>"
-                } + "\n";
-            }
-            _albumTextOnePlayer.text = aFinalText;
-            _albumTextTwoPlayer.text = aFinalText;
-            _albumTextThreePlayer.text = aFinalText;
+                    string finalText = "";
+                    foreach (var line in lines)
+                    {
+                        // Add styles to each styling
+                        finalText += line.Style switch
+                        {
+                            SongToText.Style.Header =>
+                                $"<size=100%><font-weight=800>{line.Text}</font-weight></size>",
+                            SongToText.Style.SubHeader =>
+                                $"<size=90%><alpha=#90><i><font-weight=600>{line.Text}</font-weight></i></size>",
+                            _ =>
+                                $"<size=80%><alpha=#66><i><font-weight=600>{line.Text}</font-weight></i></size>"
+                        } + "\n";
+                    }
 
-            if (playerCount == 1)
-            {
-                _albumTextOnePlayer.gameObject.SetActive(true);
-                _albumTextTwoPlayer.gameObject.SetActive(false);
-                _albumTextThreePlayer.gameObject.SetActive(false);
-                
-            }
-            if (playerCount == 2)
-            {
-                _albumTextOnePlayer.gameObject.SetActive(false);
-                _albumTextTwoPlayer.gameObject.SetActive(true);
-                _albumTextThreePlayer.gameObject.SetActive(false);
-                
-            }
-            if (playerCount >= 3)
-            {
-                _albumTextOnePlayer.gameObject.SetActive(false);
-                _albumTextTwoPlayer.gameObject.SetActive(false);
-                _albumTextThreePlayer.gameObject.SetActive(true);
-                
-            }
-            }
-        }
-        }
-        else
-        {
-            
-            if (!SettingsManager.Settings.KeepSongInfoVisible.Value)
-            {
-                // Start fading out
-                StartCoroutine(FadeCoroutine());
-            }
-
-            var lines = SongToText.ToStyled(SongToText.FORMAT_LONG, GameManager.Song);
-
-            string finalText = "";
-            foreach (var line in lines)
-            {
-                // Add styles to each styling
-                finalText += line.Style switch
-                {
-                    SongToText.Style.Header =>
-                        $"<size=100%><font-weight=800>{line.Text}</font-weight></size>",
-                    SongToText.Style.SubHeader =>
-                        $"<size=90%><alpha=#90><i><font-weight=600>{line.Text}</font-weight></i></size>",
-                    _ =>
-                        $"<size=80%><alpha=#66><i><font-weight=600>{line.Text}</font-weight></i></size>"
-                } + "\n";
-            }
-            _albumTextOnePlayer.gameObject.SetActive(false);
-            _albumTextTwoPlayer.gameObject.SetActive(false);
-            _albumTextThreePlayer.gameObject.SetActive(false);
-
-            _text.text = finalText;
-        }
+                    _albumText.gameObject.SetActive(false);
+                    _text.text = finalText;
+                    _text.gameObject.SetActive(true);
+                }
         }
     
-
         private IEnumerator FadeCoroutine()
         {
             _canvasGroup.alpha = 1f;

--- a/Assets/Script/Gameplay/HUD/SongInfoText.cs
+++ b/Assets/Script/Gameplay/HUD/SongInfoText.cs
@@ -63,12 +63,12 @@ namespace YARG.Gameplay.HUD
                     if (playerCount == 1)
                     {
                         RectTransform _albumTextRt = _albumText.GetComponent<RectTransform>(); 
-                        _albumTextRt.anchoredPosition = new Vector3(400, -500, -2);
+                        _albumTextRt.anchoredPosition = new Vector3(415, -600, -2);
                     }
                     if (playerCount == 2)
                     {
                         RectTransform _albumTextRt = _albumText.GetComponent<RectTransform>(); 
-                        _albumTextRt.anchoredPosition = new Vector3(-160, -800, -2);
+                        _albumTextRt.anchoredPosition = new Vector3(-160, -775, -2);
                         string realign = "<align=center>";
                         _albumText.text = $"{realign}{aFinalText}";
                     }

--- a/Assets/Script/Menu/DifficultySelect/DifficultySelectMenu.cs
+++ b/Assets/Script/Menu/DifficultySelect/DifficultySelectMenu.cs
@@ -104,7 +104,7 @@ namespace YARG.Menu.DifficultySelect
             ChangePlayer(0);
 
             _loadingPhrase.text = RichTextUtils.StripRichTextTags(
-                GlobalVariables.Instance.CurrentSong.LoadingPhrase, RichTextTags.BadTags);
+                GlobalVariables.Instance.CurrentSong.LoadingPhrase, RichTextUtils.BAD_TAGS);
         }
 
         private void UpdateForPlayer()

--- a/Assets/Script/Settings/SettingsManager.Settings.cs
+++ b/Assets/Script/Settings/SettingsManager.Settings.cs
@@ -55,6 +55,8 @@ namespace YARG.Settings
             }
 
             public ToggleSetting DisablePerSongBackgrounds { get; } = new(false);
+            public ToggleSetting AlbumArtBackground { get; } = new(true);
+            public ToggleSetting OverrideToAlbumBg { get; } = new(false);
 
             public void OpenCalibrator()
             {

--- a/Assets/Script/Settings/SettingsManager.Settings.cs
+++ b/Assets/Script/Settings/SettingsManager.Settings.cs
@@ -3,6 +3,7 @@ using UnityEngine;
 using UnityEngine.InputSystem;
 using YARG.Core.Audio;
 using YARG.Gameplay.HUD;
+using YARG.Gameplay;
 using YARG.Helpers;
 using YARG.Integration;
 using YARG.Menu.Persistent;
@@ -54,9 +55,13 @@ namespace YARG.Settings
                 FileExplorerHelper.OpenFolder(VenueLoader.VenueFolder);
             }
 
-            public ToggleSetting DisablePerSongBackgrounds { get; } = new(false);
-            public ToggleSetting AlbumArtBackground { get; } = new(true);
-            public ToggleSetting OverrideToAlbumBg { get; } = new(false);
+            public DropdownSetting<VenueMode> BackgroundMode { get; } = new(VenueMode.AlbumAsBackground)
+            {
+                VenueMode.Default,
+                VenueMode.GlobalVenuesOnly,
+                VenueMode.AlbumAsBackground,
+                VenueMode.OverrideToAlbumAsBackground
+            };
 
             public void OpenCalibrator()
             {

--- a/Assets/Script/Settings/SettingsManager.cs
+++ b/Assets/Script/Settings/SettingsManager.cs
@@ -29,6 +29,8 @@ namespace YARG.Settings
                 new HeaderMetadata("Venues"),
                 new ButtonRowMetadata(nameof(Settings.OpenVenueFolder)),
                 nameof(Settings.DisablePerSongBackgrounds),
+                nameof(Settings.AlbumArtBackground),
+                nameof(Settings.OverrideToAlbumBg),
 
                 new HeaderMetadata("Calibration"),
                 new ButtonRowMetadata(nameof(Settings.OpenCalibrator)),

--- a/Assets/Script/Settings/SettingsManager.cs
+++ b/Assets/Script/Settings/SettingsManager.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using Newtonsoft.Json;
 using UnityEngine;
+using UnityEngine.UI;
 using YARG.Helpers;
 using YARG.Settings.Metadata;
 using YARG.Settings.Types;
@@ -28,9 +29,7 @@ namespace YARG.Settings
 
                 new HeaderMetadata("Venues"),
                 new ButtonRowMetadata(nameof(Settings.OpenVenueFolder)),
-                nameof(Settings.DisablePerSongBackgrounds),
-                nameof(Settings.AlbumArtBackground),
-                nameof(Settings.OverrideToAlbumBg),
+                nameof(Settings.BackgroundMode),
 
                 new HeaderMetadata("Calibration"),
                 new ButtonRowMetadata(nameof(Settings.OpenCalibrator)),

--- a/Assets/Script/Venue/VenueLoader.cs
+++ b/Assets/Script/Venue/VenueLoader.cs
@@ -11,6 +11,8 @@ using System.Runtime.InteropServices;
 using YARG.Helpers.Extensions;
 using YARG.Song;
 using UnityEngine.UI;
+using YARG.Gameplay;
+using YARG.Gameplay.HUD;
 
 namespace YARG.Venue
 {
@@ -18,6 +20,14 @@ namespace YARG.Venue
     {
         Global,
         Song,
+    }
+
+    public enum VenueMode
+    {
+        Default,
+        GlobalVenuesOnly,
+        AlbumAsBackground,
+        OverrideToAlbumAsBackground
     }
 
     public readonly struct VenueInfo
@@ -52,13 +62,13 @@ namespace YARG.Venue
             const VenueSource songSource = VenueSource.Song;
 
             // If local backgrounds are disabled, skip right to global
-            if (SettingsManager.Settings.DisablePerSongBackgrounds.Value)
+            if (SettingsManager.Settings.BackgroundMode.Value == VenueMode.GlobalVenuesOnly)
             {
                 return GetVenuePathFromGlobal();
             }
 
              // If album bg override is enabled, jump to that
-            if (SettingsManager.Settings.OverrideToAlbumBg.Value)
+            if (SettingsManager.Settings.BackgroundMode.Value == VenueMode.OverrideToAlbumAsBackground)
             {
                 return CreateBgFromAlbum(song);
             }
@@ -133,7 +143,7 @@ namespace YARG.Venue
                 }
             }
             // If all fails, create background from album, if enabled
-            if (SettingsManager.Settings.AlbumArtBackground.Value)
+            if (SettingsManager.Settings.BackgroundMode.Value == VenueMode.AlbumAsBackground)
             {
                 return CreateBgFromAlbum(song);
             }

--- a/Assets/Script/Venue/VenueLoader.cs
+++ b/Assets/Script/Venue/VenueLoader.cs
@@ -5,6 +5,12 @@ using YARG.Helpers;
 using YARG.Settings;
 using YARG.Core.Song;
 using YARG.Core.Venue;
+using System.Threading.Tasks;
+using Cysharp.Threading.Tasks;
+using System.Runtime.InteropServices;
+using YARG.Helpers.Extensions;
+using YARG.Song;
+using UnityEngine.UI;
 
 namespace YARG.Venue
 {
@@ -51,12 +57,20 @@ namespace YARG.Venue
                 return GetVenuePathFromGlobal();
             }
 
+             // If album bg override is enabled, jump to that
+            if (SettingsManager.Settings.OverrideToAlbumBg.Value)
+            {
+                return CreateBgFromAlbum(song);
+            }
+                
+
             if (song.IniData != null)
             {
                 var stream = song.IniData.GetBackgroundStream(
                     BackgroundType.Yarground |
                     BackgroundType.Video |
-                    BackgroundType.Image);
+                    BackgroundType.Image |
+                    BackgroundType.Album);
 
                 if (stream.Item2 != null)
                     return new VenueInfo(songSource, stream.Item1, stream.Item2);
@@ -118,8 +132,45 @@ namespace YARG.Venue
                     }
                 }
             }
+            // If all fails, create background from album, if enabled
+            if (SettingsManager.Settings.AlbumArtBackground.Value)
+            {
+                return CreateBgFromAlbum(song);
+            }
+            else // If disabled, jump to global venues
+            {
+                return GetVenuePathFromGlobal();
+            }
+        }
+        public static VenueInfo? CreateBgFromAlbum(SongMetadata song)
+        {
+            const VenueSource songSource = VenueSource.Song;
+            string adirectory = song.Directory;
             
+            string[] albumNames =
+            {
+                "album"
+            };
 
+            string[] albumExtensions = 
+            {
+                ".png", ".jpg", ".jpeg"
+            };
+
+            foreach (var aname in albumNames)
+            {
+                var aFile = Path.Combine(adirectory, aname);
+                foreach (var ext in albumExtensions)
+                {
+                    string albumPath = aFile + ext;
+
+                    if (File.Exists(albumPath))
+                    {
+                        var stream = File.OpenRead(albumPath);
+                        return new(songSource, BackgroundType.Album, stream);
+                    }
+                }
+            }
             // If all of this fails, we can load a global venue
             return GetVenuePathFromGlobal();
         }

--- a/Assets/Settings/Localization/Settings Shared Data.asset
+++ b/Assets/Settings/Localization/Settings Shared Data.asset
@@ -899,6 +899,22 @@ MonoBehaviour:
     m_Key: Tab.Sound
     m_Metadata:
       m_Items: []
+  - m_Id: 100076407547957248
+    m_Key: Setting.General.AlbumArtBackground
+    m_Metadata:
+      m_Items: []
+  - m_Id: 100076571352305664
+    m_Key: Setting.General.AlbumArtBackground.Description
+    m_Metadata:
+      m_Items: []
+  - m_Id: 100447153650601984
+    m_Key: Setting.General.OverrideToAlbumBg
+    m_Metadata:
+      m_Items: []
+  - m_Id: 100447279752351744
+    m_Key: Setting.General.OverrideToAlbumBg.Description
+    m_Metadata:
+      m_Items: []
   m_Metadata:
     m_Items: []
   m_KeyGenerator:

--- a/Assets/Settings/Localization/Settings Shared Data.asset
+++ b/Assets/Settings/Localization/Settings Shared Data.asset
@@ -223,14 +223,6 @@ MonoBehaviour:
     m_Key: Setting.General.AudioCalibration.Description
     m_Metadata:
       m_Items: []
-  - m_Id: 53693768667619349
-    m_Key: Setting.General.DisablePerSongBackgrounds
-    m_Metadata:
-      m_Items: []
-  - m_Id: 53704501379850242
-    m_Key: Setting.General.DisablePerSongBackgrounds.Description
-    m_Metadata:
-      m_Items: []
   - m_Id: 79799556705734656
     m_Key: Setting.General.InputDeviceLogging
     m_Metadata:
@@ -899,20 +891,28 @@ MonoBehaviour:
     m_Key: Tab.Sound
     m_Metadata:
       m_Items: []
-  - m_Id: 100076407547957248
-    m_Key: Setting.General.AlbumArtBackground
+  - m_Id: 100857862591025152
+    m_Key: Setting.General.BackgroundMode
     m_Metadata:
       m_Items: []
-  - m_Id: 100076571352305664
-    m_Key: Setting.General.AlbumArtBackground.Description
+  - m_Id: 100857921143508992
+    m_Key: Setting.General.BackgroundMode.Description
     m_Metadata:
       m_Items: []
-  - m_Id: 100447153650601984
-    m_Key: Setting.General.OverrideToAlbumBg
+  - m_Id: 100858817524994048
+    m_Key: Dropdown.General.BackgroundMode.Default
     m_Metadata:
       m_Items: []
-  - m_Id: 100447279752351744
-    m_Key: Setting.General.OverrideToAlbumBg.Description
+  - m_Id: 100859254395310080
+    m_Key: Dropdown.General.BackgroundMode.GlobalVenuesOnly
+    m_Metadata:
+      m_Items: []
+  - m_Id: 100859368945946624
+    m_Key: Dropdown.General.BackgroundMode.AlbumAsBackground
+    m_Metadata:
+      m_Items: []
+  - m_Id: 100859965451472896
+    m_Key: Dropdown.General.BackgroundMode.OverrideToAlbumAsBackground
     m_Metadata:
       m_Items: []
   m_Metadata:

--- a/Assets/Settings/Localization/Settings_en-US.asset
+++ b/Assets/Settings/Localization/Settings_en-US.asset
@@ -144,10 +144,6 @@ MonoBehaviour:
       the audio play later.
     m_Metadata:
       m_Items: []
-  - m_Id: 53693768667619349
-    m_Localized: Disable Per Song Backgrounds
-    m_Metadata:
-      m_Items: []
   - m_Id: 53693768667619351
     m_Localized: Cursor Show Time
     m_Metadata:
@@ -287,11 +283,6 @@ MonoBehaviour:
       m_Items: []
   - m_Id: 53704501379850241
     m_Localized: Removes all kick notes (drums only).
-    m_Metadata:
-      m_Items: []
-  - m_Id: 53704501379850242
-    m_Localized: Disables custom backgrounds in songs and shows the ones in your
-      venue folder instead.
     m_Metadata:
       m_Items: []
   - m_Id: 53704501379850244
@@ -948,23 +939,28 @@ MonoBehaviour:
       song. Otherwise, it will fade out after 10 seconds.
     m_Metadata:
       m_Items: []
-  - m_Id: 100076407547957248
-    m_Localized: Album Art Becomes Background
+  - m_Id: 100857862591025152
+    m_Localized: Background Mode
     m_Metadata:
       m_Items: []
-  - m_Id: 100076571352305664
-    m_Localized: If a song has no background image/video, the game will use the album
-      artwork and song metadata to create a background. Overridden by Disable Per
-      Song Backgrounds. Good for chart previews!
+  - m_Id: 100857921143508992
+    m_Localized: Choose how the game handles background and venues.
     m_Metadata:
       m_Items: []
-  - m_Id: 100447153650601984
-    m_Localized: Override to Album Artwork Background
+  - m_Id: 100858817524994048
+    m_Localized: Default / Chart Backgrounds
     m_Metadata:
       m_Items: []
-  - m_Id: 100447279752351744
-    m_Localized: If enabled, album artwork will take precedence over included images
-      or videos for the background.
+  - m_Id: 100859254395310080
+    m_Localized: Global Venues Only
+    m_Metadata:
+      m_Items: []
+  - m_Id: 100859368945946624
+    m_Localized: Album Art as Background
+    m_Metadata:
+      m_Items: []
+  - m_Id: 100859965451472896
+    m_Localized: Override to Album Art
     m_Metadata:
       m_Items: []
   references:

--- a/Assets/Settings/Localization/Settings_en-US.asset
+++ b/Assets/Settings/Localization/Settings_en-US.asset
@@ -948,6 +948,25 @@ MonoBehaviour:
       song. Otherwise, it will fade out after 10 seconds.
     m_Metadata:
       m_Items: []
+  - m_Id: 100076407547957248
+    m_Localized: Album Art Becomes Background
+    m_Metadata:
+      m_Items: []
+  - m_Id: 100076571352305664
+    m_Localized: If a song has no background image/video, the game will use the album
+      artwork and song metadata to create a background. Overridden by Disable Per
+      Song Backgrounds. Good for chart previews!
+    m_Metadata:
+      m_Items: []
+  - m_Id: 100447153650601984
+    m_Localized: Override to Album Artwork Background
+    m_Metadata:
+      m_Items: []
+  - m_Id: 100447279752351744
+    m_Localized: If enabled, album artwork will take precedence over included images
+      or videos for the background.
+    m_Metadata:
+      m_Items: []
   references:
     version: 2
     RefIds: []

--- a/Assets/Settings/Localization/Settings_en-US.asset
+++ b/Assets/Settings/Localization/Settings_en-US.asset
@@ -948,19 +948,19 @@ MonoBehaviour:
     m_Metadata:
       m_Items: []
   - m_Id: 100858817524994048
-    m_Localized: Default / Chart Backgrounds
+    m_Localized: Default / Chart Backgrounds First
     m_Metadata:
       m_Items: []
   - m_Id: 100859254395310080
-    m_Localized: Global Venues Only
+    m_Localized: Global Backgrounds Only
     m_Metadata:
       m_Items: []
   - m_Id: 100859368945946624
-    m_Localized: Album Art as Background
+    m_Localized: Album Art Background as Last Resort
     m_Metadata:
       m_Items: []
   - m_Id: 100859965451472896
-    m_Localized: Override to Album Art
+    m_Localized: 'Override to Always Album Art Background '
     m_Metadata:
       m_Items: []
   references:

--- a/Assets/SnapshotShaders.meta
+++ b/Assets/SnapshotShaders.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 672882a6447759d439eea33324c4ffde
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/SnapshotShaders/Materials.meta
+++ b/Assets/SnapshotShaders/Materials.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c159823714de06e41886c09dcd932060
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/SnapshotShaders/Materials/BlurMaterial.mat
+++ b/Assets/SnapshotShaders/Materials/BlurMaterial.mat
@@ -1,0 +1,127 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &-7527024855919309778
+MonoBehaviour:
+  m_ObjectHideFlags: 11
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d0353a89b1f911e48b9e16bdc9f2e058, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  version: 5
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: BlurMaterial
+  m_Shader: {fileID: 4800000, guid: ffdbe1a51bb49354ba9adb6a5fd9cacc, type: 3}
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BaseMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _SpecGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_Lightmaps:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_LightmapsInd:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - unity_ShadowMasks:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _AlphaClip: 0
+    - _Blend: 0
+    - _BumpScale: 1
+    - _ClearCoatMask: 0
+    - _ClearCoatSmoothness: 0
+    - _Cull: 2
+    - _Cutoff: 0.5
+    - _DetailAlbedoMapScale: 1
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _EnvironmentReflections: 1
+    - _GlossMapScale: 0
+    - _Glossiness: 0
+    - _GlossyReflections: 0
+    - _KernelSize: 21
+    - _Metallic: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.005
+    - _QueueOffset: 0
+    - _ReceiveShadows: 1
+    - _Smoothness: 0.5
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _Spread: 5
+    - _SrcBlend: 1
+    - _Surface: 0
+    - _WorkflowMode: 1
+    - _ZWrite: 1
+    m_Colors:
+    - _BaseColor: {r: 1, g: 1, b: 1, a: 1}
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+    - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
+  m_BuildTextureStacks: []

--- a/Assets/SnapshotShaders/Materials/BlurMaterial.mat.meta
+++ b/Assets/SnapshotShaders/Materials/BlurMaterial.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3b5eade2dc49a2748ad794a2c503c808
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/SnapshotShaders/Shaders.meta
+++ b/Assets/SnapshotShaders/Shaders.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1611c769651f2284ea59fb4d7a97ac49
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/SnapshotShaders/Shaders/GaussianBlur.shader
+++ b/Assets/SnapshotShaders/Shaders/GaussianBlur.shader
@@ -1,0 +1,102 @@
+﻿/*	This shader implements a two-pass Gaussian blur, similar to the two-pass
+	box blur. An extra _Spread property is added to control the strength of the
+	Gaussian blur.
+*/
+Shader "Snapshot/GaussianBlur"
+{
+    Properties
+    {
+        _MainTex ("Texture", 2D) = "white" {}
+		_KernelSize("Kernel Size (N)", Int) = 21
+		_Spread("St. dev. (sigma)", Float) = 5.0
+	}
+
+	CGINCLUDE
+	#include "UnityCG.cginc"
+
+	// Define the constants used in Gaussian calculation.
+	static const float TWO_PI = 6.28319;
+	static const float E = 2.71828;
+
+	sampler2D _MainTex;
+	float4 _MainTex_ST;
+	float2 _MainTex_TexelSize;
+	int	_KernelSize;
+	float _Spread;
+
+	/*	Implement the Gaussian function in one dimension.
+	*/
+	float gaussian(int x)
+	{
+		float sigmaSqu = _Spread * _Spread;
+		return (1 / sqrt(TWO_PI * sigmaSqu)) * pow(E, -(x * x) / (2 * sigmaSqu));
+	}
+
+	ENDCG
+
+    SubShader
+    {
+        Tags 
+		{ 
+			"RenderType" = "Opaque"
+		}
+
+        Pass
+        {
+			Name "HorizontalPass"
+
+			CGPROGRAM
+			#pragma vertex vert_img
+			#pragma fragment frag_horizontal
+
+			float4 frag_horizontal(v2f_img i) : SV_Target
+			{
+				float3 col = float3(0.0, 0.0, 0.0);
+				float kernelSum = 0.0;
+
+				int upper = ((_KernelSize - 1) / 2);
+				int lower = -upper;
+
+				for (int x = lower; x <= upper; ++x)
+				{
+					float gauss = gaussian(x);
+					kernelSum += gauss;
+					col += gauss * tex2D(_MainTex, i.uv + fixed2(_MainTex_TexelSize.x * x, 0.0));
+				}
+
+				col /= kernelSum;
+				return float4(col, 1.0);
+			}
+			ENDCG
+        }
+
+		Pass
+		{
+			Name "VerticalPass"
+
+			CGPROGRAM
+			#pragma vertex vert_img
+			#pragma fragment frag_vertical
+
+			float4 frag_vertical(v2f_img i) : SV_Target
+			{
+				float3 col = float3(0.0, 0.0, 0.0);
+				float kernelSum = 0.0;
+
+				int upper = ((_KernelSize - 1) / 2);
+				int lower = -upper;
+
+				for (int y = lower; y <= upper; ++y)
+				{
+					float gauss = gaussian(y);
+					kernelSum += gauss;
+					col += gauss * tex2D(_MainTex, i.uv + fixed2(0.0, _MainTex_TexelSize.y * y));
+				}
+
+				col /= kernelSum;
+				return float4(col, 1.0);
+			}
+			ENDCG
+		}
+    }
+}

--- a/Assets/SnapshotShaders/Shaders/GaussianBlur.shader.meta
+++ b/Assets/SnapshotShaders/Shaders/GaussianBlur.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: ffdbe1a51bb49354ba9adb6a5fd9cacc
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Adds a setting that uses the album artwork and metadata of a chart to create a background venue.

TODO:
- Learn to use the transform function on cover + text so there's not 3 different sets of objects to account for multiplayer situations
- Find/make a blur + darken shader for the background image that's compliant with LGPL (SnapshotShaders will have to be replaced according to EA)
- Make it so enabling DisablePerSongBackground disables AlbumArtBackground and vice-versa