### PR TITLE
Added a localization entry for Menu.Common.Continue

### DIFF
--- a/Assets/StreamingAssets/lang/en-US.json
+++ b/Assets/StreamingAssets/lang/en-US.json
@@ -107,6 +107,7 @@
             "Cancel": "Cancel",
             "Close": "Close",
             "Confirm": "Confirm",
+            "Continue": "Continue",
             "Delete": "Delete",
             "Max": "Max",
             "Min": "Min",


### PR DESCRIPTION
This was already being referenced by ScoreScreenMenu and was coming up blank.