### PR TITLE
Wider text field for playlist category header text

### DIFF
--- a/Assets/Prefabs/Menu/MusicLibrary/SongView.prefab
+++ b/Assets/Prefabs/Menu/MusicLibrary/SongView.prefab
@@ -133,6 +133,220 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
+--- !u!1 &421090368655892875
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4810930499997639023}
+  - component: {fileID: 2771356300031571555}
+  - component: {fileID: 9056057400455014970}
+  - component: {fileID: 862664442027392143}
+  - component: {fileID: 6555663833805520409}
+  m_Layer: 5
+  m_Name: Primary_HeaderName
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4810930499997639023
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 421090368655892875}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2453857113711676863}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2771356300031571555
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 421090368655892875}
+  m_CullTransparentMesh: 1
+--- !u!114 &9056057400455014970
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 421090368655892875}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Song Name
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: ae170e91fd29a90479e906ddffb1d8ee, type: 2}
+  m_sharedMaterial: {fileID: -5480317595949376055, guid: ae170e91fd29a90479e906ddffb1d8ee,
+    type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294042673
+  m_fontColor: {r: 0.19215687, g: 0.89411765, b: 0.94509804, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 35
+  m_fontSizeBase: 35
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 0
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 1
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!114 &862664442027392143
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 421090368655892875}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreLayout: 0
+  m_MinWidth: 550
+  m_MinHeight: -1
+  m_PreferredWidth: 550
+  m_PreferredHeight: -1
+  m_FlexibleWidth: 1
+  m_FlexibleHeight: -1
+  m_LayoutPriority: 1
+--- !u!114 &6555663833805520409
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 421090368655892875}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 9056057400455014970}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 6622513572522471069}
+        m_TargetAssemblyTypeName: YARG.Menu.MusicLibrary.SongView, Assembly-CSharp
+        m_MethodName: PrimaryTextClick
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!1 &1063990577666964748
 GameObject:
   m_ObjectHideFlags: 0
@@ -168,10 +382,10 @@ RectTransform:
   m_Father: {fileID: 5939750916144769644}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 584.91, y: -30}
+  m_SizeDelta: {x: 59.82, y: 60}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &2540879919925106282
 CanvasRenderer:
@@ -349,6 +563,91 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
+--- !u!1 &2200136566915400073
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2453857113711676863}
+  - component: {fileID: 7289280668696814656}
+  - component: {fileID: 1286587419052385153}
+  m_Layer: 5
+  m_Name: Group_CategoryHeader
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2453857113711676863
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2200136566915400073}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4810930499997639023}
+  m_Father: {fileID: 2237015374050868829}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &7289280668696814656
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2200136566915400073}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 30649d3a9faa99c48a7b1166b86bf2a0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Padding:
+    m_Left: 0
+    m_Right: 0
+    m_Top: 0
+    m_Bottom: 0
+  m_ChildAlignment: 0
+  m_Spacing: 5
+  m_ChildForceExpandWidth: 0
+  m_ChildForceExpandHeight: 1
+  m_ChildControlWidth: 1
+  m_ChildControlHeight: 1
+  m_ChildScaleWidth: 0
+  m_ChildScaleHeight: 0
+  m_ReverseArrangement: 0
+--- !u!114 &1286587419052385153
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2200136566915400073}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreLayout: 0
+  m_MinWidth: 0
+  m_MinHeight: -1
+  m_PreferredWidth: 0
+  m_PreferredHeight: -1
+  m_FlexibleWidth: 1000000
+  m_FlexibleHeight: -1
+  m_LayoutPriority: 1
 --- !u!1 &2940801684206373230
 GameObject:
   m_ObjectHideFlags: 0
@@ -420,7 +719,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2237015374050868829}
-  m_RootOrder: 1
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -576,7 +875,7 @@ RectTransform:
   m_Children:
   - {fileID: 5697735259301720844}
   m_Father: {fileID: 2237015374050868829}
-  m_RootOrder: 4
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -615,12 +914,12 @@ GameObject:
   - component: {fileID: 7265306733160340330}
   - component: {fileID: 2715768359408393146}
   m_Layer: 5
-  m_Name: Group
+  m_Name: Group_SongName
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &5939750916144769644
 RectTransform:
   m_ObjectHideFlags: 0
@@ -639,10 +938,10 @@ RectTransform:
   m_Father: {fileID: 2237015374050868829}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 455.62363, y: -30}
+  m_SizeDelta: {x: 911.24725, y: 60}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &7265306733160340330
 MonoBehaviour:
@@ -725,10 +1024,10 @@ RectTransform:
   m_Father: {fileID: 5939750916144769644}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 678.505, y: -30}
+  m_SizeDelta: {x: 117.37, y: 60}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &7351933036123520269
 CanvasRenderer:
@@ -1087,7 +1386,7 @@ RectTransform:
   m_Children:
   - {fileID: 2164054022062728421}
   m_Father: {fileID: 2237015374050868829}
-  m_RootOrder: 3
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -1410,6 +1709,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 5939750916144769644}
+  - {fileID: 2453857113711676863}
   - {fileID: 9101250299772175957}
   - {fileID: 4633972722244792901}
   - {fileID: 8527945143130141787}
@@ -1462,7 +1762,7 @@ GameObject:
   - component: {fileID: 4568656012888111623}
   - component: {fileID: 3476003582385759284}
   m_Layer: 5
-  m_Name: Primary
+  m_Name: Primary_SongName
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -1483,10 +1783,10 @@ RectTransform:
   m_Father: {fileID: 5939750916144769644}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 275, y: -30}
+  m_SizeDelta: {x: 550, y: 60}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &6846856528720448028
 CanvasRenderer:
@@ -1764,6 +2064,7 @@ MonoBehaviour:
   - {fileID: 6846856528720448031}
   _secondaryText:
   - {fileID: 7006697502306556741}
+  _songNameContainer: {fileID: 4368672747380734833}
   _sideText: {fileID: 1200385484507932754}
   _starView: {fileID: 6549734375584227207}
   _secondaryTextContainer: {fileID: 4454172983210282838}
@@ -1775,6 +2076,8 @@ MonoBehaviour:
   - {fileID: 3312390955879711079}
   _favoriteUnfilled: {fileID: 289475173, guid: 81b6595c7cde06540b683feaa83291af, type: 3}
   _favouriteFilled: {fileID: 1390811379, guid: 81b6595c7cde06540b683feaa83291af, type: 3}
+  _categoryNameContainer: {fileID: 2200136566915400073}
+  _categoryText: {fileID: 9056057400455014970}
 --- !u!225 &215129106566158253
 CanvasGroup:
   m_ObjectHideFlags: 0
@@ -1938,7 +2241,7 @@ PrefabInstance:
     - target: {fileID: 4099137989180180775, guid: 8a14b88e9f52a4e41818129ae6aff258,
         type: 3}
       propertyPath: m_RootOrder
-      value: 2
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 4099137989180180775, guid: 8a14b88e9f52a4e41818129ae6aff258,
         type: 3}

--- a/Assets/Prefabs/Menu/MusicLibrary/SongView.prefab
+++ b/Assets/Prefabs/Menu/MusicLibrary/SongView.prefab
@@ -2062,6 +2062,7 @@ MonoBehaviour:
   _icon: {fileID: 91003172277932724}
   _primaryText:
   - {fileID: 6846856528720448031}
+  - {fileID: 9056057400455014970}
   _secondaryText:
   - {fileID: 7006697502306556741}
   _songNameContainer: {fileID: 4368672747380734833}

--- a/Assets/Script/Menu/MusicLibrary/SongView.cs
+++ b/Assets/Script/Menu/MusicLibrary/SongView.cs
@@ -46,7 +46,7 @@ namespace YARG.Menu.MusicLibrary
             base.Show(selected, viewType);
 
             // if used as section header, use different primary text for wider text field
-            if (viewType.Background == BaseViewType.BackgroundType.Category)
+            if(viewType.GetType() == typeof(SortHeaderViewType))
             {
                 _songNameContainer.SetActive(false);
                 _categoryNameContainer.SetActive(true);

--- a/Assets/Script/Menu/MusicLibrary/SongView.cs
+++ b/Assets/Script/Menu/MusicLibrary/SongView.cs
@@ -45,12 +45,11 @@ namespace YARG.Menu.MusicLibrary
         {
             base.Show(selected, viewType);
 
-            // use different primary text for wider text field, e.g. when used as section header
+            // use category header primary text (which supports wider text), when used as section header
             if(viewType.UseWiderPrimaryText)
             {
                 _songNameContainer.SetActive(false);
                 _categoryNameContainer.SetActive(true);
-                _categoryText.text = viewType.GetPrimaryText(selected);
             }
             else
             {

--- a/Assets/Script/Menu/MusicLibrary/SongView.cs
+++ b/Assets/Script/Menu/MusicLibrary/SongView.cs
@@ -9,6 +9,8 @@ namespace YARG.Menu.MusicLibrary
     public class SongView : ViewObject<ViewType>
     {
         [SerializeField]
+        private GameObject _songNameContainer;
+        [SerializeField]
         private TextMeshProUGUI _sideText;
         [SerializeField]
         private StarView _starView;
@@ -33,9 +35,28 @@ namespace YARG.Menu.MusicLibrary
         [SerializeField]
         private Sprite _favouriteFilled;
 
+        [Space]
+        [SerializeField]
+        private GameObject _categoryNameContainer;
+        [SerializeField]
+        private TextMeshProUGUI _categoryText;
+
         public override void Show(bool selected, ViewType viewType)
         {
             base.Show(selected, viewType);
+
+            // if used as section header, use different primary text for wider text field
+            if (viewType.Background == BaseViewType.BackgroundType.Category)
+            {
+                _songNameContainer.SetActive(false);
+                _categoryNameContainer.SetActive(true);
+                _categoryText.text = viewType.GetPrimaryText(selected);
+            }
+            else
+            {
+                _songNameContainer.SetActive(true);
+                _categoryNameContainer.SetActive(false);
+            }
 
             // Set side text
             _sideText.text = viewType.GetSideText(selected);

--- a/Assets/Script/Menu/MusicLibrary/SongView.cs
+++ b/Assets/Script/Menu/MusicLibrary/SongView.cs
@@ -45,8 +45,8 @@ namespace YARG.Menu.MusicLibrary
         {
             base.Show(selected, viewType);
 
-            // if used as section header, use different primary text for wider text field
-            if(viewType.GetType() == typeof(SortHeaderViewType))
+            // use different primary text for wider text field, e.g. when used as section header
+            if(viewType.UseWiderPrimaryText)
             {
                 _songNameContainer.SetActive(false);
                 _categoryNameContainer.SetActive(true);

--- a/Assets/Script/Menu/MusicLibrary/ViewTypes/SortHeaderViewType.cs
+++ b/Assets/Script/Menu/MusicLibrary/ViewTypes/SortHeaderViewType.cs
@@ -8,6 +8,8 @@ namespace YARG.Menu.MusicLibrary
     {
         public override BackgroundType Background => BackgroundType.Category;
 
+        public override bool UseWiderPrimaryText => true;
+
         public readonly string HeaderText;
         private readonly int _songCount;
 

--- a/Assets/Script/Menu/MusicLibrary/ViewTypes/ViewType.cs
+++ b/Assets/Script/Menu/MusicLibrary/ViewTypes/ViewType.cs
@@ -17,6 +17,8 @@ namespace YARG.Menu.MusicLibrary
 
         public virtual bool UseAsMadeFamousBy => false;
 
+        public virtual bool UseWiderPrimaryText => false;
+
         public override string GetSecondaryText(bool selected) => string.Empty;
         public virtual string GetSideText(bool selected) => string.Empty;
 


### PR DESCRIPTION
for your long playlist name needs, fixes #753
![image](https://github.com/YARC-Official/YARG/assets/40037381/d0c82668-7c5d-405c-9e2c-83ce5fe0c5c5)


- Added a new group in the SongView prefab with a second primary text as suggested by EliteAsian
- The swap happens depending on which background is chosen

Feedback is appreciated. Not quite familiar with the codebase layout yet.