### PR TITLE
Add option to sort by play count

### DIFF
--- a/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
+++ b/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
@@ -185,6 +185,13 @@ namespace YARG.Menu.MusicLibrary
             // Show no player warning
             _noPlayerWarning.SetActive(PlayerContainer.Players.Count <= 0);
 
+            // Make sure sort is not by play count if there are only bots
+            if (PlayerContainer.Players.Count(e => !e.Profile.IsBot) == 0 &&
+                SettingsManager.Settings.LibrarySort == SortAttribute.Playcount)
+            {
+                // Name makes a good fallback?
+                ChangeSort(SortAttribute.Name);
+            }
         }
 
         protected override void OnSelectedIndexChanged()

--- a/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
+++ b/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
@@ -186,7 +186,7 @@ namespace YARG.Menu.MusicLibrary
             _noPlayerWarning.SetActive(PlayerContainer.Players.Count <= 0);
 
             // Make sure sort is not by play count if there are only bots
-            if (PlayerContainer.Players.Count(e => !e.Profile.IsBot) == 0 &&
+            if (PlayerContainer.OnlyHasBots() &&
                 SettingsManager.Settings.LibrarySort == SortAttribute.Playcount)
             {
                 // Name makes a good fallback?

--- a/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
+++ b/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
@@ -630,6 +630,12 @@ namespace YARG.Menu.MusicLibrary
 
         public void ChangeSort(SortAttribute sort)
         {
+            // Keep the previous sort attribute, too, so it can be used to
+            // sort the list of unplayed songs and possibly for other things
+            if (sort != SortAttribute.Playcount)
+            {
+                SettingsManager.Settings.PreviousLibrarySort = sort;
+            }
             SettingsManager.Settings.LibrarySort = sort;
             UpdateSearch(true);
         }

--- a/Assets/Script/Menu/MusicLibrary/PopupMenu.cs
+++ b/Assets/Script/Menu/MusicLibrary/PopupMenu.cs
@@ -189,7 +189,7 @@ namespace YARG.Menu.MusicLibrary
                 }
 
                 // Skip Play count if there are no real players
-                if (sort == SortAttribute.Playcount && PlayerContainer.Players.Count(e => !e.Profile.IsBot) == 0)
+                if (sort == SortAttribute.Playcount && PlayerContainer.OnlyHasBots())
                 {
                     continue;
                 }

--- a/Assets/Script/Menu/MusicLibrary/PopupMenu.cs
+++ b/Assets/Script/Menu/MusicLibrary/PopupMenu.cs
@@ -125,7 +125,7 @@ namespace YARG.Menu.MusicLibrary
                     UpdateForState();
                 });
             }
-            
+
             var viewType = _musicLibrary.CurrentSelection;
 
             // Add/remove to favorites
@@ -184,6 +184,12 @@ namespace YARG.Menu.MusicLibrary
             {
                 // Skip theses because they don't make sense
                 if (sort == SortAttribute.Unspecified)
+                {
+                    continue;
+                }
+
+                // Skip Play count if there are no real players
+                if (sort == SortAttribute.Playcount && PlayerContainer.Players.Count(e => !e.Profile.IsBot) == 0)
                 {
                     continue;
                 }

--- a/Assets/Script/Player/PlayerContainer.cs
+++ b/Assets/Script/Player/PlayerContainer.cs
@@ -300,5 +300,17 @@ namespace YARG.Player
 
             }
         }
+
+        public static bool OnlyHasBots()
+        {
+            for (int i = 0; i < _players.Count; i++)
+            {
+                if (!_players[i].Profile.IsBot)
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
     }
 }

--- a/Assets/Script/Player/PlayerContainer.cs
+++ b/Assets/Script/Player/PlayerContainer.cs
@@ -169,7 +169,8 @@ namespace YARG.Player
 
         private static void ActiveProfilesChanged()
         {
-            if (SettingsManager.Settings.LibrarySort == SortAttribute.Playable)
+            if (SettingsManager.Settings.LibrarySort == SortAttribute.Playable ||
+                SettingsManager.Settings.LibrarySort == SortAttribute.Playcount)
             {
                 MusicLibraryMenu.SetReload(MusicLibraryReloadState.Full);
             }

--- a/Assets/Script/Scores/ScoreContainer.cs
+++ b/Assets/Script/Scores/ScoreContainer.cs
@@ -412,8 +412,6 @@ namespace YARG.Scores
         // this is the same as GetMostPlayedSongs, but is limited to the one profile and returns the entire list
         public static List<SongEntry> GetPlayedSongsForUserByPlaycount(YargProfile profile, bool order)
         {
-            // This may actually need to return a list of structs like (SongEntry, playCount)
-            // For now we can try returning a list of songs in order of play count
             var sortOrder = order ? "DESC" : "ASC";
             var profileId = profile.Id;
             var songList = new List<SongEntry>();

--- a/Assets/Script/Scores/ScoreContainer.cs
+++ b/Assets/Script/Scores/ScoreContainer.cs
@@ -434,8 +434,7 @@ namespace YARG.Scores
                 var hash = HashWrapper.Create(record.SongChecksum);
                 if (SongContainer.SongsByHash.TryGetValue(hash, out var list))
                 {
-                    // If there are songs with a duplicate hash, one will be chosen randomly
-                    songList.Add(list.Pick());
+                    songList.AddRange(list);
                 }
             }
             return songList;

--- a/Assets/Script/Settings/SettingsManager.Settings.cs
+++ b/Assets/Script/Settings/SettingsManager.Settings.cs
@@ -39,6 +39,7 @@ namespace YARG.Settings
             public bool ShowExperimentalWarningDialog = true;
 
             public SortAttribute LibrarySort = SortAttribute.Name;
+            public SortAttribute PreviousLibrarySort = SortAttribute.Name;
 
             public Dictionary<string, HUDPositionProfile> HUDPositionProfiles = new();
 

--- a/Assets/Script/Song/SongContainer.cs
+++ b/Assets/Script/Song/SongContainer.cs
@@ -158,7 +158,7 @@ namespace YARG.Song
 
         public static SongCategory[] GetSortedCategory(SortAttribute sort)
         {
-            return sort switch
+            var proposedSort = sort switch
             {
                 SortAttribute.Name => _sortTitles,
                 SortAttribute.Artist => _sortArtists,
@@ -195,15 +195,19 @@ namespace YARG.Song
                 SortAttribute.Vocals         => _sortInstruments[Instrument.Vocals],
                 SortAttribute.Harmony        => _sortInstruments[Instrument.Harmony],
                 SortAttribute.Band           => _sortInstruments[Instrument.Band],
-                // Make life better when people go back a version and we
-                // encounter sorts we don't understand by providing a
-                // default rather than a blank song library
-                _ => new Func<SongCategory[]>( () =>
-                {
-                    YargLogger.LogInfo("Invalid Sort Attribute. Defaulting to Name sort.");
-                    return _sortTitles;
-                })(),
+                _  => null
             };
+
+            // Make life better when people go back a version and we
+            // encounter sorts we don't understand by providing a
+            // default rather than a blank song library
+            if (proposedSort != null)
+            {
+                return proposedSort;
+            }
+
+            YargLogger.LogInfo("Invalid Sort Attribute. Defaulting to Name sort.");
+            return _sortTitles;
         }
 
         public static bool HasInstrument(Instrument instrument)
@@ -297,7 +301,7 @@ namespace YARG.Song
         {
             // This should never happen since play count shouldn't be selectable without
             // a non-bot profile and MusicLibraryMenu already checks for this, but let's double check
-            if (PlayerContainer.Players.Count(e => !e.Profile.IsBot) == 0)
+            if (PlayerContainer.OnlyHasBots())
             {
                 // Titles seems like a reasonable fallback
                 return _sortTitles;

--- a/Assets/Script/Song/SongContainer.cs
+++ b/Assets/Script/Song/SongContainer.cs
@@ -292,14 +292,23 @@ namespace YARG.Song
             var counts = ScoreContainer.GetPlayedSongsForUserByPlaycount(player.Profile, true);
             // Get all the unplayed songs and stuff them on the end of the list
             var zeroPlaySongs = new List<SongEntry>();
-            foreach (var list in _songCache.Entries.Values)
+            var previousSort = SettingsManager.Settings.PreviousLibrarySort;
+
+            if (previousSort == SortAttribute.Unspecified)
             {
-                var songs = list.Except(counts);
+                // I don't think this should ever happen, but I'm not certain,
+                // so belt and suspenders wins.
+                previousSort = SortAttribute.Name;
+            }
+
+            foreach (var category in GetSortedCategory(previousSort))
+            {
+                var songs = category.Songs.Except(counts);
                 zeroPlaySongs.AddRange(songs);
             }
-            counts.AddRange(zeroPlaySongs);
-            var countCategories = new SongCategory[1];
-            countCategories[0] = new SongCategory("Play Count", counts.ToArray(), "Play Count");
+            var countCategories = new SongCategory[2];
+            countCategories[0] = new SongCategory("PLAYED SONGS", counts.ToArray(), "Played Songs");
+            countCategories[1] = new SongCategory("UNPLAYED SONGS", zeroPlaySongs.ToArray(), "Unplayed Songs");
             return countCategories;
         }
 

--- a/Assets/Script/Song/SongContainer.cs
+++ b/Assets/Script/Song/SongContainer.cs
@@ -195,7 +195,14 @@ namespace YARG.Song
                 SortAttribute.Vocals         => _sortInstruments[Instrument.Vocals],
                 SortAttribute.Harmony        => _sortInstruments[Instrument.Harmony],
                 SortAttribute.Band           => _sortInstruments[Instrument.Band],
-                _ => throw new Exception("stoopid"),
+                // Make life better when people go back a version and we
+                // encounter sorts we don't understand by providing a
+                // default rather than a blank song library
+                _ => new Func<SongCategory[]>( () =>
+                {
+                    YargLogger.LogInfo("Invalid Sort Attribute. Defaulting to Name sort.");
+                    return _sortTitles;
+                })(),
             };
         }
 

--- a/Assets/StreamingAssets/lang/en-US.json
+++ b/Assets/StreamingAssets/lang/en-US.json
@@ -95,7 +95,8 @@
             "ProKeys": "Pro Keys",
             "Vocals": "Vocals",
             "Harmony": "Harmony",
-            "Band": "Band"
+            "Band": "Band",
+            "Playcount": "Play Count"
         }
     },
     "Menu": {


### PR DESCRIPTION
This PR adds a new sorting option to the song library to sort by play count.

When sorting by play count, two categories are displayed, played and unplayed. Played songs are sorted by the number of times played by the first connected profile, in descending order. Unplayed songs are sorted by whatever sort order was in use immediately prior to switching to play count order.