### PR TITLE
Fix broken subheading in Difficulty Select Screen

### DIFF
--- a/Assets/Script/Menu/DifficultySelect/DifficultySelectMenu.cs
+++ b/Assets/Script/Menu/DifficultySelect/DifficultySelectMenu.cs
@@ -87,7 +87,7 @@ namespace YARG.Menu.DifficultySelect
         private void OnEnable()
         {
             string subHeaderKey = GlobalVariables.State.IsPractice ? "Practice" : "Quickplay";
-            _subHeader.text = Localize.Key("Main.Options", subHeaderKey);
+            _subHeader.text = Localize.Key("Menu.Main.Options", subHeaderKey);
 
             // Set navigation scheme
             Navigator.Instance.PushScheme(new NavigationScheme(new()


### PR DESCRIPTION
This fixes the subheading on the Difficulty Select screen showing as "Main.Options.Quickplay" due to it having the wrong localization key.