### PR TITLE
Add note speed reduction by difficulty

### DIFF
--- a/Assets/Script/Gameplay/Player/BasePlayer.cs
+++ b/Assets/Script/Gameplay/Player/BasePlayer.cs
@@ -8,6 +8,7 @@ using YARG.Core.Engine;
 using YARG.Core.Input;
 using YARG.Core.Logging;
 using YARG.Gameplay.HUD;
+using YARG.Helpers.Extensions;
 using YARG.Input;
 using YARG.Player;
 using YARG.Settings;
@@ -27,15 +28,15 @@ namespace YARG.Gameplay.Player
                 // which is saved in the engine parameter override.
                 if (GameManager.IsReplay)
                 {
-                    return Player.Profile.NoteSpeed / (float) Player.EngineParameterOverride.SongSpeed;
+                    return Player.Profile.NoteSpeed * (SettingsManager.Settings.ReduceNoteSpeedByDifficulty.Value ? Player.Profile.CurrentDifficulty.NoteSpeedScale() : 1.0f) / (float) Player.EngineParameterOverride.SongSpeed;
                 }
 
                 if (GameManager.IsPractice && GameManager.SongSpeed < 1)
                 {
-                    return Player.Profile.NoteSpeed;
+                    return Player.Profile.NoteSpeed * (SettingsManager.Settings.ReduceNoteSpeedByDifficulty.Value ? Player.Profile.CurrentDifficulty.NoteSpeedScale() : 1.0f);
                 }
 
-                return Player.Profile.NoteSpeed / GameManager.SongSpeed;
+                return Player.Profile.NoteSpeed * (SettingsManager.Settings.ReduceNoteSpeedByDifficulty.Value ? Player.Profile.CurrentDifficulty.NoteSpeedScale() : 1.0f) / GameManager.SongSpeed;
             }
         }
 

--- a/Assets/Script/Gameplay/Player/BasePlayer.cs
+++ b/Assets/Script/Gameplay/Player/BasePlayer.cs
@@ -28,15 +28,15 @@ namespace YARG.Gameplay.Player
                 // which is saved in the engine parameter override.
                 if (GameManager.IsReplay)
                 {
-                    return Player.Profile.NoteSpeed * (SettingsManager.Settings.ReduceNoteSpeedByDifficulty.Value ? Player.Profile.CurrentDifficulty.NoteSpeedScale() : 1.0f) / (float) Player.EngineParameterOverride.SongSpeed;
+                    return Player.Profile.NoteSpeed * Player.Profile.CurrentDifficulty.NoteSpeedScale() / (float) Player.EngineParameterOverride.SongSpeed;
                 }
 
                 if (GameManager.IsPractice && GameManager.SongSpeed < 1)
                 {
-                    return Player.Profile.NoteSpeed * (SettingsManager.Settings.ReduceNoteSpeedByDifficulty.Value ? Player.Profile.CurrentDifficulty.NoteSpeedScale() : 1.0f);
+                    return Player.Profile.NoteSpeed * Player.Profile.CurrentDifficulty.NoteSpeedScale();
                 }
 
-                return Player.Profile.NoteSpeed * (SettingsManager.Settings.ReduceNoteSpeedByDifficulty.Value ? Player.Profile.CurrentDifficulty.NoteSpeedScale() : 1.0f) / GameManager.SongSpeed;
+                return Player.Profile.NoteSpeed * Player.Profile.CurrentDifficulty.NoteSpeedScale() / GameManager.SongSpeed;
             }
         }
 

--- a/Assets/Script/Helpers/Extensions/DifficultyExtensions.cs
+++ b/Assets/Script/Helpers/Extensions/DifficultyExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using YARG.Core;
+using YARG.Settings;
 
 namespace YARG.Helpers.Extensions
 {
@@ -53,15 +54,20 @@ namespace YARG.Helpers.Extensions
         /// </summary>
         public static float NoteSpeedScale(this Difficulty difficulty)
         {
+            if (!SettingsManager.Settings.ReduceNoteSpeedByDifficulty.Value)
+            {
+                return 1f;
+            }
+            
             return difficulty switch
             {
                 Difficulty.Easy       => 0.421875f,
                 Difficulty.Medium     => 0.5625f,
                 Difficulty.Hard       => 0.75f,
-                Difficulty.Expert     => 1.0f,
-                Difficulty.ExpertPlus => 1.0f,
+                Difficulty.Expert     => 1f,
+                Difficulty.ExpertPlus => 1f,
 
-                _ => 1.0f
+                _ => 1f
             };
         }
     }

--- a/Assets/Script/Helpers/Extensions/DifficultyExtensions.cs
+++ b/Assets/Script/Helpers/Extensions/DifficultyExtensions.cs
@@ -51,9 +51,6 @@ namespace YARG.Helpers.Extensions
         /// Returns the scale by which the note speed should be adjusted
         /// according to the difficulty of the track.
         /// </summary>
-        /// <remarks>
-        /// These multipliers are similar to those in the Rock Band series.
-        /// </remarks>
         public static float NoteSpeedScale(this Difficulty difficulty)
         {
             return difficulty switch

--- a/Assets/Script/Helpers/Extensions/DifficultyExtensions.cs
+++ b/Assets/Script/Helpers/Extensions/DifficultyExtensions.cs
@@ -46,5 +46,26 @@ namespace YARG.Helpers.Extensions
                 _ => "Unknown"
             };
         }
+
+        /// <summary>
+        /// Returns the scale by which the note speed should be adjusted
+        /// according to the difficulty of the track.
+        /// </summary>
+        /// <remarks>
+        /// These multipliers are the same as for the Rock Band series.
+        /// </remarks>
+        public static float NoteSpeedScale(this Difficulty difficulty)
+        {
+            return difficulty switch
+            {
+                Difficulty.Easy       => 0.5f,
+                Difficulty.Medium     => 0.66f,
+                Difficulty.Hard       => 0.83f,
+                Difficulty.Expert     => 1.0f,
+                Difficulty.ExpertPlus => 1.0f,
+
+                _ => 1.0f
+            };
+        }
     }
 }

--- a/Assets/Script/Helpers/Extensions/DifficultyExtensions.cs
+++ b/Assets/Script/Helpers/Extensions/DifficultyExtensions.cs
@@ -52,15 +52,15 @@ namespace YARG.Helpers.Extensions
         /// according to the difficulty of the track.
         /// </summary>
         /// <remarks>
-        /// These multipliers are the same as for the Rock Band series.
+        /// These multipliers are similar to those in the Rock Band series.
         /// </remarks>
         public static float NoteSpeedScale(this Difficulty difficulty)
         {
             return difficulty switch
             {
-                Difficulty.Easy       => 0.5f,
-                Difficulty.Medium     => 0.66f,
-                Difficulty.Hard       => 0.83f,
+                Difficulty.Easy       => 0.421875f,
+                Difficulty.Medium     => 0.5625f,
+                Difficulty.Hard       => 0.75f,
                 Difficulty.Expert     => 1.0f,
                 Difficulty.ExpertPlus => 1.0f,
 

--- a/Assets/Script/Persistent/GlobalVariables.cs
+++ b/Assets/Script/Persistent/GlobalVariables.cs
@@ -49,7 +49,7 @@ namespace YARG
 
         public SceneIndex CurrentScene { get; private set; } = SceneIndex.Persistent;
 
-        public string CurrentVersion { get; private set; } = "v0.12.4";
+        public string CurrentVersion { get; private set; } = "v0.12.5";
 
         protected override void SingletonAwake()
         {

--- a/Assets/Script/Playback/SongRunner.cs
+++ b/Assets/Script/Playback/SongRunner.cs
@@ -353,7 +353,7 @@ namespace YARG.Playback
                     SyncAudioTime = realAudioTime + offset;
                     SyncVisualTime = realVisualTime;
 
-                    if (_pauseSync || SyncVisualTime < offset)
+                    if (_pauseSync || SyncVisualTime < offset || SyncVisualTime >= (_mixer.Length + offset))
                     {
                         continue;
                     }

--- a/Assets/Script/Playback/SongRunner.cs
+++ b/Assets/Script/Playback/SongRunner.cs
@@ -182,22 +182,21 @@ namespace YARG.Playback
         public float SyncWorstDelta => _syncWorstDelta;
 
         /// <summary>
-        /// The instantaneous current audio time, used for audio synchronization.<br/>
+        /// The audio time used by audio synchronization.<br/>
         /// Accounts for song speed, audio calibration, and song offset.
         /// </summary>
-        public double SyncSongTime { get; private set; }
+        public double SyncAudioTime { get; private set; }
 
         /// <summary>
-        /// The instantaneous current visual time, used for audio synchronization.<br/>
+        /// The visual time used by audio synchronization.<br/>
         /// Accounts for song speed, but <b>not</b> video calibration.
         /// </summary>
         public double SyncVisualTime { get; private set; }
 
         /// <summary>
-        /// The instantaneous current visual time, used for audio synchronization.<br/>
-        /// Accounts for song speed, but <b>not</b> video calibration.
+        /// The difference between the visual and audio times used by audio synchronization.
         /// </summary>
-        public double SyncDelta => SyncVisualTime - SyncSongTime;
+        public double SyncDelta => SyncVisualTime - SyncAudioTime;
         #endregion
 
         #region Seek debugging
@@ -347,8 +346,13 @@ namespace YARG.Playback
             {
                 lock (_syncThread)
                 {
-                    double offset = SongOffset + AudioCalibration * SongSpeed;
-                    SyncVisualTime = GetRelativeInputTime(InputManager.CurrentInputTime);
+                    double realAudioTime = _mixer.GetPosition();
+                    double realVisualTime = GetRelativeInputTime(InputManager.CurrentInputTime);
+                    double offset = SongOffset + (AudioCalibration * SongSpeed);
+
+                    SyncAudioTime = realAudioTime + offset;
+                    SyncVisualTime = realVisualTime;
+
                     if (_pauseSync || SyncVisualTime < offset)
                     {
                         continue;
@@ -359,20 +363,17 @@ namespace YARG.Playback
                         _mixer.Play(false);
                     }
 
-                    RealAudioTime = _mixer.GetPosition();
-                    if (RealAudioTime >= _mixer.Length)
+                    if (realAudioTime >= _mixer.Length)
                     {
                         continue;
                     }
-
-                    SyncSongTime = RealAudioTime + offset;
 
                     // Account for song speed
                     double initialThreshold = INITIAL_SYNC_THRESH * SongSpeed;
                     double adjustThreshold = ADJUST_SYNC_THRESH * SongSpeed;
 
                     // Check the difference between visual and audio times
-                    double delta = SyncVisualTime - SyncSongTime;
+                    double delta = SyncVisualTime - SyncAudioTime;
                     double deltaAbs = Math.Abs(delta);
 
                     // Don't sync if below the initial sync threshold, and we haven't adjusted the speed
@@ -449,6 +450,8 @@ namespace YARG.Playback
             // where it will sometimes not fire the song end event when the audio ends
             // Using visual time guarantees a reliable timing source, and therefore song end timing
             RealSongTime = RealVisualTime - AudioCalibration;
+            // Not technically an input time, but needs to be updated upon request
+            RealAudioTime = _mixer.GetPosition() + SongOffset;
         }
 
         private void SetInputBase(double inputBase)

--- a/Assets/Script/Settings/SettingsManager.Settings.cs
+++ b/Assets/Script/Settings/SettingsManager.Settings.cs
@@ -71,6 +71,8 @@ namespace YARG.Settings
             public ToggleSetting ReconnectProfiles { get; } = new(true);
 
             public ToggleSetting UseCymbalModelsInFiveLane { get; } = new(true);
+
+            public ToggleSetting ReduceNoteSpeedByDifficulty { get; } = new(true);
             public SliderSetting KickBounceMultiplier { get; } = new(1f, 0f, 2f);
 
             public SliderSetting ShowCursorTimer { get; } = new(2f, 0f, 5f);

--- a/Assets/Script/Settings/SettingsManager.cs
+++ b/Assets/Script/Settings/SettingsManager.cs
@@ -50,6 +50,7 @@ namespace YARG.Settings
                 new HeaderMetadata("Other"),
                 nameof(Settings.ReconnectProfiles),
                 nameof(Settings.UseCymbalModelsInFiveLane),
+                nameof(Settings.ReduceNoteSpeedByDifficulty),
                 nameof(Settings.KickBounceMultiplier),
                 nameof(Settings.ShowCursorTimer),
                 nameof(Settings.PauseOnDeviceDisconnect),

--- a/Assets/StreamingAssets/lang/en-US.json
+++ b/Assets/StreamingAssets/lang/en-US.json
@@ -836,6 +836,10 @@
             "WrapAroundNavigation": {
                 "Name": "Wrap-Around Navigation",
                 "Description": "Allow menus to jump to the bottom of a list when scrolling past the top, or jump to the top of a list when scrolling past the bottom."
+            },
+            "ReduceNoteSpeedByDifficulty": {
+                "Name": "Reduce Note Speed By Difficulty",
+                "Description": "Reduces the note speed if playing on a lower difficulty than Expert. The note speed set by a profile is applied to Expert charts, and lower difficulty charts receive a reduction in speed."
             }
         },
         "PresetType": {

--- a/Assets/StreamingAssets/lang/en-US.json
+++ b/Assets/StreamingAssets/lang/en-US.json
@@ -838,7 +838,7 @@
                 "Description": "Allow menus to jump to the bottom of a list when scrolling past the top, or jump to the top of a list when scrolling past the bottom."
             },
             "ReduceNoteSpeedByDifficulty": {
-                "Name": "Reduce Note Speed By Difficulty",
+                "Name": "Reduce Note Speed by Difficulty",
                 "Description": "Reduces the note speed if playing on a lower difficulty than Expert. The specified note speed is applied to Expert, and lower difficulties receive a reduction in speed. This setting does not affect vocal tracks."
             }
         },

--- a/Assets/StreamingAssets/lang/en-US.json
+++ b/Assets/StreamingAssets/lang/en-US.json
@@ -839,7 +839,7 @@
             },
             "ReduceNoteSpeedByDifficulty": {
                 "Name": "Reduce Note Speed By Difficulty",
-                "Description": "Reduces the note speed if playing on a lower difficulty than Expert. The note speed set by a profile is applied to Expert charts, and lower difficulty charts receive a reduction in speed."
+                "Description": "Reduces the note speed if playing on a lower difficulty than Expert. The specified note speed is applied to Expert, and lower difficulties receive a reduction in speed. This setting does not affect vocal tracks."
             }
         },
         "PresetType": {

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ YARG (a.k.a. Yet Another Rhythm Game) is a free, open-source, plastic guitar gam
 - [🔨 Building/Contributing](#-buildingcontributing)
   - [Setup Instructions](#setup-instructions)
   - [Unity YAML Merge Tool](#unity-yaml-merge-tool)
-- [✍️ Contributing](#️-contributing)
+- [✍️ Contributing and Credits](#️-contributing-and-credits)
 - [🛡️ License](#️-license)
 - [🧰 External Licenses](#-external-licenses)
 - [📦 External Assets and Libraries](#-external-assets-and-libraries)
@@ -156,9 +156,17 @@ Resolving conflicts:
 2. If the conflict doesn't resolve automatically, open the command prompt and use `git merge-tool`.
 3. Verify that the conflict was resolved correctly, then commit/continue the merge.
 
-## ✍️ Contributing
+## ✍️ Contributing and Credits
 
 If you want to contribute, please feel free! It's recommended you join [our Discord](https://discord.gg/sqpu4R552r) so we can provide feedback quickly.
+
+In order to get your name added to the YARG credits, you need to first contribute to any of the following:
+* YARG
+* The Official Setlist and/or DLC
+* YARC Launcher
+* OpenSource
+* The community (community moderator, socials manager, etc).
+After that, you must create a pull request on [this repo](https://github.com/YARC-Official/Contributors) to get your name added. If you need help with this, feel free to ask in our Discord!
 
 ## 🛡️ License
 

--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ In order to get your name added to the YARG credits, you need to first contribut
 * YARC Launcher
 * OpenSource
 * The community (community moderator, socials manager, etc).
+
 After that, you must create a pull request on [this repo](https://github.com/YARC-Official/Contributors) to get your name added. If you need help with this, feel free to ask in our Discord!
 
 ## 🛡️ License


### PR DESCRIPTION
This PR adds a note speed reduction for all players/bots playing charts at a lower difficulty. This can be toggled in the Settings menu using the "Reduce Note Speed by Difficulty" option.

[[video]](https://www.youtube.com/watch?v=ucWM8VI1ZhE)

Notes:
- Reduce Note Speed by Difficulty is enabled by default.
- The vocal track is not affected by this option: it remains the same speed on all difficulties.
- The specified note speed is applied on Expert and Expert+, and the note speeds are reduced by 25% for each difficulty down (X->H, H->M, M->E). These reductions in speed are similar to those in the Rock Band series.