### PR TITLE
Library popup hotfix

### DIFF
--- a/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
+++ b/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
@@ -216,7 +216,9 @@ namespace YARG.Menu.MusicLibrary
 
             var viewList = (SelectedPlaylist is not null) ? CreatePlaylistViewList() : CreateNormalViewList();
 
-            HasSortHeaders = viewList.Any(x => x is SortHeaderViewType);
+            // Disable shortcuts if there are less than 2 sort headers in the viewlist
+            HasSortHeaders = viewList.Where(x => x is SortHeaderViewType)
+                             .ElementAtOrDefault(1) != null;
 
             return viewList;
         }

--- a/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
+++ b/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
@@ -217,8 +217,7 @@ namespace YARG.Menu.MusicLibrary
             var viewList = (SelectedPlaylist is not null) ? CreatePlaylistViewList() : CreateNormalViewList();
 
             // Disable shortcuts if there are less than 2 sort headers in the viewlist
-            HasSortHeaders = viewList.Where(x => x is SortHeaderViewType)
-                             .ElementAtOrDefault(1) != null;
+            HasSortHeaders = _sortedSongs is not null && _sortedSongs.Length > 1;
 
             return viewList;
         }

--- a/Assets/Script/Menu/MusicLibrary/PopupMenu.cs
+++ b/Assets/Script/Menu/MusicLibrary/PopupMenu.cs
@@ -111,21 +111,21 @@ namespace YARG.Menu.MusicLibrary
                 gameObject.SetActive(false);
             });
 
+            CreateItem("SortBy", SettingsManager.Settings.LibrarySort.ToLocalizedName(), () =>
+            {
+                _menuState = State.SortSelect;
+                UpdateForState();
+            });
+
             if (_musicLibrary.HasSortHeaders)
             {
-                CreateItem("SortBy", SettingsManager.Settings.LibrarySort.ToLocalizedName(), () =>
+                CreateItem("GoToSection", () =>
                 {
-                    _menuState = State.SortSelect;
+                    _menuState = State.GoToSection;
                     UpdateForState();
                 });
             }
             
-            CreateItem("GoToSection", () =>
-            {
-                _menuState = State.GoToSection;
-                UpdateForState();
-            });
-
             var viewType = _musicLibrary.CurrentSelection;
 
             // Add/remove to favorites


### PR DESCRIPTION
Allow changing library sort when only one sort header is present, prevent *Go To* instead when there aren't enough headers