### PR TITLE
Display songs sorted by album if artist sort is selected in MusicLibrary

### DIFF
--- a/Assets/Script/Menu/MusicLibrary/ViewTypes/SortSubHeaderViewType.cs
+++ b/Assets/Script/Menu/MusicLibrary/ViewTypes/SortSubHeaderViewType.cs
@@ -1,0 +1,29 @@
+using System.Transactions;
+using Cysharp.Threading.Tasks;
+using UnityEngine;
+using UnityEngine.AddressableAssets;
+using YARG.Helpers;
+using YARG.Helpers.Extensions;
+using YARG.Menu.Data;
+
+namespace YARG.Menu.MusicLibrary
+{
+    public class SortSubHeaderViewType : SortHeaderViewType
+    {
+        public override BackgroundType Background => BackgroundType.Category;
+
+        public SortSubHeaderViewType(string headerText, int songCount) : base(headerText, songCount)
+        {
+        }
+
+        public override string GetPrimaryText(bool selected)
+        {
+            return FormatAs(HeaderText, TextType.Secondary, selected);
+        }
+
+        public override async UniTask<Sprite> GetIcon()
+        {
+            return await UniTask.FromResult<Sprite>(null);
+        }
+    }
+}


### PR DESCRIPTION
Under each artist header, songs will be displayed starting from those with only 1 song in the album, then the albums grouped under subheadings, sorted in the album track order.