### PR TITLE
Fix venue custom shaders on linux and OSX

### DIFF
--- a/Assets/Script/Gameplay/BackgroundManager.cs
+++ b/Assets/Script/Gameplay/BackgroundManager.cs
@@ -68,21 +68,6 @@ namespace YARG.Gameplay
                     var bg = (GameObject) await bundle.LoadAssetAsync<GameObject>(
                         BundleBackgroundManager.BACKGROUND_PREFAB_PATH.ToLowerInvariant());
 
-#if UNITY_EDITOR_LINUX || UNITY_STANDALONE_LINUX || UNITY_EDITOR_OSX || UNITY_STANDALONE_OSX
-                    // Fix for non-Windows machines
-                    // Probably there's a better way to do this.
-					Renderer[] renderers = bg.GetComponentsInChildren<Renderer>();
-
-					foreach (Renderer renderer in renderers) {
-						Material[] materials = renderer.sharedMaterials;
-
-						for (int i = 0; i < materials.Length; i++) {
-							Material material = materials[i];
-							material.shader = Shader.Find(material.shader.name);
-						}
-					}
-#endif
-
                     var bgInstance = Instantiate(bg);
 
                     bgInstance.GetComponent<BundleBackgroundManager>().Bundle = bundle;


### PR DESCRIPTION
Its unclear why that shader code was added but it actually breaks all custom shaders used in venues, removing that linux/osx specific code makes custom shaders in venues work on Linux