### PR TITLE
Followup fixes to NotoSans Font addition

### DIFF
--- a/Assets/Art/Fonts/Barlow/Barlow-Black.asset
+++ b/Assets/Art/Fonts/Barlow/Barlow-Black.asset
@@ -117,9 +117,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71c1514a6bd24e1e882cebbe1904ce04, type: 3}
   m_Name: Barlow-Black
   m_EditorClassIdentifier: 
-  hashCode: 1300438238
+  hashCode: 268751407
   material: {fileID: -4723213457703258798}
-  materialHashCode: 1237947454
+  materialHashCode: 131129775
   m_Version: 1.1.0
   m_SourceFontFileGUID: 3f0b0eecdbffc064cb65ce5a0f1970d4
   m_SourceFontFile_EditorRef: {fileID: 12800000, guid: 3f0b0eecdbffc064cb65ce5a0f1970d4,
@@ -5642,7 +5642,8 @@ MonoBehaviour:
   m_FontFeatureTable:
     m_GlyphPairAdjustmentRecords: []
   fallbackFontAssets: []
-  m_FallbackFontAssetTable: []
+  m_FallbackFontAssetTable:
+  - {fileID: 11400000, guid: e89f58ff9fa87f946b273ba2fd021204, type: 2}
   m_CreationSettings:
     sourceFontFileName: 
     sourceFontFileGUID: 3f0b0eecdbffc064cb65ce5a0f1970d4

--- a/Assets/Art/Fonts/Barlow/Barlow-Bold.asset
+++ b/Assets/Art/Fonts/Barlow/Barlow-Bold.asset
@@ -89,7 +89,8 @@ MonoBehaviour:
   m_FontFeatureTable:
     m_GlyphPairAdjustmentRecords: []
   fallbackFontAssets: []
-  m_FallbackFontAssetTable: []
+  m_FallbackFontAssetTable:
+  - {fileID: 11400000, guid: 058d5dff3f1dc9e4bba3d08f5b47ac67, type: 2}
   m_CreationSettings:
     sourceFontFileName: 
     sourceFontFileGUID: 77e6e03c94f35cf4a855326ffc46a3e8

--- a/Assets/Art/Fonts/Barlow/Barlow-ExtraBold.asset
+++ b/Assets/Art/Fonts/Barlow/Barlow-ExtraBold.asset
@@ -118,9 +118,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71c1514a6bd24e1e882cebbe1904ce04, type: 3}
   m_Name: Barlow-ExtraBold
   m_EditorClassIdentifier: 
-  hashCode: -1331810042
+  hashCode: 1023105783
   material: {fileID: -6666678083345407130}
-  materialHashCode: -683440922
+  materialHashCode: 1034118903
   m_Version: 1.1.0
   m_SourceFontFileGUID: 38ed30a195d970943802e602658892be
   m_SourceFontFile_EditorRef: {fileID: 12800000, guid: 38ed30a195d970943802e602658892be,
@@ -5699,7 +5699,8 @@ MonoBehaviour:
   m_FontFeatureTable:
     m_GlyphPairAdjustmentRecords: []
   fallbackFontAssets: []
-  m_FallbackFontAssetTable: []
+  m_FallbackFontAssetTable:
+  - {fileID: 11400000, guid: acda1e3bf22ebc048a54ccfa4991623e, type: 2}
   m_CreationSettings:
     sourceFontFileName: 
     sourceFontFileGUID: 38ed30a195d970943802e602658892be

--- a/Assets/Art/Fonts/Barlow/Barlow-ExtraLight.asset
+++ b/Assets/Art/Fonts/Barlow/Barlow-ExtraLight.asset
@@ -59,9 +59,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71c1514a6bd24e1e882cebbe1904ce04, type: 3}
   m_Name: Barlow-ExtraLight
   m_EditorClassIdentifier: 
-  hashCode: 0
+  hashCode: -585896468
   material: {fileID: 2451060936698861075}
-  materialHashCode: 0
+  materialHashCode: -205744180
   m_Version: 1.1.0
   m_SourceFontFileGUID: b0527ec427ac05f418064d49031c9dbe
   m_SourceFontFile_EditorRef: {fileID: 12800000, guid: b0527ec427ac05f418064d49031c9dbe,
@@ -5544,7 +5544,8 @@ MonoBehaviour:
   m_FontFeatureTable:
     m_GlyphPairAdjustmentRecords: []
   fallbackFontAssets: []
-  m_FallbackFontAssetTable: []
+  m_FallbackFontAssetTable:
+  - {fileID: 11400000, guid: de8855e653b2bbe449a02b7db35368be, type: 2}
   m_CreationSettings:
     sourceFontFileName: 
     sourceFontFileGUID: b0527ec427ac05f418064d49031c9dbe

--- a/Assets/Art/Fonts/Barlow/Barlow-Light.asset
+++ b/Assets/Art/Fonts/Barlow/Barlow-Light.asset
@@ -5685,7 +5685,8 @@ MonoBehaviour:
   m_FontFeatureTable:
     m_GlyphPairAdjustmentRecords: []
   fallbackFontAssets: []
-  m_FallbackFontAssetTable: []
+  m_FallbackFontAssetTable:
+  - {fileID: 11400000, guid: 72090db18fe1edc4e9bc7c5df990c88a, type: 2}
   m_CreationSettings:
     sourceFontFileName: 
     sourceFontFileGUID: d1ce33e49515a24478919be9c3af4e4f

--- a/Assets/Art/Fonts/Barlow/Barlow-Medium.asset
+++ b/Assets/Art/Fonts/Barlow/Barlow-Medium.asset
@@ -5520,7 +5520,8 @@ MonoBehaviour:
   m_FontFeatureTable:
     m_GlyphPairAdjustmentRecords: []
   fallbackFontAssets: []
-  m_FallbackFontAssetTable: []
+  m_FallbackFontAssetTable:
+  - {fileID: 11400000, guid: f9ecde2560f181446bf79cf68333c86a, type: 2}
   m_CreationSettings:
     sourceFontFileName: 
     sourceFontFileGUID: d3276a51390d44c468621e7e6b009ea5

--- a/Assets/Art/Fonts/Barlow/Barlow-Regular SDF.asset
+++ b/Assets/Art/Fonts/Barlow/Barlow-Regular SDF.asset
@@ -5540,7 +5540,8 @@ MonoBehaviour:
   m_FontFeatureTable:
     m_GlyphPairAdjustmentRecords: []
   fallbackFontAssets: []
-  m_FallbackFontAssetTable: []
+  m_FallbackFontAssetTable:
+  - {fileID: 11400000, guid: 49fb77f895c547a4ebf4ccadc85b57ba, type: 2}
   m_CreationSettings:
     sourceFontFileName: 
     sourceFontFileGUID: 7741965ee37e67d4b89cb80d3bb3d433

--- a/Assets/Art/Fonts/Barlow/Barlow-SemiBold.asset
+++ b/Assets/Art/Fonts/Barlow/Barlow-SemiBold.asset
@@ -5725,7 +5725,8 @@ MonoBehaviour:
   m_FontFeatureTable:
     m_GlyphPairAdjustmentRecords: []
   fallbackFontAssets: []
-  m_FallbackFontAssetTable: []
+  m_FallbackFontAssetTable:
+  - {fileID: 11400000, guid: 52ac784f07c5f2044957974b963a80a2, type: 2}
   m_CreationSettings:
     sourceFontFileName: 
     sourceFontFileGUID: 9a96d919d885547429c5c9b823144ac8

--- a/Assets/Art/Fonts/Barlow/Barlow-Thin.asset
+++ b/Assets/Art/Fonts/Barlow/Barlow-Thin.asset
@@ -117,9 +117,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 71c1514a6bd24e1e882cebbe1904ce04, type: 3}
   m_Name: Barlow-Thin
   m_EditorClassIdentifier: 
-  hashCode: 0
+  hashCode: 1440302995
   material: {fileID: -2861737157810636639}
-  materialHashCode: 0
+  materialHashCode: -569595565
   m_Version: 1.1.0
   m_SourceFontFileGUID: 99be956b4447e5c4d942ab55cc87f867
   m_SourceFontFile_EditorRef: {fileID: 12800000, guid: 99be956b4447e5c4d942ab55cc87f867,
@@ -5710,7 +5710,8 @@ MonoBehaviour:
   m_FontFeatureTable:
     m_GlyphPairAdjustmentRecords: []
   fallbackFontAssets: []
-  m_FallbackFontAssetTable: []
+  m_FallbackFontAssetTable:
+  - {fileID: 11400000, guid: 01aaade355ee40a41a44c7f21fa3f567, type: 2}
   m_CreationSettings:
     sourceFontFileName: 
     sourceFontFileGUID: 99be956b4447e5c4d942ab55cc87f867

--- a/Assets/Art/Fonts/RedHatDisplay/RedHatDisplay-Black.asset
+++ b/Assets/Art/Fonts/RedHatDisplay/RedHatDisplay-Black.asset
@@ -241,7 +241,8 @@ MonoBehaviour:
   m_FontFeatureTable:
     m_GlyphPairAdjustmentRecords: []
   fallbackFontAssets: []
-  m_FallbackFontAssetTable: []
+  m_FallbackFontAssetTable:
+  - {fileID: 11400000, guid: e89f58ff9fa87f946b273ba2fd021204, type: 2}
   m_CreationSettings:
     sourceFontFileName: 
     sourceFontFileGUID: d0569ed00c96d0c4f90f496c3262fc40

--- a/Assets/Art/Fonts/RedHatDisplay/RedHatDisplay-Bold.asset
+++ b/Assets/Art/Fonts/RedHatDisplay/RedHatDisplay-Bold.asset
@@ -2662,7 +2662,8 @@ MonoBehaviour:
   m_FontFeatureTable:
     m_GlyphPairAdjustmentRecords: []
   fallbackFontAssets: []
-  m_FallbackFontAssetTable: []
+  m_FallbackFontAssetTable:
+  - {fileID: 11400000, guid: 058d5dff3f1dc9e4bba3d08f5b47ac67, type: 2}
   m_CreationSettings:
     sourceFontFileName: 
     sourceFontFileGUID: ce75595cb5f44284bb33934c26e74911

--- a/Assets/Art/Fonts/RedHatDisplay/RedHatDisplay-ExtraBold.asset
+++ b/Assets/Art/Fonts/RedHatDisplay/RedHatDisplay-ExtraBold.asset
@@ -194,7 +194,8 @@ MonoBehaviour:
   m_FontFeatureTable:
     m_GlyphPairAdjustmentRecords: []
   fallbackFontAssets: []
-  m_FallbackFontAssetTable: []
+  m_FallbackFontAssetTable:
+  - {fileID: 11400000, guid: acda1e3bf22ebc048a54ccfa4991623e, type: 2}
   m_CreationSettings:
     sourceFontFileName: 
     sourceFontFileGUID: f3f9a6ca26a86d948a7c7c2414d96182

--- a/Assets/Art/Fonts/RedHatDisplay/RedHatDisplay-Light.asset
+++ b/Assets/Art/Fonts/RedHatDisplay/RedHatDisplay-Light.asset
@@ -89,7 +89,8 @@ MonoBehaviour:
   m_FontFeatureTable:
     m_GlyphPairAdjustmentRecords: []
   fallbackFontAssets: []
-  m_FallbackFontAssetTable: []
+  m_FallbackFontAssetTable:
+  - {fileID: 11400000, guid: 72090db18fe1edc4e9bc7c5df990c88a, type: 2}
   m_CreationSettings:
     sourceFontFileName: 
     sourceFontFileGUID: 6b7d2aacf71b5774d8b270aae8a95a0a

--- a/Assets/Art/Fonts/RedHatDisplay/RedHatDisplay-Medium.asset
+++ b/Assets/Art/Fonts/RedHatDisplay/RedHatDisplay-Medium.asset
@@ -136,7 +136,8 @@ MonoBehaviour:
   m_FontFeatureTable:
     m_GlyphPairAdjustmentRecords: []
   fallbackFontAssets: []
-  m_FallbackFontAssetTable: []
+  m_FallbackFontAssetTable:
+  - {fileID: 11400000, guid: f9ecde2560f181446bf79cf68333c86a, type: 2}
   m_CreationSettings:
     sourceFontFileName: 
     sourceFontFileGUID: 65a0efb02f39a1942a26c6499ec5ecb1

--- a/Assets/Art/Fonts/RedHatDisplay/RedHatDisplay-SemiBold.asset
+++ b/Assets/Art/Fonts/RedHatDisplay/RedHatDisplay-SemiBold.asset
@@ -10042,7 +10042,8 @@ MonoBehaviour:
   m_FontFeatureTable:
     m_GlyphPairAdjustmentRecords: []
   fallbackFontAssets: []
-  m_FallbackFontAssetTable: []
+  m_FallbackFontAssetTable:
+  - {fileID: 11400000, guid: 52ac784f07c5f2044957974b963a80a2, type: 2}
   m_CreationSettings:
     sourceFontFileName: 
     sourceFontFileGUID: 841b50e946514264bb06eec59af8acc3

--- a/Assets/Art/Fonts/RedHatDisplay/RedHatDisplay.asset
+++ b/Assets/Art/Fonts/RedHatDisplay/RedHatDisplay.asset
@@ -136,7 +136,8 @@ MonoBehaviour:
   m_FontFeatureTable:
     m_GlyphPairAdjustmentRecords: []
   fallbackFontAssets: []
-  m_FallbackFontAssetTable: []
+  m_FallbackFontAssetTable:
+  - {fileID: 11400000, guid: 49fb77f895c547a4ebf4ccadc85b57ba, type: 2}
   m_CreationSettings:
     sourceFontFileName: 
     sourceFontFileGUID: e1c398fd071b5af419491eec407c5007

--- a/Assets/Prefabs/Menu/MusicLibrary/PopupMenuItem.prefab
+++ b/Assets/Prefabs/Menu/MusicLibrary/PopupMenuItem.prefab
@@ -151,6 +151,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _selectOnHover: 1
+  _selectOnClick: 1
   _selectedVisual: {fileID: 70200645977546920}
   _onClick:
     m_PersistentCalls:
@@ -378,7 +379,7 @@ MonoBehaviour:
   m_charWidthMaxAdj: 0
   m_enableWordWrapping: 1
   m_wordWrappingRatios: 0.4
-  m_overflowMode: 0
+  m_overflowMode: 1
   m_linkedTextComponent: {fileID: 0}
   parentLinkedComponent: {fileID: 0}
   m_enableKerning: 1


### PR DESCRIPTION
- proper fallback for all used fonts to NotoSans (only non-italic for now)
        -> fixes text not displaying properly in popup menu
- new text overflow setting in music library popup menu, now truncates text with ellipsis (before text would go on multiple lines overlapping other entries)