### PR TITLE
Add bindings for Rock Band and Riffmaster guitar solo buttons

### DIFF
--- a/Assets/Art/Menu/Common/ModifierIcons.png
+++ b/Assets/Art/Menu/Common/ModifierIcons.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b901f0b9b0a49354b441d7b9027d44591f8fd493d1c81a2133643f0f30d10410
-size 1874372
+oid sha256:aa97cf3e3c5ee473c3a91bdbfb8a0ecc2b09b90483ea0a76f03075574ff61e59
+size 2054714

--- a/Assets/Art/Menu/Common/ModifierIcons.png.meta
+++ b/Assets/Art/Menu/Common/ModifierIcons.png.meta
@@ -168,7 +168,7 @@ TextureImporter:
       edges: []
       weights: []
     - serializedVersion: 2
-      name: ModifierIcons_3
+      name: SoloTaps
       rect:
         serializedVersion: 2
         x: 1536
@@ -458,13 +458,13 @@ TextureImporter:
       Ghosting: 960618387
       HoposToTaps: 1309754347
       InfiniteFrontEnd: -1660463282
-      ModifierIcons_3: -1638818548
       ModifierIcons_4: 1692867385
       ModifierIcons_5: -1436843964
       ModifierIcons_6: 1497401919
       NoKicks: -1200274759
       NoVocalPercussion: 1841026791
       RangeCompress: -1355680061
+      SoloTaps: -1638818548
       TapsToHopos: 1609936924
       UnpitchedOnly: -2147107449
   spritePackingTag: 

--- a/Assets/Script/Input/Bindings/BindingCollection.Templates.cs
+++ b/Assets/Script/Input/Bindings/BindingCollection.Templates.cs
@@ -30,6 +30,12 @@ namespace YARG.Input
             new ButtonBinding("FiveFret.Yellow", (int) GuitarAction.YellowFret),
             new ButtonBinding("FiveFret.Blue",   (int) GuitarAction.BlueFret),
             new ButtonBinding("FiveFret.Orange", (int) GuitarAction.OrangeFret),
+            // Also need bindings for solo frets
+            new ButtonBinding("FiveFret.SoloGreen", (int) GuitarAction.SoloGreenFret),
+            new ButtonBinding("FiveFret.SoloRed",   (int) GuitarAction.SoloRedFret),
+            new ButtonBinding("FiveFret.SoloYellow",(int) GuitarAction.SoloYellowFret),
+            new ButtonBinding("FiveFret.SoloBlue",  (int) GuitarAction.SoloBlueFret),
+            new ButtonBinding("FiveFret.SoloOrange",(int) GuitarAction.SoloOrangeFret),
 
             new ButtonBinding("Guitar.StrumUp",   (int) GuitarAction.StrumUp),
             new ButtonBinding("Guitar.StrumDown", (int) GuitarAction.StrumDown),

--- a/Assets/Script/Input/Bindings/Defaults/BindingCollection.FiveFretGuitar.cs
+++ b/Assets/Script/Input/Bindings/Defaults/BindingCollection.FiveFretGuitar.cs
@@ -31,11 +31,11 @@ namespace YARG.Input
             }
             else if (guitar is RockBandGuitar rb)
             {
-                AddBinding(GuitarAction.GreenFret, rb.soloGreen);
-                AddBinding(GuitarAction.RedFret, rb.soloRed);
-                AddBinding(GuitarAction.YellowFret, rb.soloYellow);
-                AddBinding(GuitarAction.BlueFret, rb.soloBlue);
-                AddBinding(GuitarAction.OrangeFret, rb.soloOrange);
+                AddBinding(GuitarAction.SoloGreenFret, rb.soloGreen);
+                AddBinding(GuitarAction.SoloRedFret, rb.soloRed);
+                AddBinding(GuitarAction.SoloYellowFret, rb.soloYellow);
+                AddBinding(GuitarAction.SoloBlueFret, rb.soloBlue);
+                AddBinding(GuitarAction.SoloOrangeFret, rb.soloOrange);
             }
 
             // Different controllers require different defaults, so tilt binding needs to

--- a/Assets/Script/Menu/ScoreScreen/ScoreCards/ModifierIcon.cs
+++ b/Assets/Script/Menu/ScoreScreen/ScoreCards/ModifierIcon.cs
@@ -11,6 +11,7 @@ namespace YARG.Menu.ScoreScreen
         private const string GHOSTING           = "Ghosting";
         private const string INFINITE_FRONT_END = "InfiniteFrontEnd";
         private const string DYNAMIC_HIT_WINDOW = "DynamicHitWindow";
+        private const string SOLO_TAPS          = "SoloTaps";
 
         [SerializeField]
         private Image _icon;
@@ -53,6 +54,13 @@ namespace YARG.Menu.ScoreScreen
                     {
                         var icon = Instantiate(prefab, parent);
                         icon.InitializeCustom(DYNAMIC_HIT_WINDOW);
+                    }
+
+                    // Solo Taps
+                    if (enginePreset.FiveFretGuitar.SoloTaps)
+                    {
+                        var icon = Instantiate(prefab, parent);
+                        icon.InitializeCustom(SOLO_TAPS);
                     }
 
                     break;

--- a/Assets/StreamingAssets/lang/en-US.json
+++ b/Assets/StreamingAssets/lang/en-US.json
@@ -382,7 +382,12 @@
             "Red": "Red Fret (Second)",
             "Yellow": "Yellow Fret (Third)",
             "Blue": "Blue Fret (Fourth)",
-            "Orange": "Orange Fret (Fifth)"
+            "Orange": "Orange Fret (Fifth)",
+            "SoloGreen": "Solo Green Fret",
+            "SoloRed": "Solo Red Fret",
+            "SoloYellow": "Solo Yellow Fret",
+            "SoloBlue": "Solo Blue Fret",
+            "SoloOrange": "Solo Orange Fret"
         },
         "Guitar": {
             "StrumUp": "Strum Up",

--- a/Assets/StreamingAssets/lang/en-US.json
+++ b/Assets/StreamingAssets/lang/en-US.json
@@ -1371,6 +1371,10 @@
                 "SustainDropLeniency": {
                     "Name": "Sustain Drop Leniency",
                     "Description": ""
+                },
+                "SoloTaps": {
+                    "Name": "Allow Taps During Solos",
+                    "Description": "Allows solo buttons to tap notes during solos"
                 }
             },
             "HighwayPreset" : {


### PR DESCRIPTION
This PR adds bindings for solo buttons as found on Rock Band guitars and the Riffmaster and changes the default bindings for those devices to bind solo buttons as solo buttons instead of regular buttons.

See [YARG.Core PR #224](https://github.com/YARC-Official/YARG.Core/pull/224) for engine support.

Related graphical effects are included in #936 