### PR TITLE
Bug fix for Dischord and formatting

### DIFF
--- a/Assets/Prefabs/SettingPreviews/DMXInformationPanelUI.prefab
+++ b/Assets/Prefabs/SettingPreviews/DMXInformationPanelUI.prefab
@@ -308,7 +308,7 @@ MonoBehaviour:
     m_TableReference:
       m_TableCollectionName: GUID:0c40e690d26fdff4a92f0b3813ac68a4
     m_TableEntryReference:
-      m_KeyId: 123349507897450496
+      m_KeyId: 126176427112783873
       m_Key: 
     m_FallbackState: 0
     m_WaitForCompletion: 0

--- a/Assets/Script/Integration/MasterLightingController.cs
+++ b/Assets/Script/Integration/MasterLightingController.cs
@@ -105,7 +105,7 @@ namespace YARG.Integration
             get => _paused;
             set
             {
-                //On Pause, turn off the fog and strobe so people don't die, but leave the leds on, looks nice.
+                // On Pause, turn off the fog and strobe so people don't die, but leave the leds on, looks nice.
                 if (value)
                 {
                     CurrentFogState = FogState.Off;
@@ -196,7 +196,7 @@ namespace YARG.Integration
 
         public static void FireBonusFXEvent()
         {
-            //This is a instantaneous event, so we don't need to keep track of it.
+            // This is a instantaneous event, so we don't need to keep track of it.
             OnBonusFXEvent?.Invoke();
         }
     }

--- a/Assets/Script/Integration/MasterLightingGameplayMonitor.cs
+++ b/Assets/Script/Integration/MasterLightingGameplayMonitor.cs
@@ -4,10 +4,9 @@ using PlasticBand.Haptics;
 using YARG.Core;
 using YARG.Core.Chart;
 using YARG.Gameplay;
-using YARG.Integration;
 using Random = UnityEngine.Random;
 
-namespace YARG
+namespace YARG.Integration
 {
     public class MasterLightingGameplayMonitor : GameplayBehaviour
     {

--- a/Assets/Script/Integration/Sacn/SacnHardware.cs
+++ b/Assets/Script/Integration/Sacn/SacnHardware.cs
@@ -5,6 +5,7 @@ using UnityEngine;
 using YARG.Core.Chart;
 using YARG.Settings;
 using YARG.Core.Logging;
+using YARG.Integration.StageKit;
 
 namespace YARG.Integration.Sacn
 {

--- a/Assets/Script/Integration/StageKit/StageKitHardware.cs
+++ b/Assets/Script/Integration/StageKit/StageKitHardware.cs
@@ -176,7 +176,7 @@ namespace YARG.Integration.StageKit
             StrobeSpeed,
         }
 
-        private List<IStageKitHaptics> _stageKits = new();
+        private readonly List<IStageKitHaptics> _stageKits = new();
 
         // Stuff for the actual command sending to the unit
         private bool _isSendingCommands;
@@ -186,15 +186,15 @@ namespace YARG.Integration.StageKit
         private byte _currentYellowLedState;
         private byte _currentRedLedState;
 
-        //this is only for the SendCommands() command to limit swamping the kit.
+        // This is only for the SendCommands() command to limit swamping the kit.
         private byte _previousBlueLedState;
         private byte _previousGreenLedState;
         private byte _previousYellowLedState;
         private byte _previousRedLedState;
 
-        //necessary to prevent the stage kit from getting overwhelmed and dropping commands. In seconds. 0.001 is the
-        //minimum. Preliminary testing indicated that 7ms was needed to prevent dropped commands, but it seems that
-        //most songs are slow enough to allow 1ms.
+        // Necessary to prevent the stage kit from getting overwhelmed and dropping commands. In seconds. 0.001 is the
+        // minimum. Preliminary testing indicated that 7ms was needed to prevent dropped commands, but it seems that
+        // most songs are slow enough to allow 1ms.
         private const float SEND_DELAY = 0.001f;
 
         private void Start()
@@ -205,21 +205,30 @@ namespace YARG.Integration.StageKit
         protected override void SingletonDestroy()
         {
             InputSystem.onDeviceChange -= OnDeviceChange;
-            foreach (var kit in _stageKits) kit.ResetHaptics();
+            foreach (var kit in _stageKits)
+            {
+                kit.ResetHaptics();
+            }
         }
 
         public void HandleEnabledChanged(bool isEnabled)
         {
             if (isEnabled)
             {
-                //build a list of all the stage kits connected
+                // Build a list of all the stage kits connected
                 foreach (var device in InputSystem.devices)
                 {
-                    if (device is IStageKitHaptics haptics) _stageKits.Add(haptics);
+                    if (device is IStageKitHaptics haptics)
+                    {
+                        _stageKits.Add(haptics);
+                    }
                 }
 
-                //StageKits remember its last state which is neat but not needed on startup
-                foreach (var kit in _stageKits) kit.ResetHaptics();
+                // Stage Kits remember its last state which is neat but not needed on startup
+                foreach (var kit in _stageKits)
+                {
+                    kit.ResetHaptics();
+                }
 
                 MasterLightingController.OnFogState += OnFogStateEvent;
                 MasterLightingController.OnStrobeEvent += OnStrobeEvent;
@@ -287,7 +296,10 @@ namespace YARG.Integration.StageKit
                         }
 
                         foreach (var kit in _stageKits)
+                        {
                             kit.SetLeds(StageKitLedColor.Blue, (StageKitLed) curCommand.data);
+                        }
+
                         _previousBlueLedState = _currentBlueLedState;
                         break;
 
@@ -298,7 +310,10 @@ namespace YARG.Integration.StageKit
                         }
 
                         foreach (var kit in _stageKits)
+                        {
                             kit.SetLeds(StageKitLedColor.Green, (StageKitLed) curCommand.data);
+                        }
+
                         _previousGreenLedState = _currentGreenLedState;
                         break;
 
@@ -309,7 +324,10 @@ namespace YARG.Integration.StageKit
                         }
 
                         foreach (var kit in _stageKits)
+                        {
                             kit.SetLeds(StageKitLedColor.Yellow, (StageKitLed) curCommand.data);
+                        }
+
                         _previousYellowLedState = _currentYellowLedState;
                         break;
 
@@ -320,16 +338,27 @@ namespace YARG.Integration.StageKit
                         }
 
                         foreach (var kit in _stageKits)
+                        {
                             kit.SetLeds(StageKitLedColor.Red, (StageKitLed) curCommand.data);
+                        }
+
                         _previousRedLedState = _currentRedLedState;
                         break;
 
                     case (int) CommandType.FogMachine:
-                        foreach (var kit in _stageKits) kit.SetFogMachine(curCommand.data == 1);
+                        foreach (var kit in _stageKits)
+                        {
+                            kit.SetFogMachine(curCommand.data == 1);
+                        }
+
                         break;
 
                     case (int) CommandType.StrobeSpeed:
-                        foreach (var kit in _stageKits) kit.SetStrobeSpeed((StageKitStrobeSpeed) curCommand.data);
+                        foreach (var kit in _stageKits)
+                        {
+                            kit.SetStrobeSpeed((StageKitStrobeSpeed) curCommand.data);
+                        }
+
                         break;
 
                     default:
@@ -337,9 +366,9 @@ namespace YARG.Integration.StageKit
                         break;
                 }
 
-                //If there is more 1/20th of a second in commands left in the queue when the cue changes, clear it.
-                //Really fast songs can build up a queue in the thousands while in BRE or Frenzy. 1/20th of a
-                //second is said to be the blink of an eye.
+                // If there is more 1/20th of a second in commands left in the queue when the cue changes, clear it.
+                // Really fast songs can build up a queue in the thousands while in BRE or Frenzy. 1/20th of a
+                // second is said to be the blink of an eye.
                 if (things != MasterLightingController.CurrentLightingCue && _commandQueue.Count > 0.05f / SEND_DELAY)
                 {
                     _commandQueue.Clear();

--- a/Assets/Script/Integration/StageKit/StageKitInterpreter.cs
+++ b/Assets/Script/Integration/StageKit/StageKitInterpreter.cs
@@ -5,19 +5,17 @@ using UnityEngine;
 using UnityEngine.SceneManagement;
 using YARG.Core.Chart;
 using YARG.Core.Logging;
-using YARG.Integration;
-using YARG.Integration.StageKit;
 
-namespace YARG
+namespace YARG.Integration.StageKit
 {
     public class StageKitInterpreter : MonoSingleton<StageKitInterpreter>
     {
         private readonly List<StageKitLighting> _cuePrimitives = new();
-        public StageKitLightingCue CurrentLightingCue;
+        private StageKitLightingCue _currentLightingCue;
         public static StageKitLightingCue PreviousLightingCue;
         private const byte NONE = 0b00000000;
 
-        private Dictionary<LightingType, StageKitLightingCue> _cueDictionary = new()
+        private readonly Dictionary<LightingType, StageKitLightingCue> _cueDictionary = new()
         {
             { LightingType.Menu, new MenuLighting() },
             { LightingType.Score, new ScoreLighting() },
@@ -45,7 +43,7 @@ namespace YARG
 
         public static event Action<StageKitLedColor, byte> OnLedEvent;
 
-        // this class maintains the Stage Kit lighting cues and primitives
+        // This class maintains the Stage Kit lighting cues and primitives
         public void Start()
         {
             SceneManager.sceneUnloaded += OnSceneUnloaded;
@@ -65,8 +63,8 @@ namespace YARG
         private void ChangeCues(StageKitLightingCue cue)
         {
             KillCue();
-            CurrentLightingCue = cue;
-            CurrentLightingCue?.Enable();
+            _currentLightingCue = cue;
+            _currentLightingCue?.Enable();
         }
 
         public void SetLed(StageKitLedColor color, byte led)
@@ -84,32 +82,32 @@ namespace YARG
 
         private void KillCue()
         {
-            if (CurrentLightingCue == null) return;
+            if (_currentLightingCue == null) return;
 
-            foreach (var primitive in CurrentLightingCue.CuePrimitives)
+            foreach (var primitive in _currentLightingCue.CuePrimitives)
             {
                 primitive.KillSelf();
             }
 
             _cuePrimitives.Clear();
-            PreviousLightingCue = CurrentLightingCue;
-            CurrentLightingCue.DirectListenEnabled = false;
-            CurrentLightingCue = null;
+            PreviousLightingCue = _currentLightingCue;
+            _currentLightingCue.DirectListenEnabled = false;
+            _currentLightingCue = null;
         }
 
         protected virtual void OnBeatLineEvent(Beatline value)
         {
-            if (CurrentLightingCue == null)
+            if (_currentLightingCue == null)
             {
                 return;
             }
 
-            if (CurrentLightingCue.DirectListenEnabled)
+            if (_currentLightingCue.DirectListenEnabled)
             {
-                CurrentLightingCue.HandleBeatlineEvent(value.Type);
+                _currentLightingCue.HandleBeatlineEvent(value.Type);
             }
 
-            foreach (var primitive in CurrentLightingCue.CuePrimitives)
+            foreach (var primitive in _currentLightingCue.CuePrimitives)
             {
                 primitive.HandleBeatlineEvent(value.Type);
             }
@@ -117,15 +115,15 @@ namespace YARG
 
         protected virtual void OnLightingEvent(LightingEvent value)
         {
-            
-            if (value != null && value.Type == LightingType.Keyframe_Next && CurrentLightingCue != null)
+
+            if (value != null && value.Type == LightingType.Keyframe_Next && _currentLightingCue != null)
             {
-                if (CurrentLightingCue.DirectListenEnabled)
+                if (_currentLightingCue.DirectListenEnabled)
                 {
-                    CurrentLightingCue.HandleLightingEvent(value.Type);
+                    _currentLightingCue.HandleLightingEvent(value.Type);
                 }
 
-                foreach (var primitive in CurrentLightingCue.CuePrimitives)
+                foreach (var primitive in _currentLightingCue.CuePrimitives)
                 {
                     primitive.HandleLightingEvent(value.Type);
                 }
@@ -157,17 +155,17 @@ namespace YARG
 
         protected virtual void OnDrumEvent(DrumNote value)
         {
-            if (CurrentLightingCue == null)
+            if (_currentLightingCue == null)
             {
                 return;
             }
 
-            if (CurrentLightingCue.DirectListenEnabled)
+            if (_currentLightingCue.DirectListenEnabled)
             {
-                CurrentLightingCue.HandleDrumEvent(value.Pad);
+                _currentLightingCue.HandleDrumEvent(value.Pad);
             }
 
-            foreach (var primitive in CurrentLightingCue.CuePrimitives)
+            foreach (var primitive in _currentLightingCue.CuePrimitives)
             {
                 primitive.HandleDrumEvent(value.Pad);
             }
@@ -175,17 +173,17 @@ namespace YARG
 
         protected virtual void OnVocalsEvent(VocalNote value)
         {
-            if (CurrentLightingCue == null)
+            if (_currentLightingCue == null)
             {
                 return;
             }
 
-            if (CurrentLightingCue.DirectListenEnabled)
+            if (_currentLightingCue.DirectListenEnabled)
             {
-                CurrentLightingCue.HandleVocalEvent(0);
+                _currentLightingCue.HandleVocalEvent(0);
             }
 
-            foreach (var primitive in CurrentLightingCue.CuePrimitives)
+            foreach (var primitive in _currentLightingCue.CuePrimitives)
             {
                 primitive.HandleVocalEvent(0);
             }

--- a/Assets/Script/Integration/StageKit/StageKitLighting.Cues.cs
+++ b/Assets/Script/Integration/StageKit/StageKitLighting.Cues.cs
@@ -7,8 +7,8 @@ using Object = UnityEngine.Object;
 
 namespace YARG.Integration.StageKit
 {
-    //parent of primitives
-    //grandparent of cues
+    // Parent of primitives
+    // Grandparent of cues
     public abstract class StageKitLighting
     {
         protected const byte NONE = 0b00000000;
@@ -51,16 +51,12 @@ namespace YARG.Integration.StageKit
         {
         }
 
-        public virtual void OnBeat()
-        {
-        }
-
         public virtual void KillSelf()
         {
         }
     }
 
-    //This is the parent class of all lighting cues. (not primitives)
+    // This is the parent class of all lighting cues. (not primitives)
     public abstract class StageKitLightingCue : StageKitLighting
     {
         protected const StageKitLedColor COLOR_NONE = StageKitLedColor.None;
@@ -71,8 +67,8 @@ namespace YARG.Integration.StageKit
         protected const StageKitLedColor COLOR_ALL = StageKitLedColor.All;
 
         public List<StageKitLighting> CuePrimitives = new();
-        //While most cues only listen to events through their primitives, some cues listen directly to events so
-        //we only want this switched on when enabled.
+        // While most cues only listen to events through their primitives, some cues listen directly to events so
+        // We only want this switched on when enabled.
         public bool DirectListenEnabled;
     }
 
@@ -368,7 +364,7 @@ namespace YARG.Integration.StageKit
 
     public class Frenzy : StageKitLightingCue
     {
-        //red off blue yellow
+        // Red off blue yellow
         private static readonly (StageKitLedColor, byte)[] LargePatternList1 =
         {
             (RED, ALL),
@@ -393,7 +389,7 @@ namespace YARG.Integration.StageKit
             (YELLOW, ALL),
         };
 
-        //Small venue: half red, other half red, 4 green , 2 side blue, other 6 blue
+        // Small venue: half red, other half red, 4 green , 2 side blue, other 6 blue
 
         private static readonly (StageKitLedColor, byte)[] SmallPatternList1 =
         {
@@ -423,14 +419,14 @@ namespace YARG.Integration.StageKit
         {
             if (MasterLightingController.LargeVenue)
             {
-                //4 times a beats to control on and off because of the 2 different patterns on one color
+                // 4 times a beats to control on and off because of the 2 different patterns on one color
                 CuePrimitives.Add(new BeatPattern(LargePatternList1, 1f));
                 CuePrimitives.Add(new BeatPattern(LargePatternList2, 1f));
                 CuePrimitives.Add(new BeatPattern(LargePatternList3, 1f));
             }
             else
             {
-                //4 times a beats to control on and off because of the 2 different patterns on one color
+                // 4 times a beats to control on and off because of the 2 different patterns on one color
                 CuePrimitives.Add(new BeatPattern(SmallPatternList1, 1f));
                 CuePrimitives.Add(new BeatPattern(SmallPatternList2, 1f));
                 CuePrimitives.Add(new BeatPattern(SmallPatternList3, 1f));
@@ -507,7 +503,7 @@ namespace YARG.Integration.StageKit
 
         public SearchLight()
         {
-            //1 yellow@2 clockwise and 1 blue@0 counter clock.
+            // 1 yellow@2 clockwise and 1 blue@0 counter clock.
             if (MasterLightingController.LargeVenue)
             {
                 CuePrimitives.Add(new BeatPattern(LargePatternList1, 2f));
@@ -606,7 +602,7 @@ namespace YARG.Integration.StageKit
             }
             else if (StageKitInterpreter.PreviousLightingCue is Stomp)
             {
-                //do nothing (for the chop suey ending at least)
+                // Do nothing (for the chop suey ending at least)
             }
             else
             {
@@ -699,7 +695,7 @@ namespace YARG.Integration.StageKit
             CuePrimitives.Add(new BeatPattern(PatternList1, 4f));
             CuePrimitives.Add(new BeatPattern(PatternList2, 8f));
             // I thought the Manuals listens to the next but it doesn't seem to. I'll save this for funky fresh mode
-            //new ListenPattern(new List<(int, byte)>(), StageKitLightingPrimitives.ListenTypes.Next);
+            // new ListenPattern(new List<(int, byte)>(), StageKitLightingPrimitives.ListenTypes.Next);
         }
 
         public override void Enable()
@@ -874,17 +870,22 @@ namespace YARG.Integration.StageKit
             StageKitInterpreter.Instance.SetLed(RED, NONE);
             StageKitInterpreter.Instance.SetLed(BLUE, TWO | SIX);
 
-            foreach (var primitive in CuePrimitives)
-            {
-                primitive.Enable();
-            }
+            // Don't want to enable all, that turns on both blue patterns.
+            CuePrimitives[0].Enable();
+            CuePrimitives[1].Enable();
+            _blueTwo.Enable();
+            _greenPattern.Enable();
 
             DirectListenEnabled = true;
         }
 
         public override void HandleLightingEvent(LightingType eventName)
         {
-            if (eventName != LightingType.Keyframe_Next) return;
+            if (eventName != LightingType.Keyframe_Next)
+            {
+                return;
+            }
+
             if (_blueOnTwo)
             {
                 _blueTwo.KillSelf();

--- a/Assets/Script/Integration/StageKit/StageKitLighting.Primitives.cs
+++ b/Assets/Script/Integration/StageKit/StageKitLighting.Primitives.cs
@@ -26,18 +26,18 @@ namespace YARG.Integration.StageKit
         public override void Enable()
         {
             _patternIndex = 0;
-            //Brought to you by Hacky Hack and the Hacktones
+            // Brought to you by Hacky Hack and the Hacktones
             _gameManager = Object.FindObjectOfType<GameManager>();
             _gameManager.BeatEventHandler.Subscribe(OnBeat, _beatsPerCycle / _patternList.Length);
         }
 
-        public override void OnBeat()
+        private void OnBeat()
         {
             StageKitInterpreter.Instance.SetLed(_patternList[_patternIndex].color, _patternList[_patternIndex].data);
             _patternIndex++;
 
-            //some beat patterns are not continuous (single fire), so we need to kill them after
-            //they've run once otherwise they pile up.
+            // Some beat patterns are not continuous (single fire), so we need to kill them after they've run once
+            // otherwise they pile up.
             if (!_continuous && _patternIndex == _patternList.Length)
             {
                 _gameManager.BeatEventHandler.Unsubscribe(OnBeat);
@@ -139,10 +139,10 @@ namespace YARG.Integration.StageKit
 
         private void ProcessEvent()
         {
-            //This might be a bug in the official stage kit code. Instead of turning off the strobe as soon as cue
-            //changes, if the cue listens for something, it only turns off the strobe on the first event of it.
-            //To make that happen, strobe off would have to be here and removed from the master controller as well as
-            //added to the lighting event switch case for all the non-listening cues.
+            // This might be a bug in the official stage kit code. Instead of turning off the strobe as soon as cue
+            // changes, if the cue listens for something, it only turns off the strobe on the first event of it.
+            // To make that happen, strobe off would have to be here and removed from the master controller as well as
+            // added to the lighting event switch case for all the non-listening cues.
 
             if (_inverse)
             {
@@ -198,7 +198,7 @@ namespace YARG.Integration.StageKit
 
         public TimedPattern((StageKitLedColor, byte)[] patternList, float seconds)
         {
-            //Token only for timed events
+            // Token only for timed events
             _cancellationTokenSource = new CancellationTokenSource();
             _seconds = seconds;
             _patternList = patternList;


### PR DESCRIPTION
Dischord was enabling all of its primitives when it was enabled, since it swaps between the two blue patterns it shouldn't turn them both on at the same time at start, also some formatting changes.