### PR TITLE
Use Git commit information for Game Version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,6 +87,8 @@ crashlytics-build.properties
 
 # Auto-gen
 Assets/YargInput.cs
+/[Aa]ssets/[Rr]esources/version.txt
+/[Aa]ssets/[Rr]esources/version.txt.meta
 /[Aa]ssets/[Pp]ackages/
 /[Aa]ssets/[Ss]treamingAssets/sources/
 /[Aa]ssets/[Ss]treamingAssets/sources~/

--- a/Assets/Editor/Build.meta
+++ b/Assets/Editor/Build.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 206b2c5077fe4c42ade38a343eb8d678
+timeCreated: 1718055421

--- a/Assets/Editor/Build/BuildGitCommitVersion.cs
+++ b/Assets/Editor/Build/BuildGitCommitVersion.cs
@@ -7,9 +7,16 @@ namespace Editor.Build
 {
     public class BuildGitCommitVersion : IPreprocessBuildWithReport
     {
+        private const string OUTPUT_FOLDER = "Assets/Resources";
+
         public int callbackOrder { get; }
         public void OnPreprocessBuild(BuildReport report)
         {
+            if (!Directory.Exists(OUTPUT_FOLDER))
+            {
+                Directory.CreateDirectory(OUTPUT_FOLDER);
+            }
+
             File.WriteAllText("Assets/Resources/version.txt", GlobalVariables.LoadVersionFromGit());
         }
     }

--- a/Assets/Editor/Build/BuildGitCommitVersion.cs
+++ b/Assets/Editor/Build/BuildGitCommitVersion.cs
@@ -1,0 +1,16 @@
+using System.IO;
+using UnityEditor.Build;
+using UnityEditor.Build.Reporting;
+using YARG;
+
+namespace Editor.Build
+{
+    public class BuildGitCommitVersion : IPreprocessBuildWithReport
+    {
+        public int callbackOrder { get; }
+        public void OnPreprocessBuild(BuildReport report)
+        {
+            File.WriteAllText("Assets/Resources/version.txt", GlobalVariables.LoadVersionFromGit());
+        }
+    }
+}

--- a/Assets/Editor/Build/BuildGitCommitVersion.cs.meta
+++ b/Assets/Editor/Build/BuildGitCommitVersion.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 1079005979f74bd7aea37eef026e3ac2
+timeCreated: 1718055435

--- a/Assets/Script/Menu/Main/MainMenu.cs
+++ b/Assets/Script/Menu/Main/MainMenu.cs
@@ -19,7 +19,7 @@ namespace YARG.Menu.Main
 
         private void Start()
         {
-            _versionText.text = GlobalVariables.CURRENT_VERSION;
+            _versionText.text = GlobalVariables.Instance.CurrentVersion;
 
             // Show the anti-piracy dialog if it hasn't been shown already
             // Also only show it once per game launch

--- a/Assets/Script/Menu/Persistent/DevWatermark.cs
+++ b/Assets/Script/Menu/Persistent/DevWatermark.cs
@@ -11,11 +11,11 @@ namespace YARG.Menu.Persistent
         private void Start()
         {
 #if UNITY_EDITOR
-            _watermarkText.text = $"<b>YARG {GlobalVariables.CURRENT_VERSION}</b> Unity Editor";
+            _watermarkText.text = $"<b>YARG {GlobalVariables.Instance.CurrentVersion}</b> Unity Editor";
 #elif YARG_TEST_BUILD
-            _watermarkText.text = $"<b>YARG {GlobalVariables.CURRENT_VERSION}</b> Development Build";
+            _watermarkText.text = $"<b>YARG {GlobalVariables.Instance.CurrentVersion}</b> Development Build";
 #elif YARG_NIGHTLY_BUILD
-            _watermarkText.text = $"<b>YARG {GlobalVariables.CURRENT_VERSION}</b> Nightly Build";
+            _watermarkText.text = $"<b>YARG {GlobalVariables.Instance.CurrentVersion}</b> Nightly Build";
 #else
             gameObject.SetActive(false);
 #endif

--- a/Assets/Script/Persistent/GlobalVariables.cs
+++ b/Assets/Script/Persistent/GlobalVariables.cs
@@ -191,6 +191,7 @@ namespace YARG
             process.StartInfo.FileName = "git";
             process.StartInfo.RedirectStandardOutput = true;
             process.StartInfo.UseShellExecute = false;
+            process.StartInfo.CreateNoWindow = true;
 
             // Branch
             process.StartInfo.Arguments = "rev-parse --abbrev-ref HEAD";

--- a/Assets/Script/Persistent/GlobalVariables.cs
+++ b/Assets/Script/Persistent/GlobalVariables.cs
@@ -166,13 +166,20 @@ namespace YARG
             }
         }
 
-        private string LoadVersion()
+        private static string LoadVersion()
         {
 #if UNITY_EDITOR
             return LoadVersionFromGit();
 #elif YARG_TEST_BUILD || YARG_NIGHTLY_BUILD
             var versionFile = Resources.Load<TextAsset>("version");
-            return versionFile.text;
+            if (versionFile != null)
+            {
+                return versionFile.text;
+            }
+            else
+            {
+                return CurrentVersion;
+            }
 #else
             return CurrentVersion;
 #endif

--- a/Assets/Script/Persistent/GlobalVariables.cs
+++ b/Assets/Script/Persistent/GlobalVariables.cs
@@ -166,7 +166,9 @@ namespace YARG
             }
         }
 
-        private static string LoadVersion()
+        // Due to the preprocessor, it doesn't know that an instance variable is being used
+        // ReSharper disable once MemberCanBeMadeStatic.Local
+        private string LoadVersion()
         {
 #if UNITY_EDITOR
             return LoadVersionFromGit();

--- a/Assets/Script/Persistent/GlobalVariables.cs
+++ b/Assets/Script/Persistent/GlobalVariables.cs
@@ -203,7 +203,11 @@ namespace YARG
             string commit = process.StandardOutput.ReadToEnd().Trim();
             process.WaitForExit();
 
+            #if YARG_NIGHTLY_BUILD
+            return $"b{commitCount} ({commit})";
+            #else
             return $"{branch} b{commitCount} ({commit})";
+            #endif
         }
     }
 }

--- a/Assets/Script/Scores/ScoreContainer.cs
+++ b/Assets/Script/Scores/ScoreContainer.cs
@@ -63,7 +63,7 @@ namespace YARG.Scores
                 int rowsAdded = 0;
 
                 // Add the game record
-                gameRecord.GameVersion = GlobalVariables.CURRENT_VERSION;
+                gameRecord.GameVersion = GlobalVariables.Instance.CurrentVersion;
                 rowsAdded += _db.Insert(gameRecord);
 
                 // Assign the proper score entry IDs and checksums


### PR DESCRIPTION
Pulls information about the current git branch and commit to set the game version for display when in the Unity Editor and Development or Nightly builds.

`git rev-parse --abbrev-ref HEAD` - Gets the branch name at the HEAD.
`git rev-list --count HEAD` - Gets the number of commits at the HEAD.
`git rev-parse --short HEAD` - Gets the short hash of the current commit at HEAD.

During the build process, an Editor script runs and the version is saved to a `version.txt` file in the `Assets/Resources/` folder. If the game is development or nightly, it will pull the version from this file. If not, it uses the constant string in `GlobalVariables`, which should still be set for stable builds.

Needs some brief testing for Mac and Linux as it uses the `Process` class when running in Editor and during the build process, and this can be fiddly compared to Windows sometimes.