### PR TITLE
Allow drum freestyle during countdown breaks

### DIFF
--- a/Assets/Script/Gameplay/Player/DrumsPlayer.cs
+++ b/Assets/Script/Gameplay/Player/DrumsPlayer.cs
@@ -328,7 +328,10 @@ namespace YARG.Gameplay.Player
 
         private bool IsDrumFreestyle()
         {
-            return Engine.NoteIndex == 0 || Engine.NoteIndex >= Notes.Count; // TODO: add drum fill / BRE conditions
+            return Engine.NoteIndex == 0 || // Can freestyle before first note is hit/missed
+            Engine.NoteIndex >= Notes.Count || // Can freestyle after last note
+            Engine.IsWaitCountdownActive; // Can freestyle during WaitCountdown
+            // TODO: add drum fill / BRE conditions
         }
     }
 }

--- a/Assets/Script/Gameplay/Player/DrumsPlayer.cs
+++ b/Assets/Script/Gameplay/Player/DrumsPlayer.cs
@@ -329,8 +329,8 @@ namespace YARG.Gameplay.Player
         private bool IsDrumFreestyle()
         {
             return Engine.NoteIndex == 0 || // Can freestyle before first note is hit/missed
-            Engine.NoteIndex >= Notes.Count || // Can freestyle after last note
-            Engine.IsWaitCountdownActive; // Can freestyle during WaitCountdown
+                Engine.NoteIndex >= Notes.Count || // Can freestyle after last note
+                Engine.IsWaitCountdownActive; // Can freestyle during WaitCountdown
             // TODO: add drum fill / BRE conditions
         }
     }


### PR DESCRIPTION
Overhitting during those breaks is already allowed in YARG.Core, so it's a matter of adding that check to `IsDrumFreestyle()` in the YARG side