### PR TITLE
Starpower SFX only on multitrack songs.

### DIFF
--- a/Assets/Script/Audio/AudioOptions.cs
+++ b/Assets/Script/Audio/AudioOptions.cs
@@ -1,7 +1,14 @@
-// using System;
+﻿// using System;
 
 namespace YARG.Audio
 {
+    public enum StarPowerFxMode
+    {
+        Off,
+        MultitrackOnly,
+        Always
+    }
+
     public class AudioOptions
     {
         public const int WHAMMY_FFT_DEFAULT = 2048;
@@ -9,7 +16,7 @@ namespace YARG.Audio
 
         public const double MINIMUM_STEM_VOLUME = 0.15;
 
-        public bool UseStarpowerFx { get; set; }
+        public StarPowerFxMode UseStarpowerFx { get; set; }
         public bool UseWhammyFx { get; set; }
         public bool IsChipmunkSpeedup { get; set; }
 

--- a/Assets/Script/Audio/AudioOptions.cs
+++ b/Assets/Script/Audio/AudioOptions.cs
@@ -6,7 +6,7 @@ namespace YARG.Audio
     {
         Off,
         MultitrackOnly,
-        Always
+        On
     }
 
     public class AudioOptions
@@ -16,7 +16,6 @@ namespace YARG.Audio
 
         public const double MINIMUM_STEM_VOLUME = 0.15;
 
-        public StarPowerFxMode UseStarpowerFx { get; set; }
         public bool UseWhammyFx { get; set; }
         public bool IsChipmunkSpeedup { get; set; }
 

--- a/Assets/Script/Gameplay/GameManager.Audio.cs
+++ b/Assets/Script/Gameplay/GameManager.Audio.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using Cysharp.Threading.Tasks;
+using YARG.Audio;
 using YARG.Core.Audio;
 using YARG.Core.Chart;
 using YARG.Helpers.Extensions;
@@ -102,7 +103,9 @@ namespace YARG.Gameplay
 
         public void ChangeStemReverbState(SongStem stem, bool reverb)
         {
-            if (!SettingsManager.Settings.UseStarpowerFx.Value) return;
+            if (SettingsManager.Settings.UseStarpowerFx.Value == StarPowerFxMode.Off
+            || (SettingsManager.Settings.UseStarpowerFx.Value == StarPowerFxMode.MultitrackOnly
+            && stem == SongStem.Song)) return;
 
             if (!_stemStates.TryGetValue(stem, out var state)) return;
 

--- a/Assets/Script/Settings/SettingsManager.Settings.cs
+++ b/Assets/Script/Settings/SettingsManager.Settings.cs
@@ -1,6 +1,7 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.InputSystem;
+using YARG.Audio;
 using YARG.Core.Audio;
 using YARG.Gameplay.HUD;
 using YARG.Helpers;
@@ -82,7 +83,12 @@ namespace YARG.Settings
             public SliderSetting MicrophoneSensitivity { get; } = new(2f, -50f, 50f);
             public ToggleSetting MuteOnMiss            { get; } = new(true);
 
-            public ToggleSetting UseStarpowerFx   { get; } = new(true, UseStarpowerFxChange);
+            public DropdownSetting<StarPowerFxMode> UseStarpowerFx { get; } = new(StarPowerFxMode.Always, UseStarpowerFxChange)
+            {
+                StarPowerFxMode.Off,
+                StarPowerFxMode.MultitrackOnly,
+                StarPowerFxMode.Always
+            };
             public ToggleSetting ClapsInStarpower { get; } = new(true);
 
             // public ToggleSetting UseWhammyFx            { get; } = new(true, UseWhammyFxChange);
@@ -354,7 +360,7 @@ namespace YARG.Settings
                 HelpBar.Instance.MusicPlayer.UpdateVolume();
             }
 
-            private static void UseStarpowerFxChange(bool value)
+            private static void UseStarpowerFxChange(StarPowerFxMode value)
             {
                 GlobalVariables.AudioManager.Options.UseStarpowerFx = value;
             }

--- a/Assets/Script/Settings/SettingsManager.Settings.cs
+++ b/Assets/Script/Settings/SettingsManager.Settings.cs
@@ -83,11 +83,11 @@ namespace YARG.Settings
             public SliderSetting MicrophoneSensitivity { get; } = new(2f, -50f, 50f);
             public ToggleSetting MuteOnMiss            { get; } = new(true);
 
-            public DropdownSetting<StarPowerFxMode> UseStarpowerFx { get; } = new(StarPowerFxMode.Always, UseStarpowerFxChange)
+            public DropdownSetting<StarPowerFxMode> UseStarpowerFx { get; } = new(StarPowerFxMode.On)
             {
                 StarPowerFxMode.Off,
                 StarPowerFxMode.MultitrackOnly,
-                StarPowerFxMode.Always
+                StarPowerFxMode.On
             };
             public ToggleSetting ClapsInStarpower { get; } = new(true);
 
@@ -358,11 +358,6 @@ namespace YARG.Settings
             private static void MusicPlayerVolumeCallback(float volume)
             {
                 HelpBar.Instance.MusicPlayer.UpdateVolume();
-            }
-
-            private static void UseStarpowerFxChange(StarPowerFxMode value)
-            {
-                GlobalVariables.AudioManager.Options.UseStarpowerFx = value;
             }
 
             // private static void UseWhammyFxChange(bool value)

--- a/Assets/Settings/Localization/Settings Shared Data.asset
+++ b/Assets/Settings/Localization/Settings Shared Data.asset
@@ -1056,7 +1056,7 @@ MonoBehaviour:
     m_Metadata:
       m_Items: []
   - m_Id: 120322882958163968
-    m_Key: Dropdown.UseStarpowerFx.Always
+    m_Key: Dropdown.UseStarpowerFx.On
     m_Metadata:
       m_Items: []
   m_Metadata:

--- a/Assets/Settings/Localization/Settings Shared Data.asset
+++ b/Assets/Settings/Localization/Settings Shared Data.asset
@@ -1047,6 +1047,18 @@ MonoBehaviour:
     m_Key: Dropdown.StarPowerHighwayFx.Off
     m_Metadata:
       m_Items: []
+  - m_Id: 120322696970141696
+    m_Key: Dropdown.UseStarpowerFx.Off
+    m_Metadata:
+      m_Items: []
+  - m_Id: 120322832085450752
+    m_Key: Dropdown.UseStarpowerFx.MultitrackOnly
+    m_Metadata:
+      m_Items: []
+  - m_Id: 120322882958163968
+    m_Key: Dropdown.UseStarpowerFx.Always
+    m_Metadata:
+      m_Items: []
   m_Metadata:
     m_Items: []
   m_KeyGenerator:

--- a/Assets/Settings/Localization/Settings_en-US.asset
+++ b/Assets/Settings/Localization/Settings_en-US.asset
@@ -1116,7 +1116,7 @@ MonoBehaviour:
     m_Metadata:
       m_Items: []
   - m_Id: 120322882958163968
-    m_Localized: Always
+    m_Localized: On
     m_Metadata:
       m_Items: []
   references:

--- a/Assets/Settings/Localization/Settings_en-US.asset
+++ b/Assets/Settings/Localization/Settings_en-US.asset
@@ -1107,6 +1107,18 @@ MonoBehaviour:
     m_Localized: Off
     m_Metadata:
       m_Items: []
+  - m_Id: 120322696970141696
+    m_Localized: Off
+    m_Metadata:
+      m_Items: []
+  - m_Id: 120322832085450752
+    m_Localized: Multitrack Only
+    m_Metadata:
+      m_Items: []
+  - m_Id: 120322882958163968
+    m_Localized: Always
+    m_Metadata:
+      m_Items: []
   references:
     version: 2
     RefIds: []


### PR DESCRIPTION
Changes the "Use Starpower FX" toggle to a drop down. "Off" and "Always" do what the toggle used to do. "Multitrack Only" reverbs only if you're using an instrument specific stem, will not reverb the song stem.