### PR TITLE
Update to adjust for added CacheHandler.RunScan parameter (Draft PR for functionality testing purposes)

### DIFF
--- a/Assets/Script/Persistent/LoadingManager.cs
+++ b/Assets/Script/Persistent/LoadingManager.cs
@@ -94,7 +94,8 @@ namespace YARG
             var stopwatch = System.Diagnostics.Stopwatch.StartNew();
 
             var task = Task.Run(() =>
-                CacheHandler.RunScan(fast, PathHelper.SongCachePath, PathHelper.BadSongsPath, true, directories));
+                CacheHandler.RunScan(fast, PathHelper.SongCachePath, PathHelper.BadSongsPath, true, true, directories));
+
             while (!task.IsCompleted)
             {
                 UpdateSongUi();


### PR DESCRIPTION
PR solely to test removal functionality (through manually switching that toggle on and off)

Default, for now, will always be `true` - AKA, as it works now.