### PR TITLE
Inhibit drum SP activation gems during active SP

### DIFF
--- a/Assets/Script/Gameplay/Visuals/TrackElements/Drums/FiveLaneDrumsNoteElement.cs
+++ b/Assets/Script/Gameplay/Visuals/TrackElements/Drums/FiveLaneDrumsNoteElement.cs
@@ -71,7 +71,7 @@ namespace YARG.Gameplay.Visuals
             // Get colors
             var colorNoStarPower = colors.GetNoteColor(pad);
             var color = colorNoStarPower;
-            if (NoteRef.IsStarPowerActivator && Player.Engine.CanStarPowerActivate)
+            if (NoteRef.IsStarPowerActivator && Player.Engine.CanStarPowerActivate && !Player.Engine.BaseStats.IsStarPowerActive)
             {
                 color = colors.ActivationNote;
             }

--- a/Assets/Script/Gameplay/Visuals/TrackElements/Drums/FourLaneDrumsNoteElement.cs
+++ b/Assets/Script/Gameplay/Visuals/TrackElements/Drums/FourLaneDrumsNoteElement.cs
@@ -71,7 +71,7 @@ namespace YARG.Gameplay.Visuals
             // Get colors
             var colorNoStarPower = colors.GetNoteColor(pad);
             var color = colorNoStarPower;
-            if (NoteRef.IsStarPowerActivator && Player.Engine.CanStarPowerActivate)
+            if (NoteRef.IsStarPowerActivator && Player.Engine.CanStarPowerActivate && !Player.Engine.BaseStats.IsStarPowerActive)
             {
                 color = colors.ActivationNote;
             }


### PR DESCRIPTION
If the player has more than half a bar of SP during a drum fill phrase, the activation gem will be generated even if SP is active. 

This is because FourLaneDrumsNoteElement checks Player.Engine.CanStarPowerActivate to determine whether notes with the IsStarPowerActivator flag set should have their gem colored with the activation color or the normal color. CanStarPowerActivate does not consider SP activation status, so the gem ends up being purple when it shouldn't be.

This PR conditions the use of the activation color on SP not currently being active when the activator gem is spawned.
