### PR TITLE
separate labels for 5-lane drum bindings

### DIFF
--- a/Assets/Script/Input/Bindings/BindingCollection.Templates.cs
+++ b/Assets/Script/Input/Bindings/BindingCollection.Templates.cs
@@ -74,13 +74,13 @@ namespace YARG.Input
         public static BindingCollection CreateFiveLaneDrumsBindings() => new(GameMode.FiveLaneDrums)
         {
             // TODO: Velocity support
-            new IndividualButtonBinding("Drums.RedPad",       (int) DrumsAction.RedDrum),
-            new IndividualButtonBinding("Drums.YellowCymbal", (int) DrumsAction.YellowCymbal),
-            new IndividualButtonBinding("Drums.BluePad",      (int) DrumsAction.BlueDrum),
-            new IndividualButtonBinding("Drums.OrangeCymbal", (int) DrumsAction.OrangeCymbal),
-            new IndividualButtonBinding("Drums.GreenPad",     (int) DrumsAction.GreenDrum),
+            new IndividualButtonBinding("FiveDrums.RedPad",       (int) DrumsAction.RedDrum),
+            new IndividualButtonBinding("FiveDrums.YellowCymbal", (int) DrumsAction.YellowCymbal),
+            new IndividualButtonBinding("FiveDrums.BluePad",      (int) DrumsAction.BlueDrum),
+            new IndividualButtonBinding("FiveDrums.OrangeCymbal", (int) DrumsAction.OrangeCymbal),
+            new IndividualButtonBinding("FiveDrums.GreenPad",     (int) DrumsAction.GreenDrum),
 
-            new IndividualButtonBinding("Drums.Kick", (int) DrumsAction.Kick),
+            new IndividualButtonBinding("FiveDrums.Kick", (int) DrumsAction.Kick),
         };
 
         public static BindingCollection CreateProGuitarBindings() => new(GameMode.ProGuitar)

--- a/Assets/Script/Input/Bindings/BindingCollection.Templates.cs
+++ b/Assets/Script/Input/Bindings/BindingCollection.Templates.cs
@@ -59,14 +59,14 @@ namespace YARG.Input
         public static BindingCollection CreateFourLaneDrumsBindings() => new(GameMode.FourLaneDrums)
         {
             // TODO: Velocity support
-            new IndividualButtonBinding("Drums.RedPad",    (int) DrumsAction.RedDrum),
-            new IndividualButtonBinding("Drums.YellowPad", (int) DrumsAction.YellowDrum),
-            new IndividualButtonBinding("Drums.BluePad",   (int) DrumsAction.BlueDrum),
-            new IndividualButtonBinding("Drums.GreenPad",  (int) DrumsAction.GreenDrum),
+            new IndividualButtonBinding("FourDrums.RedPad",    (int) DrumsAction.RedDrum),
+            new IndividualButtonBinding("FourDrums.YellowPad", (int) DrumsAction.YellowDrum),
+            new IndividualButtonBinding("FourDrums.BluePad",   (int) DrumsAction.BlueDrum),
+            new IndividualButtonBinding("FourDrums.GreenPad",  (int) DrumsAction.GreenDrum),
 
-            new IndividualButtonBinding("Drums.YellowCymbal", (int) DrumsAction.YellowCymbal),
-            new IndividualButtonBinding("Drums.BlueCymbal",   (int) DrumsAction.BlueCymbal),
-            new IndividualButtonBinding("Drums.GreenCymbal",  (int) DrumsAction.GreenCymbal),
+            new IndividualButtonBinding("FourDrums.YellowCymbal", (int) DrumsAction.YellowCymbal),
+            new IndividualButtonBinding("FourDrums.BlueCymbal",   (int) DrumsAction.BlueCymbal),
+            new IndividualButtonBinding("FourDrums.GreenCymbal",  (int) DrumsAction.GreenCymbal),
 
             new IndividualButtonBinding("Drums.Kick", (int) DrumsAction.Kick),
         };
@@ -80,7 +80,7 @@ namespace YARG.Input
             new IndividualButtonBinding("FiveDrums.OrangeCymbal", (int) DrumsAction.OrangeCymbal),
             new IndividualButtonBinding("FiveDrums.GreenPad",     (int) DrumsAction.GreenDrum),
 
-            new IndividualButtonBinding("FiveDrums.Kick", (int) DrumsAction.Kick),
+            new IndividualButtonBinding("Drums.Kick", (int) DrumsAction.Kick),
         };
 
         public static BindingCollection CreateProGuitarBindings() => new(GameMode.ProGuitar)

--- a/Assets/Settings/Localization/Bindings Shared Data.asset
+++ b/Assets/Settings/Localization/Bindings Shared Data.asset
@@ -131,6 +131,30 @@ MonoBehaviour:
     m_Key: Vocals.StarPower
     m_Metadata:
       m_Items: []
+  - m_Id: 98568208891412480
+    m_Key: FiveDrums.RedPad
+    m_Metadata:
+      m_Items: []
+  - m_Id: 98568424168259584
+    m_Key: FiveDrums.YellowCymbal
+    m_Metadata:
+      m_Items: []
+  - m_Id: 98568490232741888
+    m_Key: FiveDrums.BluePad
+    m_Metadata:
+      m_Items: []
+  - m_Id: 98568569039519744
+    m_Key: FiveDrums.OrangeCymbal
+    m_Metadata:
+      m_Items: []
+  - m_Id: 98568633258508288
+    m_Key: FiveDrums.GreenPad
+    m_Metadata:
+      m_Items: []
+  - m_Id: 98568749721747456
+    m_Key: FiveDrums.Kick
+    m_Metadata:
+      m_Items: []
   m_Metadata:
     m_Items: []
   m_KeyGenerator:

--- a/Assets/Settings/Localization/Bindings Shared Data.asset
+++ b/Assets/Settings/Localization/Bindings Shared Data.asset
@@ -16,19 +16,19 @@ MonoBehaviour:
   m_TableCollectionNameGuidString: f465ba9635928c74faf29645191515b8
   m_Entries:
   - m_Id: 11183621110358016
-    m_Key: Drums.BlueCymbal
+    m_Key: FourDrums.BlueCymbal
     m_Metadata:
       m_Items: []
   - m_Id: 11183621135523840
-    m_Key: Drums.BluePad
+    m_Key: FourDrums.BluePad
     m_Metadata:
       m_Items: []
   - m_Id: 11183621135523841
-    m_Key: Drums.GreenCymbal
+    m_Key: FourDrums.GreenCymbal
     m_Metadata:
       m_Items: []
   - m_Id: 11183621135523842
-    m_Key: Drums.GreenPad
+    m_Key: FourDrums.GreenPad
     m_Metadata:
       m_Items: []
   - m_Id: 11183621135523843
@@ -36,15 +36,15 @@ MonoBehaviour:
     m_Metadata:
       m_Items: []
   - m_Id: 11183621135523844
-    m_Key: Drums.RedPad
+    m_Key: FourDrums.RedPad
     m_Metadata:
       m_Items: []
   - m_Id: 11183621135523845
-    m_Key: Drums.YellowCymbal
+    m_Key: FourDrums.YellowCymbal
     m_Metadata:
       m_Items: []
   - m_Id: 11183621135523846
-    m_Key: Drums.YellowPad
+    m_Key: FourDrums.YellowPad
     m_Metadata:
       m_Items: []
   - m_Id: 2124315417239552
@@ -149,10 +149,6 @@ MonoBehaviour:
       m_Items: []
   - m_Id: 98568633258508288
     m_Key: FiveDrums.GreenPad
-    m_Metadata:
-      m_Items: []
-  - m_Id: 98568749721747456
-    m_Key: FiveDrums.Kick
     m_Metadata:
       m_Items: []
   m_Metadata:

--- a/Assets/Settings/Localization/Bindings_en-US.asset
+++ b/Assets/Settings/Localization/Bindings_en-US.asset
@@ -134,6 +134,30 @@ MonoBehaviour:
     m_Localized: Star Power Activate
     m_Metadata:
       m_Items: []
+  - m_Id: 98568208891412480
+    m_Localized: Red Pad (First)
+    m_Metadata:
+      m_Items: []
+  - m_Id: 98568424168259584
+    m_Localized: Yellow Cymbal (Second)
+    m_Metadata:
+      m_Items: []
+  - m_Id: 98568490232741888
+    m_Localized: Blue Pad (Third)
+    m_Metadata:
+      m_Items: []
+  - m_Id: 98568569039519744
+    m_Localized: Orange Cymbal (Fourth)
+    m_Metadata:
+      m_Items: []
+  - m_Id: 98568633258508288
+    m_Localized: Green Pad (Fifth)
+    m_Metadata:
+      m_Items: []
+  - m_Id: 98568749721747456
+    m_Localized: Kick Pedal
+    m_Metadata:
+      m_Items: []
   references:
     version: 2
     RefIds: []

--- a/Assets/Settings/Localization/Bindings_en-US.asset
+++ b/Assets/Settings/Localization/Bindings_en-US.asset
@@ -154,10 +154,6 @@ MonoBehaviour:
     m_Localized: Green Pad (Fifth)
     m_Metadata:
       m_Items: []
-  - m_Id: 98568749721747456
-    m_Localized: Kick Pedal
-    m_Metadata:
-      m_Items: []
   references:
     version: 2
     RefIds: []


### PR DESCRIPTION
5-lane drums bindings previously reused the 4-lane localization strings, meaning the numbers were weird and Orange Cymbal was just blank. giving 5L its own strings means we can label orange and uniquely number all five lanes.