### PR TITLE
Show best % score for instrument and difficulty of the highest score

### DIFF
--- a/Assets/Script/Menu/MusicLibrary/ViewTypes/SongViewType.cs
+++ b/Assets/Script/Menu/MusicLibrary/ViewTypes/SongViewType.cs
@@ -52,6 +52,7 @@ namespace YARG.Menu.MusicLibrary
         public override string GetSideText(bool selected)
         {
             var score = ScoreContainer.GetHighScore(SongEntry.Hash);
+            var bestPctScore = ScoreContainer.GetBestPercentageScore(SongEntry.Hash);
 
             // Never played!
             if (score is null)
@@ -61,7 +62,7 @@ namespace YARG.Menu.MusicLibrary
 
             var instrument = score.Instrument.ToResourceName();
             var difficultyChar = score.Difficulty.ToChar();
-            var percent = Mathf.Floor(score.GetPercent() * 100f);
+            var percent = Mathf.Floor(bestPctScore.GetPercent() * 100f);
 
             using var builder = ZString.CreateStringBuilder();
             builder.AppendFormat("<sprite name=\"{0}\"> <b>{1}</b> {2:N0}%",

--- a/Assets/Script/Scores/ScoreContainer.cs
+++ b/Assets/Script/Scores/ScoreContainer.cs
@@ -42,6 +42,7 @@ namespace YARG.Scores
 
                 _db = new SQLiteConnection(_scoreDatabaseFile);
                 InitDatabase();
+                UpdateNullPercents();
                 FetchHighScores();
             }
             catch (Exception e)
@@ -175,6 +176,22 @@ namespace YARG.Scores
         public static PlayerScoreRecord GetBestPercentageScore(HashWrapper songChecksum)
         {
             return SongHighScoresByPct?.GetValueOrDefault(songChecksum);
+        }
+
+        public static void UpdateNullPercents()
+        {
+            try
+            {
+                var n = _db.Execute(ScoreDatabaseQueries.UPDATE_NULL_PERCENTS);
+                if (n > 0)
+                {
+                    YargLogger.LogFormatInfo("Successfully updated the percentage field on {0} rows.", n);
+                }
+            }
+            catch (Exception e)
+            {
+                YargLogger.LogException(e, "Failed to update null percents in database.");
+            }
         }
 
         public static void FetchHighScores()

--- a/Assets/Script/Scores/ScoreDatabaseQueries.cs
+++ b/Assets/Script/Scores/ScoreDatabaseQueries.cs
@@ -49,5 +49,34 @@
 
         public const string CREATE_TABLES = CREATE_PROFILES_TABLE + ";" + CREATE_GAME_HISTORY_TABLE + ";" +
             CREATE_PLAYER_GAME_HISTORY_TABLE;
+        
+        public const string BEST_SCORES_BY_PERCENT =
+        @"WITH
+            BestInstAndDiff as (SELECT PlayerScores.Instrument,
+                                    PlayerScores.Difficulty,
+                                    PlayerScores.GameRecordId,
+                                    GameRecords.SongChecksum,
+                                    max(PlayerScores.Score)
+                                FROM PlayerScores INNER JOIN GameRecords ON PlayerScores.GameRecordId = GameRecords.Id
+                                GROUP BY GameRecords.SongChecksum),
+            BestPercents as (SELECT PlayerScores.Id,
+                                    PlayerScores.GameRecordId,
+                                    PlayerScores.PlayerId,
+                                    PlayerScores.Instrument,
+                                    PlayerScores.Difficulty,
+                                    PlayerScores.EnginePresetId,
+                                    PlayerScores.Score,
+                                    PlayerScores.Stars,
+                                    PlayerScores.NotesHit,
+                                    PlayerScores.NotesMissed,
+                                    PlayerScores.IsFc,
+                                    max(ifnull(Percent, cast(NotesHit as REAL) / (NotesHit + NotesMissed))) as Percent,
+                                    GameRecords.SongChecksum
+                                FROM PlayerScores INNER JOIN GameRecords ON PlayerScores.GameRecordId = GameRecords.Id
+                                GROUP BY GameRecords.SongChecksum, PlayerScores.Instrument, PlayerScores.Difficulty)
+        SELECT BestPercents.*
+        FROM BestInstAndDiff INNER JOIN BestPercents ON BestInstAndDiff.Instrument = BestPercents.Instrument
+            AND BestInstAndDiff.Difficulty = BestPercents.Difficulty
+            AND BestInstAndDiff.SongChecksum = BestPercents.SongChecksum";
     }
 }


### PR DESCRIPTION
Re-submission of pull #779
Now finds and displays the highest % score achieved for the same instrument+difficulty and displays that instead of the % score achieved on the highest scoring run.

Assumes the `Percent` column exists in the `PlayerScores` table exists (which it does on this `engine-refactor` branch).

The additional query should be performant enough, runs in 14ms on my db of 1021 rows whereas the original query runs in 4ms.