### PR TITLE
Add sorting by PlayCount, refactor filtering and sorting a bit

### DIFF
--- a/Assets/Script/Helpers/LocaleHelper.cs
+++ b/Assets/Script/Helpers/LocaleHelper.cs
@@ -4,6 +4,8 @@ using UnityEngine.Localization.Settings;
 using YARG.Core;
 using YARG.Core.Game;
 using YARG.Core.Song;
+using YARG.Menu.MusicLibrary;
+using YARG.Song;
 
 namespace YARG.Helpers
 {
@@ -64,9 +66,9 @@ namespace YARG.Helpers
             return LocalizeString($"Modifier.{modifier}");
         }
 
-        public static string ToLocalizedName(this SongAttribute songAttribute)
+        public static string ToLocalizedName(this SortOption sortOption)
         {
-            return LocalizeString($"SongAttribute.{songAttribute}");
+            return LocalizeString($"SortOption.{sortOption}");
         }
 
         #endregion

--- a/Assets/Script/Menu/MusicLibrary/PopupMenu.cs
+++ b/Assets/Script/Menu/MusicLibrary/PopupMenu.cs
@@ -8,6 +8,7 @@ using YARG.Helpers;
 using YARG.Helpers.Extensions;
 using YARG.Menu.Navigation;
 using YARG.Settings;
+using YARG.Song;
 
 namespace YARG.Menu.MusicLibrary
 {
@@ -144,11 +145,10 @@ namespace YARG.Menu.MusicLibrary
         {
             SetHeader("Sort By...");
 
-            foreach (var sort in EnumExtensions<SongAttribute>.Values)
+            foreach (var sort in EnumExtensions<SortOption>.Values)
             {
-                // Skip theses because they don't make sense
-                if (sort == SongAttribute.Unspecified) continue;
-                if (sort == SongAttribute.Instrument) continue;
+                // Skip these because they don't make sense
+                if (sort == SortOption.Instrument) continue;
 
                 // Create an item for it
                 CreateItem(sort.ToLocalizedName(), () =>

--- a/Assets/Script/Song/SongContainer.cs
+++ b/Assets/Script/Song/SongContainer.cs
@@ -2,7 +2,9 @@
 using YARG.Core.Song.Cache;
 using YARG.Core.Song;
 using System;
+using System.Linq;
 using YARG.Helpers.Extensions;
+using YARG.Scores;
 
 namespace YARG.Song
 {
@@ -41,6 +43,7 @@ namespace YARG.Song
         private readonly List<SongCategory> _sortSongLengths = new();
         private readonly List<SongCategory> _sortDatesAdded = new();
         private readonly List<SongCategory> _sortInstruments = new();
+        private readonly List<SongCategory> _sortPlayCount = new();
 
         public IReadOnlyDictionary<string, List<SongMetadata>> Titles => _songCache.Titles;
         public IReadOnlyDictionary<string, List<SongMetadata>> Years => _songCache.Years;
@@ -115,22 +118,34 @@ namespace YARG.Song
             }
         }
 
-        public IReadOnlyList<SongCategory> GetSortedSongList(SongAttribute sort)
+        public void UpdateSongsWithPlayCount()
+        {
+            var songsWithPlayCount = ScoreContainer.GetSongsWithPlayCount();
+            _sortPlayCount.Clear();
+
+            foreach (var songGroup in songsWithPlayCount.OrderByDescending(x => x.Key))
+            {
+                _sortPlayCount.Add(new(songGroup.Key.ToString(), songGroup.Value));
+            }
+        }
+
+        public IReadOnlyList<SongCategory> GetSortedSongList(SortOption sort)
         {
             return sort switch
             {
-                SongAttribute.Name => _sortTitles,
-                SongAttribute.Artist => _sortArtists,
-                SongAttribute.Album => _sortAlbums,
-                SongAttribute.Genre => _sortGenres,
-                SongAttribute.Year => _sortYears,
-                SongAttribute.Charter => _sortCharters,
-                SongAttribute.Playlist => _sortPlaylists,
-                SongAttribute.Source => _sortSources,
-                SongAttribute.Artist_Album => _sortArtistAlbums,
-                SongAttribute.SongLength => _sortSongLengths,
-                SongAttribute.DateAdded => _sortDatesAdded,
-                SongAttribute.Instrument => _sortInstruments,
+                SortOption.Name => _sortTitles,
+                SortOption.Artist => _sortArtists,
+                SortOption.Album => _sortAlbums,
+                SortOption.Genre => _sortGenres,
+                SortOption.Year => _sortYears,
+                SortOption.Charter => _sortCharters,
+                SortOption.Playlist => _sortPlaylists,
+                SortOption.Source => _sortSources,
+                SortOption.Artist_Album => _sortArtistAlbums,
+                SortOption.SongLength => _sortSongLengths,
+                SortOption.DateAdded => _sortDatesAdded,
+                SortOption.Instrument => _sortInstruments,
+                SortOption.PlayCount => _sortPlayCount,
                 _ => throw new Exception("stoopid"),
             };
         }

--- a/Assets/Script/Song/SongExport.cs
+++ b/Assets/Script/Song/SongExport.cs
@@ -38,7 +38,7 @@ namespace YARG.Song
             // TODO: Allow customizing sorting, as well as which metadata is written and in what order
 
             using var output = new StreamWriter(path);
-            foreach (var (category, songs) in GlobalVariables.Instance.SongContainer.GetSortedSongList(SongAttribute.Artist))
+            foreach (var (category, songs) in GlobalVariables.Instance.SongContainer.GetSortedSongList(SortOption.Artist))
             {
                 output.WriteLine(category);
                 output.WriteLine("--------------------");

--- a/Assets/Script/Song/SortOption.cs
+++ b/Assets/Script/Song/SortOption.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using YARG.Core.Song;
+
+namespace YARG.Song
+{
+
+    public enum SortOption
+    {
+        Name,
+        Artist,
+        Album,
+        Artist_Album,
+        Genre,
+        Year,
+        Charter,
+        Playlist,
+        Source,
+        SongLength,
+        DateAdded,
+        Instrument,
+        PlayCount,
+    }
+
+    public static class SortOptionExtensions
+    {
+        public static SongAttribute ToSongAttribute(this SortOption sortOption)
+        {
+            switch (sortOption)
+            {
+                case SortOption.Name:         return SongAttribute.Name;
+                case SortOption.Artist:       return SongAttribute.Artist;
+                case SortOption.Album:        return SongAttribute.Album;
+                case SortOption.Artist_Album: return SongAttribute.Artist_Album;
+                case SortOption.Genre:        return SongAttribute.Genre;
+                case SortOption.Year:         return SongAttribute.Year;
+                case SortOption.Charter:      return SongAttribute.Charter;
+                case SortOption.Playlist:     return SongAttribute.Playlist;
+                case SortOption.Source:       return SongAttribute.Source;
+                case SortOption.SongLength:   return SongAttribute.SongLength;
+                case SortOption.DateAdded:    return SongAttribute.DateAdded;
+                case SortOption.Instrument:   return SongAttribute.Instrument;
+                default:                      return SongAttribute.Unspecified;
+            }
+        }
+    }
+}

--- a/Assets/Script/Song/SortOption.cs.meta
+++ b/Assets/Script/Song/SortOption.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 951e6c1cf371493fa5bd2bb36eb6ff0e
+timeCreated: 1707603489

--- a/Assets/Settings/Localization/Main Shared Data.asset
+++ b/Assets/Settings/Localization/Main Shared Data.asset
@@ -308,51 +308,51 @@ MonoBehaviour:
     m_Metadata:
       m_Items: []
   - m_Id: 77970180245151744
-    m_Key: SongAttribute.Album
+    m_Key: SortOption.Album
     m_Metadata:
       m_Items: []
   - m_Id: 77970180278706176
-    m_Key: SongAttribute.Artist
+    m_Key: SortOption.Artist
     m_Metadata:
       m_Items: []
   - m_Id: 77970180278706177
-    m_Key: SongAttribute.Artist_Album
+    m_Key: SortOption.Artist_Album
     m_Metadata:
       m_Items: []
   - m_Id: 77970180278706178
-    m_Key: SongAttribute.Charter
+    m_Key: SortOption.Charter
     m_Metadata:
       m_Items: []
   - m_Id: 77970180278706179
-    m_Key: SongAttribute.Genre
+    m_Key: SortOption.Genre
     m_Metadata:
       m_Items: []
   - m_Id: 77970180278706180
-    m_Key: SongAttribute.Instrument
+    m_Key: SortOption.Instrument
     m_Metadata:
       m_Items: []
   - m_Id: 77970180278706181
-    m_Key: SongAttribute.Name
+    m_Key: SortOption.Name
     m_Metadata:
       m_Items: []
   - m_Id: 77970180278706182
-    m_Key: SongAttribute.Playlist
+    m_Key: SortOption.Playlist
     m_Metadata:
       m_Items: []
   - m_Id: 77970180278706183
-    m_Key: SongAttribute.SongLength
+    m_Key: SortOption.SongLength
     m_Metadata:
       m_Items: []
   - m_Id: 77970180278706184
-    m_Key: SongAttribute.Source
+    m_Key: SortOption.Source
     m_Metadata:
       m_Items: []
   - m_Id: 77970180278706185
-    m_Key: SongAttribute.Unspecified
+    m_Key: SortOption.Unspecified
     m_Metadata:
       m_Items: []
   - m_Id: 77970180278706186
-    m_Key: SongAttribute.Year
+    m_Key: SortOption.Year
     m_Metadata:
       m_Items: []
   - m_Id: 82700299853488131
@@ -384,7 +384,11 @@ MonoBehaviour:
     m_Metadata:
       m_Items: []
   - m_Id: 112914116042452992
-    m_Key: SongAttribute.DateAdded
+    m_Key: SortOption.DateAdded
+    m_Metadata:
+      m_Items: []
+  - m_Id: 116764250931081216
+    m_Key: SortOption.PlayCount
     m_Metadata:
       m_Items: []
   m_Metadata:

--- a/Assets/Settings/Localization/Main_en-US.asset
+++ b/Assets/Settings/Localization/Main_en-US.asset
@@ -414,6 +414,10 @@ MonoBehaviour:
     m_Localized: Song paused...
     m_Metadata:
       m_Items: []
+  - m_Id: 116764250931081216
+    m_Localized: Play Count
+    m_Metadata:
+      m_Items: []
   references:
     version: 2
     RefIds:


### PR DESCRIPTION
Just opening a draft pull request to get some feedback.

Had to change some stuff because a lot of it was in YARG.Core but core is not aware of playcounts, and it shouldn't be either.

There was also no distinction between filterable options and sortable options, so I tried making that.

In an ideal world, the whole search gets rewritten with unit tests, and a distinction between sort options and filter options, but that's a lot more work.

Open to feedback!