### PR TITLE
Fix vocal particle colours being blue for HARM2/HARM3 notes

### DIFF
--- a/Assets/Script/Gameplay/Player/VocalsPlayer.cs
+++ b/Assets/Script/Gameplay/Player/VocalsPlayer.cs
@@ -18,7 +18,7 @@ namespace YARG.Gameplay.Player
     public class VocalsPlayer : BasePlayer
     {
         public VocalsEngineParameters EngineParams { get; private set; }
-        public VocalsEngine Engine { get; private set; }
+        public VocalsEngine           Engine       { get; private set; }
 
         public override BaseEngine BaseEngine => Engine;
 
@@ -34,14 +34,6 @@ namespace YARG.Gameplay.Player
         public override float[] StarMultiplierThresholds { get; protected set; } =
         {
             0.21f, 0.46f, 0.77f, 1.85f, 3.08f, 4.18f
-        };
-
-        // TODO: Temporary until color profiles for vocals
-        public readonly Color[] Colors =
-        {
-            new(0f, 0.800f, 1f, 1f),
-            new(1f, 0.522f, 0f, 1f),
-            new(1f, 0.859f, 0f, 1f)
         };
 
         public override int[] StarScoreThresholds { get; protected set; }
@@ -86,7 +78,7 @@ namespace YARG.Gameplay.Player
                 var startSpeed = main.startSpeed;
                 startSpeed.constant *= player.Profile.NoteSpeed;
                 main.startSpeed = startSpeed;
-                main.startColor = Colors[partIndex];
+                main.startColor = GameManager.VocalTrack.Colors[partIndex];
             }
 
             // Get the notes from the specific harmony or solo part

--- a/Assets/Script/Gameplay/Player/VocalsPlayer.cs
+++ b/Assets/Script/Gameplay/Player/VocalsPlayer.cs
@@ -60,9 +60,6 @@ namespace YARG.Gameplay.Player
 
             base.Initialize(index, player, chart, lastHighScore);
 
-            hud.Initialize(player.EnginePreset);
-            _hud = hud;
-
             var partIndex = Player.Profile.CurrentInstrument == Instrument.Harmony
                 ? Player.Profile.HarmonyIndex
                 : 0;

--- a/Assets/Script/Gameplay/Player/VocalsPlayer.cs
+++ b/Assets/Script/Gameplay/Player/VocalsPlayer.cs
@@ -18,7 +18,7 @@ namespace YARG.Gameplay.Player
     public class VocalsPlayer : BasePlayer
     {
         public VocalsEngineParameters EngineParams { get; private set; }
-        public VocalsEngine           Engine       { get; private set; }
+        public VocalsEngine Engine { get; private set; }
 
         public override BaseEngine BaseEngine => Engine;
 
@@ -34,6 +34,14 @@ namespace YARG.Gameplay.Player
         public override float[] StarMultiplierThresholds { get; protected set; } =
         {
             0.21f, 0.46f, 0.77f, 1.85f, 3.08f, 4.18f
+        };
+
+        // TODO: Temporary until color profiles for vocals
+        public readonly Color[] Colors =
+        {
+            new(0f, 0.800f, 1f, 1f),
+            new(1f, 0.522f, 0f, 1f),
+            new(1f, 0.859f, 0f, 1f)
         };
 
         public override int[] StarScoreThresholds { get; protected set; }
@@ -60,6 +68,13 @@ namespace YARG.Gameplay.Player
 
             base.Initialize(index, player, chart, lastHighScore);
 
+            hud.Initialize(player.EnginePreset);
+            _hud = hud;
+
+            var partIndex = Player.Profile.CurrentInstrument == Instrument.Harmony
+                ? Player.Profile.HarmonyIndex
+                : 0;
+
             // Update speed of particles
             var particles = _hittingParticleGroup.GetComponentsInChildren<ParticleSystem>();
             foreach (var system in particles)
@@ -71,14 +86,12 @@ namespace YARG.Gameplay.Player
                 var startSpeed = main.startSpeed;
                 startSpeed.constant *= player.Profile.NoteSpeed;
                 main.startSpeed = startSpeed;
+                main.startColor = Colors[partIndex];
             }
 
             // Get the notes from the specific harmony or solo part
 
             var multiTrack = chart.GetVocalsTrack(Player.Profile.CurrentInstrument);
-            var partIndex = Player.Profile.CurrentInstrument == Instrument.Harmony
-                ? Player.Profile.HarmonyIndex
-                : 0;
 
             var track = multiTrack.Parts[partIndex];
             player.Profile.ApplyVocalModifiers(track);


### PR DESCRIPTION
This PR is to fix the vocal particle colours always being rendered blue, regardless of whether they are solo, HARM1 (blue), HARM2 (red), or HARM3 (yellow). 

![vocalParticleColours](https://github.com/user-attachments/assets/d5846156-6294-4dbd-893c-5ccf678b2a75)

Note to the reviewer: This implementation matches the implementation for colouring the vocal notes themselves, which was clearly marked as a temporary solution (see VocalTrack.cs). As such, the hard-coded colour set should be replaced with colour profiles for vocals later on.