### PR TITLE
Incorporate all vocal parts for harmony countdowns

### DIFF
--- a/Assets/Script/Gameplay/Player/Vocals/VocalTrack.cs
+++ b/Assets/Script/Gameplay/Player/Vocals/VocalTrack.cs
@@ -461,10 +461,5 @@ namespace YARG.Gameplay.Player
 
             ResetPracticeSection();
         }
-
-        public bool IsPrimaryPlayer(VocalsPlayer thisPlayer)
-        {
-            return thisPlayer == _vocalPlayers[0];
-        }
     }
 }

--- a/Assets/Script/Gameplay/Player/VocalsPlayer.cs
+++ b/Assets/Script/Gameplay/Player/VocalsPlayer.cs
@@ -118,6 +118,22 @@ namespace YARG.Gameplay.Player
             }
 
             Engine = CreateEngine();
+            if (vocalIndex == 0)
+            {
+                if (Player.Profile.CurrentInstrument == Instrument.Vocals)
+                {
+                    Engine.BuildCountdownsFromSelectedPart();
+                }
+                else
+                {
+                    Engine.BuildCountdownsFromAllParts(chart);
+                }
+
+                Engine.OnCountdownChange += (measuresLeft, countdownLength, endTime) =>
+                {
+                    GameManager.VocalTrack.UpdateCountdown(measuresLeft, countdownLength, endTime);
+                };
+            }
 
             if (GameManager.IsPractice)
             {
@@ -207,11 +223,6 @@ namespace YARG.Gameplay.Player
                 _lastHitTime = hitting
                     ? GameManager.InputTime
                     : null;
-            };
-
-            engine.OnCountdownChange += (measuresLeft, countdownLength, endTime) =>
-            {
-                GameManager.VocalTrack.UpdateCountdown(measuresLeft, countdownLength, endTime);
             };
 
             return engine;

--- a/Assets/Script/Gameplay/Player/VocalsPlayer.cs
+++ b/Assets/Script/Gameplay/Player/VocalsPlayer.cs
@@ -126,7 +126,7 @@ namespace YARG.Gameplay.Player
                 }
                 else
                 {
-                    Engine.BuildCountdownsFromAllParts(chart);
+                    Engine.BuildCountdownsFromAllParts(multiTrack.Parts);
                 }
 
                 Engine.OnCountdownChange += (measuresLeft, countdownLength, endTime) =>


### PR DESCRIPTION
Bug fix for the following issue:
https://discord.com/channels/1086048856678084609/1287329560282796096

Requires YARG.Core PR 215 to work

This also fixes vocal countdown behavior so that only the first vocals player will listen for OnCountdownUpdate events.