### PR TITLE
Global Keyboard Navigation

### DIFF
--- a/Assets/Script/Menu/Navigation/Navigator.cs
+++ b/Assets/Script/Menu/Navigation/Navigator.cs
@@ -61,8 +61,6 @@ namespace YARG.Menu.Navigation
             MenuAction.Right,
         };
 
-        private static Keyboard menuKeyboard;
-
         private static Dictionary<Key, MenuAction> KeyboardMenuActions = new()
         {
             { Key.UpArrow, MenuAction.Up },


### PR DESCRIPTION
I've implemented basic global keyboard navigation for the following keys:

```
Key.UpArrow = MenuAction.Up
Key.DownArrow = MenuAction.Down
Key.LeftArrow = MenuAction.Left
Key.RightArrow = MenuAction.Right
Key.Enter = MenuAction.Green
Key.Escape = MenuAction.Red
```

When pressed, these keys simulate the specified input action for the first player. It works on all screens and does not require binding.

I'm happy with this and would like to see it merged, but I'd also like to start a conversation about more enhanced input.

For example, I'd love to see Page Down go to Next Section and Page Up go to Previous Section in the Music list. Unfortunately, there is no MenuAction for Next and Previous Section. This is currently implemented as a combo of holding Orange plus Up or Down. I was able to simulate holding and releasing Orange, but because this happens so quickly the popup menu appears. This is due to using a timer on Orange.

Ideally, I would prefer to see MenuActions added for Next Section and Previous Section. This could work on many menus (including settings) but it would require an update to Yarg.Core. I'm seeking input on this change. I could include it as part of this PR or as a separate one.