### PR TITLE
Handle camera cut before venue set

### DIFF
--- a/Assets/Script/Integration/StageKit/StageKitInterpreter.cs
+++ b/Assets/Script/Integration/StageKit/StageKitInterpreter.cs
@@ -117,6 +117,11 @@ namespace YARG
 
         protected virtual void OnLightingEvent(LightingEvent value)
         {
+            if (CurrentLightingCue == null)
+            {
+                return;
+            }
+            
             if (value != null && value.Type == LightingType.Keyframe_Next)
             {
                 if (CurrentLightingCue.DirectListenEnabled)


### PR DESCRIPTION
Adding this null check fixes the problem of having camera cuts which then use Next before a venue cue is set.