### PR TITLE
Slightly improve high score loading performance

### DIFF
--- a/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
+++ b/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
@@ -88,6 +88,7 @@ namespace YARG.Menu.MusicLibrary
         private List<HoldContext> _heldInputs = new();
 
         private int _primaryHeaderIndex;
+        private bool _shouldDisplaySoloHighScores;
 
         protected override void Awake()
         {
@@ -147,6 +148,8 @@ namespace YARG.Menu.MusicLibrary
                 _currentSong = CurrentlyPlaying;
             }
 
+            _shouldDisplaySoloHighScores = PlayerContainer.Players.Count(e => !e.Profile.IsBot) == 1;
+
             StemSettings.ApplySettings = SettingsManager.Settings.ApplyVolumesInMusicLibrary.Value;
             _previewDelay = 0;
             if (_reloadState == MusicLibraryReloadState.Full)
@@ -180,6 +183,7 @@ namespace YARG.Menu.MusicLibrary
 
             // Show no player warning
             _noPlayerWarning.SetActive(PlayerContainer.Players.Count <= 0);
+
         }
 
         protected override void OnSelectedIndexChanged()
@@ -223,8 +227,6 @@ namespace YARG.Menu.MusicLibrary
 
             return viewList;
         }
-
-        private bool ShouldDisplaySoloHighScores => PlayerContainer.Players.Count(e => !e.Profile.IsBot) == 1;
 
         private List<ViewType> CreateNormalViewList()
         {
@@ -325,7 +327,7 @@ namespace YARG.Menu.MusicLibrary
 
         private PlayerScoreRecord GetHighScoreForSong(SongEntry song)
         {
-            if (!ShouldDisplaySoloHighScores)
+            if (!_shouldDisplaySoloHighScores)
             {
                 return null;
             }
@@ -345,7 +347,7 @@ namespace YARG.Menu.MusicLibrary
 
         private GameRecord GetBandHighScoreForSong(SongEntry song)
         {
-            if (ShouldDisplaySoloHighScores)
+            if (_shouldDisplaySoloHighScores)
             {
                 return null;
             }


### PR DESCRIPTION
This PR slightly improves performance when loading high scores on the Music Library screen, which triggers when entering the Music Library screen, as well as whenever the sorting is changed. Note that the performance improvement is modest at best under normal circumstances - we're looking at a 0.2ms improvement with a music library of about 500 songs. Note that the first load is always much slower as the scores have to be fetched from the database. Subsequent calls are cached, and this is where the majority of the benefit will be seen.

![Screenshot 2024-10-25 134408](https://github.com/user-attachments/assets/5a5d6993-d0bd-4bc6-99df-9ea7d4f5910f)
Before change


![Screenshot 2024-10-25 134433](https://github.com/user-attachments/assets/706048d5-7374-4e5d-b85b-b111f9e2d1ea)
After change