### PR TITLE
Convert SongContainer to a static class

### DIFF
--- a/Assets/Script/Gameplay/GameManager.Loading.cs
+++ b/Assets/Script/Gameplay/GameManager.Loading.cs
@@ -16,6 +16,7 @@ using YARG.Player;
 using YARG.Replays;
 using YARG.Scores;
 using YARG.Settings;
+using YARG.Song;
 
 namespace YARG.Gameplay
 {
@@ -107,7 +108,7 @@ namespace YARG.Gameplay
             // Load song
             if (IsReplay)
             {
-                if (!global.SongContainer.SongsByHash.TryGetValue(global.CurrentReplay.SongChecksum, out var songs))
+                if (!SongContainer.SongsByHash.TryGetValue(global.CurrentReplay.SongChecksum, out var songs))
                 {
                     ToastManager.ToastWarning("Song not present in library");
                     global.LoadScene(SceneIndex.Menu);

--- a/Assets/Script/Menu/History/ViewTypes/GameRecordViewType.cs
+++ b/Assets/Script/Menu/History/ViewTypes/GameRecordViewType.cs
@@ -22,14 +22,16 @@ namespace YARG.Menu.History
         public override bool UseFullContainer => true;
 
         public readonly GameRecord GameRecord;
-        private readonly SongEntry _SongEntry;
+        private readonly SongEntry _songEntry;
 
         public GameRecordViewType(GameRecord gameRecord)
         {
             GameRecord = gameRecord;
 
-            var songsByHash = GlobalVariables.Instance.SongContainer.SongsByHash;
-            _SongEntry = songsByHash.GetValueOrDefault(new HashWrapper(gameRecord.SongChecksum))?.FirstOrDefault();
+            if (SongContainer.SongsByHash.TryGetValue(new HashWrapper(gameRecord.SongChecksum), out var songs))
+            {
+                _songEntry = songs[0];
+            }
         }
 
         public override string GetPrimaryText(bool selected)
@@ -44,7 +46,7 @@ namespace YARG.Menu.History
 
         public override void ViewClick()
         {
-            if (_SongEntry is null) return;
+            if (_songEntry is null) return;
 
             PlayReplay().Forget();
         }
@@ -100,7 +102,7 @@ namespace YARG.Menu.History
             // We're good!
             GlobalVariables.Instance.IsReplay = true;
             GlobalVariables.Instance.CurrentReplay = replayEntry;
-            GlobalVariables.Instance.CurrentSong = _SongEntry;
+            GlobalVariables.Instance.CurrentSong = _songEntry;
 
             GlobalVariables.AudioManager.UnloadSong();
             GlobalVariables.Instance.LoadScene(SceneIndex.Gameplay);
@@ -109,9 +111,9 @@ namespace YARG.Menu.History
         public override async UniTask<Sprite> GetIcon()
         {
             // TODO: Show "song missing" icon instead
-            if (_SongEntry is null) return null;
+            if (_songEntry is null) return null;
 
-            return await SongSources.SourceToIcon(_SongEntry.Source);
+            return await SongSources.SourceToIcon(_songEntry.Source);
         }
 
         public override GameInfo? GetGameInfo()

--- a/Assets/Script/Menu/History/ViewTypes/ReplayViewType.cs
+++ b/Assets/Script/Menu/History/ViewTypes/ReplayViewType.cs
@@ -22,13 +22,9 @@ namespace YARG.Menu.History
         public ReplayViewType(ReplayEntry replayEntry)
         {
             _replayEntry = replayEntry;
-
-            var songsByHash = GlobalVariables.Instance.SongContainer.SongsByHash;
-
-            var songsForHash = songsByHash.GetValueOrDefault(replayEntry.SongChecksum);
-            if (songsForHash is not null)
+            if (SongContainer.SongsByHash.TryGetValue(replayEntry.SongChecksum, out var songs))
             {
-                _songEntry = songsForHash[0];
+                _songEntry = songs[0];
             }
         }
 

--- a/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
+++ b/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
@@ -184,7 +184,7 @@ namespace YARG.Menu.MusicLibrary
             var list = new List<ViewType>();
 
             // Return if there are no songs (or they haven't loaded yet)
-            if (_sortedSongs is null || GlobalVariables.Instance.SongContainer.Count <= 0) return list;
+            if (_sortedSongs is null || SongContainer.Count <= 0) return list;
 
             // Get the number of songs
             int count = _sortedSongs.Sum(section => section.Songs.Count);
@@ -238,11 +238,8 @@ namespace YARG.Menu.MusicLibrary
             }
             else
             {
-                var songContainer = GlobalVariables.Instance.SongContainer;
-
                 // Add "ALL SONGS" header right above the songs
-                list.Insert(0,
-                    new CategoryViewType("ALL SONGS", songContainer.Count, songContainer.Songs));
+                list.Insert(0, new CategoryViewType("ALL SONGS", SongContainer.Count, SongContainer.Songs));
 
                 if (_recommendedSongs != null)
                 {
@@ -285,7 +282,7 @@ namespace YARG.Menu.MusicLibrary
             }, BACK_ID));
 
             // Return if there are no songs (or they haven't loaded yet)
-            if (_sortedSongs is null || GlobalVariables.Instance.SongContainer.Count <= 0) return list;
+            if (_sortedSongs is null || SongContainer.Count <= 0) return list;
 
             // Get the number of songs
             int count = _sortedSongs.Sum(section => section.Songs.Count);
@@ -309,7 +306,7 @@ namespace YARG.Menu.MusicLibrary
 
         private void SetRecommendedSongs()
         {
-            if (GlobalVariables.Instance.SongContainer.Count > 5)
+            if (SongContainer.Count > 5)
             {
                 _recommendedSongs = RecommendedSongs.GetRecommendedSongs();
             }
@@ -358,14 +355,9 @@ namespace YARG.Menu.MusicLibrary
                 foreach (var hash in SelectedPlaylist.SongHashes)
                 {
                     // Get the first song with the specified hash
-                    var song = GlobalVariables.Instance
-                        .SongContainer
-                        .SongsByHash
-                        .GetValueOrDefault(hash)?[0];
-
-                    if (song is not null)
+                    if (SongContainer.SongsByHash.TryGetValue(hash, out var song))
                     {
-                        songs.Add(song);
+                        songs.Add(song[0]);
                     }
                 }
 

--- a/Assets/Script/Menu/MusicLibrary/RecommendedSongs.cs
+++ b/Assets/Script/Menu/MusicLibrary/RecommendedSongs.cs
@@ -56,8 +56,7 @@ namespace YARG.Menu.MusicLibrary
             const float STARTING_RNG = .75f;
             const float RNG_DECREMENT = .25f;
 
-            var sources = GlobalVariables.Instance.SongContainer.Sources;
-            sources.TryGetValue(_YARGSOURCE, out var yargSongs);
+            SongContainer.Sources.TryGetValue(_YARGSOURCE, out var yargSongs);
 
             float yargSongRNG = yargSongs != null ? STARTING_RNG : 0;
             while (_recommendedSongs.Count < 5)
@@ -70,7 +69,7 @@ namespace YARG.Menu.MusicLibrary
                 }
                 else
                 {
-                    song = GlobalVariables.Instance.SongContainer.GetRandomSong();
+                    song = SongContainer.GetRandomSong();
                 }
 
                 if (!_recommendedSongs.Contains(song))
@@ -90,7 +89,7 @@ namespace YARG.Menu.MusicLibrary
 
         private static void AddSongsFromTopPlayedArtists(ref List<SongEntry> mostPlayed)
         {
-            var artists = GlobalVariables.Instance.SongContainer.Artists;
+            var artists = SongContainer.Artists;
             while (mostPlayed.Count > 0)
             {
                 int songIndex = Random.Range(0, mostPlayed.Count);

--- a/Assets/Script/Menu/Persistent/MusicPlayer.cs
+++ b/Assets/Script/Menu/Persistent/MusicPlayer.cs
@@ -8,6 +8,7 @@ using YARG.Settings;
 using YARG.Helpers.Extensions;
 using YARG.Core.Audio;
 using YARG.Core.Song;
+using YARG.Song;
 
 namespace YARG.Menu.Persistent
 {
@@ -39,7 +40,7 @@ namespace YARG.Menu.Persistent
             await UniTask.WaitUntil(() => !LoadingManager.Instance.IsLoading);
 
             // Disable if there are no songs to play
-            if (GlobalVariables.Instance.SongContainer.Count <= 0)
+            if (SongContainer.Count <= 0)
             {
                 gameObject.SetActive(false);
                 return;
@@ -57,7 +58,7 @@ namespace YARG.Menu.Persistent
 
         private async UniTask NextSong()
         {
-            var song = GlobalVariables.Instance.SongContainer.GetRandomSong();
+            var song = SongContainer.GetRandomSong();
             NowPlaying = song;
             await UniTask.RunOnThreadPool(() => song.LoadAudio(GlobalVariables.AudioManager, 1f, SongStem.Crowd));
 

--- a/Assets/Script/Menu/Settings/SongManager/SettingsDirectory.cs
+++ b/Assets/Script/Menu/Settings/SongManager/SettingsDirectory.cs
@@ -3,6 +3,7 @@ using TMPro;
 using UnityEngine;
 using YARG.Helpers;
 using YARG.Settings;
+using YARG.Song;
 
 namespace YARG.Menu.Settings
 {
@@ -36,7 +37,7 @@ namespace YARG.Menu.Settings
                 pathText.text = SongFolders[_index];
 
                 int songCount = 0;
-                foreach (var song in GlobalVariables.Instance.SongContainer.Songs)
+                foreach (var song in SongContainer.Songs)
                     if (song.Directory.StartsWith(SongFolders[_index]))
                         ++songCount;
 

--- a/Assets/Script/Persistent/GlobalVariables.cs
+++ b/Assets/Script/Persistent/GlobalVariables.cs
@@ -45,7 +45,6 @@ namespace YARG
         public static IAudioManager AudioManager { get; private set; }
 
         public SceneIndex CurrentScene { get; private set; } = SceneIndex.Persistent;
-        public SongContainer SongContainer { get; set; }
 
         [HideInInspector]
         public SongEntry CurrentSong;

--- a/Assets/Script/Persistent/LoadingManager.cs
+++ b/Assets/Script/Persistent/LoadingManager.cs
@@ -162,7 +162,7 @@ namespace YARG
                 directories.Remove(setlistPath);
             }
 
-            GlobalVariables.Instance.SongContainer = new SongContainer(task.Result);
+            SongContainer.Refresh(task.Result);
             MusicLibraryMenu.SetRefresh();
         }
 

--- a/Assets/Script/Scores/ScoreContainer.cs
+++ b/Assets/Script/Scores/ScoreContainer.cs
@@ -10,6 +10,7 @@ using YARG.Core.Song;
 using YARG.Helpers;
 using YARG.Helpers.Extensions;
 using YARG.Player;
+using YARG.Song;
 
 namespace YARG.Scores
 {
@@ -179,12 +180,11 @@ namespace YARG.Scores
                     $"BY `Count` DESC LIMIT {maxCount}";
                 var playCounts = _db.Query<PlayCountRecord>(query);
 
-                var allSongs = GlobalVariables.Instance.SongContainer.SongsByHash;
                 var mostPlayed = new List<SongEntry>();
                 foreach (var record in playCounts)
                 {
                     var hash = new HashWrapper(record.SongChecksum);
-                    if (allSongs.TryGetValue(hash, out var list))
+                    if (SongContainer.SongsByHash.TryGetValue(hash, out var list))
                     {
                         mostPlayed.Add(list.Pick());
                     }

--- a/Assets/Script/Song/SongContainer.cs
+++ b/Assets/Script/Song/SongContainer.cs
@@ -24,72 +24,71 @@ namespace YARG.Song
         }
     }
 
-    public class SongContainer
+    public static class SongContainer
     {
-        private readonly SongCache _songCache = new();
-        private readonly List<SongEntry> _songs = new();
+        private static SongCache _songCache = new();
+        private static List<SongEntry> _songs = new();
 
-        private readonly List<SongCategory> _sortTitles = new();
-        private readonly List<SongCategory> _sortArtists = new();
-        private readonly List<SongCategory> _sortAlbums = new();
-        private readonly List<SongCategory> _sortGenres = new();
-        private readonly List<SongCategory> _sortYears = new();
-        private readonly List<SongCategory> _sortCharters = new();
-        private readonly List<SongCategory> _sortPlaylists = new();
-        private readonly List<SongCategory> _sortSources = new();
-        private readonly List<SongCategory> _sortArtistAlbums = new();
-        private readonly List<SongCategory> _sortSongLengths = new();
-        private readonly List<SongCategory> _sortDatesAdded = new();
-        private readonly List<SongCategory> _sortInstruments = new();
+        private static List<SongCategory> _sortTitles = new();
+        private static List<SongCategory> _sortArtists = new();
+        private static List<SongCategory> _sortAlbums = new();
+        private static List<SongCategory> _sortGenres = new();
+        private static List<SongCategory> _sortYears = new();
+        private static List<SongCategory> _sortCharters = new();
+        private static List<SongCategory> _sortPlaylists = new();
+        private static List<SongCategory> _sortSources = new();
+        private static List<SongCategory> _sortArtistAlbums = new();
+        private static List<SongCategory> _sortSongLengths = new();
+        private static List<SongCategory> _sortDatesAdded = new();
+        private static List<SongCategory> _sortInstruments = new();
 
-        public IReadOnlyDictionary<string, List<SongEntry>> Titles => _songCache.Titles;
-        public IReadOnlyDictionary<string, List<SongEntry>> Years => _songCache.Years;
-        public IReadOnlyDictionary<string, List<SongEntry>> ArtistAlbums => _songCache.ArtistAlbums;
-        public IReadOnlyDictionary<string, List<SongEntry>> SongLengths => _songCache.SongLengths;
-        public IReadOnlyDictionary<string, List<SongEntry>> Instruments => _songCache.Instruments;
-        public IReadOnlyDictionary<DateTime, List<SongEntry>> AddedDates => _songCache.DatesAdded;
-        public IReadOnlyDictionary<SortString, List<SongEntry>> Artists => _songCache.Artists;
-        public IReadOnlyDictionary<SortString, List<SongEntry>> Albums => _songCache.Albums;
-        public IReadOnlyDictionary<SortString, List<SongEntry>> Genres => _songCache.Genres;
-        public IReadOnlyDictionary<SortString, List<SongEntry>> Charters => _songCache.Charters;
-        public IReadOnlyDictionary<SortString, List<SongEntry>> Playlists => _songCache.Playlists;
-        public IReadOnlyDictionary<SortString, List<SongEntry>> Sources => _songCache.Sources;
+        public static IReadOnlyDictionary<string, List<SongEntry>> Titles => _songCache.Titles;
+        public static IReadOnlyDictionary<string, List<SongEntry>> Years => _songCache.Years;
+        public static IReadOnlyDictionary<string, List<SongEntry>> ArtistAlbums => _songCache.ArtistAlbums;
+        public static IReadOnlyDictionary<string, List<SongEntry>> SongLengths => _songCache.SongLengths;
+        public static IReadOnlyDictionary<string, List<SongEntry>> Instruments => _songCache.Instruments;
+        public static IReadOnlyDictionary<DateTime, List<SongEntry>> AddedDates => _songCache.DatesAdded;
+        public static IReadOnlyDictionary<SortString, List<SongEntry>> Artists => _songCache.Artists;
+        public static IReadOnlyDictionary<SortString, List<SongEntry>> Albums => _songCache.Albums;
+        public static IReadOnlyDictionary<SortString, List<SongEntry>> Genres => _songCache.Genres;
+        public static IReadOnlyDictionary<SortString, List<SongEntry>> Charters => _songCache.Charters;
+        public static IReadOnlyDictionary<SortString, List<SongEntry>> Playlists => _songCache.Playlists;
+        public static IReadOnlyDictionary<SortString, List<SongEntry>> Sources => _songCache.Sources;
 
-        public int Count => _songs.Count;
-        public IReadOnlyDictionary<HashWrapper, List<SongEntry>> SongsByHash => _songCache.Entries;
-        public IReadOnlyList<SongEntry> Songs => _songs;
+        public static int Count => _songs.Count;
+        public static IReadOnlyDictionary<HashWrapper, List<SongEntry>> SongsByHash => _songCache.Entries;
+        public static IReadOnlyList<SongEntry> Songs => _songs;
 
-        public SongContainer() { }
-
-        public SongContainer(SongCache cache)
+        public static void Refresh(SongCache cache)
         {
             _songCache = cache;
+            _songs.Clear();
             foreach (var node in cache.Entries)
                 _songs.AddRange(node.Value);
             _songs.TrimExcess();
 
-            _sortArtists = Convert(cache.Artists, SongAttribute.Artist);
-            _sortAlbums = Convert(cache.Albums, SongAttribute.Album);
-            _sortGenres = Convert(cache.Genres, SongAttribute.Genre);
-            _sortCharters = Convert(cache.Charters, SongAttribute.Charter);
-            _sortPlaylists = Convert(cache.Playlists, SongAttribute.Playlist);
-            _sortSources = Convert(cache.Sources, SongAttribute.Source);
+            Convert(_sortArtists, cache.Artists, SongAttribute.Artist);
+            Convert(_sortAlbums, cache.Albums, SongAttribute.Album);
+            Convert(_sortGenres, cache.Genres, SongAttribute.Genre);
+            Convert(_sortCharters, cache.Charters, SongAttribute.Charter);
+            Convert(_sortPlaylists, cache.Playlists, SongAttribute.Playlist);
+            Convert(_sortSources, cache.Sources, SongAttribute.Source);
 
-            _sortTitles = Cast(cache.Titles);
-            _sortYears = Cast(cache.Years);
-            _sortArtistAlbums = Cast(cache.ArtistAlbums);
-            _sortSongLengths = Cast(cache.SongLengths);
-            _sortInstruments = Cast(cache.Instruments);
+            Cast(_sortTitles, cache.Titles);
+            Cast(_sortYears, cache.Years);
+            Cast(_sortArtistAlbums, cache.ArtistAlbums);
+            Cast(_sortSongLengths, cache.SongLengths);
+            Cast(_sortInstruments, cache.Instruments);
 
-            _sortDatesAdded = new();
+            _sortDatesAdded.Clear();
             foreach (var node in cache.DatesAdded)
             {
                 _sortDatesAdded.Add(new(node.Key.ToLongDateString(), node.Value));
             }
 
-            static List<SongCategory> Convert(SortedDictionary<SortString, List<SongEntry>> list, SongAttribute attribute)
+            static void Convert(List<SongCategory> sections, SortedDictionary<SortString, List<SongEntry>> list, SongAttribute attribute)
             {
-                List<SongCategory> sections = new(list.Count);
+                sections.Clear();
                 foreach (var node in list)
                 {
                     string key = node.Key;
@@ -101,21 +100,19 @@ namespace YARG.Song
                     }
                     sections.Add(new(key, node.Value));
                 }
-                return sections;
             }
 
-            static List<SongCategory> Cast(SortedDictionary<string, List<SongEntry>> list)
+            static void Cast(List<SongCategory> sections, SortedDictionary<string, List<SongEntry>> list)
             {
-                List<SongCategory> sections = new(list.Count);
+                sections.Clear();
                 foreach (var section in list)
                 {
                     sections.Add(new SongCategory(section.Key, section.Value));
                 }
-                return sections;
             }
         }
 
-        public IReadOnlyList<SongCategory> GetSortedSongList(SongAttribute sort)
+        public static IReadOnlyList<SongCategory> GetSortedSongList(SongAttribute sort)
         {
             return sort switch
             {
@@ -135,7 +132,7 @@ namespace YARG.Song
             };
         }
 
-        public SongEntry GetRandomSong()
+        public static SongEntry GetRandomSong()
         {
             return _songs.Pick();
         }

--- a/Assets/Script/Song/SongExport.cs
+++ b/Assets/Script/Song/SongExport.cs
@@ -38,7 +38,7 @@ namespace YARG.Song
             // TODO: Allow customizing sorting, as well as which metadata is written and in what order
 
             using var output = new StreamWriter(path);
-            foreach (var (category, songs) in GlobalVariables.Instance.SongContainer.GetSortedSongList(SongAttribute.Artist))
+            foreach (var (category, songs) in SongContainer.GetSortedSongList(SongAttribute.Artist))
             {
                 output.WriteLine(category);
                 output.WriteLine("--------------------");
@@ -57,7 +57,7 @@ namespace YARG.Song
             var songs = new List<OuvertSongData>();
 
             // Convert SongInfo to OuvertSongData
-            foreach (var song in GlobalVariables.Instance.SongContainer.Songs)
+            foreach (var song in SongContainer.Songs)
             {
                 songs.Add(new OuvertSongData
                 {

--- a/Assets/Script/Song/SongSearching.cs
+++ b/Assets/Script/Song/SongSearching.cs
@@ -13,7 +13,7 @@ namespace YARG.Song
         {
             searches.Clear();
             var filter = new FilterNode(sort, string.Empty);
-            var songs = GlobalVariables.Instance.SongContainer.GetSortedSongList(sort);
+            var songs = SongContainer.GetSortedSongList(sort);
             searches.Add(new SearchNode(filter, songs));
             return songs;
         }
@@ -61,7 +61,7 @@ namespace YARG.Song
             {
                 searches.Clear();
                 var filter = currentFilters[0];
-                var songs = GlobalVariables.Instance.SongContainer.GetSortedSongList(filter.attribute);
+                var songs = SongContainer.GetSortedSongList(filter.attribute);
                 if (filter.attribute == SongAttribute.Instrument)
                 {
                     songs = FilterInstruments(songs, filter.argument);


### PR DESCRIPTION
The lifetime for access to all the variables contained in the class spans the entire uptime of the app. Having them all be statically accessible directly from the class itself instead of indirectly through a GlobalVariables instance makes operations on it easier to follow.

+ Extra benefit on fewer allocations through not having to create new lists.