### PR TITLE
Stem-muting, countdown, and notification bugfixes

### DIFF
--- a/Assets/Prefabs/Gameplay/HUD/CountdownDisplay.prefab
+++ b/Assets/Prefabs/Gameplay/HUD/CountdownDisplay.prefab
@@ -135,7 +135,7 @@ CanvasGroup:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4618290287218134900}
   m_Enabled: 1
-  m_Alpha: 1
+  m_Alpha: 0
   m_Interactable: 1
   m_BlocksRaycasts: 1
   m_IgnoreParentGroups: 0

--- a/Assets/Prefabs/Gameplay/HUD/TrackView.prefab
+++ b/Assets/Prefabs/Gameplay/HUD/TrackView.prefab
@@ -247,7 +247,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!224 &9014481999390702953
 RectTransform:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Gameplay/HUD/TrackView.prefab
+++ b/Assets/Prefabs/Gameplay/HUD/TrackView.prefab
@@ -1087,7 +1087,7 @@ PrefabInstance:
     - target: {fileID: 4618290287218134900, guid: 249f3206655c65946a0f15b17834fca4,
         type: 3}
       propertyPath: m_IsActive
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 249f3206655c65946a0f15b17834fca4, type: 3}

--- a/Assets/Scenes/Gameplay.unity
+++ b/Assets/Scenes/Gameplay.unity
@@ -1402,7 +1402,7 @@ PrefabInstance:
     - target: {fileID: 227366190812778480, guid: 039fee0ec42345d4f88c0625255415d4,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 142.36188
+      value: -142.36191
       objectReference: {fileID: 0}
     - target: {fileID: 1682100932476655723, guid: 039fee0ec42345d4f88c0625255415d4,
         type: 3}
@@ -1532,7 +1532,7 @@ PrefabInstance:
     - target: {fileID: 2517693471320601084, guid: 039fee0ec42345d4f88c0625255415d4,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: -142.36188
+      value: 142.36191
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
@@ -2801,6 +2801,113 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _topPaddingForVocals: 220
+--- !u!1001 &412813829
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1517088745}
+    m_Modifications:
+    - target: {fileID: 3967995507941194808, guid: 249f3206655c65946a0f15b17834fca4,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3967995507941194808, guid: 249f3206655c65946a0f15b17834fca4,
+        type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3967995507941194808, guid: 249f3206655c65946a0f15b17834fca4,
+        type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 3967995507941194808, guid: 249f3206655c65946a0f15b17834fca4,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3967995507941194808, guid: 249f3206655c65946a0f15b17834fca4,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3967995507941194808, guid: 249f3206655c65946a0f15b17834fca4,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 120.00003
+      objectReference: {fileID: 0}
+    - target: {fileID: 3967995507941194808, guid: 249f3206655c65946a0f15b17834fca4,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3967995507941194808, guid: 249f3206655c65946a0f15b17834fca4,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3967995507941194808, guid: 249f3206655c65946a0f15b17834fca4,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3967995507941194808, guid: 249f3206655c65946a0f15b17834fca4,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3967995507941194808, guid: 249f3206655c65946a0f15b17834fca4,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3967995507941194808, guid: 249f3206655c65946a0f15b17834fca4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3967995507941194808, guid: 249f3206655c65946a0f15b17834fca4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3967995507941194808, guid: 249f3206655c65946a0f15b17834fca4,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3967995507941194808, guid: 249f3206655c65946a0f15b17834fca4,
+        type: 3}
+      propertyPath: m_ConstrainProportionsScale
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4618290287218134900, guid: 249f3206655c65946a0f15b17834fca4,
+        type: 3}
+      propertyPath: m_Name
+      value: CountdownDisplay
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 249f3206655c65946a0f15b17834fca4, type: 3}
+--- !u!114 &412813830 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4549246668167681472, guid: 249f3206655c65946a0f15b17834fca4,
+    type: 3}
+  m_PrefabInstance: {fileID: 412813829}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e01a15edf7c559e49a771df09251d09b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &412813831 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 3967995507941194808, guid: 249f3206655c65946a0f15b17834fca4,
+    type: 3}
+  m_PrefabInstance: {fileID: 412813829}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &417575064 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 1682100933276730678, guid: 039fee0ec42345d4f88c0625255415d4,
@@ -3441,6 +3548,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
+  - {fileID: 1517088745}
   - {fileID: 1338572397}
   m_Father: {fileID: 1330928976}
   m_RootOrder: 0
@@ -4230,22 +4338,22 @@ PrefabInstance:
     - target: {fileID: 2933889975780695480, guid: f8c143f8514898b4fb85fbadc18550c0,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2933889975780695480, guid: f8c143f8514898b4fb85fbadc18550c0,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2933889975780695480, guid: f8c143f8514898b4fb85fbadc18550c0,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 30.000036
       objectReference: {fileID: 0}
     - target: {fileID: 2933889975780695480, guid: f8c143f8514898b4fb85fbadc18550c0,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -32
       objectReference: {fileID: 0}
     - target: {fileID: 5322898957872382039, guid: f8c143f8514898b4fb85fbadc18550c0,
         type: 3}
@@ -5689,7 +5797,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 626807278}
-  m_RootOrder: 0
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 0}
@@ -6213,6 +6321,43 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1494490346}
   m_CullTransparentMesh: 1
+--- !u!1 &1517088744
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1517088745}
+  m_Layer: 5
+  m_Name: Centered Elements
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1517088745
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1517088744}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 412813831}
+  m_Father: {fileID: 626807278}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -100}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &1561845651
 GameObject:
   m_ObjectHideFlags: 0
@@ -8133,6 +8278,11 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 5801866611232935394, guid: f09d7030713b2e34dbc210e5e014add2,
+        type: 3}
+      propertyPath: _countdownDisplay
+      value: 
+      objectReference: {fileID: 412813830}
     - target: {fileID: 5801866611232935397, guid: f09d7030713b2e34dbc210e5e014add2,
         type: 3}
       propertyPath: m_RootOrder

--- a/Assets/Script/Audio/Bass/BassStemChannel.cs
+++ b/Assets/Script/Audio/Bass/BassStemChannel.cs
@@ -117,12 +117,15 @@ namespace YARG.Audio.BASS
         protected override void SetVolume_Internal(double volume)
         {
             _volume = volume;
-            if (!Bass.ChannelSetAttribute(_streamHandles.Stream, ChannelAttribute.Volume, volume))
+
+            // Using ChannelSlideAttribute with a duration of 0 here instead of ChannelSetAttribute
+            // This will cancel any slides in progress that were started SetReverb_Internal
+            if (!Bass.ChannelSlideAttribute(_streamHandles.Stream, ChannelAttribute.Volume, (float) volume, 0))
                 YargLogger.LogFormatError("Failed to set stream volume: {0}!", Bass.LastError);
 
-            double reverbVolume = _isReverbing ? volume * BassHelpers.REVERB_VOLUME_MULTIPLIER : 0;
-
-            if (!Bass.ChannelSetAttribute(_reverbHandles.Stream, ChannelAttribute.Volume, reverbVolume))
+            float reverbVolume = _isReverbing ? (float) volume * BassHelpers.REVERB_VOLUME_MULTIPLIER : 0;
+            
+            if (!Bass.ChannelSlideAttribute(_reverbHandles.Stream, ChannelAttribute.Volume, reverbVolume, 0))
                 YargLogger.LogFormatError("Failed to set reverb volume: {0}!", Bass.LastError);
         }
 

--- a/Assets/Script/Audio/Bass/BassStemChannel.cs
+++ b/Assets/Script/Audio/Bass/BassStemChannel.cs
@@ -121,12 +121,16 @@ namespace YARG.Audio.BASS
             // Using ChannelSlideAttribute with a duration of 0 here instead of ChannelSetAttribute
             // This will cancel any slides in progress that were started SetReverb_Internal
             if (!Bass.ChannelSlideAttribute(_streamHandles.Stream, ChannelAttribute.Volume, (float) volume, 0))
+            {
                 YargLogger.LogFormatError("Failed to set stream volume: {0}!", Bass.LastError);
+            }
 
             float reverbVolume = _isReverbing ? (float) volume * BassHelpers.REVERB_VOLUME_MULTIPLIER : 0;
             
             if (!Bass.ChannelSlideAttribute(_reverbHandles.Stream, ChannelAttribute.Volume, reverbVolume, 0))
+            {
                 YargLogger.LogFormatError("Failed to set reverb volume: {0}!", Bass.LastError);
+            }
         }
 
         protected override void SetReverb_Internal(bool reverb)

--- a/Assets/Script/Gameplay/HUD/CountdownDisplay.cs
+++ b/Assets/Script/Gameplay/HUD/CountdownDisplay.cs
@@ -42,14 +42,26 @@ namespace YARG.Gameplay.HUD
                 return;
             }
 
-            ToggleDisplay(measuresLeft > WaitCountdown.END_COUNTDOWN_MEASURE);
+            double currentTime = GameManager.SongTime;
+
+            bool shouldDisplay = measuresLeft > WaitCountdown.END_COUNTDOWN_MEASURE;
+            if (GameManager.IsPractice)
+            {
+                double sectionStartTime = GameManager.PracticeManager.TimeStart;
+                if (currentTime <= sectionStartTime)
+                {
+                    // Do not show a countdown before the start of a practice section
+                    // where all of the notes before that section are removed for practice stats
+                    shouldDisplay = false;
+                }
+            }
+
+            ToggleDisplay(shouldDisplay);
             
             if (!gameObject.activeSelf)
             {
                 return;
             }
-            
-            double currentTime = GameManager.SongTime;
 
             int displayNumber = DisplayStyle switch
             {
@@ -87,6 +99,7 @@ namespace YARG.Gameplay.HUD
             {
                 _canvasGroup.alpha = 0f;
                 gameObject.SetActive(true);
+
                 _currentCoroutine = StartCoroutine(ShowCoroutine());
             }
             else

--- a/Assets/Script/Gameplay/HUD/TrackViewManager.cs
+++ b/Assets/Script/Gameplay/HUD/TrackViewManager.cs
@@ -60,9 +60,6 @@ namespace YARG.Gameplay.HUD
             // Apply the vocal track texture
             var rt = GameManager.VocalTrack.InitializeRenderTexture(ratio);
             _vocalImage.texture = rt;
-
-            // Create link between VocalTrack and the CountdownDisplay inside of this transform
-            GameManager.VocalTrack.InitializeCountdownDisplay(_vocalsCountdownDisplay);
         }
 
         public VocalsPlayerHUD CreateVocalsPlayerHUD()

--- a/Assets/Script/Gameplay/Player/Vocals/VocalTrack.cs
+++ b/Assets/Script/Gameplay/Player/Vocals/VocalTrack.cs
@@ -259,13 +259,6 @@ namespace YARG.Gameplay.Player
             AllowStarPower = true;
         }
 
-        public void InitializeCountdownDisplay(CountdownDisplay newPrefabInstance)
-        {
-            // The CountdownDisplay for VocalTrack lives inside of TrackViewManager's transform
-            // to prevent stretching the countdown circle into an oval when resizing the track
-            _countdownDisplay = newPrefabInstance;
-        }
-
         public VocalsPlayer CreatePlayer()
         {
             var player = Instantiate(_vocalPlayerPrefab, _playerContainer);


### PR DESCRIPTION
-Fix for stem-muting while SP reverb is in the process of fading in or out
-Fix for countdowns appearing right before the start of a practice section where the earlier notes in the chart are artificially removed
-Added countdowns back into the vocal track prefab after they were taken out
-Fixed TrackView notifications not appearing by re-checking the box that makes them active by default.

This is a modified version of my PR from last month, rebased to the latest changes. I saw that Nathan fixed vocal range changes in practice mode so I took that out.

Regarding the practice mode countdown fix - I changed how it's structured in Unity so that countdowns are active by default with an alpha of 0 to keep them hidden. This way, `Awake()` is called at the start of a song and the script can detect if it's in practice mode.