### PR TITLE
Added linux file opener support

### DIFF
--- a/Assets/Script/Helpers/FileExplorerHelper.cs
+++ b/Assets/Script/Helpers/FileExplorerHelper.cs
@@ -82,6 +82,8 @@ namespace YARG.Helpers
             Process.Start("explorer.exe", folderPath);
 #elif UNITY_STANDALONE_OSX
             Process.Start("open", $"\"{folderPath}\"");
+#elif  UNITY_STANDALONE_LINUX
+            Process.Start("xdg-open", folderPath);
 #else
             GUIUtility.systemCopyBuffer = folderPath;
             DialogManager.Instance.ShowMessage(


### PR DESCRIPTION
Linux typically uses XDG-open to handle file paths and opening things. 

Dealing with .NET could be considered torture 