### PR TITLE
Add active graphics api to watermark text

### DIFF
--- a/Assets/Script/Menu/Persistent/DevWatermark.cs
+++ b/Assets/Script/Menu/Persistent/DevWatermark.cs
@@ -11,11 +11,11 @@ namespace YARG.Menu.Persistent
         private void Start()
         {
 #if UNITY_EDITOR
-            _watermarkText.text = $"<b>YARG {GlobalVariables.Instance.CurrentVersion}</b> Unity Editor";
+            _watermarkText.text = $"<b>YARG {GlobalVariables.Instance.CurrentVersion}</b> Unity Editor ({SystemInfo.graphicsDeviceType})";
 #elif YARG_TEST_BUILD
-            _watermarkText.text = $"<b>YARG {GlobalVariables.Instance.CurrentVersion}</b> Development Build";
+            _watermarkText.text = $"<b>YARG {GlobalVariables.Instance.CurrentVersion}</b> Development Build ({SystemInfo.graphicsDeviceType})";
 #elif YARG_NIGHTLY_BUILD
-            _watermarkText.text = $"<b>YARG {GlobalVariables.Instance.CurrentVersion}</b> Nightly Build";
+            _watermarkText.text = $"<b>YARG {GlobalVariables.Instance.CurrentVersion}</b> Nightly Build ({SystemInfo.graphicsDeviceType})";
 #else
             gameObject.SetActive(false);
 #endif


### PR DESCRIPTION
Makes it a little easier to debug user graphics issues when we need to see which graphics api is currently active