### PR TITLE
Take star power into account when checking for bass groove

### DIFF
--- a/Assets/Script/Gameplay/Player/TrackPlayer.cs
+++ b/Assets/Script/Gameplay/Player/TrackPlayer.cs
@@ -269,7 +269,7 @@ namespace YARG.Gameplay.Player
                 }
             }
 
-            bool currentBassGrooveState = IsBass && stats.ScoreMultiplier == BaseParameters.MaxMultiplier;
+            bool currentBassGrooveState = IsBass && groove;
 
             if (!PreviousBassGrooveState && currentBassGrooveState)
             {


### PR DESCRIPTION
Fixes a bug where the bass groove text pops up when you get the 6x multiplier under star power instead of 12x:

![image](https://github.com/YARC-Official/YARG/assets/141366895/e0cb811e-ebc0-447e-953e-02411e122ab0)
