### PR TITLE
Use ZString package for formatting text to text boxes in gameplay

### DIFF
--- a/Assets/Script/Gameplay/GameManager.cs
+++ b/Assets/Script/Gameplay/GameManager.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
+using Cysharp.Text;
 using Cysharp.Threading.Tasks;
 using TMPro;
 using UnityEngine;
@@ -212,42 +213,38 @@ namespace YARG.Gameplay
             // Any updates happening after this will not reflect until the next frame
             if (_isShowDebugText)
             {
-                _debugText.text = null;
+                using var text = ZString.CreateStringBuilder(true);
 
                 if (_players[0] is FiveFretPlayer fiveFretPlayer)
                 {
-                    byte buttonMask = fiveFretPlayer.Engine.State.ButtonMask;
-                    int noteIndex = fiveFretPlayer.Engine.State.NoteIndex;
-                    var ticksPerBeat = fiveFretPlayer.Engine.State.TicksEveryBeat;
-                    var ticksPerMeasure = fiveFretPlayer.Engine.State.TicksEveryMeasure;
-                    double starPower = fiveFretPlayer.Engine.EngineStats.StarPowerAmount;
+                    var state = fiveFretPlayer.Engine.State;
+                    var stats = fiveFretPlayer.Engine.EngineStats;
 
-                    _debugText.text +=
-                        $"Note index: {noteIndex}\n" +
-                        $"Buttons: {buttonMask}\n" +
-                        $"Star Power: {starPower:0.0000}\n" +
-                        $"Ticks per beat: {ticksPerBeat}\n" +
-                        $"Ticks per measure: {ticksPerMeasure}\n";
+                    text.AppendFormat("Note index: {0}\n", state.NoteIndex);
+                    text.AppendFormat("Buttons: {0}\n", state.ButtonMask);
+                    text.AppendFormat("Star Power: {0:0.0000}\n", stats.StarPowerAmount);
+                    text.AppendFormat("Ticks per beat: {0}\n", state.TicksEveryBeat);
+                    text.AppendFormat("Ticks per measure: {0}\n", state.TicksEveryMeasure);
                 }
                 else if (_players[0] is DrumsPlayer drumsPlayer)
                 {
-                    int noteIndex = drumsPlayer.Engine.State.NoteIndex;
+                    var state = drumsPlayer.Engine.State;
 
-                    _debugText.text +=
-                        $"Note index: {noteIndex}\n";
+                    text.AppendFormat("Note index: {0}\n", state.NoteIndex);
                 }
 
-                _debugText.text +=
-                    $"Song time: {_songRunner.SongTime:0.000000}\n" +
-                    $"Visual time: {_songRunner.VisualTime:0.000000}\n" +
-                    $"Input time: {_songRunner.InputTime:0.000000}\n" +
-                    $"Pause time: {_songRunner.PauseStartTime:0.000000}\n" +
-                    $"Sync difference: {_songRunner.SyncVisualTime - _songRunner.SyncSongTime:0.000000}\n" +
-                    $"Sync start delta: {_songRunner.SyncStartDelta:0.000000}\n" +
-                    $"Speed adjustment: {_songRunner.SyncSpeedAdjustment:0.00}\n" +
-                    $"Speed multiplier: {_songRunner.SyncSpeedMultiplier}\n" +
-                    $"Input base: {_songRunner.InputTimeBase:0.000000}\n" +
-                    $"Input offset: {_songRunner.InputTimeOffset:0.000000}\n";
+                text.AppendFormat("Song time: {0:0.000000}\n", _songRunner.SongTime);
+                text.AppendFormat("Visual time: {0:0.000000}\n", _songRunner.VisualTime);
+                text.AppendFormat("Input time: {0:0.000000}\n", _songRunner.InputTime);
+                text.AppendFormat("Pause time: {0:0.000000}\n", _songRunner.PauseStartTime);
+                text.AppendFormat("Sync difference: {0:0.000000}\n", _songRunner.SyncVisualTime - _songRunner.SyncSongTime);
+                text.AppendFormat("Sync start delta: {0:0.000000}\n", _songRunner.SyncStartDelta);
+                text.AppendFormat("Speed adjustment: {0:0.00}\n", _songRunner.SyncSpeedAdjustment);
+                text.AppendFormat("Speed multiplier: {0}\n", _songRunner.SyncSpeedMultiplier);
+                text.AppendFormat("Input base: {0:0.000000}\n", _songRunner.InputTimeBase);
+                text.AppendFormat("Input offset: {0:0.000000}\n", _songRunner.InputTimeOffset);
+
+                _debugText.SetText(text);
             }
         }
 

--- a/Assets/Script/Gameplay/HUD/InputViewer/InputViewerButton.cs
+++ b/Assets/Script/Gameplay/HUD/InputViewer/InputViewerButton.cs
@@ -1,6 +1,8 @@
-﻿using TMPro;
+﻿using Cysharp.Text;
+using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
+using YARG.Helpers.Extensions;
 
 namespace YARG.Gameplay.HUD
 {
@@ -74,13 +76,9 @@ namespace YARG.Gameplay.HUD
 
         public void UpdateVisual()
         {
-            WriteDoubleToBuffer(_inputTimeBuffer, _inputTime);
-            WriteDoubleToBuffer(_holdTimeBuffer, _holdTime);
-            WriteIntToBuffer(_pressCountBuffer, _pressCount);
-
-            _inputTimeText.SetCharArray(_inputTimeBuffer, 0, _inputTimeBuffer.Length);
-            _holdTimeText.SetCharArray(_holdTimeBuffer, 0, _holdTimeBuffer.Length);
-            _pressCountText.SetCharArray(_pressCountBuffer, 0, _pressCountBuffer.Length);
+            _inputTimeText.SetText(_inputTime);
+            _holdTimeText.SetText(_holdTime);
+            _pressCountText.SetText(_pressCount);
 
             var color = ButtonColor;
             color.a = _isPressed ? 0.8f : DISABLED_ALPHA;
@@ -105,117 +103,7 @@ namespace YARG.Gameplay.HUD
             {
                 _holdTime = _gameManager.InputTime - _holdStartTime + GameManager.SONG_START_DELAY;
 
-                WriteDoubleToBuffer(_holdTimeBuffer, _holdTime);
-                _holdTimeText.SetCharArray(_holdTimeBuffer, 0, _holdTimeBuffer.Length);
-            }
-        }
-
-        private static void WriteDoubleToBuffer(char[] buffer, double num)
-        {
-            const int fractionLength = 3;
-
-            if (num == 0)
-            {
-                buffer[0] = '0';
-                buffer[1] = '.';
-                buffer[2] = '0';
-                buffer[3] = '0';
-                buffer[4] = '0';
-            }
-
-            // Clear buffer
-            for (int i = 0; i < buffer.Length; i++)
-            {
-                buffer[i] = '\0';
-            }
-
-            int whole = (int) num;
-            int fraction = (int) ((num - whole) * 1000);
-
-            // -1 for decimal point
-            int integerLength = buffer.Length - fractionLength - 1;
-
-            // Write whole number
-            int wholeEndIndex = integerLength - 1;
-            int index = wholeEndIndex;
-
-            if (whole == 0)
-            {
-                buffer[wholeEndIndex] = '0';
-            }
-
-            while (whole > 0 && index >= 0)
-            {
-                buffer[index--] = (char) ('0' + (whole % 10));
-                whole /= 10;
-            }
-
-            index = integerLength;
-
-            // Write decimal point
-            buffer[index++] = '.';
-
-            // Write fraction
-            buffer[index++] = (char) ('0' + (fraction / 100));
-
-            fraction %= 100;
-            buffer[index++] = (char) ('0' + (fraction / 10));
-
-            fraction %= 10;
-            buffer[index] = (char) ('0' + fraction);
-
-            TrimNullStart(buffer);
-        }
-
-        private static void WriteIntToBuffer(char[] buffer, int num)
-        {
-            // Clear buffer
-            for (int i = 0; i < buffer.Length; i++)
-            {
-                buffer[i] = '\0';
-            }
-
-            if (num == 0)
-            {
-                buffer[0] = '0';
-                return;
-            }
-
-            int index = buffer.Length - 1;
-            while (num > 0 && index >= 0)
-            {
-                buffer[index--] = (char) ('0' + (num % 10));
-                num /= 10;
-            }
-
-            TrimNullStart(buffer);
-        }
-
-        private static void TrimNullStart(char[] buffer)
-        {
-            bool nonNullFound = false;
-            for (int i = 0; i < buffer.Length; i++)
-            {
-                if (buffer[i] != '\0')
-                {
-                    nonNullFound = true;
-                    break;
-                }
-            }
-
-            if (!nonNullFound)
-            {
-                return;
-            }
-
-            while (buffer[0] == '\0')
-            {
-                for (int i = 0; i < buffer.Length - 1; i++)
-                {
-                    buffer[i] = buffer[i + 1];
-                }
-
-                buffer[^1] = '\0';
+                _holdTimeText.SetText(_holdTime);
             }
         }
     }

--- a/Assets/Script/Gameplay/HUD/LyricBar.cs
+++ b/Assets/Script/Gameplay/HUD/LyricBar.cs
@@ -1,6 +1,4 @@
-using System.Collections.Generic;
-using System.Text;
-using System.Text.RegularExpressions;
+using Cysharp.Text;
 using TMPro;
 using UnityEngine;
 using YARG.Core.Chart;
@@ -99,12 +97,15 @@ namespace YARG.Gameplay.HUD
                 currIndex++;
 
             // No update necessary
-            if (_lyricText.text != null && _currentLyricIndex == currIndex)
+            if (_currentLyricIndex == currIndex)
                 return;
 
             // Construct lyrics to be displayed
+            using var output = ZString.CreateStringBuilder(true);
+
             // Start highlight
-            StringBuilder output = new("<color=#5CB9FF>");
+            output.Append("<color=#5CB9FF>");
+
             int i = 0;
             while (i < currIndex)
             {
@@ -126,7 +127,7 @@ namespace YARG.Gameplay.HUD
             }
 
             _currentLyricIndex = currIndex;
-            _lyricText.text = output.ToString();
+            _lyricText.SetText(output);
         }
     }
 }

--- a/Assets/Script/Gameplay/HUD/Practice/PracticeHud.cs
+++ b/Assets/Script/Gameplay/HUD/Practice/PracticeHud.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Cysharp.Text;
 using TMPro;
 using UnityEngine;
 using YARG.Core.Chart;
@@ -54,7 +55,7 @@ namespace YARG.Gameplay.HUD
                 return;
             }
 
-            speedPercentText.text = $"{GameManager.SelectedSongSpeed * 100f:0}%";
+            speedPercentText.SetTextFormat("{0:0}%", GameManager.SelectedSongSpeed * 100f);
 
             int notesHit = 0;
             int totalNotes = 0;
@@ -73,8 +74,8 @@ namespace YARG.Gameplay.HUD
                 _percentHit = (float)notesHit / totalNotes;
             }
 
-            notesHitTotalText.text = $"{notesHit}/{totalNotes}";
-            percentHitText.text = $"{Mathf.FloorToInt(_percentHit * 100)}%";
+            notesHitTotalText.SetTextFormat("{0}/{1}", notesHit, totalNotes);
+            percentHitText.SetTextFormat("{0}%", Mathf.FloorToInt(_percentHit * 100));
 
             while(_currentSectionIndex < _sections.Length && GameManager.SongTime >= _sections[_currentSectionIndex].TimeEnd)
             {
@@ -82,7 +83,7 @@ namespace YARG.Gameplay.HUD
 
                 if(_currentSectionIndex < _sections.Length)
                 {
-                    sectionText.text = $"{_sections[_currentSectionIndex].Name}";
+                    sectionText.text = _sections[_currentSectionIndex].Name;
                 }
             }
         }
@@ -93,14 +94,14 @@ namespace YARG.Gameplay.HUD
             {
                 _bestPercentHit = _percentHit;
 
-                bestPercentText.text = $"{Mathf.FloorToInt(_percentHit * 100)}%";
+                bestPercentText.SetTextFormat("{0}%", Mathf.FloorToInt(_percentHit * 100));
             }
 
             _currentSectionIndex = 0;
 
             if(_sections.Length > 0)
             {
-                sectionText.text = $"{_sections[_currentSectionIndex].Name}";
+                sectionText.text = _sections[_currentSectionIndex].Name;
             }
         }
 
@@ -119,7 +120,7 @@ namespace YARG.Gameplay.HUD
             _bestPercentHit = 0f;
 
             bestPercentText.text = "0%";
-            sectionText.text = $"{_sections[_currentSectionIndex].Name}";
+            sectionText.text = _sections[_currentSectionIndex].Name;
         }
     }
 }

--- a/Assets/Script/Gameplay/HUD/SoloBox.cs
+++ b/Assets/Script/Gameplay/HUD/SoloBox.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections;
+using Cysharp.Text;
 using DG.Tweening;
 using TMPro;
 using UnityEngine;
@@ -64,7 +65,7 @@ namespace YARG.Gameplay.HUD
 
             // Set some dummy text
             _soloTopText.text = "0%";
-            _soloBottomText.text = $"0/{_solo.NoteCount}";
+            _soloBottomText.SetTextFormat("0/{0}", _solo.NoteCount);
 
             // Fade in the box
             yield return _soloBoxCanvasGroup
@@ -76,8 +77,8 @@ namespace YARG.Gameplay.HUD
         {
             if (_soloEnded) return;
 
-            _soloTopText.text = $"{HitPercent}%";
-            _soloBottomText.text = $"{_solo.NotesHit}/{_solo.NoteCount}";
+            _soloTopText.SetTextFormat("{0}%", HitPercent);
+            _soloBottomText.SetTextFormat("{0}/{1}", _solo.NotesHit, _solo.NoteCount);
         }
 
         public void EndSolo(int soloBonus, Action endCallback)
@@ -116,7 +117,7 @@ namespace YARG.Gameplay.HUD
             _soloFullText.colorGradientPreset = gradient;
 
             // Display final hit percentage
-            _soloFullText.text = $"{HitPercent}%";
+            _soloFullText.SetTextFormat("{0}%", HitPercent);
 
             yield return new WaitForSeconds(1f);
 
@@ -139,7 +140,7 @@ namespace YARG.Gameplay.HUD
             yield return new WaitForSeconds(1f);
 
             // Show point bonus
-            _soloFullText.text = $"{soloBonus:N0}\nPOINTS";
+            _soloFullText.SetTextFormat("{0:N0}\nPOINTS", soloBonus);
 
             yield return new WaitForSeconds(1f);
 

--- a/Assets/Script/Gameplay/HUD/VocalsPlayerHUD.cs
+++ b/Assets/Script/Gameplay/HUD/VocalsPlayerHUD.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections;
+using Cysharp.Text;
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
@@ -46,7 +47,10 @@ namespace YARG.Gameplay.HUD
         {
             _comboMeterFillTarget = phrasePercent;
 
-            _multiplierText.text = multiplier != 1 ? $"{multiplier}<sub>x</sub>" : string.Empty;
+            if (multiplier != 1)
+                _multiplierText.SetTextFormat("{0}<sub>x</sub>", multiplier);
+            else
+                _multiplierText.text = string.Empty;
 
             _starPowerFill.fillAmount = starPowerPercent;
         }

--- a/Assets/Script/Gameplay/Visuals/ComboMeter.cs
+++ b/Assets/Script/Gameplay/Visuals/ComboMeter.cs
@@ -1,4 +1,5 @@
-﻿using TMPro;
+﻿using Cysharp.Text;
+using TMPro;
 using UnityEngine;
 using YARG.Core.Game;
 
@@ -35,7 +36,10 @@ namespace YARG.Gameplay.Visuals
 
         public void SetCombo(int multiplier, int maxMultiplier, int combo)
         {
-            _multiplierText.text = multiplier != 1 ? $"{multiplier}<sub>x</sub>" : string.Empty;
+            if (multiplier != 1)
+                _multiplierText.SetTextFormat("{0}<sub>x</sub>", multiplier);
+            else
+                _multiplierText.text = string.Empty;
 
             int index = combo % 10;
             if (multiplier != 1 && index == 0)

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -13,6 +13,7 @@
       "scopes": [
         "com.coffee.softmask-for-ugui",
         "com.cysharp.unitask",
+        "com.cysharp.zstring",
         "com.github-glitchenzo.nugetforunity",
         "com.marijnzwemmer.unity-toolbar-extender",
         "com.openupm",
@@ -23,6 +24,7 @@
   "dependencies": {
     "com.coffee.softmask-for-ugui": "1.0.2",
     "com.cysharp.unitask": "2.5.0",
+    "com.cysharp.zstring": "2.5.1",
     "com.github-glitchenzo.nugetforunity": "3.1.3",
     "com.marijnzwemmer.unity-toolbar-extender": "1.4.2",
     "com.starasgames.tmpro-dynamic-data-cleaner": "1.0.0",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -14,6 +14,13 @@
       "dependencies": {},
       "url": "https://package.openupm.com"
     },
+    "com.cysharp.zstring": {
+      "version": "2.5.1",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://package.openupm.com"
+    },
     "com.github-glitchenzo.nugetforunity": {
       "version": "3.1.3",
       "depth": 0,

--- a/ProjectSettings/PackageManagerSettings.asset
+++ b/ProjectSettings/PackageManagerSettings.asset
@@ -40,6 +40,7 @@ MonoBehaviour:
     m_Scopes:
     - com.coffee.softmask-for-ugui
     - com.cysharp.unitask
+    - com.cysharp.zstring
     - com.github-glitchenzo.nugetforunity
     - com.marijnzwemmer.unity-toolbar-extender
     - com.openupm
@@ -47,7 +48,7 @@ MonoBehaviour:
     m_IsDefault: 0
     m_Capabilities: 0
     m_ConfigSource: 4
-  m_UserSelectedRegistryName: Keijiro
+  m_UserSelectedRegistryName: package.openupm.com
   m_UserAddingNewScopedRegistry: 0
   m_RegistryInfoDraft:
     m_Modified: 0


### PR DESCRIPTION
Remembered about the existence of [ZString](https://github.com/Cysharp/ZString) and realized we don't have to write custom text formatting to avoid allocations anymore lol

This should help reduce the amount of stuttering that might happen every so often, allocation rates during gameplay are noticeably reduced (100 KB/s -> 60 KB/s). There's still other allocations to track down, but this is a good start for now.

These changes will unfortunately not reflect in the editor due to TextMeshPro always updating the internal string instance when in the editor, which is done to keep the inspector up to date:

![image](https://github.com/YARC-Official/YARG/assets/29052821/bc8f039c-a2f7-45b4-9a48-e308505bfacf)
