### PR TITLE
Results Screen: Remove unnecessary horizontal scrolling

### DIFF
--- a/Assets/Prefabs/Menu/ScoreScreen/DrumsScoreCard.prefab
+++ b/Assets/Prefabs/Menu/ScoreScreen/DrumsScoreCard.prefab
@@ -75,7 +75,7 @@ PrefabInstance:
     - target: {fileID: 1007692541323341066, guid: 1b5d8949b9f2d7345a0fed53e687c843,
         type: 3}
       propertyPath: m_Value
-      value: 1
+      value: 1.0000076
       objectReference: {fileID: 0}
     - target: {fileID: 1516494443395727076, guid: 1b5d8949b9f2d7345a0fed53e687c843,
         type: 3}
@@ -399,27 +399,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2885240813551093152, guid: 1b5d8949b9f2d7345a0fed53e687c843,
         type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 480
-      objectReference: {fileID: 0}
-    - target: {fileID: 2885240813551093152, guid: 1b5d8949b9f2d7345a0fed53e687c843,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 837
-      objectReference: {fileID: 0}
-    - target: {fileID: 2885240813551093152, guid: 1b5d8949b9f2d7345a0fed53e687c843,
-        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2885240813551093152, guid: 1b5d8949b9f2d7345a0fed53e687c843,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2885240813551093152, guid: 1b5d8949b9f2d7345a0fed53e687c843,
-        type: 3}
-      propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2885240813551093152, guid: 1b5d8949b9f2d7345a0fed53e687c843,
@@ -440,16 +425,6 @@ PrefabInstance:
     - target: {fileID: 2885240813551093152, guid: 1b5d8949b9f2d7345a0fed53e687c843,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2885240813551093152, guid: 1b5d8949b9f2d7345a0fed53e687c843,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2885240813551093152, guid: 1b5d8949b9f2d7345a0fed53e687c843,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2885240813551093152, guid: 1b5d8949b9f2d7345a0fed53e687c843,

--- a/Assets/Prefabs/Menu/ScoreScreen/GuitarScoreCard.prefab
+++ b/Assets/Prefabs/Menu/ScoreScreen/GuitarScoreCard.prefab
@@ -352,7 +352,7 @@ PrefabInstance:
     - target: {fileID: 1007692541323341066, guid: 1b5d8949b9f2d7345a0fed53e687c843,
         type: 3}
       propertyPath: m_Value
-      value: 1
+      value: 1.0000007
       objectReference: {fileID: 0}
     - target: {fileID: 1516494443395727076, guid: 1b5d8949b9f2d7345a0fed53e687c843,
         type: 3}
@@ -676,27 +676,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2885240813551093152, guid: 1b5d8949b9f2d7345a0fed53e687c843,
         type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 480
-      objectReference: {fileID: 0}
-    - target: {fileID: 2885240813551093152, guid: 1b5d8949b9f2d7345a0fed53e687c843,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 837
-      objectReference: {fileID: 0}
-    - target: {fileID: 2885240813551093152, guid: 1b5d8949b9f2d7345a0fed53e687c843,
-        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2885240813551093152, guid: 1b5d8949b9f2d7345a0fed53e687c843,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2885240813551093152, guid: 1b5d8949b9f2d7345a0fed53e687c843,
-        type: 3}
-      propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2885240813551093152, guid: 1b5d8949b9f2d7345a0fed53e687c843,
@@ -717,16 +702,6 @@ PrefabInstance:
     - target: {fileID: 2885240813551093152, guid: 1b5d8949b9f2d7345a0fed53e687c843,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2885240813551093152, guid: 1b5d8949b9f2d7345a0fed53e687c843,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2885240813551093152, guid: 1b5d8949b9f2d7345a0fed53e687c843,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2885240813551093152, guid: 1b5d8949b9f2d7345a0fed53e687c843,

--- a/Assets/Prefabs/Menu/ScoreScreen/ProKeysScoreCard.prefab
+++ b/Assets/Prefabs/Menu/ScoreScreen/ProKeysScoreCard.prefab
@@ -75,7 +75,7 @@ PrefabInstance:
     - target: {fileID: 1007692541323341066, guid: 1b5d8949b9f2d7345a0fed53e687c843,
         type: 3}
       propertyPath: m_Value
-      value: 1
+      value: 1.0000076
       objectReference: {fileID: 0}
     - target: {fileID: 1516494443395727076, guid: 1b5d8949b9f2d7345a0fed53e687c843,
         type: 3}
@@ -399,27 +399,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2885240813551093152, guid: 1b5d8949b9f2d7345a0fed53e687c843,
         type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 480
-      objectReference: {fileID: 0}
-    - target: {fileID: 2885240813551093152, guid: 1b5d8949b9f2d7345a0fed53e687c843,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 837
-      objectReference: {fileID: 0}
-    - target: {fileID: 2885240813551093152, guid: 1b5d8949b9f2d7345a0fed53e687c843,
-        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2885240813551093152, guid: 1b5d8949b9f2d7345a0fed53e687c843,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2885240813551093152, guid: 1b5d8949b9f2d7345a0fed53e687c843,
-        type: 3}
-      propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2885240813551093152, guid: 1b5d8949b9f2d7345a0fed53e687c843,
@@ -440,16 +425,6 @@ PrefabInstance:
     - target: {fileID: 2885240813551093152, guid: 1b5d8949b9f2d7345a0fed53e687c843,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2885240813551093152, guid: 1b5d8949b9f2d7345a0fed53e687c843,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2885240813551093152, guid: 1b5d8949b9f2d7345a0fed53e687c843,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2885240813551093152, guid: 1b5d8949b9f2d7345a0fed53e687c843,

--- a/Assets/Prefabs/Menu/ScoreScreen/ScoreCard.prefab
+++ b/Assets/Prefabs/Menu/ScoreScreen/ScoreCard.prefab
@@ -1166,7 +1166,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 480, y: 837}
+  m_SizeDelta: {x: 470, y: 837}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &2885240813551093157
 MonoBehaviour:
@@ -3183,6 +3183,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6232041351873830570, guid: 81863a63e0d96cf459c263ee0ea6f98e,
+        type: 3}
+      propertyPath: m_Value
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8632074353890534202, guid: 81863a63e0d96cf459c263ee0ea6f98e,
         type: 3}

--- a/Assets/Prefabs/Menu/ScoreScreen/StatInfo.prefab
+++ b/Assets/Prefabs/Menu/ScoreScreen/StatInfo.prefab
@@ -37,7 +37,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 480, y: 21}
+  m_SizeDelta: {x: 470, y: 21}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &5955370018740084784
 MonoBehaviour:

--- a/Assets/Prefabs/Menu/ScoreScreen/VocalsScoreCard.prefab
+++ b/Assets/Prefabs/Menu/ScoreScreen/VocalsScoreCard.prefab
@@ -157,6 +157,11 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 2558536234367322089, guid: 1b5d8949b9f2d7345a0fed53e687c843,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 2644023843467096552, guid: 1b5d8949b9f2d7345a0fed53e687c843,
         type: 3}
       propertyPath: m_AnchorMax.y
@@ -394,27 +399,12 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2885240813551093152, guid: 1b5d8949b9f2d7345a0fed53e687c843,
         type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 480
-      objectReference: {fileID: 0}
-    - target: {fileID: 2885240813551093152, guid: 1b5d8949b9f2d7345a0fed53e687c843,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 837
-      objectReference: {fileID: 0}
-    - target: {fileID: 2885240813551093152, guid: 1b5d8949b9f2d7345a0fed53e687c843,
-        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2885240813551093152, guid: 1b5d8949b9f2d7345a0fed53e687c843,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2885240813551093152, guid: 1b5d8949b9f2d7345a0fed53e687c843,
-        type: 3}
-      propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2885240813551093152, guid: 1b5d8949b9f2d7345a0fed53e687c843,
@@ -435,16 +425,6 @@ PrefabInstance:
     - target: {fileID: 2885240813551093152, guid: 1b5d8949b9f2d7345a0fed53e687c843,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2885240813551093152, guid: 1b5d8949b9f2d7345a0fed53e687c843,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 2885240813551093152, guid: 1b5d8949b9f2d7345a0fed53e687c843,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2885240813551093152, guid: 1b5d8949b9f2d7345a0fed53e687c843,
@@ -610,6 +590,21 @@ PrefabInstance:
     - target: {fileID: 2958724853193943092, guid: 1b5d8949b9f2d7345a0fed53e687c843,
         type: 3}
       propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3191902544221229210, guid: 1b5d8949b9f2d7345a0fed53e687c843,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3191902544221229210, guid: 1b5d8949b9f2d7345a0fed53e687c843,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3191902544221229210, guid: 1b5d8949b9f2d7345a0fed53e687c843,
+        type: 3}
+      propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3280583778863149243, guid: 1b5d8949b9f2d7345a0fed53e687c843,

--- a/Assets/Scenes/ScoreScene.unity
+++ b/Assets/Scenes/ScoreScene.unity
@@ -748,7 +748,7 @@ MonoBehaviour:
     m_Top: 0
     m_Bottom: 0
   m_ChildAlignment: 4
-  m_Spacing: 15
+  m_Spacing: 10
   m_ChildForceExpandWidth: 0
   m_ChildForceExpandHeight: 1
   m_ChildControlWidth: 0


### PR DESCRIPTION
This PR fixes a minor issue on the results screen that causes the score cards to not quite fit on the screen when there are exactly 4 players, which causes unneeded horizontal scrolling. This is done by slightly reducing the width of the score cards and spacing between them.

*Before*
![YARG-ScrollFixBefore](https://github.com/user-attachments/assets/4144f909-94dd-4f54-96f7-807d094331ed)

*After*
![YARG-ScrollFixAfter](https://github.com/user-attachments/assets/fde160ac-0f31-48c9-b6bc-40ab47c974c7)

Note: This issue only occurs when using a resolution with a 16:9 aspect ratio. Wider aspect ratios have more horizontal space to begin with and therefore have enough space for 4 score cards by default.
