### PR TITLE
update 4L Cymbal binding strings to account for Lefty Flip

### DIFF
--- a/Assets/Script/Input/Bindings/BindingCollection.Templates.cs
+++ b/Assets/Script/Input/Bindings/BindingCollection.Templates.cs
@@ -66,7 +66,7 @@ namespace YARG.Input
 
             new IndividualButtonBinding("FourDrums.YellowCymbal", (int) DrumsAction.YellowCymbal),
             new IndividualButtonBinding("FourDrums.BlueCymbal",   (int) DrumsAction.BlueCymbal),
-            new IndividualButtonBinding("FourDrums.GreenCymbal",  (int) DrumsAction.GreenCymbal),
+            new IndividualButtonBinding("FourDrums.GreenCymbal", "FourDrums.RedCymbal", (int) DrumsAction.GreenCymbal),
 
             new IndividualButtonBinding("Drums.Kick", (int) DrumsAction.Kick),
         };

--- a/Assets/Script/Input/Bindings/ButtonBinding.cs
+++ b/Assets/Script/Input/Bindings/ButtonBinding.cs
@@ -201,6 +201,10 @@ namespace YARG.Input
         {
         }
 
+        public ButtonBinding(string name, string namelefty, int action) : base(name, namelefty, action)
+        {
+        }
+
         protected override Dictionary<string, string> SerializeParameters()
         {
             var parameters = new Dictionary<string, string>();

--- a/Assets/Script/Input/Bindings/ButtonBinding.cs
+++ b/Assets/Script/Input/Bindings/ButtonBinding.cs
@@ -201,7 +201,7 @@ namespace YARG.Input
         {
         }
 
-        public ButtonBinding(string name, string namelefty, int action) : base(name, namelefty, action)
+        public ButtonBinding(string name, string nameLefty, int action) : base(name, nameLefty, action)
         {
         }
 

--- a/Assets/Script/Input/Bindings/ControlBinding.cs
+++ b/Assets/Script/Input/Bindings/ControlBinding.cs
@@ -75,11 +75,11 @@ namespace YARG.Input
             Action = action;
         }
 		
-        public ControlBinding(string name, string namelefty, int action)
+        public ControlBinding(string name, string nameLefty, int action)
         {
             Key = name;
             Name = new("Bindings", name);
-            NameLefty = new("Bindings", namelefty);
+            NameLefty = new("Bindings", nameLefty);
             Action = action;
         }
 
@@ -224,7 +224,7 @@ namespace YARG.Input
         {
         }
 
-        public ControlBinding(string name, string namelefty, int action) : base(name, namelefty, action)
+        public ControlBinding(string name, string nameLefty, int action) : base(name, nameLefty, action)
         {
         }
 

--- a/Assets/Script/Input/Bindings/ControlBinding.cs
+++ b/Assets/Script/Input/Bindings/ControlBinding.cs
@@ -44,6 +44,11 @@ namespace YARG.Input
         /// The name for this binding.
         /// </summary>
         public LocalizedString Name { get; }
+		
+        /// <summary>
+        /// Alternate name for this binding, representing lefty-flip
+        /// </summary>
+        public LocalizedString NameLefty { get; }
 
         /// <summary>
         /// The key string for this binding.
@@ -66,6 +71,15 @@ namespace YARG.Input
         {
             Key = name;
             Name = new("Bindings", name);
+            NameLefty = Name;
+            Action = action;
+        }
+		
+        public ControlBinding(string name, string namelefty, int action)
+        {
+            Key = name;
+            Name = new("Bindings", name);
+            NameLefty = new("Bindings", namelefty);
             Action = action;
         }
 
@@ -207,6 +221,10 @@ namespace YARG.Input
         public    IReadOnlyList<TBinding> Bindings => _bindings;
 
         public ControlBinding(string name, int action) : base(name, action)
+        {
+        }
+
+        public ControlBinding(string name, string namelefty, int action) : base(name, namelefty, action)
         {
         }
 

--- a/Assets/Script/Input/Bindings/IndividualButtonBinding.cs
+++ b/Assets/Script/Input/Bindings/IndividualButtonBinding.cs
@@ -11,6 +11,10 @@ namespace YARG.Input
         {
         }
 
+        public IndividualButtonBinding(string name, string namelefty, int action) : base(name, namelefty, action)
+        {
+        }
+
         protected override void OnStateChanged(SingleButtonBinding binding, double time)
         {
             // Update debounce on all bindings

--- a/Assets/Script/Input/Bindings/IndividualButtonBinding.cs
+++ b/Assets/Script/Input/Bindings/IndividualButtonBinding.cs
@@ -11,7 +11,7 @@ namespace YARG.Input
         {
         }
 
-        public IndividualButtonBinding(string name, string namelefty, int action) : base(name, namelefty, action)
+        public IndividualButtonBinding(string name, string nameLefty, int action) : base(name, nameLefty, action)
         {
         }
 

--- a/Assets/Script/Menu/ProfileInfo/EditBinds/BindGroups/BindHeader.cs
+++ b/Assets/Script/Menu/ProfileInfo/EditBinds/BindGroups/BindHeader.cs
@@ -38,7 +38,11 @@ namespace YARG.Menu.ProfileInfo
             _player = player;
             _binding = binding;
 
-            _bindingNameText.StringReference = binding.Name;
+            if (player.Profile.LeftyFlip) {
+                _bindingNameText.StringReference = binding.NameLefty;
+            } else {
+                _bindingNameText.StringReference = binding.Name;
+            }
 
             var icons = MenuData.NavigationIcons;
             if (editBindsTab.SelectingMenuBinds && icons.HasIcon((MenuAction) binding.Action))

--- a/Assets/Script/Menu/ProfileInfo/EditBinds/BindGroups/BindHeader.cs
+++ b/Assets/Script/Menu/ProfileInfo/EditBinds/BindGroups/BindHeader.cs
@@ -38,9 +38,12 @@ namespace YARG.Menu.ProfileInfo
             _player = player;
             _binding = binding;
 
-            if (player.Profile.LeftyFlip) {
+            if (player.Profile.LeftyFlip)
+            {
                 _bindingNameText.StringReference = binding.NameLefty;
-            } else {
+            }
+            else
+            {
                 _bindingNameText.StringReference = binding.Name;
             }
 

--- a/Assets/Settings/Localization/Bindings Shared Data.asset
+++ b/Assets/Settings/Localization/Bindings Shared Data.asset
@@ -151,6 +151,10 @@ MonoBehaviour:
     m_Key: FiveDrums.GreenPad
     m_Metadata:
       m_Items: []
+  - m_Id: 104795453274738688
+    m_Key: FourDrums.RedCymbal
+    m_Metadata:
+      m_Items: []
   m_Metadata:
     m_Items: []
   m_KeyGenerator:

--- a/Assets/Settings/Localization/Bindings_en-US.asset
+++ b/Assets/Settings/Localization/Bindings_en-US.asset
@@ -99,7 +99,7 @@ MonoBehaviour:
     m_Metadata:
       m_Items: []
   - m_Id: 11183621110358016
-    m_Localized: Blue Cymbal (Second)
+    m_Localized: Blue Cymbal (Third)
     m_Metadata:
       m_Items: []
   - m_Id: 11183621135523840
@@ -107,7 +107,7 @@ MonoBehaviour:
     m_Metadata:
       m_Items: []
   - m_Id: 11183621135523841
-    m_Localized: Green Cymbal (Third)
+    m_Localized: Green Cymbal (Fourth), lefty Right Cymbal (First)
     m_Metadata:
       m_Items: []
   - m_Id: 11183621135523842
@@ -123,7 +123,7 @@ MonoBehaviour:
     m_Metadata:
       m_Items: []
   - m_Id: 11183621135523845
-    m_Localized: Yellow Cymbal (First)
+    m_Localized: Yellow Cymbal (Second)
     m_Metadata:
       m_Items: []
   - m_Id: 11183621135523846

--- a/Assets/Settings/Localization/Bindings_en-US.asset
+++ b/Assets/Settings/Localization/Bindings_en-US.asset
@@ -107,7 +107,7 @@ MonoBehaviour:
     m_Metadata:
       m_Items: []
   - m_Id: 11183621135523841
-    m_Localized: Green Cymbal (Fourth), lefty Red Cymbal (First)
+    m_Localized: Green Cymbal (Fourth)
     m_Metadata:
       m_Items: []
   - m_Id: 11183621135523842
@@ -152,6 +152,10 @@ MonoBehaviour:
       m_Items: []
   - m_Id: 98568633258508288
     m_Localized: Green Pad (Fifth)
+    m_Metadata:
+      m_Items: []
+  - m_Id: 104795453274738688
+    m_Localized: Red Cymbal (First)
     m_Metadata:
       m_Items: []
   references:

--- a/Assets/Settings/Localization/Bindings_en-US.asset
+++ b/Assets/Settings/Localization/Bindings_en-US.asset
@@ -107,7 +107,7 @@ MonoBehaviour:
     m_Metadata:
       m_Items: []
   - m_Id: 11183621135523841
-    m_Localized: Green Cymbal (Fourth), lefty Right Cymbal (First)
+    m_Localized: Green Cymbal (Fourth), lefty Red Cymbal (First)
     m_Metadata:
       m_Items: []
   - m_Id: 11183621135523842


### PR DESCRIPTION
Renumbered four-lane cymbals to match their lanes, expanded Green Cymbal string to encompass its role as Red Cymbal