### PR TITLE
Introduce deadzone for Vocal Needle Rotation

### DIFF
--- a/Assets/Script/Gameplay/Player/VocalsPlayer.cs
+++ b/Assets/Script/Gameplay/Player/VocalsPlayer.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Linq;
+﻿using System.Linq;
 using UnityEngine;
 using UnityEngine.AddressableAssets;
 using YARG.Core;
@@ -21,7 +20,7 @@ namespace YARG.Gameplay.Player
     public class VocalsPlayer : BasePlayer
     {
         public VocalsEngineParameters EngineParams { get; private set; }
-        public VocalsEngine Engine { get; private set; }
+        public VocalsEngine           Engine       { get; private set; }
 
         public override BaseEngine BaseEngine => Engine;
 
@@ -49,8 +48,8 @@ namespace YARG.Gameplay.Player
         private MicInputContext _inputContext;
 
         private VocalNote _lastTargetNote;
-        private double? _lastHitTime;
-        private double? _lastSingTime;
+        private double?   _lastHitTime;
+        private double?   _lastSingTime;
 
         private VocalsPlayerHUD _hud;
         private VocalPercussionTrack _percussionTrack;

--- a/Assets/Script/Gameplay/Player/VocalsPlayer.cs
+++ b/Assets/Script/Gameplay/Player/VocalsPlayer.cs
@@ -391,12 +391,6 @@ namespace YARG.Gameplay.Player
 
         private float GetNeedleRotation(float pitchDist)
         {
-            // This prevents a division by zero when calculating rotation.
-            if (EngineParams.PitchWindow == EngineParams.PitchWindowPerfect)
-            {
-                return 0.0f;
-            }
-
             const float NEEDLE_ROT_MAX = 12f;
 
             // Reduce the provided distance by applying a dead zone. This will prevent oversteer if the player's current pitch is well within the "Perfect" window.

--- a/Assets/Script/Gameplay/Player/VocalsPlayer.cs
+++ b/Assets/Script/Gameplay/Player/VocalsPlayer.cs
@@ -391,33 +391,13 @@ namespace YARG.Gameplay.Player
 
         private float GetNeedleRotation(float pitchDist)
         {
-            // This prevents a division by zero when calculating rotation.
-            if (EngineParams.PitchWindow == EngineParams.PitchWindowPerfect)
-            {
-                return 0.0f;
-            }
-
             const float NEEDLE_ROT_MAX = 12f;
 
-            // Reduce the provided distance by applying a dead zone. This will prevent oversteer if the player's current pitch is well within the "Perfect" window.
-            var deadzoneInSemitones = EngineParams.PitchWindowPerfect / 2;
-            var adjustedPitchDist = ApplyPitchDeadZone(pitchDist, deadzoneInSemitones);
-
-            // Determine how off that is compared to the hit window
-            float distPercent = Mathf.Clamp(adjustedPitchDist / (EngineParams.PitchWindow - deadzoneInSemitones), -1f, 1f);
+            // Determine how off the pitch distance is compared to the hit window
+            float distPercent = Mathf.Clamp(pitchDist / (EngineParams.PitchWindow), -1f, 1f);
 
             // Use that to get the target rotation
             return distPercent * NEEDLE_ROT_MAX;
-        }
-
-        private float ApplyPitchDeadZone(float pitchDist, float deadZoneInSemitones)
-        {
-            if (pitchDist >= 0.0f)
-            {
-                return Mathf.Max(0.0f, pitchDist - deadZoneInSemitones);
-            }
-
-            return Mathf.Min(0.0f, pitchDist + deadZoneInSemitones);
         }
 
         private void UpdatePercussionPhrase(double time)


### PR DESCRIPTION
In the current nightly build, vocal needles have a tendency to overstreer constantly while gliding over notes, and will almost never be straight, no matter how close to the correct pitch you're singing.

![image](https://github.com/user-attachments/assets/ad85ad99-c6fc-4899-94eb-dce4713ef3c0)

*Please ignore the custom Engine Preset in the screenshot. It happens on the default preset as well.*

This is due to a bug in the code that used the wrong `HitWindow` property to calculate the rotation. This has been fixed. In addition, this PR introduces a "dead zone" to this rotation, which forces the needle to have no rotation (making it perfectly parallel to the note its gliding over) if the vocalists pitch is well within the "Perfect" window. During my testing, I've noticed that a deadzone equal to half the current "Perfect" window seems to work well, but I'm open to suggestion on this. This window is provided from the player's current Engine Preset.


