### PR TITLE
Disable SP in practice

### DIFF
--- a/Assets/Script/Gameplay/Player/Vocals/VocalTrack.Spawning.cs
+++ b/Assets/Script/Gameplay/Player/Vocals/VocalTrack.Spawning.cs
@@ -158,7 +158,7 @@ namespace YARG.Gameplay.Player
                 if (!_lyricContainer.TrySpawnLyric(
                     tracker.CurrentLyric,
                     tracker.GetProbableNoteAtLyric(),
-                    tracker.CurrentPhrase.IsStarPower,
+                    AllowStarPower && tracker.CurrentPhrase.IsStarPower,
                     harmonyIndex))
                 {
                     tracker.NextLyric();

--- a/Assets/Script/Gameplay/Player/Vocals/VocalTrack.cs
+++ b/Assets/Script/Gameplay/Player/Vocals/VocalTrack.cs
@@ -104,6 +104,8 @@ namespace YARG.Gameplay.Player
 
         public bool HarmonyShowing => _vocalsTrack.Instrument == Instrument.Harmony;
 
+        public bool AllowStarPower;
+
         public float CurrentNoteWidth =>
             ((_currentTrackTop - TRACK_BOTTOM) / (_viewRange.Max - _viewRange.Min)) * NOTE_WIDTH_MULTIPLIER;
 
@@ -193,6 +195,8 @@ namespace YARG.Gameplay.Player
 
             // Hide overlay
             _starpowerMaterial.SetFloat(_alphaMultiplier, 0f);
+
+            AllowStarPower = true;
         }
 
         public VocalsPlayer CreatePlayer()

--- a/Assets/Script/Gameplay/PracticeManager.cs
+++ b/Assets/Script/Gameplay/PracticeManager.cs
@@ -4,6 +4,7 @@ using YARG.Core.Chart;
 using YARG.Core.Input;
 using YARG.Gameplay.HUD;
 using YARG.Menu.Navigation;
+using YARG.Settings;
 
 namespace YARG.Gameplay
 {
@@ -141,10 +142,13 @@ namespace YARG.Gameplay
             TimeStart = timeStart;
             TimeEnd = timeEnd;
 
+            bool allowPracticeSP = SettingsManager.Settings.EnablePracticeSP.Value;
             foreach (var player in GameManager.Players)
             {
                 player.SetPracticeSection(tickStart, tickEnd);
+                player.BaseEngine.AllowStarPower(allowPracticeSP);
             }
+
             GameManager.VocalTrack.SetPracticeSection(tickStart, tickEnd);
 
             GameManager.SetSongTime(timeStart);

--- a/Assets/Script/Gameplay/PracticeManager.cs
+++ b/Assets/Script/Gameplay/PracticeManager.cs
@@ -149,6 +149,7 @@ namespace YARG.Gameplay
                 player.BaseEngine.AllowStarPower(allowPracticeSP);
             }
 
+            GameManager.VocalTrack.AllowStarPower = allowPracticeSP;
             GameManager.VocalTrack.SetPracticeSection(tickStart, tickEnd);
 
             GameManager.SetSongTime(timeStart);

--- a/Assets/Script/Settings/SettingsManager.Settings.cs
+++ b/Assets/Script/Settings/SettingsManager.Settings.cs
@@ -203,6 +203,7 @@ namespace YARG.Settings
 
             public ToggleSetting ShowHitWindow { get; } = new(false, ShowHitWindowCallback);
             public ToggleSetting DisableTextNotifications { get; } = new(false);
+            public ToggleSetting EnablePracticeSP { get; } = new(false);
 
             public DropdownSetting<NoteStreakFrequencyMode> NoteStreakFrequency { get; }
                 = new(NoteStreakFrequencyMode.Frequent)

--- a/Assets/Script/Settings/SettingsManager.cs
+++ b/Assets/Script/Settings/SettingsManager.cs
@@ -119,6 +119,7 @@ namespace YARG.Settings
                 new HeaderMetadata("Other"),
                 nameof(Settings.ShowHitWindow),
                 nameof(Settings.DisableTextNotifications),
+                nameof(Settings.EnablePracticeSP),
                 nameof(Settings.NoteStreakFrequency),
                 nameof(Settings.LyricDisplay),
                 nameof(Settings.SongTimeOnScoreBox),

--- a/Assets/StreamingAssets/lang/en-US.json
+++ b/Assets/StreamingAssets/lang/en-US.json
@@ -537,7 +537,7 @@
             },
             "EnablePracticeSP": {
                 "Name": "Star Power in Practice",
-                "Description": "Allow Star Power phrases and activation while in Practice Mode."
+                "Description": "Allow Star Power phrases while in Practice Mode."
             },
             "FpsCap": {
                 "Name": "FPS Cap",

--- a/Assets/StreamingAssets/lang/en-US.json
+++ b/Assets/StreamingAssets/lang/en-US.json
@@ -492,7 +492,7 @@
             },
             "DisableTextNotifications": {
                 "Name": "Disable Text Notifications",
-                "Description": "Disables text notification on the track such as \"100-Note Streak\" and \"Full Combo."
+                "Description": "Disables text notification on the track such as \"100-Note Streak\" and \"Full Combo.\""
             },
             "DMXBlueChannels": {
                 "Name": "DMX Blue",

--- a/Assets/StreamingAssets/lang/en-US.json
+++ b/Assets/StreamingAssets/lang/en-US.json
@@ -535,6 +535,10 @@
                 "PauseName": "Drums",
                 "Description": "Adjusts the song's drum track volume. Only does something if the song is multi-track."
             },
+            "EnablePracticeSP": {
+                "Name": "Star Power in Practice",
+                "Description": "Allow Star Power phrases and activation while in Practice Mode."
+            },
             "FpsCap": {
                 "Name": "FPS Cap",
                 "Description": "The framerate cap. <color=white>YOU DO NOT NEED TO PLAY YARG ON 1000FPS.</color> VSync recommended."


### PR DESCRIPTION
Adds a setting to automatically strip star power from notes while in Practice mode. On by default.

Requires YARG.Core branch `disable-sp-core` to run