### PR TITLE
Update star power haptics in UpdateBaseVisuals instead of OnStarPowerPhraseHit

### DIFF
--- a/Assets/Script/Gameplay/Player/BasePlayer.cs
+++ b/Assets/Script/Gameplay/Player/BasePlayer.cs
@@ -321,11 +321,6 @@ namespace YARG.Gameplay.Player
             {
                 GlobalVariables.AudioManager.PlaySoundEffect(SfxSample.StarPowerAward);
             }
-
-            foreach (var haptics in SantrollerHaptics)
-            {
-                haptics.SetStarPowerFill((float) BaseStats.StarPowerAmount);
-            }
         }
 
         protected virtual void OnStarPowerStatus(bool active)

--- a/Assets/Script/Gameplay/Player/TrackPlayer.cs
+++ b/Assets/Script/Gameplay/Player/TrackPlayer.cs
@@ -244,6 +244,11 @@ namespace YARG.Gameplay.Player
             SunburstEffects.SetSunburstEffects(groove, stats.IsStarPowerActive);
 
             TrackView.UpdateNoteStreak(stats.Combo);
+
+            foreach (var haptics in SantrollerHaptics)
+            {
+                haptics.SetStarPowerFill((float) BaseStats.StarPowerAmount);
+            }
         }
 
         protected override void UpdateNotes(double songTime)


### PR DESCRIPTION
The haptics were supposed to get live updates of the current star power status so that the leds would fade in and out in response to the players star power state, however that was  not happening as the star power haptics were not being updated in the right place