### PR TITLE
Fix More Options menu not opening on click

### DIFF
--- a/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
+++ b/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
@@ -514,7 +514,7 @@ namespace YARG.Menu.MusicLibrary
         {
             var holdContext = _heldInputs.FirstOrDefault(i => i.Context.IsSameAs(ctx));
 
-            if (ctx.Action == MenuAction.Orange && holdContext?.Timer > 0)
+            if (ctx.Action == MenuAction.Orange && (holdContext?.Timer > 0 || ctx.Player is null))
                 _popupMenu.gameObject.SetActive(true);
 
             _heldInputs.RemoveAll(i => i.Context.IsSameAs(ctx));

--- a/Assets/Script/Menu/Navigation/NavigationScheme.cs
+++ b/Assets/Script/Menu/Navigation/NavigationScheme.cs
@@ -52,6 +52,8 @@ namespace YARG.Menu.Navigation
                 _handler?.Invoke(context);
             }
 
+            public void InvokeHoldOffHandler() => InvokeHoldOffHandler(new(Action, null));
+
             public void InvokeHoldOffHandler(NavigationContext context)
             {
                 _onHoldOffHandler?.Invoke(context);

--- a/Assets/Script/Menu/Persistent/HelpBarButton.cs
+++ b/Assets/Script/Menu/Persistent/HelpBarButton.cs
@@ -5,7 +5,6 @@ using UnityEngine.EventSystems;
 using YARG.Core.Input;
 using YARG.Menu.Data;
 using YARG.Menu.Navigation;
-using YARG.Core.Logging;
 
 namespace YARG.Menu.Persistent
 {

--- a/Assets/Script/Menu/Persistent/HelpBarButton.cs
+++ b/Assets/Script/Menu/Persistent/HelpBarButton.cs
@@ -5,10 +5,11 @@ using UnityEngine.EventSystems;
 using YARG.Core.Input;
 using YARG.Menu.Data;
 using YARG.Menu.Navigation;
+using YARG.Core.Logging;
 
 namespace YARG.Menu.Persistent
 {
-    public class HelpBarButton : MonoBehaviour, IPointerEnterHandler, IPointerExitHandler, IPointerDownHandler
+    public class HelpBarButton : MonoBehaviour, IPointerEnterHandler, IPointerExitHandler, IPointerDownHandler, IPointerUpHandler
     {
         [SerializeField]
         private Image _buttonImage;
@@ -73,6 +74,11 @@ namespace YARG.Menu.Persistent
             _buttonImage.color = Color.grey;
             _buttonLabel.color = Color.grey;
             _buttonText.color = Color.grey;
+        }
+
+        public void OnPointerUp(PointerEventData eventData)
+        {
+            _entry?.InvokeHoldOffHandler();
         }
 
         public void OnClick()

--- a/Assets/Script/Menu/Persistent/HelpBarButton.cs
+++ b/Assets/Script/Menu/Persistent/HelpBarButton.cs
@@ -73,16 +73,13 @@ namespace YARG.Menu.Persistent
             _buttonImage.color = Color.grey;
             _buttonLabel.color = Color.grey;
             _buttonText.color = Color.grey;
+
+            _entry?.Invoke();
         }
 
         public void OnPointerUp(PointerEventData eventData)
         {
             _entry?.InvokeHoldOffHandler();
-        }
-
-        public void OnClick()
-        {
-            _entry?.Invoke();
         }
     }
 }


### PR DESCRIPTION
After #756 since the menu opening was moved to on button release it doesn't trigger the opening the menu, adding in the onPointerUp on the HelperButton in the menu footer to trigger it.