### PR TITLE
Added note speed reduction by difficulty

### DIFF
--- a/Assets/Script/Gameplay/Player/BasePlayer.cs
+++ b/Assets/Script/Gameplay/Player/BasePlayer.cs
@@ -8,6 +8,7 @@ using YARG.Core.Engine;
 using YARG.Core.Input;
 using YARG.Core.Logging;
 using YARG.Gameplay.HUD;
+using YARG.Helpers.Extensions;
 using YARG.Input;
 using YARG.Player;
 using YARG.Settings;
@@ -29,15 +30,15 @@ namespace YARG.Gameplay.Player
                 // which is saved in the engine parameter override.
                 if (GameManager.IsReplay)
                 {
-                    return Player.Profile.NoteSpeed / (float) Player.EngineParameterOverride.SongSpeed;
+                    return Player.Profile.NoteSpeed * Player.Profile.CurrentDifficulty.NoteSpeedScale() / (float) Player.EngineParameterOverride.SongSpeed;
                 }
 
                 if (GameManager.IsPractice && GameManager.SongSpeed < 1)
                 {
-                    return Player.Profile.NoteSpeed;
+                    return Player.Profile.NoteSpeed * Player.Profile.CurrentDifficulty.NoteSpeedScale();
                 }
 
-                return Player.Profile.NoteSpeed / GameManager.SongSpeed;
+                return Player.Profile.NoteSpeed * Player.Profile.CurrentDifficulty.NoteSpeedScale() / GameManager.SongSpeed;
             }
         }
 

--- a/Assets/Script/Gameplay/Player/BasePlayer.cs
+++ b/Assets/Script/Gameplay/Player/BasePlayer.cs
@@ -25,20 +25,22 @@ namespace YARG.Gameplay.Player
         {
             get
             {
+                float noteSpeed = Player.Profile.NoteSpeed * Player.Profile.CurrentDifficulty.NoteSpeedScale();
+
                 // If we're in a replay, don't change the note speed (it should be like a video
                 // slowing down/speeding up). The actual song speed should be taken into account though,
                 // which is saved in the engine parameter override.
                 if (GameManager.IsReplay)
                 {
-                    return Player.Profile.NoteSpeed * Player.Profile.CurrentDifficulty.NoteSpeedScale() / (float) Player.EngineParameterOverride.SongSpeed;
+                    return noteSpeed / (float) Player.EngineParameterOverride.SongSpeed;
                 }
 
                 if (GameManager.IsPractice && GameManager.SongSpeed < 1)
                 {
-                    return Player.Profile.NoteSpeed * Player.Profile.CurrentDifficulty.NoteSpeedScale();
+                    return noteSpeed;
                 }
 
-                return Player.Profile.NoteSpeed * Player.Profile.CurrentDifficulty.NoteSpeedScale() / GameManager.SongSpeed;
+                return noteSpeed / GameManager.SongSpeed;
             }
         }
 

--- a/Assets/Script/Helpers/Extensions/DifficultyExtensions.cs
+++ b/Assets/Script/Helpers/Extensions/DifficultyExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using YARG.Core;
+using YARG.Settings;
 
 namespace YARG.Helpers.Extensions
 {
@@ -44,6 +45,29 @@ namespace YARG.Helpers.Extensions
                 Difficulty.ExpertPlus => "Expert+",
 
                 _ => "Unknown"
+            };
+        }
+
+        /// <summary>
+        /// Returns the scale by which the note speed should be adjusted
+        /// according to the difficulty of the track.
+        /// </summary>
+        public static float NoteSpeedScale(this Difficulty difficulty)
+        {
+            if (!SettingsManager.Settings.ReduceNoteSpeedByDifficulty.Value)
+            {
+                return 1f;
+            }
+            
+            return difficulty switch
+            {
+                Difficulty.Easy       => 0.421875f,
+                Difficulty.Medium     => 0.5625f,
+                Difficulty.Hard       => 0.75f,
+                Difficulty.Expert     => 1f,
+                Difficulty.ExpertPlus => 1f,
+
+                _ => 1f
             };
         }
     }

--- a/Assets/Script/Settings/SettingsManager.Settings.cs
+++ b/Assets/Script/Settings/SettingsManager.Settings.cs
@@ -72,6 +72,8 @@ namespace YARG.Settings
             public ToggleSetting ReconnectProfiles { get; } = new(true);
 
             public ToggleSetting UseCymbalModelsInFiveLane { get; } = new(true);
+
+            public ToggleSetting ReduceNoteSpeedByDifficulty { get; } = new(true);
             public SliderSetting KickBounceMultiplier { get; } = new(1f, 0f, 2f);
 
             public SliderSetting ShowCursorTimer { get; } = new(2f, 0f, 5f);

--- a/Assets/Script/Settings/SettingsManager.cs
+++ b/Assets/Script/Settings/SettingsManager.cs
@@ -51,6 +51,7 @@ namespace YARG.Settings
                 new HeaderMetadata("Other"),
                 nameof(Settings.ReconnectProfiles),
                 nameof(Settings.UseCymbalModelsInFiveLane),
+                nameof(Settings.ReduceNoteSpeedByDifficulty),
                 nameof(Settings.KickBounceMultiplier),
                 nameof(Settings.ShowCursorTimer),
                 nameof(Settings.PauseOnDeviceDisconnect),

--- a/Assets/StreamingAssets/lang/en-US.json
+++ b/Assets/StreamingAssets/lang/en-US.json
@@ -870,6 +870,10 @@
             "WrapAroundNavigation": {
                 "Name": "Wrap-Around Navigation",
                 "Description": "Allow menus to jump to the bottom of a list when scrolling past the top, or jump to the top of a list when scrolling past the bottom."
+            },
+            "ReduceNoteSpeedByDifficulty": {
+                "Name": "Reduce Note Speed by Difficulty",
+                "Description": "Reduces the note speed if playing on a lower difficulty than Expert. The specified note speed is applied to Expert, and lower difficulties receive a reduction in speed. This setting does not affect vocal tracks."
             }
         },
         "PresetType": {


### PR DESCRIPTION
This PR adds a note speed reduction for all players/bots playing charts at a lower difficulty. This can be toggled in the Settings menu using the "Reduce Note Speed by Difficulty" option.

[[video]](https://www.youtube.com/watch?v=ucWM8VI1ZhE)

Notes:
- Reduce Note Speed by Difficulty is enabled by default.
- The vocal track is not affected by this option: it remains the same speed on all difficulties.
- The specified note speed is applied on Expert and Expert+, and the note speeds are reduced by 25% for each difficulty down (X->H, H->M, M->E). These reductions in speed are similar to those in the Rock Band series.