### PR TITLE
Removed udp port binding

### DIFF
--- a/Assets/Plugins/Haukcode.sACN/SACNClient.cs
+++ b/Assets/Plugins/Haukcode.sACN/SACNClient.cs
@@ -116,7 +116,6 @@ namespace Haukcode.sACN
 
             listenSocket.ExclusiveAddressUse = false;
             listenSocket.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
-            listenSocket.Bind(new IPEndPoint(IPAddress.Any, port));
             // Only join local LAN group
             listenSocket.SetSocketOption(SocketOptionLevel.IP, SocketOptionName.MulticastTimeToLive, 1);
 


### PR DESCRIPTION
Vestigial oversight from when this library also received. Shouldn't bind to a port when just sending. That would lock out/crash program who would try to bind to that same port.