### PR TITLE
Fix issue where clicking too fast on back button would pop all menus

### DIFF
--- a/Assets/Script/Menu/MenuManager.cs
+++ b/Assets/Script/Menu/MenuManager.cs
@@ -107,33 +107,34 @@ namespace YARG.Menu
 
         public void PopMenu()
         {
+            //Don't pop the only remaining menu
+            if (_openMenus.Count == 1)
+            {
+                return;
+            }
+
             // Close the currently open one
-            if (_openMenus.TryPeek(out var currentMenuEnum) &&
+            if (_openMenus.TryPop(out var currentMenuEnum) &&
                 _menus.TryGetValue(currentMenuEnum, out var currentMenu))
             {
                 currentMenu.gameObject.SetActive(false);
             }
 
-            _openMenus.Pop();
-            var menu = _openMenus.Peek();
-
-            // Show the under one
-            if (_menus.TryGetValue(menu, out var newMenu))
+            if (_openMenus.TryPeek(out var newMenuEnum) &&
+                _menus.TryGetValue(newMenuEnum, out var newMenu))
             {
                 newMenu.gameObject.SetActive(true);
             }
             else
             {
-                throw new InvalidOperationException($"Failed to open menu {menu}.");
+                throw new InvalidOperationException($"Failed to open menu {newMenuEnum}.");
             }
         }
 
         public void ReactivateCurrentMenu()
         {
-            var menu = _openMenus.Peek();
-
             // Show the under one
-            if (_menus.TryGetValue(menu, out var newMenu))
+            if (_openMenus.TryPeek(out var menu) && _menus.TryGetValue(menu, out var newMenu))
             {
                 newMenu.gameObject.SetActive(false);
                 newMenu.gameObject.SetActive(true);


### PR DESCRIPTION
Fixes this issue: https://discord.com/channels/1086048856678084609/1292168111587463260/1292168111587463260

Since both left and right click do the same thing, it's easy to click so fast on the back button that pop is called twice.  In other words, the click listener fires twice before the back button is removed from the screen.

Fix is to disregard the PopMenu call if there's only one menu in the stack.

Also cleans up the PopMenu() method