### PR TITLE
Music Library UX improvements

### DIFF
--- a/Assets/Script/Menu/Common/ListMenu/ListMenu.cs
+++ b/Assets/Script/Menu/Common/ListMenu/ListMenu.cs
@@ -111,19 +111,19 @@ namespace YARG.Menu.ListMenu
 
         /// <summary>
         /// Sets the <see cref="SelectedIndex"/> to the first match (via the <paramref name="predicate"/>).
-        /// If the <paramref name="offset"/> is specified, it will offset the select index by that amount.
+        /// If the <paramref name="searchStartIndex"/> is specified, it will offset the select index by that amount.
         /// If nothing is found, the index remains unchanged.
         /// </summary>
         /// <returns>
         /// Whether or not the index was set.
         /// </returns>
-        protected bool SetIndexTo(Predicate<TViewType> predicate, int offset = 0)
+        protected bool SetIndexTo(Predicate<TViewType> predicate, int searchStartIndex = 0)
         {
-            for (int i = 0; i < _viewList.Count; i++)
+            for (int i = searchStartIndex; i < _viewList.Count; i++)
             {
                 if (predicate(_viewList[i]))
                 {
-                    SelectedIndex = i + offset;
+                    SelectedIndex = i;
                     return true;
                 }
             }

--- a/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
+++ b/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
@@ -71,6 +71,8 @@ namespace YARG.Menu.MusicLibrary
         protected override int ExtraListViewPadding => 15;
         protected override bool CanScroll => !_popupMenu.gameObject.activeSelf;
 
+        public bool HasSortHeaders { get; private set; }
+
         private SongCategory[] _sortedSongs;
         private IEnumerable<IGrouping<string, (ViewType, int)>> _shortcutQuery;
 
@@ -209,12 +211,11 @@ namespace YARG.Menu.MusicLibrary
             // Shortcuts will be re-queried every time the list is refreshed
             _shortcutQuery = null;
 
-            if (SelectedPlaylist is not null)
-            {
-                return CreatePlaylistViewList();
-            }
+            var viewList = (SelectedPlaylist is not null) ? CreatePlaylistViewList() : CreateNormalViewList();
 
-            return CreateNormalViewList();
+            HasSortHeaders = viewList.Any(x => x is SortHeaderViewType);
+
+            return viewList;
         }
 
         private List<ViewType> CreateNormalViewList()

--- a/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
+++ b/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
@@ -258,7 +258,7 @@ namespace YARG.Menu.MusicLibrary
                         displayName = SongSources.Default.GetDisplayName();
                     }
                 }
-                list.Add(new SortHeaderViewType(displayName, section.Songs.Length, section.Shortcut));
+                list.Add(new SortHeaderViewType(displayName, section.Songs.Length, section.CategoryGroup));
 
                 // Add all of the songs
                 list.AddRange(section.Songs.Select(song => new SongViewType(this, song)));

--- a/Assets/Script/Menu/MusicLibrary/PopupMenu.cs
+++ b/Assets/Script/Menu/MusicLibrary/PopupMenu.cs
@@ -1,4 +1,4 @@
-using System.Linq;
+﻿using System.Linq;
 using TMPro;
 using UnityEngine;
 using UnityEngine.Events;
@@ -111,11 +111,13 @@ namespace YARG.Menu.MusicLibrary
                 gameObject.SetActive(false);
             });
 
-            CreateItem("SortBy", SettingsManager.Settings.LibrarySort.ToLocalizedName(), () =>
+            if (_musicLibrary.HasSortHeaders)
             {
-                _menuState = State.SortSelect;
-                UpdateForState();
-            });
+                CreateItem("Sort By: " + SettingsManager.Settings.LibrarySort.ToLocalizedName(), () =>
+                {
+                    _menuState = State.SortSelect;
+                    UpdateForState();
+                });
 
             CreateItem("GoToSection", () =>
             {

--- a/Assets/Script/Menu/MusicLibrary/PopupMenu.cs
+++ b/Assets/Script/Menu/MusicLibrary/PopupMenu.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using TMPro;
 using UnityEngine;
 using UnityEngine.Events;
@@ -215,41 +215,14 @@ namespace YARG.Menu.MusicLibrary
         {
             SetLocalizedHeader("GoTo");
 
-            if (SettingsManager.Settings.LibrarySort
-                is SortAttribute.Artist
-                or SortAttribute.Album
-                or SortAttribute.Artist_Album)
+            foreach (var headerGroup in _musicLibrary.GetShortcuts())
             {
-
-                foreach (var (header, index) in _musicLibrary.GetSections()
-                    .GroupBy(x => GetGroupChar(x.Item1).ToAsciiUpper())
-                    .Select(g => g.First()))
+                int firstHeaderIndexInGroup = headerGroup.First().Item2;
+                CreateItem(headerGroup.Key, () =>
                 {
-
-                    CreateItemUnlocalized(GetGroupChar(header).ToString(), () =>
-                    {
-                        _musicLibrary.SelectedIndex = index;
-                        gameObject.SetActive(false);
-                    });
-                }
-            }
-            else
-            {
-                foreach (var (header, index) in _musicLibrary.GetSections())
-                {
-                    CreateItemUnlocalized(((SortHeaderViewType) header).HeaderText, () =>
-                    {
-                        _musicLibrary.SelectedIndex = index;
-                        gameObject.SetActive(false);
-                    });
-                }
-            }
-
-            return;
-
-            static char GetGroupChar(ViewType header)
-            {
-                return SortString.RemoveArticle(((SortHeaderViewType) header).HeaderText)[0];
+                    _musicLibrary.SelectedIndex = firstHeaderIndexInGroup;
+                    gameObject.SetActive(false);
+                });
             }
         }
 

--- a/Assets/Script/Menu/MusicLibrary/PopupMenu.cs
+++ b/Assets/Script/Menu/MusicLibrary/PopupMenu.cs
@@ -113,12 +113,13 @@ namespace YARG.Menu.MusicLibrary
 
             if (_musicLibrary.HasSortHeaders)
             {
-                CreateItem("Sort By: " + SettingsManager.Settings.LibrarySort.ToLocalizedName(), () =>
+                CreateItem("SortBy", SettingsManager.Settings.LibrarySort.ToLocalizedName(), () =>
                 {
                     _menuState = State.SortSelect;
                     UpdateForState();
                 });
-
+            }
+            
             CreateItem("GoToSection", () =>
             {
                 _menuState = State.GoToSection;
@@ -217,12 +218,11 @@ namespace YARG.Menu.MusicLibrary
         {
             SetLocalizedHeader("GoTo");
 
-            foreach (var headerGroup in _musicLibrary.GetShortcuts())
+            foreach (var (name, index) in _musicLibrary.Shortcuts)
             {
-                int firstHeaderIndexInGroup = headerGroup.First().Item2;
-                CreateItem(headerGroup.Key, () =>
+                CreateItemUnlocalized(name, () =>
                 {
-                    _musicLibrary.SelectedIndex = firstHeaderIndexInGroup;
+                    _musicLibrary.SelectedIndex = index;
                     gameObject.SetActive(false);
                 });
             }

--- a/Assets/Script/Menu/MusicLibrary/ViewTypes/SortHeaderViewType.cs
+++ b/Assets/Script/Menu/MusicLibrary/ViewTypes/SortHeaderViewType.cs
@@ -14,12 +14,12 @@ namespace YARG.Menu.MusicLibrary
         public readonly string ShortcutName;
         private readonly int _songCount;
 
-        public SortHeaderViewType(string headerText, int songCount, string shortcutName = null)
+        public SortHeaderViewType(string headerText, int songCount, string shortcutName)
         {
             HeaderText = headerText;
             _songCount = songCount;
-
-            ShortcutName = shortcutName == null ? headerText : shortcutName;
+            
+            ShortcutName = shortcutName;
         }
 
         public override string GetPrimaryText(bool selected)

--- a/Assets/Script/Menu/MusicLibrary/ViewTypes/SortHeaderViewType.cs
+++ b/Assets/Script/Menu/MusicLibrary/ViewTypes/SortHeaderViewType.cs
@@ -11,12 +11,15 @@ namespace YARG.Menu.MusicLibrary
         public override bool UseWiderPrimaryText => true;
 
         public readonly string HeaderText;
+        public readonly string ShortcutName;
         private readonly int _songCount;
 
-        public SortHeaderViewType(string headerText, int songCount)
+        public SortHeaderViewType(string headerText, int songCount, string shortcutName = null)
         {
             HeaderText = headerText;
             _songCount = songCount;
+
+            ShortcutName = shortcutName == null ? headerText : shortcutName;
         }
 
         public override string GetPrimaryText(bool selected)

--- a/Assets/Script/Song/SongContainer.cs
+++ b/Assets/Script/Song/SongContainer.cs
@@ -421,7 +421,7 @@ namespace YARG.Song
             {
                 if (singleCategoryName.Length == 0)
                 {
-                    return "Unknown";
+                    return string.Empty;
                 }
 
                 char first = singleCategoryName[0];

--- a/Assets/Script/Song/SongContainer.cs
+++ b/Assets/Script/Song/SongContainer.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using YARG.Core.Song.Cache;
 using YARG.Core.Song;
 using System;
@@ -406,20 +406,24 @@ namespace YARG.Song
                 return sections;
             }
 
-            static SongCategory[] Cast(SortedDictionary<string, List<SongEntry>> list, bool createCategoryGroups = false)
+            static SongCategory[] Cast(SortedDictionary<string, List<SongEntry>> list)
             {
                 var sections = new SongCategory[list.Count];
                 int index = 0;
                 foreach (var (key, section) in list)
                 {
-                    string categoryGroupName = createCategoryGroups ? GenerateGroupName(SortString.RemoveArticle(key)) : key;
-                    sections[index++] = new SongCategory(key, section.ToArray(), categoryGroupName);
+                    sections[index++] = new SongCategory(key, section.ToArray(), key);
                 }
                 return sections;
             }
 
             static string GenerateGroupName(string singleCategoryName)
             {
+                if (singleCategoryName.Length == 0)
+                {
+                    return "Unknown";
+                }
+
                 char first = singleCategoryName[0];
 
                 if (char.IsLetter(first))
@@ -432,7 +436,7 @@ namespace YARG.Song
                 }
                 else
                 {
-                    return ".";
+                    return first.ToString();
                 }
             }
         }

--- a/Assets/Script/Song/SongContainer.cs
+++ b/Assets/Script/Song/SongContainer.cs
@@ -57,34 +57,34 @@ namespace YARG.Song
     public readonly struct SongCategory
     {
         public readonly string Category;
-        public readonly string Shortcut;
+        public readonly string CategoryGroup;
         public readonly SongEntry[] Songs;
 
-        public SongCategory(string category, SongEntry[] songs, bool createShortcut = false)
+        public SongCategory(string category, SongEntry[] songs, bool createGroup = false)
         {
             Category = category;
             Songs = songs;
 
-            if (createShortcut)
+            if (createGroup)
             {
                 char firstChar = SortString.RemoveArticle(category)[0];
 
                 if (char.IsLetter(firstChar))
                 {
-                    Shortcut = firstChar.ToAsciiUpper().ToString();
+                    CategoryGroup = firstChar.ToAsciiUpper().ToString();
                 }
                 else if (char.IsDigit(firstChar))
                 {
-                    Shortcut = "0-9";
+                    CategoryGroup = "0-9";
                 }
                 else
                 {
-                    Shortcut = ".";
+                    CategoryGroup = ".";
                 }
             }
             else
             {
-                Shortcut = category;
+                CategoryGroup = category;
             }
         }
 
@@ -340,16 +340,16 @@ namespace YARG.Song
         private static void FillContainers()
         {
             _songs = SetAllSongs(_songCache.Entries);
-            _sortArtists   = Convert(_songCache.Artists, SongAttribute.Artist, createShortcuts:true);
-            _sortAlbums    = Convert(_songCache.Albums, SongAttribute.Album, createShortcuts:true);
+            _sortArtists   = Convert(_songCache.Artists, SongAttribute.Artist, createCategoryGroups:true);
+            _sortAlbums    = Convert(_songCache.Albums, SongAttribute.Album, createCategoryGroups:true);
             _sortGenres    = Convert(_songCache.Genres, SongAttribute.Genre);
-            _sortCharters  = Convert(_songCache.Charters, SongAttribute.Charter, createShortcuts:true);
+            _sortCharters  = Convert(_songCache.Charters, SongAttribute.Charter, createCategoryGroups:true);
             _sortPlaylists = Convert(_songCache.Playlists, SongAttribute.Playlist);
             _sortSources   = Convert(_songCache.Sources, SongAttribute.Source);
 
             _sortTitles       = Cast(_songCache.Titles);
             _sortYears        = Cast(_songCache.Years);
-            _sortArtistAlbums = Cast(_songCache.ArtistAlbums, createShortcuts:true);
+            _sortArtistAlbums = Cast(_songCache.ArtistAlbums, createCategoryGroups:true);
             _sortSongLengths  = Cast(_songCache.SongLengths);
             _playables = null;
 
@@ -403,7 +403,7 @@ namespace YARG.Song
                 return songs;
             }
 
-            static SongCategory[] Convert(SortedDictionary<SortString, List<SongEntry>> list, SongAttribute attribute, bool createShortcuts = false)
+            static SongCategory[] Convert(SortedDictionary<SortString, List<SongEntry>> list, SongAttribute attribute, bool createCategoryGroups = false)
             {
                 var sections = new SongCategory[list.Count];
                 int index = 0;
@@ -416,18 +416,18 @@ namespace YARG.Song
                         if (node.Key.Length > 1)
                             key += node.Key.Str[1..];
                     }
-                    sections[index++] = new SongCategory(key, node.Value.ToArray(), createShortcuts);
+                    sections[index++] = new SongCategory(key, node.Value.ToArray(), createCategoryGroups);
                 }
                 return sections;
             }
 
-            static SongCategory[] Cast(SortedDictionary<string, List<SongEntry>> list, bool createShortcuts = false)
+            static SongCategory[] Cast(SortedDictionary<string, List<SongEntry>> list, bool createCategoryGroups = false)
             {
                 var sections = new SongCategory[list.Count];
                 int index = 0;
                 foreach (var section in list)
                 {
-                    sections[index++] = new SongCategory(section.Key, section.Value.ToArray(), createShortcuts);
+                    sections[index++] = new SongCategory(section.Key, section.Value.ToArray(), createCategoryGroups);
                 }
                 return sections;
             }

--- a/Assets/Script/Song/SongSearching.cs
+++ b/Assets/Script/Song/SongSearching.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using YARG.Core;
@@ -6,6 +6,7 @@ using YARG.Core.Logging;
 using YARG.Core.Song;
 using YARG.Helpers.Extensions;
 using YARG.Player;
+using YARG.Settings;
 
 namespace YARG.Song
 {
@@ -275,14 +276,13 @@ namespace YARG.Song
                 {
                     entriesToSearch.AddRange(entry.Songs);
                 }
-                return new SongCategory[] { new("Search Results", UnspecifiedSearch(filter, entriesToSearch)) };
+                return new SongCategory[] { new("Search Results", UnspecifiedSearch(filter, entriesToSearch), null)};
             }
 
             if (filter.Attribute >= SortAttribute.FiveFretGuitar)
             {
                 return SearchInstrument(filter, searchList);
             }
-
 
             var match = GetPredicate(filter);
             var result = new SongCategory[searchList.Length];
@@ -292,7 +292,7 @@ namespace YARG.Song
                 var entries = node.Songs.Where(match).ToArray();
                 if (entries.Length > 0)
                 {
-                    result[count++] = new SongCategory(node.Category, entries);
+                    result[count++] = new SongCategory(node.Category, entries, node.CategoryGroup);
                 }
             }
             return result[..count];
@@ -489,7 +489,7 @@ namespace YARG.Song
                 var songs = node.Songs.Intersect(songsToMatch).ToArray();
                 if (songs.Length > 0)
                 {
-                    result[count++] = new SongCategory(node.Category, songs);
+                    result[count++] = new SongCategory(node.Category, songs, node.CategoryGroup);
                 }
             }
             return result[..count];


### PR DESCRIPTION
- Go To Section popup will now combine entries for Artist/Album/Charter/Artist+Album sorts that begin with either digits or symbols. The logic for creating these groupings will only be run once per song cache build.
- LINQ queries for creating Go To Section shortcuts will only need to run once per Search/Filter/Sort change.
- Sort By and Go To Section popup actions will not be displayed if there are no `SortHeaderViewType` instances in the library (e.g., results from typing in search field)
- Changing Sort By type while highlighting a song in the Recommended Songs section will now jump to that song's position in the main library instead of staying in the recommended section.