### PR TITLE
Voice Activated Star Power setting for Vocalists

### DIFF
--- a/Assets/Script/Gameplay/Player/VocalsPlayer.cs
+++ b/Assets/Script/Gameplay/Player/VocalsPlayer.cs
@@ -11,6 +11,7 @@ using YARG.Gameplay.HUD;
 using YARG.Helpers;
 using YARG.Input;
 using YARG.Player;
+using YARG.Settings;
 
 namespace YARG.Gameplay.Player
 {
@@ -125,9 +126,11 @@ namespace YARG.Gameplay.Player
         {
             if (!GameManager.IsReplay)
             {
+                var singToActivateStarPower = SettingsManager.Settings.VoiceActivatedVocalStarPower.Value;
+
                 // Create the engine params from the engine preset
                 EngineParams = Player.EnginePreset.Vocals.Create(StarMultiplierThresholds,
-                    Player.Profile.CurrentDifficulty, MicDevice.UPDATES_PER_SECOND);
+                    Player.Profile.CurrentDifficulty, MicDevice.UPDATES_PER_SECOND, singToActivateStarPower);
             }
             else
             {

--- a/Assets/Script/Input/Bindings/BindingCollection.Templates.cs
+++ b/Assets/Script/Input/Bindings/BindingCollection.Templates.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using YARG.Core;
 using YARG.Core.Input;
 
@@ -144,6 +144,7 @@ namespace YARG.Input
             // new AxisBinding("Vocals.Pitch", (int) VocalsAction.Pitch),
 
             new IndividualButtonBinding("Vocals.Hit", (int) VocalsAction.Hit),
+            new IndividualButtonBinding("Vocals.StarPower", (int) VocalsAction.StarPower)
         };
 
         public static BindingCollection CreateGameplayBindings(GameMode mode)

--- a/Assets/Script/Input/Bindings/Defaults/BindingCollection.Gamepad.cs
+++ b/Assets/Script/Input/Bindings/Defaults/BindingCollection.Gamepad.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Cysharp.Threading.Tasks;
 using UnityEngine.InputSystem;
 using UnityEngine.InputSystem.XInput;
@@ -124,7 +124,8 @@ namespace YARG.Input
             if (Mode != GameMode.Vocals)
                 return false;
 
-            AddBinding(VocalsAction.Hit, gamepad.selectButton);
+            AddBinding(VocalsAction.Hit, gamepad.aButton);
+            AddBinding(VocalsAction.StarPower, gamepad.selectButton);
 
             return true;
         }

--- a/Assets/Script/Input/Bindings/Defaults/BindingCollection.Keyboard.cs
+++ b/Assets/Script/Input/Bindings/Defaults/BindingCollection.Keyboard.cs
@@ -1,4 +1,4 @@
-using UnityEngine.InputSystem;
+﻿using UnityEngine.InputSystem;
 using YARG.Core;
 using YARG.Core.Input;
 
@@ -179,6 +179,7 @@ namespace YARG.Input
                 return false;
 
             AddBinding(VocalsAction.Hit, keyboard.backspaceKey);
+            AddBinding(VocalsAction.StarPower, keyboard.spaceKey);
 
             return true;
         }

--- a/Assets/Script/Settings/SettingsManager.Settings.cs
+++ b/Assets/Script/Settings/SettingsManager.Settings.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Net;
 using UnityEngine;
 using UnityEngine.InputSystem;
@@ -73,6 +73,8 @@ namespace YARG.Settings
 
             public ToggleSetting UseCymbalModelsInFiveLane { get; } = new(true);
             public SliderSetting KickBounceMultiplier { get; } = new(1f, 0f, 2f);
+
+            public ToggleSetting VoiceActivatedVocalStarPower {get; } = new(true);
 
             public SliderSetting ShowCursorTimer { get; } = new(2f, 0f, 5f);
 

--- a/Assets/Script/Settings/SettingsManager.Settings.cs
+++ b/Assets/Script/Settings/SettingsManager.Settings.cs
@@ -76,7 +76,7 @@ namespace YARG.Settings
             public ToggleSetting ReduceNoteSpeedByDifficulty { get; } = new(true);
             public SliderSetting KickBounceMultiplier { get; } = new(1f, 0f, 2f);
 
-            public ToggleSetting VoiceActivatedVocalStarPower {get; } = new(true);
+            public ToggleSetting VoiceActivatedVocalStarPower { get; } = new(true);
 
             public SliderSetting ShowCursorTimer { get; } = new(2f, 0f, 5f);
 

--- a/Assets/Script/Settings/SettingsManager.cs
+++ b/Assets/Script/Settings/SettingsManager.cs
@@ -52,6 +52,7 @@ namespace YARG.Settings
                 nameof(Settings.ReconnectProfiles),
                 nameof(Settings.UseCymbalModelsInFiveLane),
                 nameof(Settings.KickBounceMultiplier),
+                nameof(Settings.VoiceActivatedVocalStarPower),
                 nameof(Settings.ShowCursorTimer),
                 nameof(Settings.PauseOnDeviceDisconnect),
                 nameof(Settings.PauseOnFocusLoss),

--- a/Assets/StreamingAssets/lang/en-US.json
+++ b/Assets/StreamingAssets/lang/en-US.json
@@ -769,7 +769,7 @@
             },
             "VoiceActivatedVocalStarPower" : {
 				"Name": "Voice Activated Star Power (Vocals)",
-				"Description": "If enabled, vocalists can activate their Star Power by making noise when not singing (or by singing badly). Keybindings can be used instead, regardless of this setting."
+				"Description": "If enabled, vocalists can activate their Star Power by making a noise. Keybinds can be used instead, regardless of this setting."
 			},
             "VSync": {
                 "Name": "Enable VSync",

--- a/Assets/StreamingAssets/lang/en-US.json
+++ b/Assets/StreamingAssets/lang/en-US.json
@@ -767,6 +767,10 @@
                 "PauseName": "Vocals",
                 "Description": "Adjusts the song's vocal track volume. Only does something if the song is multi-track."
             },
+            "VoiceActivatedVocalStarPower" : {
+				"Name": "Voice Activated Star Power (Vocals)",
+				"Description": "If enabled, vocalists can activate their Star Power by making noise when not singing (or by singing badly). Keybindings can be used instead, regardless of this setting."
+			},
             "VSync": {
                 "Name": "Enable VSync",
                 "Description": "Enables VSync. VSync caps the framerate at your monitor's maximum framerate, and prevents tearing."


### PR DESCRIPTION
By default, vocalists are able to activate Star Power by making noise when not singing. This PR adds adds a new setting, which allows them to disable this behaviour if desired. Regardless of this setting, they can still activate SP by using a keybinding.

![image](https://github.com/user-attachments/assets/1f9889a6-4217-4030-9f4c-4e8781579213)

Note to the reviewer: Internally, this feature is named "SingToActivateStarPower". Since vocalists don't technically need to sing to activate Star Power - any noise will do, including shouting, dropping the mic, or heckling the drummer - I've named this setting "Voice Activated Star Power (Vocals)" instead. Let me know if you'd like it to be named something else.

Requires https://github.com/YARC-Official/YARG.Core/pull/203 from YARG.Core.