### PR TITLE
Add "Make Nightly Build" menu option to Unity Editor

### DIFF
--- a/Assets/Editor/MakeTestBuild.cs
+++ b/Assets/Editor/MakeTestBuild.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq;
 using UnityEditor;
 
@@ -7,9 +7,21 @@ namespace Editor
     public static class MakeTestBuild
     {
         private const string YARG_TEST_BUILD = "YARG_TEST_BUILD";
+        private const string YARG_NIGHTLY_BUILD = "YARG_NIGHTLY_BUILD";
 
         [MenuItem("File/Make Test Build", false, 220)]
         public static void MakeTestBuildClicked()
+        {
+            MakeBuild(YARG_TEST_BUILD);
+        }
+
+        [MenuItem("File/Make Nightly Build", false, 220)]
+        public static void MakeNightlyBuildClicked()
+        {
+            MakeBuild(YARG_NIGHTLY_BUILD);
+        }
+
+        public static void MakeBuild(string defineSymbol)
         {
             // Get build settings
             var buildSettings = BuildPlayerWindow.DefaultBuildMethods.GetBuildPlayerOptions(default);
@@ -22,8 +34,11 @@ namespace Editor
 
             // Set test build define
             var buildDefines = buildSettings.extraScriptingDefines ?? Array.Empty<string>();
-            if (!originalDefines.Contains(YARG_TEST_BUILD) && !buildDefines.Contains(YARG_TEST_BUILD))
-                ArrayUtility.Add(ref buildDefines, YARG_TEST_BUILD);
+            if (!originalDefines.Contains(defineSymbol) && !buildDefines.Contains(defineSymbol))
+            {
+                ArrayUtility.Add(ref buildDefines, defineSymbol);
+            }
+
             buildSettings.extraScriptingDefines = buildDefines;
 
             // Build the player


### PR DESCRIPTION
This adds a "Make Nightly Build" menu option to the Unity Editor, below the "Make Test Build" menu option. It functions the same as the existing option, but sets YARG_NIGHTLY_BUILD compile flag so that the resulting build will use the nightly save data folder.