### PR TITLE
Add an option to disable the search button

### DIFF
--- a/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
+++ b/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
@@ -99,7 +99,7 @@ namespace YARG.Menu.MusicLibrary
         private void OnEnable()
         {
             // Set navigation scheme
-            Navigator.Instance.PushScheme(new NavigationScheme(new()
+            var navigationEntries = new List<NavigationScheme.Entry>
             {
                 new NavigationScheme.Entry(MenuAction.Up, "Menu.Common.Up",
                     ctx =>
@@ -131,11 +131,20 @@ namespace YARG.Menu.MusicLibrary
                     () => CurrentSelection?.PrimaryButtonClick()),
 
                 new NavigationScheme.Entry(MenuAction.Red, "Menu.Common.Back", Back),
-                new NavigationScheme.Entry(MenuAction.Blue, "Menu.MusicLibrary.Search",
-                    () => _searchField.Focus()),
-                new NavigationScheme.Entry(MenuAction.Orange, "Menu.MusicLibrary.MoreOptions",
-                    OnButtonHit, OnButtonRelease),
-            }, false));
+            };
+
+            // Conditionally add the search action entry
+            if (!SettingsManager.Settings.DisableSearchButton.Value)
+            {
+                navigationEntries.Add(new NavigationScheme.Entry(MenuAction.Blue, "Menu.MusicLibrary.Search",
+                    () => _searchField.Focus()));
+            }
+            // Add "more options" entry after search to maintain original order.
+            navigationEntries.Add(new NavigationScheme.Entry(MenuAction.Orange, "Menu.MusicLibrary.MoreOptions",
+                OnButtonHit, OnButtonRelease));
+
+            // Push the navigation scheme with the final list of entries
+            Navigator.Instance.PushScheme(new NavigationScheme(navigationEntries, false));
 
             // Restore search
             _searchField.Restore();

--- a/Assets/Script/Settings/SettingsManager.Settings.cs
+++ b/Assets/Script/Settings/SettingsManager.Settings.cs
@@ -88,6 +88,7 @@ namespace YARG.Settings
             public ToggleSetting PauseOnFocusLoss { get; } = new(true);
 
             public ToggleSetting WrapAroundNavigation { get; } = new(true);
+            public ToggleSetting DisableSearchButton { get; } = new(false);
             public ToggleSetting AmIAwesome { get; } = new(false);
 
             #endregion

--- a/Assets/Script/Settings/SettingsManager.cs
+++ b/Assets/Script/Settings/SettingsManager.cs
@@ -61,6 +61,7 @@ namespace YARG.Settings
                 nameof(Settings.PauseOnDeviceDisconnect),
                 nameof(Settings.PauseOnFocusLoss),
                 nameof(Settings.WrapAroundNavigation),
+                nameof(Settings.DisableSearchButton),
                 nameof(Settings.AmIAwesome),
             },
             new SongManagerTab("SongManager", icon: "Songs")

--- a/Assets/StreamingAssets/lang/en-US.json
+++ b/Assets/StreamingAssets/lang/en-US.json
@@ -945,6 +945,10 @@
                 "Name": "Wrap-Around Navigation",
                 "Description": "Allow menus to jump to the bottom of a list when scrolling past the top, or jump to the top of a list when scrolling past the bottom."
             },
+            "DisableSearchButton": {
+                "Name": "Disable Search Button",
+                "Description": "Disables the search button to help with accidental presses, therefore requiring keyboard/mouse to back out. You can still click the search bar."
+            },
             "ReduceNoteSpeedByDifficulty": {
                 "Name": "Reduce Note Speed by Difficulty",
                 "Description": "Reduces the note speed if playing on a lower difficulty than Expert. The specified note speed is applied to Expert, and lower difficulties receive a reduction in speed. This setting does not affect vocal tracks."


### PR DESCRIPTION
Adds an option to disable the search button. Disabled by default, but useful for users who accidentally press search and then need to use their kbm to back out of it.