### PR TITLE
Fixed 'sluggish' stage kit lights

### DIFF
--- a/Assets/Script/Settings/SettingsManager.Settings.cs
+++ b/Assets/Script/Settings/SettingsManager.Settings.cs
@@ -362,6 +362,11 @@ namespace YARG.Settings
 
             private static void StageKitEnabledCallback(bool value)
             {
+                //To avoid being toggled on twice at start
+                if (!IsInitialized)
+                {
+                    return;
+                }
                 StageKitHardware.Instance.HandleEnabledChanged(value);
             }
 


### PR DESCRIPTION
If enabled, it would run twice at start.