### PR TITLE
Added Master Dimmer values setting

### DIFF
--- a/Assets/Script/Integration/Sacn/SacnInterpreter.cs
+++ b/Assets/Script/Integration/Sacn/SacnInterpreter.cs
@@ -190,10 +190,11 @@ namespace YARG.Integration.Sacn
 
             //Many DMX fixtures have a 'Master dimmer' channel that controls the overall brightness of the fixture.
             //Got to turn those on.
-            foreach (int t in _dimmerChannels)
+            for (int i = 0; i < 8; i++)
             {
-                SetChannel(t, (byte) DimmerEnum.On);
+                SetChannel(_dimmerChannels[i], (byte)SettingsManager.Settings.DMXDimmerValues.Value[i]);
             }
+
         }
 
         public void UpdateDMXChannelNumbers()

--- a/Assets/Script/Settings/SettingsManager.Settings.cs
+++ b/Assets/Script/Settings/SettingsManager.Settings.cs
@@ -291,6 +291,8 @@ namespace YARG.Settings
 
             public IntSetting DMXUniverseChannel { get; } = new(1, 1, 65535);
 
+            public DMXChannelsSetting DMXDimmerValues { get; } = new(new[] { 255, 255, 255, 255, 255, 255, 255, 255 });
+
             #endregion
 
             #region Debug and Developer

--- a/Assets/Script/Settings/SettingsManager.cs
+++ b/Assets/Script/Settings/SettingsManager.cs
@@ -159,6 +159,7 @@ namespace YARG.Settings
                 nameof(Settings.DMXKeysChannel),
                 new HeaderMetadata("AdvancedDMXSettings"),
                 nameof(Settings.DMXUniverseChannel),
+                nameof(Settings.DMXDimmerValues),
                 //NYI
                 //nameof(Settings.DMXPerformerChannel)
                 new HeaderMetadata("RB3E"),

--- a/Assets/Settings/Localization/Settings Shared Data.asset
+++ b/Assets/Settings/Localization/Settings Shared Data.asset
@@ -1269,6 +1269,8 @@ MonoBehaviour:
       m_Items: []
   - m_Id: 141442680402108416
     m_Key: Setting.RB3EBroadcastIP.Description
+    m_Metadata:
+      m_Items: []
   - m_Id: 142536672422289408
     m_Key: Setting.DMXSecondaryCueChannel
     m_Metadata:
@@ -1423,6 +1425,14 @@ MonoBehaviour:
       m_Items: []
   - m_Id: 146130013221191680
     m_Key: Setting.ReconnectProfiles.Description
+    m_Metadata:
+      m_Items: []
+  - m_Id: 154060765403439104
+    m_Key: Setting.DMXDimmerValues
+    m_Metadata:
+      m_Items: []
+  - m_Id: 154060811591114752
+    m_Key: Setting.DMXDimmerValues.Description
     m_Metadata:
       m_Items: []
   m_Metadata:

--- a/Assets/Settings/Localization/Settings_en-US.asset
+++ b/Assets/Settings/Localization/Settings_en-US.asset
@@ -243,7 +243,8 @@ MonoBehaviour:
     m_Metadata:
       m_Items: []
   - m_Id: 116747023324405789
-    m_Localized: Any channel set here will be set to max (255) on game start. Useful
+    m_Localized: Channels listed here will be set on game start. Default value is
+      max (255), can be changed in 'DMX Master Dimmer Values' setting below. Useful
       for fixtures that have a master dimmer channel.
     m_Metadata:
       m_Items: []
@@ -1366,6 +1367,8 @@ MonoBehaviour:
   - m_Id: 141442680402108416
     m_Localized: Sets the target IP for the RB3E data stream packets. 255.255.255.255
       is the broadcast address for the current network
+    m_Metadata:
+      m_Items: []
   - m_Id: 142536672422289408
     m_Localized: DMX Secondary Cue Change
     m_Metadata:
@@ -1530,6 +1533,15 @@ MonoBehaviour:
       m_Items: []
   - m_Id: 146130013221191680
     m_Localized: At startup, reconnect previously connected profiles.
+    m_Metadata:
+      m_Items: []
+  - m_Id: 154060765403439104
+    m_Localized: DMX Master Dimmer Values
+    m_Metadata:
+      m_Items: []
+  - m_Id: 154060811591114752
+    m_Localized: These are the respective values that the Master Dimmer channels
+      willl be set to when YARG starts.
     m_Metadata:
       m_Items: []
   references:


### PR DESCRIPTION
An advanced setting, this allows the Master Dimmers to be set to something other than 255 on game start, as some fixture don't have 100% at 255 for some reason...