### PR TITLE
Option to prioritize displaying higher % scores in MusicLibrary

### DIFF
--- a/Assets/Script/Menu/MusicLibrary/ViewTypes/SongViewType.cs
+++ b/Assets/Script/Menu/MusicLibrary/ViewTypes/SongViewType.cs
@@ -19,6 +19,12 @@ namespace YARG.Menu.MusicLibrary
         Off
     }
 
+    public enum HighScorePriorityMode
+    {
+        Percentage,
+        Score
+    }
+
     public class SongViewType : ViewType
     {
         public override BackgroundType Background => BackgroundType.Normal;
@@ -51,7 +57,7 @@ namespace YARG.Menu.MusicLibrary
 
         public override string GetSideText(bool selected)
         {
-            var score = ScoreContainer.GetHighScore(SongEntry.Hash);
+            var score = ScoreContainer.GetHighScore(SongEntry.Hash, SettingsManager.Settings.HighScorePriority.Value);
 
             // Never played!
             if (score is null)
@@ -84,7 +90,7 @@ namespace YARG.Menu.MusicLibrary
                 return null;
             }
 
-            var score = ScoreContainer.GetHighScore(SongEntry.Hash);
+            var score = ScoreContainer.GetHighScore(SongEntry.Hash, SettingsManager.Settings.HighScorePriority.Value);
             return score?.Stars;
         }
 

--- a/Assets/Script/Scores/ScoreContainer.cs
+++ b/Assets/Script/Scores/ScoreContainer.cs
@@ -96,13 +96,13 @@ namespace YARG.Scores
                     SongHighScores.Add(songChecksum, bestScore);
                 }
 
-                var bestScoreByPct = playerEntries.Find(p => p.Score == playerEntries.Max(x => x.Percent));
+                var bestScoreByPct = playerEntries.Find(p => p.Percent == playerEntries.Max(x => x.Percent));
 
                 if (SongHighScoresByPct.TryGetValue(songChecksum, out var highScoreByPct))
                 {
                     if ((bestScoreByPct.IsFc && !highScoreByPct.IsFc)
-                    || (bestScoreByPct.IsFc == highScoreByPct.IsFc && bestScoreByPct.Percent > highScoreByPct.Percent)
-                    || (bestScoreByPct.IsFc == highScoreByPct.IsFc && bestScoreByPct.Percent == highScoreByPct.Percent && bestScoreByPct.Difficulty > highScoreByPct.Difficulty))
+                    || ((bestScoreByPct.IsFc == highScoreByPct.IsFc) && (bestScoreByPct.Percent > highScoreByPct.Percent))
+                    || ((bestScoreByPct.IsFc == highScoreByPct.IsFc) && (bestScoreByPct.Percent == highScoreByPct.Percent) && (bestScoreByPct.Difficulty > highScoreByPct.Difficulty)))
                     {
                         SongHighScoresByPct[songChecksum] = bestScoreByPct;
                     }

--- a/Assets/Script/Scores/ScoreContainer.cs
+++ b/Assets/Script/Scores/ScoreContainer.cs
@@ -96,7 +96,9 @@ namespace YARG.Scores
                     SongHighScores.Add(songChecksum, bestScore);
                 }
 
-                var bestScoreByPct = playerEntries.Find(p => p.Percent == playerEntries.Max(x => x.Percent));
+                var fcFilter = playerEntries.Where(p => p.IsFc == playerEntries.Max(x => x.IsFc));
+                var scoreFilter = fcFilter.Where(p => p.Percent == fcFilter.Max(x => x.Percent));
+                var bestScoreByPct = scoreFilter.Where(p => p.Difficulty == scoreFilter.Max(x => x.Difficulty)).First();
 
                 if (SongHighScoresByPct.TryGetValue(songChecksum, out var highScoreByPct))
                 {
@@ -186,7 +188,7 @@ namespace YARG.Scores
             {
                 const string highScores = "SELECT *, MAX(Score) FROM PlayerScores " +
                     "INNER JOIN GameRecords ON PlayerScores.GameRecordId = GameRecords.Id GROUP BY GameRecords.SongChecksum";
-                // Tries to pick the best result by looking at isFc -> Percentage -> Difficulty
+                // Tries to pick the best result by looking at IsFc -> Percentage -> Difficulty
                 const string highScoresByPct = @"WITH Temp as (SELECT Id, GameRecordId, PlayerId, Instrument,
                                                  Difficulty, EnginePresetId, Score, Stars, NotesHit, NotesMissed, IsFc,
                                                  ifnull(Percent, cast(NotesHit as REAL) / (NotesHit + NotesMissed)) as Percent FROM PlayerScores)

--- a/Assets/Script/Settings/SettingsManager.Settings.cs
+++ b/Assets/Script/Settings/SettingsManager.Settings.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using UnityEngine;
 using UnityEngine.InputSystem;
@@ -92,6 +93,13 @@ namespace YARG.Settings
                 HighScoreInfoMode.Stars,
                 HighScoreInfoMode.Score,
                 HighScoreInfoMode.Off
+            };
+
+            public DropdownSetting<HighScorePriorityMode> HighScorePriority { get; }
+                = new(HighScorePriorityMode.Score)
+            {
+                HighScorePriorityMode.Score,
+                HighScorePriorityMode.Percentage
             };
 
             #endregion

--- a/Assets/Script/Settings/SettingsManager.cs
+++ b/Assets/Script/Settings/SettingsManager.cs
@@ -51,7 +51,8 @@ namespace YARG.Settings
                 nameof(Settings.UseFullDirectoryForPlaylists),
                 new HeaderMetadata("MusicLibrary"),
                 nameof(Settings.ShowFavoriteButton),
-                nameof(Settings.HighScoreInfo)
+                nameof(Settings.HighScoreInfo),
+                nameof(Settings.HighScorePriority)
             },
             new MetadataTab("Sound", icon: "Sound")
             {

--- a/Assets/Settings/Localization/Settings Shared Data.asset
+++ b/Assets/Settings/Localization/Settings Shared Data.asset
@@ -1407,6 +1407,22 @@ MonoBehaviour:
     m_Key: Setting.ReconnectProfiles.Description
     m_Metadata:
       m_Items: []
+  - m_Id: 152317105188937728
+    m_Key: Setting.HighScorePriority
+    m_Metadata:
+      m_Items: []
+  - m_Id: 152319874444599296
+    m_Key: Dropdown.HighScorePriority.Percentage
+    m_Metadata:
+      m_Items: []
+  - m_Id: 152319907466354688
+    m_Key: Dropdown.HighScorePriority.Score
+    m_Metadata:
+      m_Items: []
+  - m_Id: 152321634580078592
+    m_Key: Setting.HighScorePriority.Description
+    m_Metadata:
+      m_Items: []
   m_Metadata:
     m_Items: []
   m_KeyGenerator:

--- a/Assets/Settings/Localization/Settings_en-US.asset
+++ b/Assets/Settings/Localization/Settings_en-US.asset
@@ -1512,6 +1512,23 @@ MonoBehaviour:
     m_Localized: At startup, reconnect previously connected profiles.
     m_Metadata:
       m_Items: []
+  - m_Id: 152317105188937728
+    m_Localized: High Score Priority
+    m_Metadata:
+      m_Items: []
+  - m_Id: 152319907466354688
+    m_Localized: Score
+    m_Metadata:
+      m_Items: []
+  - m_Id: 152319874444599296
+    m_Localized: Percentage
+    m_Metadata:
+      m_Items: []
+  - m_Id: 152321634580078592
+    m_Localized: Determines whether the result with the best percentage or the best
+      score is displayed in the Music Library.
+    m_Metadata:
+      m_Items: []
   references:
     version: 2
     RefIds: []


### PR DESCRIPTION
Discussion threads:
https://discord.com/channels/1086048856678084609/1211121737358512238
https://discord.com/channels/1086048856678084609/1086048857714069519/1236879158663970889

Tries to display the best FC/percentage result, ties are broken by difficulty.

If the PlayerScores table is from the older version without the Percentage column / is not populated with data, it will try to fill it with the calculated value.