### PR TITLE
Removed Strobe and Fog from Cue Change channel

### DIFF
--- a/Assets/Plugins/Haukcode.sACN/README.txt
+++ b/Assets/Plugins/Haukcode.sACN/README.txt
@@ -1,5 +1,5 @@
 This library is a modified version of Haukcode.sACN.
-The orginial can be found here: https://github.com/HakanL/Haukcode.sACN
+The original can be found here: https://github.com/HakanL/Haukcode.sACN
 
 Modifications made are:
 1) Removal of all code related to reading packets, not needed.

--- a/Assets/Script/Integration/Sacn/SacnHardware.cs
+++ b/Assets/Script/Integration/Sacn/SacnHardware.cs
@@ -35,21 +35,13 @@ namespace YARG.Integration.Sacn
             SilhouettesSpotlight = 160,
             Searchlights = 170,
             Sweep = 180,
-            StrobeOff = 190,
-            StrobeSlow = 191,
-            StrobeMedium = 192,
-            StrobeFast = 193,
-            StrobeFastest = 194,
-            BlackoutFast = 200,
-            BlackoutSlow = 205,
+            BlackoutFast = 190,
+            BlackoutSlow = 200,
             BlackoutSpotlight = 210,
             FlareSlow = 220,
-            FlareFast = 225,
-            BigRockEnding = 230,
-            BonusEffect = 240,
-            BonusEffectOptional = 245,
-            FogOn = 250,
-            FogOff = 255
+            FlareFast = 230,
+            BigRockEnding = 240,
+            BonusEffect = 250,
         }
 
         // DMX spec says 44 updates per second is the max
@@ -95,16 +87,6 @@ namespace YARG.Integration.Sacn
                 StageKitStrobeSpeed.Fastest => 255,
                 _                           => throw new ArgumentOutOfRangeException(nameof(value), value, null)
             };
-
-            _dataPacket[_cueChangeChannel - 1] = value switch
-            {
-                StageKitStrobeSpeed.Off     => (byte) CueEnum.StrobeOff,
-                StageKitStrobeSpeed.Slow    => (byte) CueEnum.StrobeSlow,
-                StageKitStrobeSpeed.Medium  => (byte) CueEnum.StrobeMedium,
-                StageKitStrobeSpeed.Fast    => (byte) CueEnum.StrobeFast,
-                StageKitStrobeSpeed.Fastest => (byte) CueEnum.StrobeFastest,
-                _                           => throw new ArgumentOutOfRangeException(nameof(value), value, null)
-            };
         }
 
         private void OnBonusFXEvent()
@@ -117,12 +99,10 @@ namespace YARG.Integration.Sacn
             if (fogState == MasterLightingController.FogState.On)
             {
                 _dataPacket[_fogChannel - 1] = 255;
-                _dataPacket[_cueChangeChannel - 1] = (byte) CueEnum.FogOn;
             }
             else
             {
                 _dataPacket[_fogChannel - 1] = 0;
-                _dataPacket[_cueChangeChannel - 1] = (byte) CueEnum.FogOff;
             }
         }
 
@@ -159,11 +139,6 @@ namespace YARG.Integration.Sacn
                 LightingType.Keyframe_First        => (byte) CueEnum.KeyframeFirst,
                 LightingType.Keyframe_Next         => (byte) CueEnum.KeyframeNext,
                 LightingType.Keyframe_Previous     => (byte) CueEnum.KeyframePrevious,
-                LightingType.Strobe_Fast           => (byte) CueEnum.StrobeFast,
-                LightingType.Strobe_Fastest        => (byte) CueEnum.StrobeFastest,
-                LightingType.Strobe_Medium         => (byte) CueEnum.StrobeMedium,
-                LightingType.Strobe_Off            => (byte) CueEnum.StrobeOff,
-                LightingType.Strobe_Slow           => (byte) CueEnum.StrobeSlow,
                 LightingType.Warm_Automatic        => (byte) CueEnum.WarmLoop,
                 LightingType.Warm_Manual           => (byte) CueEnum.WarmManual,
                 LightingType.BigRockEnding         => (byte) CueEnum.BigRockEnding,
@@ -296,6 +271,7 @@ namespace YARG.Integration.Sacn
         }
     }
 }
+
 /*
     "If you ever drop your keys into a river of molten lava, let'em go...because man, they're gone.'
 

--- a/Assets/Settings/Localization/Settings_en-US.asset
+++ b/Assets/Settings/Localization/Settings_en-US.asset
@@ -1235,40 +1235,26 @@ MonoBehaviour:
 
       180 - Sweep
 
-      190 - Strobe
-      (off)
+      190 - Blackout
+      (fast)
 
-      191 - Strobe (slow)
-
-      192 - Strobe (medium)
-
-      193 -
-      Strobe (fast)
-
-      194 - Strobe (fastest)
-
-      200 - Blackout (fast)
-
-      205
-      - Blackout (slow)
+      200 - Blackout (slow)
 
       210 - Blackout (spotlight)
 
-      220 - Flare (slow)
+      220
+      - Flare (slow)
 
-      225
-      - Flare (fast)
+      230 - Flare (fast)
 
-      230 - Big Rock Ending
+      240 - Big Rock Ending
 
-      240 - Bonus Effect
+      250
+      - Bonus Effect
 
-      245
-      - Bonus Effect (optional)
 
-      250 - Fog on
-
-      255 - Fog off'
+      For Strobe and Fog status listen to their respective
+      channels.'
     m_Metadata:
       m_Items: []
   - m_Id: 133417141387255824


### PR DESCRIPTION
There are instances when a strobe or fog call will happen the same frame as a light cue, in that case the cue change channel will miss one of them. This change means the fog and strobe state should be read directly from their respective existing state channels.