### PR TITLE
Add remaining text notifications and setting for note streak frequency

### DIFF
--- a/Assets/Script/Gameplay/HUD/New Variables Group Asset.asset
+++ b/Assets/Script/Gameplay/HUD/New Variables Group Asset.asset
@@ -1,0 +1,18 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b1e3e22ff9634e441a479f01f905a2f7, type: 3}
+  m_Name: New Variables Group Asset
+  m_EditorClassIdentifier: 
+  m_Variables: []
+  references:
+    version: 2
+    RefIds: []

--- a/Assets/Script/Gameplay/HUD/New Variables Group Asset.asset.meta
+++ b/Assets/Script/Gameplay/HUD/New Variables Group Asset.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 531b17790c52a4351a7c92e99add8721
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Script/Gameplay/HUD/TextNotificationQueue.cs
+++ b/Assets/Script/Gameplay/HUD/TextNotificationQueue.cs
@@ -71,5 +71,7 @@ namespace YARG.Gameplay.HUD
         BassGroove,
         FullCombo,
         StarPowerReady,
+        HotStart,
+        StrongFinish,
     }
 }

--- a/Assets/Script/Gameplay/HUD/TextNotifications.cs
+++ b/Assets/Script/Gameplay/HUD/TextNotifications.cs
@@ -5,6 +5,13 @@ using YARG.Settings;
 
 namespace YARG.Gameplay.HUD
 {
+    public enum NoteStreakFrequencyMode
+    {
+        Frequent,
+        Sparse,
+        Disabled
+    }
+
     public class TextNotifications : MonoBehaviour
     {
         [SerializeField]
@@ -46,6 +53,26 @@ namespace YARG.Gameplay.HUD
             _notificationQueue.Enqueue(new TextNotification(TextNotificationType.FullCombo, "FULL COMBO"));
         }
 
+        public void ShowHotStart()
+        {
+            _notificationQueue.Enqueue(new TextNotification(TextNotificationType.HotStart, "HOT START"));
+        }
+
+        public void ShowBassGroove()
+        {
+            _notificationQueue.Enqueue(new TextNotification(TextNotificationType.BassGroove, "BASS GROOVE"));
+        }
+
+        public void ShowStarPowerReady()
+        {
+            _notificationQueue.Enqueue(new TextNotification(TextNotificationType.StarPowerReady, "OVERDRIVE READY"));
+        }
+
+        public void ShowStrongFinish()
+        {
+            _notificationQueue.Enqueue(new TextNotification(TextNotificationType.StrongFinish, "STRONG FINISH"));
+        }
+
         public void UpdateNoteStreak(int streak)
         {
             // Don't build up notifications during a solo
@@ -67,7 +94,11 @@ namespace YARG.Gameplay.HUD
             // Queue the note streak notification
             if (_streak >= _nextStreakCount)
             {
-                _notificationQueue.Enqueue(new TextNotification(TextNotificationType.NoteStreak, $"{_nextStreakCount}-NOTE STREAK"));
+                if (!SettingsManager.Settings.NoteStreakFrequency.ValueEquals(NoteStreakFrequencyMode.Sparse))
+                {
+                    _notificationQueue.Enqueue(new TextNotification(TextNotificationType.NoteStreak,
+                        $"{_nextStreakCount}-NOTE STREAK"));
+                }
                 NextNoteStreakNotification();
             }
         }
@@ -105,20 +136,42 @@ namespace YARG.Gameplay.HUD
 
         private void NextNoteStreakNotification()
         {
-            switch (_nextStreakCount)
+            if (SettingsManager.Settings.NoteStreakFrequency.ValueEquals(NoteStreakFrequencyMode.Frequent))
             {
-                case 0:
-                    _nextStreakCount = 50;
-                    break;
-                case 50:
-                    _nextStreakCount = 100;
-                    break;
-                case 100:
-                    _nextStreakCount = 250;
-                    break;
-                case >= 250:
-                    _nextStreakCount += 250;
-                    break;
+                switch (_nextStreakCount)
+                {
+                    case 0:
+                        _nextStreakCount = 50;
+                        break;
+                    case 50:
+                        _nextStreakCount = 100;
+                        break;
+                    case >= 100:
+                        _nextStreakCount += 100;
+                        break;
+                }
+            }
+            else if (SettingsManager.Settings.NoteStreakFrequency.ValueEquals(NoteStreakFrequencyMode.Sparse))
+            {
+                switch (_nextStreakCount)
+                {
+                    case 0:
+                        _nextStreakCount = 50;
+                        break;
+                    case 50:
+                        _nextStreakCount = 100;
+                        break;
+                    case 100:
+                        _nextStreakCount = 250;
+                        break;
+                    case >= 250:
+                        _nextStreakCount += 250;
+                        break;
+                }
+            }
+            else
+            {
+                _nextStreakCount = int.MaxValue;
             }
         }
 

--- a/Assets/Script/Gameplay/HUD/TrackView.cs
+++ b/Assets/Script/Gameplay/HUD/TrackView.cs
@@ -107,6 +107,26 @@ namespace YARG.Gameplay.HUD
             _textNotifications.ShowFullCombo();
         }
 
+        public void ShowHotStart()
+        {
+            _textNotifications.ShowHotStart();
+        }
+
+        public void ShowBassGroove()
+        {
+            _textNotifications.ShowBassGroove();
+        }
+
+        public void ShowStarPowerReady()
+        {
+            _textNotifications.ShowStarPowerReady();
+        }
+
+        public void ShowStrongFinish()
+        {
+            _textNotifications.ShowStrongFinish();
+        }
+
         public void ForceReset()
         {
             _textNotifications.gameObject.SetActive(true);

--- a/Assets/Script/Settings/SettingsManager.Settings.cs
+++ b/Assets/Script/Settings/SettingsManager.Settings.cs
@@ -125,6 +125,14 @@ namespace YARG.Settings
             public ToggleSetting ShowHitWindow            { get; } = new(false, ShowHitWindowCallback);
             public ToggleSetting DisableTextNotifications { get; } = new(false);
 
+            public DropdownSetting<NoteStreakFrequencyMode> NoteStreakFrequency { get; }
+                = new(NoteStreakFrequencyMode.Frequent)
+            {
+                NoteStreakFrequencyMode.Frequent,
+                NoteStreakFrequencyMode.Sparse,
+                NoteStreakFrequencyMode.Disabled
+            };
+
             public DropdownSetting<SongProgressMode> SongTimeOnScoreBox { get; } = new(SongProgressMode.CountUpOnly)
             {
                 SongProgressMode.None,

--- a/Assets/Script/Settings/SettingsManager.cs
+++ b/Assets/Script/Settings/SettingsManager.cs
@@ -82,6 +82,7 @@ namespace YARG.Settings
                 new HeaderMetadata("Other"),
                 nameof(Settings.ShowHitWindow),
                 nameof(Settings.DisableTextNotifications),
+                nameof(Settings.NoteStreakFrequency),
                 nameof(Settings.LyricDisplay),
                 nameof(Settings.SongTimeOnScoreBox),
                 nameof(Settings.GraphicalProgressOnScoreBox),

--- a/Assets/Settings/Localization/Settings Shared Data.asset
+++ b/Assets/Settings/Localization/Settings Shared Data.asset
@@ -1047,6 +1047,26 @@ MonoBehaviour:
     m_Key: Dropdown.StarPowerHighwayFx.Off
     m_Metadata:
       m_Items: []
+  - m_Id: 119173371822858240
+    m_Key: Setting.NoteStreakFrequency
+    m_Metadata:
+      m_Items: []
+  - m_Id: 119173704238227456
+    m_Key: Setting.NoteStreakFrequency.Description
+    m_Metadata:
+      m_Items: []
+  - m_Id: 119174161593524224
+    m_Key: Dropdown.NoteStreakFrequency.Frequent
+    m_Metadata:
+      m_Items: []
+  - m_Id: 119174220057927680
+    m_Key: Dropdown.NoteStreakFrequency.Sparse
+    m_Metadata:
+      m_Items: []
+  - m_Id: 119174263120846848
+    m_Key: Dropdown.NoteStreakFrequency.Disabled
+    m_Metadata:
+      m_Items: []
   m_Metadata:
     m_Items: []
   m_KeyGenerator:

--- a/Assets/Settings/Localization/Settings_en-US.asset
+++ b/Assets/Settings/Localization/Settings_en-US.asset
@@ -1107,6 +1107,26 @@ MonoBehaviour:
     m_Localized: Off
     m_Metadata:
       m_Items: []
+  - m_Id: 119173371822858240
+    m_Localized: Note Streak Frequency
+    m_Metadata:
+      m_Items: []
+  - m_Id: 119173704238227456
+    m_Localized: Sets the frequency of note streak notifications.
+    m_Metadata:
+      m_Items: []
+  - m_Id: 119174263120846848
+    m_Localized: Disabled
+    m_Metadata:
+      m_Items: []
+  - m_Id: 119174220057927680
+    m_Localized: Sparse (50, 100, 250, 500, 750, ...)
+    m_Metadata:
+      m_Items: []
+  - m_Id: 119174161593524224
+    m_Localized: Frequent (50, 100, 200, 300, 400, ...)
+    m_Metadata:
+      m_Items: []
   references:
     version: 2
     RefIds: []


### PR DESCRIPTION
Added the following text notifications:

- `BASS GROOVE` (reach a 6x multiplier; automatically removes note streak from queue)
- `HOT START` (reach a 4x multiplier without missing any notes or overhitting)
- `OVERDRIVE READY` (marked as `StarPowerReady` internally)
- `STRONG FINISH` (finish the song with at least a 4x multiplier)

Changed `%d-NOTE STREAK` to be configurable with the following milestones:

- `Frequent` (matches Guitar Hero {50, 100, 200, 300, ...})
- `Sparse` (matches ScoreSpy {50, 100, 250, 500, 750, ...})
- `Disabled`