### PR TITLE
Re-implement various sound effects from v0.11

### DIFF
--- a/Assets/Script/Audio/Bass/BassAudioManager.cs
+++ b/Assets/Script/Audio/Bass/BassAudioManager.cs
@@ -207,7 +207,7 @@ namespace YARG.Audio.BASS
 
                 if (!File.Exists(sfxPath))
                 {
-                    Debug.LogError($"SFX {sfxPath} does not exist!");
+                    Debug.LogWarning($"SFX Sample {sfxFile} does not exist!");
                     continue;
                 }
 

--- a/Assets/Script/Audio/Bass/BassAudioManager.cs
+++ b/Assets/Script/Audio/Bass/BassAudioManager.cs
@@ -573,6 +573,13 @@ namespace YARG.Audio.BASS
         public void SetPosition(double position, bool desyncCompensation = true)
             => _mixer?.SetPosition(position, desyncCompensation);
 
+        public bool HasStem(SongStem stem)
+        {
+            if (_mixer is null) return false;
+
+            return _mixer.Channels.ContainsKey(stem) && _mixer.Channels[stem].Count > 0;
+        }
+
         private void OnSongEnd()
         {
             Pause();

--- a/Assets/Script/Audio/Bass/BassHelpers.cs
+++ b/Assets/Script/Audio/Bass/BassHelpers.cs
@@ -12,6 +12,7 @@ namespace YARG.Audio.BASS
         public const double PLAYBACK_BUFFER_DESYNC = PLAYBACK_BUFFER_LENGTH / 1000.0;
 
         public const float SONG_VOLUME_MULTIPLIER = 0.7f;
+        public const float REVERB_VOLUME_MULTIPLIER = 0.85f;
 
         public const int FADE_TIME_MILLISECONDS = 1000;
 

--- a/Assets/Script/Audio/Bass/BassHelpers.cs
+++ b/Assets/Script/Audio/Bass/BassHelpers.cs
@@ -38,7 +38,7 @@ namespace YARG.Audio.BASS
 
         public static readonly PeakEQParameters HighEqParams = new()
         {
-            fBandwidth = 0.75f, fCenter = 6000.0f, fGain = 2f
+            fBandwidth = 0.75f, fCenter = 6000.0f, fGain = 2.25f
         };
 
         public static readonly DXReverbParameters DXReverbParams = new()
@@ -48,7 +48,7 @@ namespace YARG.Audio.BASS
 
         public static readonly ReverbParameters FreeverbParams = new()
         {
-            fDryMix = 0.5f, fWetMix = 1.5f, fRoomSize = 0.75f, fDamp = 0.5f, fWidth = 1.0f, lMode = 0
+            fDryMix = 0.5f, fWetMix = 1.5f, fRoomSize = 0.8f, fDamp = 0.6f, fWidth = 1.0f, lMode = 0
         };
 
         public static int FXAddParameters(int streamHandle, EffectType type, IEffectParameter parameters,

--- a/Assets/Script/Audio/Interfaces/IAudioManager.cs
+++ b/Assets/Script/Audio/Interfaces/IAudioManager.cs
@@ -67,5 +67,7 @@ namespace YARG.Audio
 
         public double GetPosition(bool desyncCompensation = true);
         public void SetPosition(double position, bool desyncCompensation = true);
+
+        public bool HasStem(SongStem stem);
     }
 }

--- a/Assets/Script/Gameplay/GameManager.Audio.cs
+++ b/Assets/Script/Gameplay/GameManager.Audio.cs
@@ -93,9 +93,8 @@ namespace YARG.Gameplay
             }
             else
             {
-                state.Muted--;
+                state.Muted = Math.Max(0, state.Muted - 1);
             }
-
             var volume = state.GetVolumeLevel();
             GlobalVariables.AudioManager.SetStemVolume(stem, volume);
 
@@ -122,19 +121,10 @@ namespace YARG.Gameplay
             }
             else
             {
-                state.ReverbCount--;
+                state.ReverbCount = Math.Max(0, state.ReverbCount - 1);
             }
 
-            if(state.ReverbCount > 0)
-            {
-                GlobalVariables.AudioManager.ApplyReverb(stem, true);
-                EditorDebug.Log($"Applied reverb to {stem}");
-            }
-            else
-            {
-                GlobalVariables.AudioManager.ApplyReverb(stem, false);
-                EditorDebug.Log($"Removed reverb from {stem}");
-            }
+            GlobalVariables.AudioManager.ApplyReverb(stem, state.ReverbCount > 0);
         }
 
         private void OnAudioEnd()

--- a/Assets/Script/Gameplay/GameManager.Audio.cs
+++ b/Assets/Script/Gameplay/GameManager.Audio.cs
@@ -10,10 +10,11 @@ namespace YARG.Gameplay
 {
     public partial class GameManager
     {
-        public class StemState
+        public struct StemState
         {
             public int Total;
             public int Muted;
+            public int ReverbCount;
 
             public float GetVolumeLevel()
             {
@@ -32,6 +33,8 @@ namespace YARG.Gameplay
         {
             // The stem states are initialized in "CreatePlayers"
             _stemStates.Clear();
+            _stemStates.Add(SongStem.Keys, new StemState
+                { Total = 1});
 
             bool isYargSong = Song.Source.Str.ToLowerInvariant() == "yarg";
             GlobalVariables.AudioManager.Options.UseMinimumStemVolume = isYargSong;
@@ -61,7 +64,7 @@ namespace YARG.Gameplay
         {
             if (!SettingsManager.Settings.MuteOnMiss.Value) return;
 
-            if (!_stemStates.TryGetValue(stem, out var state)) return;
+            if (!GlobalVariables.AudioManager.HasStem(stem) || !_stemStates.TryGetValue(stem, out var state)) return;
 
             if (muted)
             {
@@ -83,6 +86,33 @@ namespace YARG.Gameplay
                 GlobalVariables.AudioManager.SetStemVolume(SongStem.Drums2, volume);
                 GlobalVariables.AudioManager.SetStemVolume(SongStem.Drums3, volume);
                 GlobalVariables.AudioManager.SetStemVolume(SongStem.Drums4, volume);
+            }
+        }
+
+        public void ChangeStemReverbState(SongStem stem, bool reverb)
+        {
+            if (!SettingsManager.Settings.UseStarpowerFx.Value) return;
+
+            if (!GlobalVariables.AudioManager.HasStem(stem) || !_stemStates.TryGetValue(stem, out var state)) return;
+
+            if (reverb)
+            {
+                state.ReverbCount++;
+            }
+            else
+            {
+                state.ReverbCount--;
+            }
+
+            if(state.ReverbCount > 0)
+            {
+                GlobalVariables.AudioManager.ApplyReverb(stem, true);
+                EditorDebug.Log($"Applied reverb to {stem}");
+            }
+            else
+            {
+                GlobalVariables.AudioManager.ApplyReverb(stem, false);
+                EditorDebug.Log($"Removed reverb from {stem}");
             }
         }
 

--- a/Assets/Script/Gameplay/GameManager.Audio.cs
+++ b/Assets/Script/Gameplay/GameManager.Audio.cs
@@ -85,7 +85,7 @@ namespace YARG.Gameplay
         {
             if (!SettingsManager.Settings.MuteOnMiss.Value) return;
 
-            if (!GlobalVariables.AudioManager.HasStem(stem) || !_stemStates.TryGetValue(stem, out var state)) return;
+            if (!_stemStates.TryGetValue(stem, out var state)) return;
 
             if (muted)
             {
@@ -113,7 +113,7 @@ namespace YARG.Gameplay
         {
             if (!SettingsManager.Settings.UseStarpowerFx.Value) return;
 
-            if (!GlobalVariables.AudioManager.HasStem(stem) || !_stemStates.TryGetValue(stem, out var state)) return;
+            if (!_stemStates.TryGetValue(stem, out var state)) return;
 
             if (reverb)
             {
@@ -124,7 +124,19 @@ namespace YARG.Gameplay
                 state.ReverbCount = Math.Max(0, state.ReverbCount - 1);
             }
 
-            GlobalVariables.AudioManager.ApplyReverb(stem, state.ReverbCount > 0);
+            bool reverbActive = state.ReverbCount > 0;
+
+            GlobalVariables.AudioManager.ApplyReverb(stem, reverbActive);
+
+            // Reverb all of the stems for songs with multiple drum stems
+            // TODO: Implement proper drum stem reverbing
+            if (stem == SongStem.Drums)
+            {
+                GlobalVariables.AudioManager.ApplyReverb(SongStem.Drums1, reverbActive);
+                GlobalVariables.AudioManager.ApplyReverb(SongStem.Drums2, reverbActive);
+                GlobalVariables.AudioManager.ApplyReverb(SongStem.Drums3, reverbActive);
+                GlobalVariables.AudioManager.ApplyReverb(SongStem.Drums4, reverbActive);
+            }
         }
 
         private void OnAudioEnd()

--- a/Assets/Script/Gameplay/GameManager.Audio.cs
+++ b/Assets/Script/Gameplay/GameManager.Audio.cs
@@ -36,7 +36,7 @@ namespace YARG.Gameplay
         {
             // The stem states are initialized in "CreatePlayers"
             _stemStates.Clear();
-            _stemStates.Add(SongStem.Keys, new StemState
+            _stemStates.Add(SongStem.Song, new StemState
                 { Total = 1});
 
             bool isYargSong = Song.Source.Str.ToLowerInvariant() == "yarg";

--- a/Assets/Script/Gameplay/Player/BasePlayer.cs
+++ b/Assets/Script/Gameplay/Player/BasePlayer.cs
@@ -73,6 +73,8 @@ namespace YARG.Gameplay.Player
 
         protected BaseInputViewer InputViewer { get; private set; }
 
+        protected bool _isStemMuted;
+
         private List<GameInput> _replayInputs;
 
         private int _replayInputIndex;
@@ -145,9 +147,12 @@ namespace YARG.Gameplay.Player
 
         public abstract void SetPracticeSection(uint start, uint end);
 
-        public virtual void SetStarPowerFX(bool status)
+        // TODO Make this more generic
+        public abstract void SetStemMuteState(bool muted);
+
+        public virtual void SetStarPowerFX(bool active)
         {
-            GameManager.ChangeStemReverbState(SongStem.Song, status);
+            GameManager.ChangeStemReverbState(SongStem.Song, active);
         }
 
         public virtual void SetReplayTime(double time)
@@ -310,7 +315,7 @@ namespace YARG.Gameplay.Player
                     ? SfxSample.StarPowerDeploy
                     : SfxSample.StarPowerRelease);
 
-                SetStarPowerFX(status);
+                SetStarPowerFX(active);
             }
 
             GameManager.ChangeStarPowerStatus(active);

--- a/Assets/Script/Gameplay/Player/BasePlayer.cs
+++ b/Assets/Script/Gameplay/Player/BasePlayer.cs
@@ -145,6 +145,11 @@ namespace YARG.Gameplay.Player
 
         public abstract void SetPracticeSection(uint start, uint end);
 
+        public virtual void SetStarPowerFX(bool status)
+        {
+            GameManager.ChangeStemReverbState(SongStem.Song, status);
+        }
+
         public virtual void SetReplayTime(double time)
         {
             _replayInputIndex = BaseEngine.ProcessUpToTime(time, ReplayInputs);
@@ -304,6 +309,8 @@ namespace YARG.Gameplay.Player
                 GlobalVariables.AudioManager.PlaySoundEffect(status
                     ? SfxSample.StarPowerDeploy
                     : SfxSample.StarPowerRelease);
+
+                SetStarPowerFX(status);
             }
 
             foreach (var haptics in SantrollerHaptics)

--- a/Assets/Script/Gameplay/Player/BasePlayer.cs
+++ b/Assets/Script/Gameplay/Player/BasePlayer.cs
@@ -73,6 +73,7 @@ namespace YARG.Gameplay.Player
 
         protected BaseInputViewer InputViewer { get; private set; }
 
+        protected int  _lastCombo;
         protected bool _isStemMuted;
 
         private List<GameInput> _replayInputs;

--- a/Assets/Script/Gameplay/Player/DrumsPlayer.cs
+++ b/Assets/Script/Gameplay/Player/DrumsPlayer.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using UnityEngine;
 using YARG.Core;
+using YARG.Core.Audio;
 using YARG.Core.Chart;
 using YARG.Core.Engine.Drums;
 using YARG.Core.Engine.Drums.Engines;
@@ -159,6 +160,31 @@ namespace YARG.Gameplay.Player
         protected override void UpdateVisuals(double songTime)
         {
             UpdateBaseVisuals(Engine.EngineStats, EngineParams, songTime);
+        }
+
+        public override void SetStemMuteState(bool muted)
+        {
+            if (!_isStemMuted && muted)
+            {
+                return;
+            }
+
+            var stem = Player.Profile.CurrentInstrument.ToSongStem();
+
+            // TODO Drums needs specific handling
+
+            // Try to fallback to drums stem if specific stem is not available
+            if (!GlobalVariables.AudioManager.HasStem(stem))
+            {
+                stem = SongStem.Drums;
+                if(!GlobalVariables.AudioManager.HasStem(stem))
+                {
+                    return;
+                }
+            }
+
+            GameManager.ChangeStemMuteState(stem, muted);
+            _isStemMuted = muted;
         }
 
         protected override void ResetVisuals()

--- a/Assets/Script/Gameplay/Player/DrumsPlayer.cs
+++ b/Assets/Script/Gameplay/Player/DrumsPlayer.cs
@@ -164,27 +164,43 @@ namespace YARG.Gameplay.Player
 
         public override void SetStemMuteState(bool muted)
         {
-            if (!_isStemMuted && muted)
+            if (_isStemMuted == muted)
             {
                 return;
             }
 
-            var stem = Player.Profile.CurrentInstrument.ToSongStem();
+            bool anyDrumsStems = GlobalVariables.AudioManager.HasStem(SongStem.Drums) ||
+                                 GlobalVariables.AudioManager.HasStem(SongStem.Drums1) ||
+                                 GlobalVariables.AudioManager.HasStem(SongStem.Drums2) ||
+                                 GlobalVariables.AudioManager.HasStem(SongStem.Drums3) ||
+                                 GlobalVariables.AudioManager.HasStem(SongStem.Drums4);
 
-            // TODO Drums needs specific handling
-
-            // Try to fallback to drums stem if specific stem is not available
-            if (!GlobalVariables.AudioManager.HasStem(stem))
+            // Don't mute if no drum stems are available
+            if (!anyDrumsStems)
             {
-                stem = SongStem.Drums;
-                if(!GlobalVariables.AudioManager.HasStem(stem))
-                {
-                    return;
-                }
+                return;
             }
 
-            GameManager.ChangeStemMuteState(stem, muted);
+            GameManager.ChangeStemMuteState(SongStem.Drums, muted);
             _isStemMuted = muted;
+        }
+
+        public override void SetStarPowerFX(bool active)
+        {
+            bool anyDrumsStems = GlobalVariables.AudioManager.HasStem(SongStem.Drums) ||
+                GlobalVariables.AudioManager.HasStem(SongStem.Drums1) ||
+                GlobalVariables.AudioManager.HasStem(SongStem.Drums2) ||
+                GlobalVariables.AudioManager.HasStem(SongStem.Drums3) ||
+                GlobalVariables.AudioManager.HasStem(SongStem.Drums4);
+
+            // Fall back to Song stem if drums stem is not available
+            if(!anyDrumsStems)
+            {
+                base.SetStarPowerFX(active);
+                return;
+            }
+
+            GameManager.ChangeStemReverbState(SongStem.Drums, active);
         }
 
         protected override void ResetVisuals()

--- a/Assets/Script/Gameplay/Player/FiveFretPlayer.cs
+++ b/Assets/Script/Gameplay/Player/FiveFretPlayer.cs
@@ -200,6 +200,16 @@ namespace YARG.Gameplay.Player
             }
         }
 
+        protected override void OnOverstrum()
+        {
+            base.OnOverstrum();
+
+            var overstrumSample = SfxSample.Overstrum1 + Random.Range(0, 3);
+
+            // Wait until overstrum SFX are finalised before enabling this
+            //GlobalVariables.AudioManager.PlaySoundEffect(overstrumSample);
+        }
+
         private void OnSustainStart(GuitarNote parent)
         {
             foreach (var note in parent.ChordEnumerator())

--- a/Assets/Script/Gameplay/Player/FiveFretPlayer.cs
+++ b/Assets/Script/Gameplay/Player/FiveFretPlayer.cs
@@ -151,10 +151,16 @@ namespace YARG.Gameplay.Player
             if (!GlobalVariables.AudioManager.HasStem(playerStem))
             {
                 playerStem = SongStem.Guitar;
+
+                // Fall back to Song stem if guitar stem is not available
+                if(!GlobalVariables.AudioManager.HasStem(playerStem))
+                {
+                    base.SetStarPowerFX(active);
+                    return;
+                }
             }
 
             GameManager.ChangeStemReverbState(playerStem, active);
-            base.SetStarPowerFX(active);
         }
 
         protected override void ResetVisuals()

--- a/Assets/Script/Gameplay/Player/FiveFretPlayer.cs
+++ b/Assets/Script/Gameplay/Player/FiveFretPlayer.cs
@@ -119,7 +119,30 @@ namespace YARG.Gameplay.Player
             }
         }
 
-        public override void SetStarPowerFX(bool status)
+        public override void SetStemMuteState(bool muted)
+        {
+            if (_isStemMuted == muted)
+            {
+                return;
+            }
+
+            var stem = Player.Profile.CurrentInstrument.ToSongStem();
+
+            // Try to fallback to guitar stem if specific stem is not available
+            if (!GlobalVariables.AudioManager.HasStem(stem))
+            {
+                stem = SongStem.Guitar;
+                if(!GlobalVariables.AudioManager.HasStem(stem))
+                {
+                    return;
+                }
+            }
+
+            GameManager.ChangeStemMuteState(stem, muted);
+            _isStemMuted = muted;
+        }
+
+        public override void SetStarPowerFX(bool active)
         {
             var instrument = Player.Profile.CurrentInstrument;
             var playerStem = instrument.ToSongStem();
@@ -130,8 +153,8 @@ namespace YARG.Gameplay.Player
                 playerStem = SongStem.Guitar;
             }
 
-            GameManager.ChangeStemReverbState(playerStem, status);
-            base.SetStarPowerFX(status);
+            GameManager.ChangeStemReverbState(playerStem, active);
+            base.SetStarPowerFX(active);
         }
 
         protected override void ResetVisuals()
@@ -214,7 +237,7 @@ namespace YARG.Gameplay.Player
             // Leniency is handled by the engine's sustain burst threshold.
             if (!parent.IsDisjoint && dropped)
             {
-                ShouldMuteStem = true;
+                SetStemMuteState(true);
             }
         }
 

--- a/Assets/Script/Gameplay/Player/FiveFretPlayer.cs
+++ b/Assets/Script/Gameplay/Player/FiveFretPlayer.cs
@@ -1,5 +1,6 @@
 ﻿using UnityEngine;
 using YARG.Core;
+using YARG.Core.Audio;
 using YARG.Core.Chart;
 using YARG.Core.Engine.Guitar;
 using YARG.Core.Engine.Guitar.Engines;
@@ -116,6 +117,21 @@ namespace YARG.Gameplay.Player
             {
                 _fretArray.SetPressed((int) fret, Engine.IsFretHeld(fret));
             }
+        }
+
+        public override void SetStarPowerFX(bool status)
+        {
+            var instrument = Player.Profile.CurrentInstrument;
+            var playerStem = instrument.ToSongStem();
+
+            // Try to fallback to guitar stem if specific stem is not available
+            if (!GlobalVariables.AudioManager.HasStem(playerStem))
+            {
+                playerStem = SongStem.Guitar;
+            }
+
+            GameManager.ChangeStemReverbState(playerStem, status);
+            base.SetStarPowerFX(status);
         }
 
         protected override void ResetVisuals()

--- a/Assets/Script/Gameplay/Player/FiveFretPlayer.cs
+++ b/Assets/Script/Gameplay/Player/FiveFretPlayer.cs
@@ -206,8 +206,7 @@ namespace YARG.Gameplay.Player
 
             var overstrumSample = SfxSample.Overstrum1 + Random.Range(0, 3);
 
-            // Wait until overstrum SFX are finalised before enabling this
-            //GlobalVariables.AudioManager.PlaySoundEffect(overstrumSample);
+            GlobalVariables.AudioManager.PlaySoundEffect(overstrumSample);
         }
 
         private void OnSustainStart(GuitarNote parent)

--- a/Assets/Script/Gameplay/Player/TrackPlayer.cs
+++ b/Assets/Script/Gameplay/Player/TrackPlayer.cs
@@ -346,6 +346,8 @@ namespace YARG.Gameplay.Player
             {
                 TrackView.ShowFullCombo();
             }
+
+            _lastCombo = Combo;
         }
 
         protected virtual void OnNoteMissed(int index, TNote note)
@@ -357,6 +359,13 @@ namespace YARG.Gameplay.Player
             }
 
             SetStemMuteState(true);
+
+            if (_lastCombo >= 10)
+            {
+                GlobalVariables.AudioManager.PlaySoundEffect(SfxSample.NoteMiss);
+            }
+
+            _lastCombo = Combo;
 
             foreach (var haptics in SantrollerHaptics)
             {
@@ -371,6 +380,11 @@ namespace YARG.Gameplay.Player
                 ComboMeter.SetFullCombo(false);
                 IsFc = false;
             }
+
+            _lastCombo = Combo;
+
+            // Need an overstrum sound
+            //GlobalVariables.AudioManager.PlaySoundEffect(SfxSample.Overstrum);
         }
 
         protected virtual void OnSoloStart(SoloSection solo)

--- a/Assets/Script/Gameplay/Player/TrackPlayer.cs
+++ b/Assets/Script/Gameplay/Player/TrackPlayer.cs
@@ -59,20 +59,6 @@ namespace YARG.Gameplay.Player
 
         public Vector2 HUDViewportPosition => TrackCamera.WorldToViewportPoint(_hudLocation.position);
 
-        private bool _shouldMuteStem;
-        public bool ShouldMuteStem
-        {
-            get => _shouldMuteStem;
-            protected set
-            {
-                // Skip if there's no change
-                if (value == _shouldMuteStem) return;
-
-                _shouldMuteStem = value;
-                GameManager.ChangeStemMuteState(Player.Profile.CurrentInstrument.ToSongStem(), value);
-            }
-        }
-
         protected List<Beatline> Beatlines;
         protected int BeatlineIndex;
 
@@ -111,7 +97,7 @@ namespace YARG.Gameplay.Player
         {
             // "Muting a stem" isn't technically a visual,
             // but it's a form of feedback so we'll put it here.
-            ShouldMuteStem = false;
+            SetStemMuteState(false);
 
             ComboMeter.SetFullCombo(IsFc);
             TrackView.ForceReset();
@@ -345,7 +331,7 @@ namespace YARG.Gameplay.Player
 
         protected virtual void OnNoteHit(int index, TNote note)
         {
-            ShouldMuteStem = false;
+            SetStemMuteState(false);
             if (_currentMultiplier != _previousMultiplier)
             {
                 _previousMultiplier = _currentMultiplier;
@@ -370,7 +356,7 @@ namespace YARG.Gameplay.Player
                 IsFc = false;
             }
 
-            ShouldMuteStem = true;
+            SetStemMuteState(true);
 
             foreach (var haptics in SantrollerHaptics)
             {

--- a/Assets/Script/Gameplay/Player/TrackPlayer.cs
+++ b/Assets/Script/Gameplay/Player/TrackPlayer.cs
@@ -382,9 +382,6 @@ namespace YARG.Gameplay.Player
             }
 
             _lastCombo = Combo;
-
-            // Need an overstrum sound
-            //GlobalVariables.AudioManager.PlaySoundEffect(SfxSample.Overstrum);
         }
 
         protected virtual void OnSoloStart(SoloSection solo)

--- a/Assets/Script/Gameplay/Player/VocalsPlayer.cs
+++ b/Assets/Script/Gameplay/Player/VocalsPlayer.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using UnityEngine;
 using YARG.Audio;
 using YARG.Core;
+using YARG.Core.Audio;
 using YARG.Core.Chart;
 using YARG.Core.Engine;
 using YARG.Core.Engine.Vocals;
@@ -351,6 +352,11 @@ namespace YARG.Gameplay.Player
 
             Engine = CreateEngine();
             ResetPracticeSection();
+        }
+
+        public override void SetStemMuteState(bool muted)
+        {
+            // Vocals has no stem muting
         }
 
         protected override bool InterceptInput(ref GameInput input)

--- a/Assets/Script/Gameplay/Player/VocalsPlayer.cs
+++ b/Assets/Script/Gameplay/Player/VocalsPlayer.cs
@@ -129,6 +129,18 @@ namespace YARG.Gameplay.Player
                 {
                     IsFc = false;
                 }
+
+                _lastCombo = Combo;
+            };
+
+            engine.OnNoteMissed += (_, _) =>
+            {
+                if (_lastCombo >= 2)
+                {
+                    GlobalVariables.AudioManager.PlaySoundEffect(SfxSample.NoteMiss);
+                }
+
+                _lastCombo = Combo;
             };
 
             return engine;


### PR DESCRIPTION
Reintroduces a couple of things that existed prior to the rewrite.

- Star Power reverb is back (and adjusted slightly)
- Note miss sound effect is back
- Fix some issues with stem muting and refactored the code
- Added definitions and code to play Overstrum SFX (sound files still need to be finalised and added)

Includes a YARG.Core update for the overstrum sample definitions