### PR TITLE
Fail gracefully when loading a song with missing audio files

### DIFF
--- a/Assets/Script/Audio/Bass/BassStemMixer.cs
+++ b/Assets/Script/Audio/Bass/BassStemMixer.cs
@@ -325,7 +325,7 @@ namespace YARG.Audio.BASS
         {
             if (_channels.Count == 0)
             {
-                _mainHandle.Dispose();
+                _mainHandle?.Dispose();
                 return;
             }
 


### PR DESCRIPTION
To repro:

1. Scan songs that are in YARG format (multiple files in a directory, notes.mid, album.png, song.ini, song.ogg)
2. Find a working song and move the song.ogg into a backup dir within the song folder
3. Go back to YARG and play the song

Expected: Error message that files are missing

Old screenshot:

![image](https://github.com/user-attachments/assets/f3fe9005-54fd-40fc-b4f1-14a43ad347b6)

New:

![image](https://github.com/user-attachments/assets/56ecb011-93ac-4aa1-b5b9-abacdd528ca2)

Issue was caused by `_mainHandle` being null because no stems were added
