### PR TITLE
Re-implement holding down the orange fret for section navigation in MusicLibrary

### DIFF
--- a/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
+++ b/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
@@ -348,7 +348,7 @@ namespace YARG.Menu.MusicLibrary
         private void CalculateCategoryHeaderIndices(List<ViewType> list)
         {
             _sectionHeaderIndices = list.Select((v, i) => (v, i)).
-                Where(viewTypeEntry => viewTypeEntry.v is SortHeaderViewType || viewTypeEntry.v is CategoryViewType).
+                Where(viewTypeEntry => viewTypeEntry.v is SortHeaderViewType or CategoryViewType).
                 Select(viewTypeEntry => viewTypeEntry.i).ToList();
         }
 

--- a/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
+++ b/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
@@ -500,6 +500,11 @@ namespace YARG.Menu.MusicLibrary
             MenuManager.Instance.PopMenu();
         }
 
+        private bool IsButtonHeldByPlayer(YargPlayer player, MenuAction button)
+        {
+            return _heldInputs.Any(i => i.Context.Player == player && i.Context.Action == button);
+        }
+
         private void OnButtonHit(NavigationContext ctx)
         {
             _heldInputs.Add(new HoldContext(ctx));
@@ -513,11 +518,6 @@ namespace YARG.Menu.MusicLibrary
                 _popupMenu.gameObject.SetActive(true);
 
             _heldInputs.RemoveAll(i => i.Context.IsSameAs(ctx));
-        }
-
-        private bool IsButtonHeldByPlayer(YargPlayer player, MenuAction button)
-        {
-            return _heldInputs.Any(i => i.Context.Player == player && i.Context.Action == button);
         }
 
         private void GoToNextSection()

--- a/Assets/Script/Menu/Navigation/NavigationScheme.cs
+++ b/Assets/Script/Menu/Navigation/NavigationScheme.cs
@@ -52,7 +52,7 @@ namespace YARG.Menu.Navigation
                 _handler?.Invoke(context);
             }
 
-            public void InvokeHolddOffHandler(NavigationContext context)
+            public void InvokeHoldOffHandler(NavigationContext context)
             {
                 _onHoldOffHandler?.Invoke(context);
             }
@@ -93,7 +93,7 @@ namespace YARG.Menu.Navigation
         {
             foreach (var entry in _entries.Where(i => i.Action == context.Action))
             {
-                entry.InvokeHolddOffHandler(context);
+                entry.InvokeHoldOffHandler(context);
             }
         }
     }

--- a/Assets/Script/Menu/Navigation/NavigationScheme.cs
+++ b/Assets/Script/Menu/Navigation/NavigationScheme.cs
@@ -27,19 +27,22 @@ namespace YARG.Menu.Navigation
             public readonly MenuAction Action;
             public readonly string DisplayName;
             private readonly Action<NavigationContext> _handler;
+            private readonly Action<NavigationContext> _onHoldOffHandler;
 
-            public Entry(MenuAction action, string displayName, Action handler)
+            public Entry(MenuAction action, string displayName, Action handler, Action onHoldOffHandler = null)
             {
                 Action = action;
                 DisplayName = displayName;
                 _handler = _ => handler?.Invoke();
+                _onHoldOffHandler = _ => onHoldOffHandler?.Invoke();
             }
 
-            public Entry(MenuAction action, string displayName, Action<NavigationContext> handler)
+            public Entry(MenuAction action, string displayName, Action<NavigationContext> handler, Action<NavigationContext> onHoldOffHandler = null)
             {
                 Action = action;
                 DisplayName = displayName;
                 _handler = handler;
+                _onHoldOffHandler = onHoldOffHandler;
             }
 
             public void Invoke() => Invoke(new(Action, null));
@@ -47,6 +50,11 @@ namespace YARG.Menu.Navigation
             public void Invoke(NavigationContext context)
             {
                 _handler?.Invoke(context);
+            }
+
+            public void InvokeHolddOffHandler(NavigationContext context)
+            {
+                _onHoldOffHandler?.Invoke(context);
             }
         }
 
@@ -78,6 +86,14 @@ namespace YARG.Menu.Navigation
             foreach (var entry in _entries.Where(i => i.Action == context.Action))
             {
                 entry.Invoke(context);
+            }
+        }
+
+        public void InvokeHoldOffFuncs(NavigationContext context)
+        {
+            foreach (var entry in _entries.Where(i => i.Action == context.Action))
+            {
+                entry.InvokeHolddOffHandler(context);
             }
         }
     }

--- a/Assets/Script/Menu/Navigation/Navigator.cs
+++ b/Assets/Script/Menu/Navigation/Navigator.cs
@@ -57,6 +57,8 @@ namespace YARG.Menu.Navigation
             MenuAction.Down,
             MenuAction.Left,
             MenuAction.Right,
+
+            MenuAction.Orange,
         };
 
         private class HoldContext
@@ -137,6 +139,7 @@ namespace YARG.Menu.Navigation
         private void EndNavigationHold(NavigationContext context)
         {
             _heldInputs.RemoveAll(i => i.Context.IsSameAs(context));
+            InvokeHoldOffEvent(context);
         }
 
         public bool IsHeld(MenuAction action)
@@ -156,6 +159,19 @@ namespace YARG.Menu.Navigation
             if (_schemeStack.Count > 0)
             {
                 _schemeStack.Peek().InvokeFuncs(ctx);
+            }
+        }
+
+        private void InvokeHoldOffEvent(NavigationContext ctx)
+        {
+            if (DisableMenuInputs)
+            {
+                return;
+            }
+
+            if (_schemeStack.Count > 0)
+            {
+                _schemeStack.Peek().InvokeHoldOffFuncs(ctx);
             }
         }
 

--- a/Assets/Script/Menu/Navigation/Navigator.cs
+++ b/Assets/Script/Menu/Navigation/Navigator.cs
@@ -57,11 +57,9 @@ namespace YARG.Menu.Navigation
             MenuAction.Down,
             MenuAction.Left,
             MenuAction.Right,
-
-            MenuAction.Orange,
         };
 
-        private class HoldContext
+        public class HoldContext
         {
             public readonly NavigationContext Context;
             public float Timer = INPUT_REPEAT_COOLDOWN;


### PR DESCRIPTION
Hold orange + strum up and down to go to next/previous sections, seems like a capability that was in a previous version as discussed here: https://github.com/YARC-Official/YARG/issues/755

https://github.com/YARC-Official/YARG/assets/141366895/3a81e04a-73d9-4605-a4fb-eb02ac788916

