### PR TITLE
Auto-generate fog events if there are none

### DIFF
--- a/Assets/Script/Gameplay/GameManager.Loading.cs
+++ b/Assets/Script/Gameplay/GameManager.Loading.cs
@@ -246,9 +246,14 @@ namespace YARG.Gameplay
                 if (File.Exists(VenueAutoGenerationPreset.DefaultPath))
                 {
                     var preset = new VenueAutoGenerationPreset(VenueAutoGenerationPreset.DefaultPath);
+
+                    if (!preset.ChartHasFog(Chart)) // This is separate because we may want to add fog even if venue is authored
+                    {
+                        Chart = preset.GenerateFogEvents(Chart);
+                    }
+                    
                     if (Chart.VenueTrack.Lighting.Count == 0)
                     {
-                        Debug.Log("Auto-generating venue lighting...");
                         Chart = preset.GenerateLightingEvents(Chart);
                     }
 

--- a/Assets/Script/Settings/VenueAutoGenerationPreset.cs
+++ b/Assets/Script/Settings/VenueAutoGenerationPreset.cs
@@ -423,11 +423,11 @@ namespace YARG.Settings
         {
             var lastTick = chart.GetLastTick();
             var resolution = chart.Resolution;
-            var startInterval = 8 * 4;
-            var fogOnInterval = 32 * 4;
-            var fogOffInterval = 8 * 4;
+            const uint startInterval = 8 * 4;
+            const uint fogOnInterval = 32 * 4;
+            const uint fogOffInterval = 8 * 4;
 
-            uint nextTick = (uint)(resolution * startInterval);
+            uint nextTick = (uint) (resolution * startInterval);
             while (nextTick < lastTick)
             {
                 chart.VenueTrack.Stage.Add(new StageEffectEvent(
@@ -435,7 +435,7 @@ namespace YARG.Settings
                     VenueEventFlags.None,
                     chart.SyncTrack.TickToTime(nextTick),
                     nextTick));
-                uint fogOffTick = nextTick + (uint)(resolution * fogOffInterval);
+                uint fogOffTick = nextTick + (uint) (resolution * fogOffInterval);
                 if (fogOffTick < lastTick)
                 {
                     chart.VenueTrack.Stage.Add(new StageEffectEvent(
@@ -448,7 +448,7 @@ namespace YARG.Settings
                 {
                     break;
                 }
-                nextTick += (uint)(resolution * fogOnInterval);
+                nextTick += (uint) (resolution * fogOnInterval);
             }
 
             return chart;


### PR DESCRIPTION
![image](https://github.com/YARC-Official/YARG/assets/23385965/38767cc9-1000-4cf9-8a0f-c007ceacce02)
![image](https://github.com/YARC-Official/YARG/assets/23385965/e6e17f82-bb40-4c60-94ea-977ee85f24b7)
This PR autogenerates the aforementioned FogOn/FogOff events; it happens before the venue lighting autogeneration, since the venue might be authored but still not have any fog events.
Tested by @TheFatBastid