### PR TITLE
Fix venues shaders on OSX (again)

### DIFF
--- a/Assets/Script/Gameplay/BackgroundManager.cs
+++ b/Assets/Script/Gameplay/BackgroundManager.cs
@@ -6,8 +6,8 @@ using Cysharp.Threading.Tasks;
 using UnityEngine;
 using UnityEngine.UI;
 using UnityEngine.Video;
-using YARG.Core.Extensions;
 using YARG.Core.IO;
+using YARG.Core.Logging;
 using YARG.Core.Venue;
 using YARG.Helpers.Extensions;
 using YARG.Settings;
@@ -79,13 +79,17 @@ namespace YARG.Gameplay
 
                     if (shaderBundleData != null && shaderBundleData.bytes.Length > 0)
                     {
+                        YargLogger.LogInfo("Loading Metal shader bundle");
                         shaderBundle = await AssetBundle.LoadFromMemoryAsync(shaderBundleData.bytes);
                         var allAssets = shaderBundle.LoadAllAssets<Shader>();
                         foreach (var shader in allAssets)
                         {
                             metalShaders.Add(shader.name, shader);
                         }
-
+                    }
+                    else
+                    {
+                        YargLogger.LogInfo("Did not find Metal shader bundle");
                     }
 
                     // Yarground comes with shaders for dx11/dx12/glcore/vulkan
@@ -100,11 +104,13 @@ namespace YARG.Gameplay
                             var shaderName = material.shader.name;
                             if (metalShaders.TryGetValue(shaderName, out var shader))
                             {
+                                YargLogger.LogFormatDebug("Found bundled shader {0}", shaderName);
                                 // We found shader from Yarground
                                 material.shader = shader;
                             }
                             else
                             {
+                                YargLogger.LogFormatDebug("Did not find bundled shader {0}", shaderName);
                                 // Fallback to try to find among builtin shaders
                                 material.shader = Shader.Find(shaderName);
                             }

--- a/Assets/Script/Gameplay/BackgroundManager.cs
+++ b/Assets/Script/Gameplay/BackgroundManager.cs
@@ -91,7 +91,7 @@ namespace YARG.Gameplay
                     // Yarground comes with shaders for dx11/dx12/glcore/vulkan
                     // Metal shaders used on OSX come in this separate bundle
                     // Update our renderers to use them
-                    var renderers = bg.GetComponentsInChildren<Renderer>();
+                    var renderers = bg.GetComponentsInChildren<Renderer>(true);
 
                     foreach (var renderer in renderers)
                     {

--- a/Assets/Script/Venue/BundleBackgroundManager.cs
+++ b/Assets/Script/Venue/BundleBackgroundManager.cs
@@ -123,7 +123,7 @@ namespace YARG.Venue
                     var filePath = Path.Combine(Application.temporaryCachePath, BACKGROUND_SHADER_BUNDLE_NAME);
                     var assetPath = Path.Combine(Application.dataPath, BACKGROUND_SHADER_BUNDLE_NAME);
                     File.Move(filePath, assetPath);
-                    AssetDatabase.ImportAsset(assetPath);
+                    AssetDatabase.ImportAsset(Path.Combine("Assets", BACKGROUND_SHADER_BUNDLE_NAME));
                 }
                 // Now delete our material clones
                 foreach (var assetPath in materialAssets)
@@ -138,7 +138,7 @@ namespace YARG.Venue
 
                 var assetPaths = new[]
                 {
-                    "Assets/" + BACKGROUND_SHADER_BUNDLE_NAME,
+                    Path.Combine("Assets/", BACKGROUND_SHADER_BUNDLE_NAME),
                     BACKGROUND_PREFAB_PATH
                 };
 


### PR DESCRIPTION
Previously we were exporting shaders for OSX separately. Unfortunately that does not guarantee that all shader variants were exported. To mitigate that we now export materials instead. However to avoid doubling of resulting yarground size we replace all textures with dummy on export.
On load we fixup all the shaders to pick up from osx-specific subbundle