### PR TITLE
Update LitFade shader kick color correction

### DIFF
--- a/Assets/Art/Shaders/Gameplay/LitFade.shadergraph
+++ b/Assets/Art/Shaders/Gameplay/LitFade.shadergraph
@@ -2836,7 +2836,7 @@
     "m_Hidden": false,
     "m_ShaderOutputName": "Saturation",
     "m_StageCapability": 3,
-    "m_Value": 1.2000000476837159,
+    "m_Value": 1.5,
     "m_DefaultValue": 1.0,
     "m_Labels": []
 }
@@ -4151,7 +4151,7 @@
     "m_Hidden": false,
     "m_ShaderOutputName": "Offset",
     "m_StageCapability": 3,
-    "m_Value": -24.0,
+    "m_Value": -25.0,
     "m_DefaultValue": 0.0,
     "m_Labels": []
 }


### PR DESCRIPTION
### Notes

Slightly tweaked the `Emission with color correction` setting to make the default kick and open note colors look less distorted. The kick color now much more closely resembles orange than yellow and better matches the RB4 kick color.

### Testing

- Works well with most colors (such as purple, red, blue, etc) and does not distort them.
- For some cases like green, the color can be slightly off (green appears ever so slightly yellowish, for example), but this was an issue present before these changes.