### PR TITLE
Don't attempt to pulse the star meter once gold has been achieved.

### DIFF
--- a/Assets/Script/Gameplay/HUD/ScoreBox/StarScoreDisplay.cs
+++ b/Assets/Script/Gameplay/HUD/ScoreBox/StarScoreDisplay.cs
@@ -37,7 +37,7 @@ namespace YARG.Gameplay.HUD
                 return;
 
             _goldMeterBeatCount++;
-            if (_goldMeterBeatCount % 2 == 0 && _currentStar == 5)
+            if (_goldMeterBeatCount % 2 == 0 && _currentStar == 5 && !_isGoldAchieved)
             {
                 foreach (var star in _starObjects)
                 {


### PR DESCRIPTION
After earning 5 gold stars, an error is repeatedly emitted to the debug log: "game object with animator is inactive". This happens because the gold star animator's Play method continues being called every second beatline even after the normal star object has been disabled.

This PR conditions the call to PulseGoldMeter on 5GS not having been reached, resolving the log spam.  