### PR TITLE
Change default tilt activation threshold for Riffmaster

### DIFF
--- a/Assets/Script/Input/Bindings/Defaults/BindingCollection.FiveFretGuitar.cs
+++ b/Assets/Script/Input/Bindings/Defaults/BindingCollection.FiveFretGuitar.cs
@@ -7,6 +7,7 @@ namespace YARG.Input
     public partial class BindingCollection
     {
         private static ActuationSettings _tiltSettings = new() { ButtonPressThreshold = 1.0f };
+        private static readonly ActuationSettings _riffmasterTiltSettings = new() { ButtonPressThreshold = 0.7f };
 
         private bool SetDefaultGameplayBindings(FiveFretGuitar guitar)
         {
@@ -35,17 +36,13 @@ namespace YARG.Input
                 AddBinding(GuitarAction.YellowFret, rb.soloYellow);
                 AddBinding(GuitarAction.BlueFret, rb.soloBlue);
                 AddBinding(GuitarAction.OrangeFret, rb.soloOrange);
-
-                if (guitar is RiffmasterGuitar riff)
-                {
-                    BindingCollection._tiltSettings = new() { ButtonPressThreshold = 0.7f };
-                }
             }
 
             // Different controllers require different defaults, so tilt binding needs to
             // happen after any special cases for different controller types are handled
+            var tiltSettings = guitar is RiffmasterGuitar ? _riffmasterTiltSettings : _tiltSettings;
             AddBinding(GuitarAction.StarPower, guitar.selectButton);
-            AddBinding(GuitarAction.StarPower, guitar.tilt, _tiltSettings);
+            AddBinding(GuitarAction.StarPower, guitar.tilt, tiltSettings);
 
             return true;
         }

--- a/Assets/Script/Input/Bindings/Defaults/BindingCollection.FiveFretGuitar.cs
+++ b/Assets/Script/Input/Bindings/Defaults/BindingCollection.FiveFretGuitar.cs
@@ -6,7 +6,7 @@ namespace YARG.Input
 {
     public partial class BindingCollection
     {
-        private static ActuationSettings _tiltSettings = new() { ButtonPressThreshold = 1f };
+        private static ActuationSettings _tiltSettings = new() { ButtonPressThreshold = 0.7f };
 
         private bool SetDefaultGameplayBindings(FiveFretGuitar guitar)
         {

--- a/Assets/Script/Input/Bindings/Defaults/BindingCollection.FiveFretGuitar.cs
+++ b/Assets/Script/Input/Bindings/Defaults/BindingCollection.FiveFretGuitar.cs
@@ -6,7 +6,7 @@ namespace YARG.Input
 {
     public partial class BindingCollection
     {
-        private static ActuationSettings _tiltSettings = new() { ButtonPressThreshold = 0.7f };
+        private static ActuationSettings _tiltSettings = new() { ButtonPressThreshold = 1.0f };
 
         private bool SetDefaultGameplayBindings(FiveFretGuitar guitar)
         {
@@ -22,9 +22,6 @@ namespace YARG.Input
             AddBinding(GuitarAction.StrumUp, guitar.strumUp);
             AddBinding(GuitarAction.StrumDown, guitar.strumDown);
 
-            AddBinding(GuitarAction.StarPower, guitar.selectButton);
-            AddBinding(GuitarAction.StarPower, guitar.tilt, _tiltSettings);
-
             AddBinding(GuitarAction.Whammy, guitar.whammy);
 
             if (guitar is GuitarHeroGuitar gh)
@@ -38,7 +35,17 @@ namespace YARG.Input
                 AddBinding(GuitarAction.YellowFret, rb.soloYellow);
                 AddBinding(GuitarAction.BlueFret, rb.soloBlue);
                 AddBinding(GuitarAction.OrangeFret, rb.soloOrange);
+
+                if (guitar is RiffmasterGuitar riff)
+                {
+                    BindingCollection._tiltSettings = new() { ButtonPressThreshold = 0.7f };
+                }
             }
+
+            // Different controllers require different defaults, so tilt binding needs to
+            // happen after any special cases for different controller types are handled
+            AddBinding(GuitarAction.StarPower, guitar.selectButton);
+            AddBinding(GuitarAction.StarPower, guitar.tilt, _tiltSettings);
 
             return true;
         }


### PR DESCRIPTION
The default tilt sensor activation threshold being 1.0 makes it impossible to activate SP with tilt by default on the Riffmaster. The maximum possible value appears to be somewhere between 0.9 and 0.95.

This PR changes the default activation threshold to 0.7, which seems to still provide plenty of headroom for avoiding unintentional activation.