### PR TITLE
Remove " " from Album-Artist.

### DIFF
--- a/Assets/Settings/Localization/Main_en-US.asset
+++ b/Assets/Settings/Localization/Main_en-US.asset
@@ -220,7 +220,7 @@ MonoBehaviour:
     m_Metadata:
       m_Items: []
   - m_Id: 77970180278706177
-    m_Localized: '"Artist - Album"'
+    m_Localized: 'Artist - Album'
     m_Metadata:
       m_Items: []
   - m_Id: 77970180278706178


### PR DESCRIPTION
Kinda bugged me to see `"Album - Artist"` in the sort list instead of just `Album - Artist`.

As far as I can tell, this doesn't have any adverse affects, but someone more familiar with the codebase should confirm.