### PR TITLE
Added Bass.ChannelGetData call to Stem Mixer

### DIFF
--- a/Assets/Script/Audio/Bass/BassAudioManager.cs
+++ b/Assets/Script/Audio/Bass/BassAudioManager.cs
@@ -577,6 +577,16 @@ namespace YARG.Audio.BASS
         public void SetPosition(double position, bool bufferCompensation = true)
             => _mixer?.SetPosition(position, bufferCompensation);
 
+        public int GetData(float[] buffer)
+        {
+            if (_mixer == null)
+            {
+                return -1;
+            }
+
+            return _mixer.GetData(buffer);
+        }
+
         public bool HasStem(SongStem stem)
         {
             if (_mixer is null) return false;

--- a/Assets/Script/Audio/Bass/BassStemMixer.cs
+++ b/Assets/Script/Audio/Bass/BassStemMixer.cs
@@ -195,6 +195,17 @@ namespace YARG.Audio.BASS
                 Debug.LogError($"Failed to reset stream: {Bass.LastError}");
         }
 
+        public int GetData(float[] buffer)
+        {
+            int data = Bass.ChannelGetData(_mixerHandle, buffer, (int) (DataFlags.FFT256));
+            if (data < 0)
+            {
+                return (int) Bass.LastError;
+            }
+
+            return data;
+        }
+
         public void SetPlayVolume(bool fadeIn)
         {
             foreach (var stem in Channels.Values)

--- a/Assets/Script/Audio/Interfaces/IAudioManager.cs
+++ b/Assets/Script/Audio/Interfaces/IAudioManager.cs
@@ -70,6 +70,8 @@ namespace YARG.Audio
         public double GetPosition(bool bufferCompensation = true);
         public void SetPosition(double position, bool bufferCompensation = true);
 
+        public int GetData(float[] buffer);
+
         public bool HasStem(SongStem stem);
     }
 }

--- a/Assets/Script/Audio/Interfaces/IStemMixer.cs
+++ b/Assets/Script/Audio/Interfaces/IStemMixer.cs
@@ -31,6 +31,8 @@ namespace YARG.Audio
 
         public void SetPosition(double position, bool bufferCompensation = true);
 
+        public int GetData(float[] buffer);
+
         public void SetPlayVolume(bool fadeIn);
 
         public void SetSpeed(float speed);


### PR DESCRIPTION
To make game objects or particles in the background scene react to the sound being played, the Bass.ChannelGetData call had to be created in the BassStemMixer to extract the audio data from the stems. 

Audio visualizers are able to be created in the future with this get data call extended in as shown below.

## Demo

https://github.com/YARC-Official/YARG/assets/25489150/5186da67-3c23-415c-8ab3-eedde59605b9

