### PR TITLE
Wrap-around navigation for menus

### DIFF
--- a/Assets/Script/Gameplay/HUD/Practice/PracticeSectionMenu.cs
+++ b/Assets/Script/Gameplay/HUD/Practice/PracticeSectionMenu.cs
@@ -35,7 +35,18 @@ namespace YARG.Gameplay.HUD
             get => _hoveredIndex;
             private set
             {
-                _hoveredIndex = Mathf.Clamp(value, 0, _sections.Count - 1);
+                if (value > _sections.Count - 1)
+                {
+                    _hoveredIndex = 0;
+                }
+                else if (value < 0)
+                {
+                    _hoveredIndex = _sections.Count - 1;
+                }
+                else
+                {
+                    _hoveredIndex = value;
+                }
 
                 UpdateSectionViews();
             }

--- a/Assets/Script/Gameplay/HUD/Practice/PracticeSectionMenu.cs
+++ b/Assets/Script/Gameplay/HUD/Practice/PracticeSectionMenu.cs
@@ -4,6 +4,7 @@ using UnityEngine.InputSystem;
 using YARG.Core.Chart;
 using YARG.Core.Input;
 using YARG.Menu.Navigation;
+using YARG.Settings;
 
 namespace YARG.Gameplay.HUD
 {
@@ -35,17 +36,24 @@ namespace YARG.Gameplay.HUD
             get => _hoveredIndex;
             private set
             {
-                if (value > _sections.Count - 1)
+                if (SettingsManager.Settings.WrapAroundNavigation.Value)
                 {
-                    _hoveredIndex = 0;
-                }
-                else if (value < 0)
-                {
-                    _hoveredIndex = _sections.Count - 1;
+                    if (value > _sections.Count - 1)
+                    {
+                        _hoveredIndex = 0;
+                    }
+                    else if (value < 0)
+                    {
+                        _hoveredIndex = _sections.Count - 1;
+                    }
+                    else
+                    {
+                        _hoveredIndex = value;
+                    }
                 }
                 else
                 {
-                    _hoveredIndex = value;
+                     _hoveredIndex = Mathf.Clamp(value, 0, _sections.Count - 1);
                 }
 
                 UpdateSectionViews();

--- a/Assets/Script/Gameplay/HUD/Practice/PracticeSectionMenu.cs
+++ b/Assets/Script/Gameplay/HUD/Practice/PracticeSectionMenu.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.InputSystem;
 using YARG.Core.Chart;
@@ -17,6 +18,7 @@ namespace YARG.Gameplay.HUD
 
         private bool _navigationPushed;
         private bool _hasSelectedSections;
+        private bool _allowWrapAround;
 
         private List<Section> _sections;
         public IReadOnlyList<Section> Sections => _sections;
@@ -36,7 +38,7 @@ namespace YARG.Gameplay.HUD
             get => _hoveredIndex;
             private set
             {
-                if (SettingsManager.Settings.WrapAroundNavigation.Value)
+                if (_allowWrapAround)
                 {
                     if (value > _sections.Count - 1)
                     {
@@ -142,8 +144,14 @@ namespace YARG.Gameplay.HUD
             {
                 new NavigationScheme.Entry(MenuAction.Green, "Confirm", Confirm),
                 new NavigationScheme.Entry(MenuAction.Red, "Back", Back),
-                new NavigationScheme.Entry(MenuAction.Up, "Up", Up),
-                new NavigationScheme.Entry(MenuAction.Down, "Down", Down)
+                new NavigationScheme.Entry(MenuAction.Up, "Up", ctx => {
+                    _allowWrapAround = !ctx.IsRepeat && SettingsManager.Settings.WrapAroundNavigation.Value;
+                    HoveredIndex--;
+                }),
+                new NavigationScheme.Entry(MenuAction.Down, "Down", ctx => {
+                    _allowWrapAround = !ctx.IsRepeat && SettingsManager.Settings.WrapAroundNavigation.Value;
+                    HoveredIndex++;
+                })
             }, false));
 
 
@@ -192,16 +200,6 @@ namespace YARG.Gameplay.HUD
                     _pauseMenuManager.PushMenu(PauseMenuManager.Menu.PracticePause);
                 }
             }
-        }
-
-        private void Up()
-        {
-            HoveredIndex--;
-        }
-
-        private void Down()
-        {
-            HoveredIndex++;
         }
 
         private void Update()

--- a/Assets/Script/Menu/Common/ListMenu/ListMenu.cs
+++ b/Assets/Script/Menu/Common/ListMenu/ListMenu.cs
@@ -40,9 +40,17 @@ namespace YARG.Menu.ListMenu
                 {
                     _selectedIndex = 0;
                 }
+                else if (value > _viewList.Count - 1)
+                {
+                    _selectedIndex = 0;
+                }
+                else if (value < 0)
+                {
+                    _selectedIndex = _viewList.Count - 1;
+                }
                 else
                 {
-                    _selectedIndex = Mathf.Clamp(value, 0, _viewList.Count - 1);
+                    _selectedIndex = value;
                 }
 
                 OnSelectedIndexChanged();

--- a/Assets/Script/Menu/Common/ListMenu/ListMenu.cs
+++ b/Assets/Script/Menu/Common/ListMenu/ListMenu.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.InputSystem;
 using UnityEngine.UI;
+using YARG.Settings;
 
 namespace YARG.Menu.ListMenu
 {
@@ -40,17 +41,26 @@ namespace YARG.Menu.ListMenu
                 {
                     _selectedIndex = 0;
                 }
-                else if (value > _viewList.Count - 1)
+                else if (SettingsManager.Settings.WrapAroundNavigation.Value)
                 {
-                    _selectedIndex = 0;
-                }
-                else if (value < 0)
-                {
-                    _selectedIndex = _viewList.Count - 1;
+                    // Wrap to bottom/top of list when moving past the start/end range
+                    if (value > _viewList.Count - 1)
+                    {
+                        _selectedIndex = 0;
+                    }
+                    else if (value < 0)
+                    {
+                        _selectedIndex = _viewList.Count - 1;
+                    }
+                    else
+                    {
+                        _selectedIndex = value;
+                    }
                 }
                 else
                 {
-                    _selectedIndex = value;
+                    // Do not allow selection to move past the start or end range
+                    _selectedIndex = Mathf.Clamp(value, 0, _viewList.Count - 1);
                 }
 
                 OnSelectedIndexChanged();

--- a/Assets/Script/Menu/Common/ListMenu/ListMenu.cs
+++ b/Assets/Script/Menu/Common/ListMenu/ListMenu.cs
@@ -136,7 +136,7 @@ namespace YARG.Menu.ListMenu
             SelectedIndex = Mathf.FloorToInt(_scrollbar.value * (_viewList.Count - 1));
         }
 
-        public void SetWrapAroundState (bool newState)
+        public void SetWrapAroundState(bool newState)
         {
             if (SettingsManager.Settings.WrapAroundNavigation.Value)
             {

--- a/Assets/Script/Menu/Common/ListMenu/ListMenu.cs
+++ b/Assets/Script/Menu/Common/ListMenu/ListMenu.cs
@@ -29,6 +29,8 @@ namespace YARG.Menu.ListMenu
         private List<TViewType> _viewList;
         private readonly List<TViewObject> _viewObjects = new();
 
+        private bool _allowWrapAround;
+
         public IReadOnlyList<TViewType> ViewList => _viewList;
 
         private int _selectedIndex;
@@ -41,7 +43,7 @@ namespace YARG.Menu.ListMenu
                 {
                     _selectedIndex = 0;
                 }
-                else if (SettingsManager.Settings.WrapAroundNavigation.Value)
+                else if (_allowWrapAround)
                 {
                     // Wrap to bottom/top of list when moving past the start/end range
                     if (value > _viewList.Count - 1)
@@ -132,6 +134,18 @@ namespace YARG.Menu.ListMenu
         public void OnScrollBarChange()
         {
             SelectedIndex = Mathf.FloorToInt(_scrollbar.value * (_viewList.Count - 1));
+        }
+
+        public void SetWrapAroundState (bool newState)
+        {
+            if (SettingsManager.Settings.WrapAroundNavigation.Value)
+            {
+                _allowWrapAround = newState;
+            }
+            else if (_allowWrapAround)
+            {
+                _allowWrapAround = false;
+            }
         }
 
         private void UpdateScrollbar()

--- a/Assets/Script/Menu/History/HistoryMenu.cs
+++ b/Assets/Script/Menu/History/HistoryMenu.cs
@@ -47,9 +47,15 @@ namespace YARG.Menu.History
             Navigator.Instance.PushScheme(new NavigationScheme(new()
             {
                 new NavigationScheme.Entry(MenuAction.Up, "Up",
-                    () => SelectedIndex--),
+                    ctx => {
+                        SetWrapAroundState(!ctx.IsRepeat);
+                        SelectedIndex--;
+                    }),
                 new NavigationScheme.Entry(MenuAction.Down, "Down",
-                    () => SelectedIndex++),
+                    ctx => {
+                        SetWrapAroundState(!ctx.IsRepeat);
+                        SelectedIndex++;
+                    }),
                 new NavigationScheme.Entry(MenuAction.Green, "Confirm",
                     () => CurrentSelection?.ViewClick()),
 

--- a/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
+++ b/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
@@ -98,19 +98,27 @@ namespace YARG.Menu.MusicLibrary
                     ctx =>
                     {
                         if (IsButtonHeldByPlayer(ctx.Player, MenuAction.Orange))
+                        {
                             GoToPreviousSection();
+                        }
                         else
+                        {
                             SetWrapAroundState(!ctx.IsRepeat);
                             SelectedIndex--;
+                        }
                     }),
                 new NavigationScheme.Entry(MenuAction.Down, "Down",
                     ctx =>
                     {
                         if (IsButtonHeldByPlayer(ctx.Player, MenuAction.Orange))
+                        {
                             GoToNextSection();
+                        }
                         else
+                        {
                             SetWrapAroundState(!ctx.IsRepeat);
                             SelectedIndex++;
+                        }
                     }),
                 new NavigationScheme.Entry(MenuAction.Green, "Confirm",
                     () => CurrentSelection?.PrimaryButtonClick()),

--- a/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
+++ b/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
@@ -100,6 +100,7 @@ namespace YARG.Menu.MusicLibrary
                         if (IsButtonHeldByPlayer(ctx.Player, MenuAction.Orange))
                             GoToPreviousSection();
                         else
+                            SetWrapAroundState(!ctx.IsRepeat);
                             SelectedIndex--;
                     }),
                 new NavigationScheme.Entry(MenuAction.Down, "Down",
@@ -108,6 +109,7 @@ namespace YARG.Menu.MusicLibrary
                         if (IsButtonHeldByPlayer(ctx.Player, MenuAction.Orange))
                             GoToNextSection();
                         else
+                            SetWrapAroundState(!ctx.IsRepeat);
                             SelectedIndex++;
                     }),
                 new NavigationScheme.Entry(MenuAction.Green, "Confirm",

--- a/Assets/Script/Menu/Navigation/NavigationGroup.cs
+++ b/Assets/Script/Menu/Navigation/NavigationGroup.cs
@@ -148,7 +148,7 @@ namespace YARG.Menu.Navigation
             {
                 if (!isHeld && SettingsManager.Settings.WrapAroundNavigation.Value)
                 {
-                    SelectFirst();
+                    SelectAt(0, SelectionOrigin.Navigation);
                 }
                 return;
             }
@@ -170,7 +170,7 @@ namespace YARG.Menu.Navigation
             {
                 if (!isHeld && SettingsManager.Settings.WrapAroundNavigation.Value)
                 {
-                    SelectLast();
+                    SelectAt(_navigatables.Count - 1, SelectionOrigin.Navigation);
                 }
                 return;
             }

--- a/Assets/Script/Menu/Navigation/NavigationGroup.cs
+++ b/Assets/Script/Menu/Navigation/NavigationGroup.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 using YARG.Core.Logging;
+using YARG.Settings;
 
 namespace YARG.Menu.Navigation
 {
@@ -145,7 +146,10 @@ namespace YARG.Menu.Navigation
             // If the selection will go out of range...
             if (SelectedIndex is not { } selected || selected < 0 || selected >= _navigatables.Count - 1)
             {
-                SelectFirst();
+                if (SettingsManager.Settings.WrapAroundNavigation.Value)
+                {
+                    SelectFirst();
+                }
                 return;
             }
 
@@ -164,7 +168,10 @@ namespace YARG.Menu.Navigation
             // If the selection is invalid...
             if (SelectedIndex is not { } selected || selected <= 0)
             {
-                SelectLast();
+                if (SettingsManager.Settings.WrapAroundNavigation.Value)
+                {
+                    SelectLast();
+                }
                 return;
             }
 

--- a/Assets/Script/Menu/Navigation/NavigationGroup.cs
+++ b/Assets/Script/Menu/Navigation/NavigationGroup.cs
@@ -145,6 +145,7 @@ namespace YARG.Menu.Navigation
             // If the selection will go out of range...
             if (SelectedIndex is not { } selected || selected < 0 || selected >= _navigatables.Count - 1)
             {
+                SelectFirst();
                 return;
             }
 
@@ -163,6 +164,7 @@ namespace YARG.Menu.Navigation
             // If the selection is invalid...
             if (SelectedIndex is not { } selected || selected <= 0)
             {
+                SelectLast();
                 return;
             }
 

--- a/Assets/Script/Menu/Navigation/NavigationGroup.cs
+++ b/Assets/Script/Menu/Navigation/NavigationGroup.cs
@@ -134,7 +134,7 @@ namespace YARG.Menu.Navigation
             SelectAt(_navigatables.Count - 1);
         }
 
-        public void SelectNext()
+        public void SelectNext(bool isHeld = false)
         {
             // Allows the user to quickly select an option without needing mouse
             if (SelectedIndex is null)
@@ -146,7 +146,7 @@ namespace YARG.Menu.Navigation
             // If the selection will go out of range...
             if (SelectedIndex is not { } selected || selected < 0 || selected >= _navigatables.Count - 1)
             {
-                if (SettingsManager.Settings.WrapAroundNavigation.Value)
+                if (!isHeld && SettingsManager.Settings.WrapAroundNavigation.Value)
                 {
                     SelectFirst();
                 }
@@ -156,7 +156,7 @@ namespace YARG.Menu.Navigation
             SelectAt(selected + 1, SelectionOrigin.Navigation);
         }
 
-        public void SelectPrevious()
+        public void SelectPrevious(bool isHeld = false)
         {
             // Allows the user to quickly select an option without needing mouse
             if (SelectedIndex is null)
@@ -168,7 +168,7 @@ namespace YARG.Menu.Navigation
             // If the selection is invalid...
             if (SelectedIndex is not { } selected || selected <= 0)
             {
-                if (SettingsManager.Settings.WrapAroundNavigation.Value)
+                if (!isHeld && SettingsManager.Settings.WrapAroundNavigation.Value)
                 {
                     SelectLast();
                 }

--- a/Assets/Script/Menu/Navigation/NavigationScheme.cs
+++ b/Assets/Script/Menu/Navigation/NavigationScheme.cs
@@ -9,14 +9,14 @@ namespace YARG.Menu.Navigation
     {
         public readonly struct Entry
         {
-            public static readonly Entry NavigateUp = new(MenuAction.Up, "Up", () =>
+            public static readonly Entry NavigateUp = new(MenuAction.Up, "Up", context =>
             {
-                NavigationGroup.CurrentNavigationGroup.SelectPrevious();
+                NavigationGroup.CurrentNavigationGroup.SelectPrevious(context.IsRepeat);
             });
 
-            public static readonly Entry NavigateDown = new(MenuAction.Down, "Down", () =>
+            public static readonly Entry NavigateDown = new(MenuAction.Down, "Down", context =>
             {
-                NavigationGroup.CurrentNavigationGroup.SelectNext();
+                NavigationGroup.CurrentNavigationGroup.SelectNext(context.IsRepeat);
             });
 
             public static readonly Entry NavigateSelect = new(MenuAction.Green, "Confirm", () =>

--- a/Assets/Script/Settings/SettingsManager.Settings.cs
+++ b/Assets/Script/Settings/SettingsManager.Settings.cs
@@ -74,6 +74,7 @@ namespace YARG.Settings
             public ToggleSetting PauseOnDeviceDisconnect { get; } = new(true);
             public ToggleSetting PauseOnFocusLoss { get; } = new(true);
 
+            public ToggleSetting WrapAroundNavigation { get; } = new(false);
             public ToggleSetting AmIAwesome { get; } = new(false);
 
             #endregion

--- a/Assets/Script/Settings/SettingsManager.cs
+++ b/Assets/Script/Settings/SettingsManager.cs
@@ -42,6 +42,7 @@ namespace YARG.Settings
                 nameof(Settings.ShowCursorTimer),
                 nameof(Settings.PauseOnDeviceDisconnect),
                 nameof(Settings.PauseOnFocusLoss),
+                nameof(Settings.WrapAroundNavigation),
                 nameof(Settings.AmIAwesome),
             },
             new SongManagerTab("SongManager", icon: "Songs")

--- a/Assets/Settings/Localization/Settings Shared Data.asset
+++ b/Assets/Settings/Localization/Settings Shared Data.asset
@@ -1435,6 +1435,14 @@ MonoBehaviour:
     m_Key: Setting.DMXDimmerValues.Description
     m_Metadata:
       m_Items: []
+  - m_Id: 164946747873472512
+    m_Key: Setting.WrapAroundNavigation
+    m_Metadata:
+      m_Items: []
+  - m_Id: 164947486993723392
+    m_Key: Setting.WrapAroundNavigation.Description
+    m_Metadata:
+      m_Items: []
   m_Metadata:
     m_Items: []
   m_KeyGenerator:

--- a/Assets/Settings/Localization/Settings_en-US.asset
+++ b/Assets/Settings/Localization/Settings_en-US.asset
@@ -1544,6 +1544,15 @@ MonoBehaviour:
       willl be set to when YARG starts.
     m_Metadata:
       m_Items: []
+  - m_Id: 164946747873472512
+    m_Localized: Wrap-Around Navigation
+    m_Metadata:
+      m_Items: []
+  - m_Id: 164947486993723392
+    m_Localized: Allow menus to jump to the bottom of a list when scrolling past
+      the top, or jump to the top of a list when scrolling past the bottom.
+    m_Metadata:
+      m_Items: []
   references:
     version: 2
     RefIds: []


### PR DESCRIPTION
Replaced clamp functions on nav selection index. More lines, but arguably better for UX. Addresses issue [YARG-178](https://yarg.youtrack.cloud/issue/YARG-178/Allow-wrap-around-when-navigating-lists-with-a-controller)