### PR TITLE
Fix crunchy audio when whammy is enabled

### DIFF
--- a/Assets/Script/Audio/Bass/BassAudioManager.cs
+++ b/Assets/Script/Audio/Bass/BassAudioManager.cs
@@ -302,7 +302,7 @@ namespace YARG.Audio.BASS
                             DrumSfxSamples[(int) sfxSample] = sfx;
                         }
                         break;
-                    }  
+                    }
                 }
             }
 
@@ -492,8 +492,15 @@ namespace YARG.Audio.BASS
 
         internal static bool SetupPitchBend(in PitchShiftParametersStruct pitchParams, StreamHandle handles)
         {
-            handles.CompressorFX = BassHelpers.FXAddParameters(handles.Stream, EffectType.PitchShift, pitchParams);
-            if (handles.CompressorFX == 0)
+            var pitchParamsFixed = new PitchShiftParameters
+            {
+                fPitchShift = pitchParams.fPitchShift,
+                fSemitones = pitchParams.fSemitones,
+                lFFTsize = pitchParams.FFTSize,
+                lOsamp = pitchParams.OversampleFactor
+            };
+            handles.PitchFX = BassHelpers.AddPitchShiftToChannel(handles.Stream, pitchParamsFixed);
+            if (handles.PitchFX == 0)
             {
                 YargLogger.LogError("Failed to set up pitch bend for main stream!");
                 return false;


### PR DESCRIPTION
Fix is to use the `PitchShiftParameters` instead of `PitchShiftParametersStruct` when passing into `Bass.FXSetParameters` initially

After that we can use the struct and it will work fine.

If I try to use `PitchShiftParameters` instead of `PitchShiftParametersStruct` everywhere, pitch shift just stops working.  Probably something to do with the pointer reference, but I couldn't figure it out.  


Crunchy:
https://github.com/user-attachments/assets/47852b74-7c68-4e93-9ce9-bf02f6fdb91f

Fixed:
https://github.com/user-attachments/assets/39f8c618-6571-41d8-b77d-1c8649cad38d

Relates to:
https://discord.com/channels/1086048856678084609/1287813697577685084

