### PR TITLE
Fixed small Stage Kit oversight.

### DIFF
--- a/Assets/Script/Integration/StageKit/StageKitGameplay.cs
+++ b/Assets/Script/Integration/StageKit/StageKitGameplay.cs
@@ -257,9 +257,10 @@ namespace YARG.Integration.StageKit
                     break;
 
                 case LightingType.Strobe_Fast:
-                    //This might be a bug in the official code that i'm trying to replicate here, as slow
-                    //doesn't seem to do it.
+                    //Lighting cues are NEVER on with Fast Strobe.
+                    //Not sure about Slow Strobe.
                     KillCue();
+                    _controller.AllLedsOff();
                     _controller.SetStrobeSpeed(StageKitStrobeSpeed.Fast);
                     break;
 


### PR DESCRIPTION
Cues were being killed (stopped), but the LEDs were not actually being turned off. Would cause the LEDs to look like they were 'hanging unresponsive.' No LEDs are ever on when Strobe Fast is.