### PR TITLE
Prefer Vulkan over glcore on Linux

### DIFF
--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -562,7 +562,7 @@ PlayerSettings:
     m_APIs: 1000000011000000
     m_Automatic: 0
   - m_BuildTarget: LinuxStandaloneSupport
-    m_APIs: 1100000015000000
+    m_APIs: 1500000011000000
     m_Automatic: 0
   m_BuildTargetVRSettings: []
   m_DefaultShaderChunkSizeInMB: 16


### PR DESCRIPTION
Vulkan generally seem to work better and is the default for unity on Linux for quite a few years now