### PR TITLE
Add support for shift indicators for five fret instruments

### DIFF
--- a/Assets/Art/Materials/Gameplay/Track/RangeIndicator.mat
+++ b/Assets/Art/Materials/Gameplay/Track/RangeIndicator.mat
@@ -7,7 +7,7 @@ Material:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name: Beatline
+  m_Name: RangeIndicator
   m_Shader: {fileID: -6465566751694194690, guid: 0c474304b74472f4a8b212da29713486,
     type: 3}
   m_ValidKeywords:
@@ -120,7 +120,7 @@ Material:
     - _ZWrite: 0
     m_Colors:
     - _BaseColor: {r: 1, g: 1, b: 1, a: 0.2509804}
-    - _Color: {r: 1, g: 1, b: 1, a: 0.29803923}
+    - _Color: {r: 1, g: 0.8984233, b: 0.38207546, a: 1}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
     - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
   m_BuildTextureStacks: []

--- a/Assets/Art/Materials/Gameplay/Track/RangeIndicator.mat.meta
+++ b/Assets/Art/Materials/Gameplay/Track/RangeIndicator.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0f33545ac0907484db3513086bcf7f1e
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Gameplay/Visual/FiveFretVisual.prefab
+++ b/Assets/Prefabs/Gameplay/Visual/FiveFretVisual.prefab
@@ -50,6 +50,54 @@ MonoBehaviour:
   _trackWidth: 2
   _leftKickFretPosition: {fileID: 1059056642713352937}
   _rightKickFretPosition: {fileID: 5240670873078094218}
+--- !u!1 &7276030750432966965
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2340138966499918158}
+  - component: {fileID: 1740989957536135886}
+  m_Layer: 0
+  m_Name: Range Indicator Pool
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2340138966499918158
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7276030750432966965}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3199692730525133945}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1740989957536135886
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7276030750432966965}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 96bcf9b96b014fb2b4973640b487a73d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  <Prefab>k__BackingField: {fileID: 6252920090088018630, guid: 742bbf327b6e5644ab4d1c6e3b417c1f,
+    type: 3}
+  _prewarmAmount: 2
+  _objectCap: 5
 --- !u!1 &7521437454948058467
 GameObject:
   m_ObjectHideFlags: 0
@@ -368,6 +416,7 @@ MonoBehaviour:
   BeatlinePool: {fileID: 155632028176750329}
   _fretArray: {fileID: 1060069523843335645}
   _shiftIndicatorPool: {fileID: 8077044597088283256}
+  _rangeIndicatorPool: {fileID: 1740989957536135886}
 --- !u!114 &7617442645122152992 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 1051735628184240032, guid: 5800c42510b55c549be95ec3ecd75e1c,

--- a/Assets/Prefabs/Gameplay/Visual/FiveFretVisual.prefab
+++ b/Assets/Prefabs/Gameplay/Visual/FiveFretVisual.prefab
@@ -45,10 +45,59 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   FretCount: 5
+  DontFlipColorsLeftyFlip: 0
   UseKickFrets: 0
   _trackWidth: 2
   _leftKickFretPosition: {fileID: 1059056642713352937}
   _rightKickFretPosition: {fileID: 5240670873078094218}
+--- !u!1 &7521437454948058467
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2813829336632564173}
+  - component: {fileID: 8077044597088283256}
+  m_Layer: 0
+  m_Name: Shift Indicator Pool
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2813829336632564173
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7521437454948058467}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3199692730525133945}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &8077044597088283256
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7521437454948058467}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 96bcf9b96b014fb2b4973640b487a73d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  <Prefab>k__BackingField: {fileID: 8633516561021093830, guid: d29c09ffc7e0eab4fba5cd025695b6b9,
+    type: 3}
+  _prewarmAmount: 4
+  _objectCap: 12
 --- !u!1001 &7434902305530561920
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -198,6 +247,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 031a2b07fd65f864d9c4ded2d545c9e5, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!4 &3199692730525133945 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5425012175883758073, guid: 5800c42510b55c549be95ec3ecd75e1c,
+    type: 3}
+  m_PrefabInstance: {fileID: 7434902305530561920}
+  m_PrefabAsset: {fileID: 0}
 --- !u!114 &3700759359327549745 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 6085956593584340145, guid: 5800c42510b55c549be95ec3ecd75e1c,
@@ -312,6 +367,7 @@ MonoBehaviour:
   NotePool: {fileID: 5534384060604769120}
   BeatlinePool: {fileID: 155632028176750329}
   _fretArray: {fileID: 1060069523843335645}
+  _shiftIndicatorPool: {fileID: 8077044597088283256}
 --- !u!114 &7617442645122152992 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 1051735628184240032, guid: 5800c42510b55c549be95ec3ecd75e1c,

--- a/Assets/Prefabs/Gameplay/Visual/TrackElements/FiveFretShiftIndicator.prefab
+++ b/Assets/Prefabs/Gameplay/Visual/TrackElements/FiveFretShiftIndicator.prefab
@@ -1,0 +1,145 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1853935546069261956
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3864215348229787682}
+  - component: {fileID: 8298455742636404952}
+  - component: {fileID: 5920531868209772154}
+  - component: {fileID: 414530232161363740}
+  m_Layer: 6
+  m_Name: Quad
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3864215348229787682
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1853935546069261956}
+  m_LocalRotation: {x: 0.0000019967556, y: 0.7071068, z: -0.7071068, w: 0.0000019967556}
+  m_LocalPosition: {x: -0.64, y: 0.05, z: -0.02}
+  m_LocalScale: {x: 0.5, y: 0.17, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4327806709304797894}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 90, y: 0, z: -180}
+--- !u!33 &8298455742636404952
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1853935546069261956}
+  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &5920531868209772154
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1853935546069261956}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 41d34a8ec31b11640bbc9115d018d585, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!64 &414530232161363740
+MeshCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1853935546069261956}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 4
+  m_Convex: 0
+  m_CookingOptions: 30
+  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!1 &8633516561021093830
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4327806709304797894}
+  - component: {fileID: -5509375559706405389}
+  m_Layer: 6
+  m_Name: FiveFretShiftIndicator
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4327806709304797894
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8633516561021093830}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3864215348229787682}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &-5509375559706405389
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8633516561021093830}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: bf614b13bedd4614b7002d57c143bdaa, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Prefabs/Gameplay/Visual/TrackElements/FiveFretShiftIndicator.prefab.meta
+++ b/Assets/Prefabs/Gameplay/Visual/TrackElements/FiveFretShiftIndicator.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: d29c09ffc7e0eab4fba5cd025695b6b9
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Gameplay/Visual/TrackElements/RangeIndicator.prefab
+++ b/Assets/Prefabs/Gameplay/Visual/TrackElements/RangeIndicator.prefab
@@ -1,0 +1,163 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &3527424456898888500
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7198541889438366942}
+  m_Layer: 0
+  m_Name: Parent
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7198541889438366942
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3527424456898888500}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8707734253209399491}
+  m_Father: {fileID: 1909203970316929669}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &6252920090088018630
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1909203970316929669}
+  - component: {fileID: -5843215986850199860}
+  m_Layer: 0
+  m_Name: RangeIndicator
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1909203970316929669
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6252920090088018630}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7198541889438366942}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &-5843215986850199860
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6252920090088018630}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 50e27ecabe214d549c66e50a02d48609, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _meshRenderer: {fileID: 2354173079749435183}
+--- !u!1 &7553305558568405431
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8707734253209399491}
+  - component: {fileID: 1032493748813444212}
+  - component: {fileID: 2354173079749435183}
+  m_Layer: 0
+  m_Name: Mesh
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8707734253209399491
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7553305558568405431}
+  m_LocalRotation: {x: 0.7071068, y: -0, z: -0, w: 0.7071068}
+  m_LocalPosition: {x: 0, y: 0.001, z: 0.04}
+  m_LocalScale: {x: 2, y: 0.050000004, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7198541889438366942}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 90, y: 0, z: 0}
+--- !u!33 &1032493748813444212
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7553305558568405431}
+  m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &2354173079749435183
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7553305558568405431}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 0f33545ac0907484db3513086bcf7f1e, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}

--- a/Assets/Prefabs/Gameplay/Visual/TrackElements/RangeIndicator.prefab.meta
+++ b/Assets/Prefabs/Gameplay/Visual/TrackElements/RangeIndicator.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 742bbf327b6e5644ab4d1c6e3b417c1f
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Script/Gameplay/Player/FiveFretPlayer.cs
+++ b/Assets/Script/Gameplay/Player/FiveFretPlayer.cs
@@ -24,7 +24,11 @@ namespace YARG.Gameplay.Player
     public sealed class FiveFretPlayer : TrackPlayer<GuitarEngine, GuitarNote>
     {
         private const double SUSTAIN_END_MUTE_THRESHOLD      = 0.1;
-        private const int    SHIFT_INDICATOR_MEASURES_BEFORE = 5;
+
+        private const int   SHIFT_INDICATOR_MEASURES_BEFORE  = 5;
+        private const float WIDTH_NUMERATOR                  = 2f;
+        private const float WIDTH_DENOMINATOR                = 5f;
+        private const float SHIFT_INDICATOR_DEFAULT_POSITION = 1f;
 
         public override bool ShouldUpdateInputsOnResume => true;
 
@@ -46,6 +50,7 @@ namespace YARG.Gameplay.Player
         {
             public double Time;
             public bool   LeftSide;
+            public int    Offset;
         }
 
         private List<FiveFretRangeShift>  _allRangeShiftEvents = new();
@@ -235,6 +240,9 @@ namespace YARG.Gameplay.Player
                 }
 
                 YargLogger.LogDebug("Shift indicator spawned!");
+
+                var indicatorXPosition = ((WIDTH_NUMERATOR / WIDTH_DENOMINATOR) * shiftIndicator.Offset) + SHIFT_INDICATOR_DEFAULT_POSITION;
+                ((GuitarShiftIndicatorElement) poolable).transform.localPosition.WithX(indicatorXPosition);
 
                 ((GuitarShiftIndicatorElement) poolable).RangeShiftIndicator = shiftIndicator;
                 poolable.EnableFromPool();
@@ -537,7 +545,8 @@ namespace YARG.Gameplay.Player
                     _shiftIndicators.Enqueue(new RangeShiftIndicator
                     {
                         Time = beatlines[realIndex].Time,
-                        LeftSide = shiftLeft
+                        LeftSide = shiftLeft,
+                        Offset = shiftLeft ? shift.Range - 1 : (shift.Range + shift.Size) - 6
                     });
                 }
 

--- a/Assets/Script/Gameplay/Player/FiveFretPlayer.cs
+++ b/Assets/Script/Gameplay/Player/FiveFretPlayer.cs
@@ -48,7 +48,8 @@ namespace YARG.Gameplay.Player
             public bool   LeftSide;
         }
 
-        private Queue<FiveFretRangeShift>  _rangeShiftEvents;
+        private List<FiveFretRangeShift>  _allRangeShiftEvents = new();
+        private Queue<FiveFretRangeShift>  _rangeShiftEventQueue = new();
         private FiveFretRangeShift         CurrentRange { get; set; }
         private Queue<RangeShiftIndicator> _shiftIndicators = new();
         private int                        _shiftIndicatorIndex;
@@ -73,6 +74,7 @@ namespace YARG.Gameplay.Player
         private int _sustainCount;
 
         private SongStem _stem;
+        private double   _practiceSectionStartTime;
 
         public override void Initialize(int index, YargPlayer player, SongChart chart, TrackView trackView, StemMixer mixer, int? currentHighScore)
         {
@@ -155,15 +157,39 @@ namespace YARG.Gameplay.Player
         public override void ResetPracticeSection()
         {
             base.ResetPracticeSection();
+            ResetRangeShift(_practiceSectionStartTime);
 
             _fretArray.ResetAll();
         }
 
-        // TODO: Figure out why this isn't a valid declaration so we can fix replay seeking
-        // public override void SetReplayTime(float time)
-        // {
-        //     base.SetReplayTime(time);
-        // }
+        public override void SetPracticeSection(uint start, uint end)
+        {
+            base.SetPracticeSection(start, end);
+
+            // This will set the current range correctly
+            _practiceSectionStartTime = SyncTrack.TickToTime(start);
+            InitializeRangeShift(SyncTrack.TickToTime(start));
+        }
+
+        public override void SetReplayTime(double time)
+        {
+            ResetRangeShift(time);
+            base.SetReplayTime(time);
+        }
+
+        private void ResetRangeShift(double time)
+        {
+            // Despawn shift indicators and rebuild the shift queues based on the replay time
+            _rangeShiftEventQueue.Clear();
+            _shiftIndicators.Clear();
+            for (var i = 0; i < _shiftIndicatorPool.AllSpawned.Count; i++)
+            {
+                var poolable = _shiftIndicatorPool.AllSpawned[i];
+                _shiftIndicatorPool.Return(poolable);
+            }
+
+            InitializeRangeShift(time);
+        }
 
         protected override void UpdateVisuals(double songTime)
         {
@@ -179,15 +205,9 @@ namespace YARG.Gameplay.Player
 
         public void UpdateRangeShift(double songTime)
         {
-            if (!_rangeShiftEvents.TryPeek(out var nextShift))
+            if (!_rangeShiftEventQueue.TryPeek(out var nextShift))
             {
                 return;
-            }
-
-            if (!nextShift.Shown && nextShift.Time >= songTime - SpawnTimeOffset)
-            {
-                var shiftLeft = nextShift.Range > CurrentRange.Range;
-                nextShift.Shown = true;
             }
 
             if (_fretPulseStarting && _fretPulseStartTime <= songTime)
@@ -221,24 +241,19 @@ namespace YARG.Gameplay.Player
 
                 _shiftIndicators.Dequeue();
 
-                // TODO: Adjust this to start when the first shift indicator reaches the strike line
                 if (!_fretPulseStarting)
                 {
                     _fretPulseStarting = true;
-                    // Why is this not producing the right time?
-                    // It is supposed to start pulsing when the shift indicator hits the strike line
-                    // Time - -STRIKE_LINE_POS / NoteSpeed is too early by something like 4 beats
-                    // Time alone is too late by a couple of beats
 
-                    // This works, but the math is all wrong and just happens to produce the right answer
+                    // TODO: This works, but I'm sure there is more correct math
                     _fretPulseStartTime = shiftIndicator.Time - ((-STRIKE_LINE_POS / NoteSpeed) / 2) + nextShift.BeatDuration * 1.25;
                 }
             }
 
-            // TODO: Also need to deal with seeking in replays somewhere
+            // Turn off the pulsing and switch active frets now that we're in the new range
             if (nextShift.Time <= songTime)
             {
-                _rangeShiftEvents.Dequeue();
+                _rangeShiftEventQueue.Dequeue();
                 for (var i = 0; i < _fretArray.FretCount; i++)
                 {
                     _fretArray.SetFretColorPulse(i, false, (float) nextShift.BeatDuration);
@@ -408,8 +423,9 @@ namespace YARG.Gameplay.Player
         }
 
 
-        private void InitializeRangeShift()
+        private void InitializeRangeShift(double time = 0)
         {
+            _rangeShiftEventQueue.Clear();
             // Default to everything on
             _activeFrets = new bool[_fretArray.FretCount];
             for (int i = 0; i < _fretArray.FretCount; i++)
@@ -417,29 +433,60 @@ namespace YARG.Gameplay.Player
                 _activeFrets[i] = true;
             }
 
-            var events = FiveFretRangeShift.GetRangeShiftEvents(NoteTrack.TextEvents, NoteTrack.Difficulty);
-            // Fewer than two range shifts makes no sense
-            if (events.Count < 1)
+            if (_allRangeShiftEvents.Count == 0)
             {
-                _rangeShiftEvents = new Queue<FiveFretRangeShift>();
+                // Since we don't have a list yet, get it
+                _allRangeShiftEvents =
+                    FiveFretRangeShift.GetRangeShiftEvents(NoteTrack.TextEvents, NoteTrack.Difficulty);
+            }
+
+            // Fewer than two range shifts makes no sense
+            if (_allRangeShiftEvents.Count < 1)
+            {
+                // _rangeShiftEventQueue = new Queue<FiveFretRangeShift>();
                 return;
             }
 
-            if (events.Count == 1)
+            if (_allRangeShiftEvents.Count == 1)
             {
                 // There are no actual shifts, but we should dim unused frets
-                SetActiveFretsForShiftEvent(events[0]);
-                CurrentRange = events[0];
-                _rangeShiftEvents = new Queue<FiveFretRangeShift>();
+                SetActiveFretsForShiftEvent(_allRangeShiftEvents[0]);
+                CurrentRange = _allRangeShiftEvents[0];
+                // _rangeShiftEventQueue = new Queue<FiveFretRangeShift>();
                 return;
             }
 
             // Turns out that we have range shifts that need indicators
-            var firstEvent = events[0];
-            CurrentRange = firstEvent;
+            var firstEvent = _allRangeShiftEvents[0];
+            _rangeShiftEventQueue = new Queue<FiveFretRangeShift>();
+
+            FiveFretRangeShift mostRecentEvent = firstEvent;
+
+            // Only queue range shifts that happen after time
+            foreach (var e in _allRangeShiftEvents)
+            {
+                // The first event just sets the starting range, so skip it
+                if (_allRangeShiftEvents.IndexOf(e) == 0)
+                {
+                    continue;
+                }
+                // These have no visible effect on the track, so we just
+                // want to make sure any that are current or in the future are queued
+                // and to figure out which was the most recent event
+                if (e.Time >= time)
+                {
+                    _rangeShiftEventQueue.Enqueue(e);
+                    continue;
+                }
+
+                if (e.Time > mostRecentEvent.Time)
+                {
+                    mostRecentEvent = e;
+                }
+            }
+
+            CurrentRange = mostRecentEvent;
             SetActiveFretsForShiftEvent(CurrentRange);
-            events.RemoveAt(0);
-            _rangeShiftEvents = new Queue<FiveFretRangeShift>(events);
 
             // Figure out where the indicators should go
             var beatlines = Beatlines
@@ -447,10 +494,10 @@ namespace YARG.Gameplay.Player
                 .ToList();
 
             _shiftIndicators.Clear();
-            int lastShiftRange = firstEvent.Range;
+            int lastShiftRange = mostRecentEvent.Range;
             int beatlineIndex = 0;
 
-            foreach (var shift in _rangeShiftEvents.ToList())
+            foreach (var shift in _rangeShiftEventQueue.ToList())
             {
                 if (shift.Range == lastShiftRange)
                 {
@@ -497,9 +544,6 @@ namespace YARG.Gameplay.Player
                 // In case we have no samples for this shift event, 0.5 is a reasonable default
                 shift.BeatDuration = firstBeatTime < double.MaxValue ? (lastBeatTime - firstBeatTime) / SHIFT_INDICATOR_MEASURES_BEFORE : 0.5;
             }
-
-            // TODO: Remove this test shit
-            // _fretArray.UpdateFretActiveState(_activeFrets);
         }
 
         private void SetActiveFretsForShiftEvent(FiveFretRangeShift range)

--- a/Assets/Script/Gameplay/Player/FiveFretPlayer.cs
+++ b/Assets/Script/Gameplay/Player/FiveFretPlayer.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 using YARG.Audio;
@@ -16,6 +17,7 @@ using YARG.Gameplay.Visuals;
 using YARG.Helpers;
 using YARG.Player;
 using YARG.Settings;
+using Random = UnityEngine.Random;
 
 namespace YARG.Gameplay.Player
 {
@@ -458,9 +460,8 @@ namespace YARG.Gameplay.Player
                 var shiftLeft = shift.Range > lastShiftRange;
                 lastShiftRange = shift.Range;
 
-                int beatTimeSamples = 0;
-                double beatTimeDelta = 0;
                 double lastBeatTime = 0;
+                double firstBeatTime = double.MaxValue;
 
                 // Find the first beatline index after the range shift
                 for (; beatlineIndex < beatlines.Count; beatlineIndex++)
@@ -484,9 +485,7 @@ namespace YARG.Gameplay.Player
                         break;
                     }
 
-                    beatTimeDelta += lastBeatTime - beatlines[realIndex].Time;
-                    lastBeatTime = beatlines[realIndex].Time;
-                    beatTimeSamples++;
+                    firstBeatTime = beatlines[realIndex].Time < firstBeatTime ? beatlines[realIndex].Time : firstBeatTime;
 
                     _shiftIndicators.Enqueue(new RangeShiftIndicator
                     {
@@ -496,7 +495,7 @@ namespace YARG.Gameplay.Player
                 }
 
                 // In case we have no samples for this shift event, 0.5 is a reasonable default
-                shift.BeatDuration = beatTimeSamples > 0 ? beatTimeDelta / beatTimeSamples : 0.5;
+                shift.BeatDuration = firstBeatTime < double.MaxValue ? (lastBeatTime - firstBeatTime) / SHIFT_INDICATOR_MEASURES_BEFORE : 0.5;
             }
 
             // TODO: Remove this test shit

--- a/Assets/Script/Gameplay/Player/FiveFretPlayer.cs
+++ b/Assets/Script/Gameplay/Player/FiveFretPlayer.cs
@@ -504,7 +504,7 @@ namespace YARG.Gameplay.Player
                     continue;
                 }
 
-                var shiftLeft = shift.Range > lastShiftRange;
+                var shiftLeft = Player.Profile.LeftyFlip ? shift.Range < lastShiftRange : shift.Range > lastShiftRange;
                 lastShiftRange = shift.Range;
 
                 double lastBeatTime = 0;

--- a/Assets/Script/Gameplay/Player/FiveFretPlayer.cs
+++ b/Assets/Script/Gameplay/Player/FiveFretPlayer.cs
@@ -48,6 +48,7 @@ namespace YARG.Gameplay.Player
             public double Time;
             public bool   LeftSide;
             public int    Offset;
+            public bool   RangeIndicator;
         }
 
         private List<FiveFretRangeShift>   _allRangeShiftEvents  = new();
@@ -65,6 +66,8 @@ namespace YARG.Gameplay.Player
         private FretArray _fretArray;
         [SerializeField]
         private Pool _shiftIndicatorPool;
+        [SerializeField]
+        private Pool _rangeIndicatorPool;
 
         public override float[] StarMultiplierThresholds { get; protected set; } =
             GuitarStarMultiplierThresholds;
@@ -190,6 +193,12 @@ namespace YARG.Gameplay.Player
                 _shiftIndicatorPool.Return(poolable);
             }
 
+            for (var i = 0; i < _rangeIndicatorPool.AllSpawned.Count; i++)
+            {
+                var poolable = _rangeIndicatorPool.AllSpawned[i];
+                _rangeIndicatorPool.Return(poolable);
+            }
+
             InitializeRangeShift(time);
         }
 
@@ -214,6 +223,12 @@ namespace YARG.Gameplay.Player
 
             if (_shiftIndicators.TryPeek(out var shiftIndicator) && shiftIndicator.Time <= songTime + SpawnTimeOffset)
             {
+                // The range indicator is dealt with in its own function
+                if (shiftIndicator.RangeIndicator)
+                {
+                    SpawnRangeIndicator(nextShift);
+                    return;
+                }
                 if (!_shiftIndicatorPool.CanSpawnAmount(1))
                 {
                     return;
@@ -264,6 +279,28 @@ namespace YARG.Gameplay.Player
                 CurrentRange = nextShift;
                 SetActiveFretsForShiftEvent(nextShift);
             }
+        }
+
+        private void SpawnRangeIndicator(FiveFretRangeShift nextShift)
+        {
+            if (!_rangeIndicatorPool.CanSpawnAmount(1))
+            {
+                return;
+            }
+
+            var poolable = _rangeIndicatorPool.TakeWithoutEnabling();
+            if (poolable == null)
+            {
+                YargLogger.LogWarning("Attempted to spawn range indicator, but it's at its cap!");
+                return;
+            }
+
+            YargLogger.LogDebug("Range indicator spawned!");
+
+            ((GuitarRangeIndicatorElement) poolable).RangeShift = nextShift;
+            poolable.EnableFromPool();
+
+            _shiftIndicators.Dequeue();
         }
 
         public override void SetStemMuteState(bool muted)
@@ -524,7 +561,7 @@ namespace YARG.Gameplay.Player
 
                 // Add the indicators before the range shift
                 // While we're doing this, figure out the time between beats
-                for (int i = SHIFT_INDICATOR_MEASURES_BEFORE; i > 1; i--)
+                for (int i = SHIFT_INDICATOR_MEASURES_BEFORE; i > 0; i--)
                 {
                     var realIndex = beatlineIndex - i;
 
@@ -541,6 +578,7 @@ namespace YARG.Gameplay.Player
                         Time = beatlines[realIndex].Time,
                         LeftSide = shiftLeft,
                         Offset = shiftLeft ? ((shift.Range + shift.Size) - 6) * -1 : shift.Range - 1,
+                        RangeIndicator = i == 1,
                     });
                 }
 

--- a/Assets/Script/Gameplay/Player/FiveFretPlayer.cs
+++ b/Assets/Script/Gameplay/Player/FiveFretPlayer.cs
@@ -22,7 +22,7 @@ namespace YARG.Gameplay.Player
     public sealed class FiveFretPlayer : TrackPlayer<GuitarEngine, GuitarNote>
     {
         private const double SUSTAIN_END_MUTE_THRESHOLD      = 0.1;
-        private const int    SHIFT_INDICATOR_MEASURES_BEFORE = 4;
+        private const int    SHIFT_INDICATOR_MEASURES_BEFORE = 5;
 
         public override bool ShouldUpdateInputsOnResume => true;
 
@@ -51,7 +51,7 @@ namespace YARG.Gameplay.Player
         private Queue<RangeShiftIndicator> _shiftIndicators = new();
         private int                        _shiftIndicatorIndex;
         private bool                       _fretPulseStarting;
-        private double                     _fretPulseTime;
+        private double                     _fretPulseStartTime;
 
         private bool[] _activeFrets;
 
@@ -157,6 +157,7 @@ namespace YARG.Gameplay.Player
             _fretArray.ResetAll();
         }
 
+        // TODO: Figure out why this isn't a valid declaration so we can fix replay seeking
         // public override void SetReplayTime(float time)
         // {
         //     base.SetReplayTime(time);
@@ -166,7 +167,6 @@ namespace YARG.Gameplay.Player
         {
             UpdateBaseVisuals(Engine.EngineStats, EngineParams, songTime);
 
-            // TODO: Do whatever is necessary to update the fret range and show range shift indicators
             UpdateRangeShift(songTime);
 
             for (var fret = GuitarAction.GreenFret; fret <= GuitarAction.OrangeFret; fret++)
@@ -188,7 +188,7 @@ namespace YARG.Gameplay.Player
                 nextShift.Shown = true;
             }
 
-            if (_fretPulseStarting && _fretPulseTime <= songTime)
+            if (_fretPulseStarting && _fretPulseStartTime <= songTime)
             {
                 for (var i = nextShift.Range - 1; i < nextShift.Range + nextShift.Size - 1; i++)
                 {
@@ -227,8 +227,9 @@ namespace YARG.Gameplay.Player
                     // It is supposed to start pulsing when the shift indicator hits the strike line
                     // Time - -STRIKE_LINE_POS / NoteSpeed is too early by something like 4 beats
                     // Time alone is too late by a couple of beats
-                    // This is slightly early, but I give up for now
-                    _fretPulseTime = shiftIndicator.Time - ((-STRIKE_LINE_POS / NoteSpeed) / 2);
+
+                    // This works, but the math is all wrong and just happens to produce the right answer
+                    _fretPulseStartTime = shiftIndicator.Time - ((-STRIKE_LINE_POS / NoteSpeed) / 2) + nextShift.BeatDuration * 1.25;
                 }
             }
 
@@ -418,7 +419,6 @@ namespace YARG.Gameplay.Player
             // Fewer than two range shifts makes no sense
             if (events.Count < 1)
             {
-                // TODO: Make sure there's nothing else to do before bailing
                 _rangeShiftEvents = new Queue<FiveFretRangeShift>();
                 return;
             }
@@ -427,7 +427,6 @@ namespace YARG.Gameplay.Player
             {
                 // There are no actual shifts, but we should dim unused frets
                 SetActiveFretsForShiftEvent(events[0]);
-                // TODO: Make sure there's nothing else to do before bailing
                 CurrentRange = events[0];
                 _rangeShiftEvents = new Queue<FiveFretRangeShift>();
                 return;
@@ -475,7 +474,7 @@ namespace YARG.Gameplay.Player
 
                 // Add the indicators before the range shift
                 // While we're doing this, figure out the time between beats
-                for (int i = SHIFT_INDICATOR_MEASURES_BEFORE; i >= 1; i--)
+                for (int i = SHIFT_INDICATOR_MEASURES_BEFORE; i > 1; i--)
                 {
                     var realIndex = beatlineIndex - i;
 
@@ -485,7 +484,7 @@ namespace YARG.Gameplay.Player
                         break;
                     }
 
-                    beatTimeDelta += beatlines[realIndex].Time - lastBeatTime;
+                    beatTimeDelta += lastBeatTime - beatlines[realIndex].Time;
                     lastBeatTime = beatlines[realIndex].Time;
                     beatTimeSamples++;
 
@@ -501,7 +500,7 @@ namespace YARG.Gameplay.Player
             }
 
             // TODO: Remove this test shit
-            _fretArray.UpdateFretActiveState(_activeFrets);
+            // _fretArray.UpdateFretActiveState(_activeFrets);
         }
 
         private void SetActiveFretsForShiftEvent(FiveFretRangeShift range)

--- a/Assets/Script/Gameplay/Player/FiveFretPlayer.cs
+++ b/Assets/Script/Gameplay/Player/FiveFretPlayer.cs
@@ -38,6 +38,8 @@ namespace YARG.Gameplay.Player
 
         public GuitarEngineParameters EngineParams { get; private set; }
 
+        private double TimeFromSpawnToStrikeline => SpawnTimeOffset - (-STRIKE_LINE_POS / NoteSpeed);
+
         public struct RangeShiftIndicator
         {
             public double Time;
@@ -48,6 +50,8 @@ namespace YARG.Gameplay.Player
         private FiveFretRangeShift         CurrentRange { get; set; }
         private Queue<RangeShiftIndicator> _shiftIndicators = new();
         private int                        _shiftIndicatorIndex;
+        private bool                       _fretPulseStarting;
+        private double                     _fretPulseTime;
 
         private bool[] _activeFrets;
 
@@ -153,6 +157,11 @@ namespace YARG.Gameplay.Player
             _fretArray.ResetAll();
         }
 
+        // public override void SetReplayTime(float time)
+        // {
+        //     base.SetReplayTime(time);
+        // }
+
         protected override void UpdateVisuals(double songTime)
         {
             UpdateBaseVisuals(Engine.EngineStats, EngineParams, songTime);
@@ -179,6 +188,16 @@ namespace YARG.Gameplay.Player
                 nextShift.Shown = true;
             }
 
+            if (_fretPulseStarting && _fretPulseTime <= songTime)
+            {
+                for (var i = nextShift.Range - 1; i < nextShift.Range + nextShift.Size - 1; i++)
+                {
+                    _fretArray.SetFretColorPulse(i, true, (float) nextShift.BeatDuration);
+                }
+
+                _fretPulseStarting = false;
+            }
+
             if (_shiftIndicators.TryPeek(out var shiftIndicator) && shiftIndicator.Time <= songTime + SpawnTimeOffset)
             {
                 if (!_shiftIndicatorPool.CanSpawnAmount(1))
@@ -200,10 +219,16 @@ namespace YARG.Gameplay.Player
 
                 _shiftIndicators.Dequeue();
 
-                // TODO: We should start pulsing the shifted fret colors here (maybe here, that might be too soon)
-                for (var i = nextShift.Range - 1; i < nextShift.Range + nextShift.Size - 1; i++)
+                // TODO: Adjust this to start when the first shift indicator reaches the strike line
+                if (!_fretPulseStarting)
                 {
-                    _fretArray.SetFretColorPulse(i, true);
+                    _fretPulseStarting = true;
+                    // Why is this not producing the right time?
+                    // It is supposed to start pulsing when the shift indicator hits the strike line
+                    // Time - -STRIKE_LINE_POS / NoteSpeed is too early by something like 4 beats
+                    // Time alone is too late by a couple of beats
+                    // This is slightly early, but I give up for now
+                    _fretPulseTime = shiftIndicator.Time - ((-STRIKE_LINE_POS / NoteSpeed) / 2);
                 }
             }
 
@@ -213,7 +238,7 @@ namespace YARG.Gameplay.Player
                 _rangeShiftEvents.Dequeue();
                 for (var i = 0; i < _fretArray.FretCount; i++)
                 {
-                    _fretArray.SetFretColorPulse(i, false);
+                    _fretArray.SetFretColorPulse(i, false, (float) nextShift.BeatDuration);
                 }
 
                 CurrentRange = nextShift;
@@ -434,16 +459,22 @@ namespace YARG.Gameplay.Player
                 var shiftLeft = shift.Range > lastShiftRange;
                 lastShiftRange = shift.Range;
 
+                int beatTimeSamples = 0;
+                double beatTimeDelta = 0;
+                double lastBeatTime = 0;
+
                 // Find the first beatline index after the range shift
                 for (; beatlineIndex < beatlines.Count; beatlineIndex++)
                 {
                     if (beatlines[beatlineIndex].Time > shift.Time)
                     {
+                        lastBeatTime = beatlines[beatlineIndex].Time;
                         break;
                     }
                 }
 
                 // Add the indicators before the range shift
+                // While we're doing this, figure out the time between beats
                 for (int i = SHIFT_INDICATOR_MEASURES_BEFORE; i >= 1; i--)
                 {
                     var realIndex = beatlineIndex - i;
@@ -454,12 +485,19 @@ namespace YARG.Gameplay.Player
                         break;
                     }
 
+                    beatTimeDelta += beatlines[realIndex].Time - lastBeatTime;
+                    lastBeatTime = beatlines[realIndex].Time;
+                    beatTimeSamples++;
+
                     _shiftIndicators.Enqueue(new RangeShiftIndicator
                     {
                         Time = beatlines[realIndex].Time,
                         LeftSide = shiftLeft
                     });
                 }
+
+                // In case we have no samples for this shift event, 0.5 is a reasonable default
+                shift.BeatDuration = beatTimeSamples > 0 ? beatTimeDelta / beatTimeSamples : 0.5;
             }
 
             // TODO: Remove this test shit

--- a/Assets/Script/Gameplay/Player/FiveFretPlayer.cs
+++ b/Assets/Script/Gameplay/Player/FiveFretPlayer.cs
@@ -26,9 +26,6 @@ namespace YARG.Gameplay.Player
         private const double SUSTAIN_END_MUTE_THRESHOLD      = 0.1;
 
         private const int   SHIFT_INDICATOR_MEASURES_BEFORE  = 5;
-        private const float WIDTH_NUMERATOR                  = 2f;
-        private const float WIDTH_DENOMINATOR                = 5f;
-        private const float SHIFT_INDICATOR_DEFAULT_POSITION = 1f;
 
         public override bool ShouldUpdateInputsOnResume => true;
 
@@ -241,9 +238,6 @@ namespace YARG.Gameplay.Player
 
                 YargLogger.LogDebug("Shift indicator spawned!");
 
-                var indicatorXPosition = ((WIDTH_NUMERATOR / WIDTH_DENOMINATOR) * shiftIndicator.Offset) + SHIFT_INDICATOR_DEFAULT_POSITION;
-                ((GuitarShiftIndicatorElement) poolable).transform.localPosition.WithX(indicatorXPosition);
-
                 ((GuitarShiftIndicatorElement) poolable).RangeShiftIndicator = shiftIndicator;
                 poolable.EnableFromPool();
 
@@ -254,6 +248,8 @@ namespace YARG.Gameplay.Player
                     _fretPulseStarting = true;
 
                     // TODO: This works, but I'm sure there is more correct math
+                    //  This doesn't actually work for sufficiently slow bpm, it ends up being late by one beatline
+                    //  That may be because of the switch to starting the indicators 5 beatlines ahead?
                     _fretPulseStartTime = shiftIndicator.Time - ((-STRIKE_LINE_POS / NoteSpeed) / 2) + nextShift.BeatDuration * 1.25;
                 }
             }
@@ -546,7 +542,7 @@ namespace YARG.Gameplay.Player
                     {
                         Time = beatlines[realIndex].Time,
                         LeftSide = shiftLeft,
-                        Offset = shiftLeft ? shift.Range - 1 : (shift.Range + shift.Size) - 6
+                        Offset = shiftLeft ? ((shift.Range + shift.Size) - 6) * -1 : shift.Range - 1,
                     });
                 }
 

--- a/Assets/Script/Gameplay/Player/TrackPlayer.cs
+++ b/Assets/Script/Gameplay/Player/TrackPlayer.cs
@@ -184,6 +184,8 @@ namespace YARG.Gameplay.Player
             NoteTrack = OriginalNoteTrack;
             Notes = NoteTrack.Notes;
 
+            var events = NoteTrack.TextEvents;
+
             Engine = CreateEngine();
 
             if (GameManager.IsPractice)

--- a/Assets/Script/Gameplay/Visuals/Fret/Fret.cs
+++ b/Assets/Script/Gameplay/Visuals/Fret/Fret.cs
@@ -36,12 +36,12 @@ namespace YARG.Gameplay.Visuals
         // TODO: Consider making this customizable or perhaps just a desaturated and dimmed version of the base color
         private UnityEngine.Color _inactiveColor = new(0.321f, 0.321f, 0.321f, 1.0f);
 
-        private bool  _active            = true;
-        private bool  _colorChangeEnabled = false;
-        private bool  _fadeDirection    = true;
+        private bool _active             = true;
+        private bool _colorChangeEnabled = false;
+        private bool _fadeDirection      = true;
         // True is pulsing, false is fading
-        private bool  _pulseOrFade       = true;
-        private float _fadeDuration;
+        private bool  _pulseOrFade  = true;
+        private float _fadeDuration = 0.25f;
         private float _fadeStartTime;
         private float _fadeEndTime;
         private float _fadeAmount = 0.0f;
@@ -131,40 +131,53 @@ namespace YARG.Gameplay.Visuals
             }
         }
 
-        // TODO: May need to take a duration here..
-        public void DimColor()
+        public void DimColor(bool fade = true)
         {
             _active = false;
             _fadeDirection = false;
             _colorChangeEnabled = true;
             _fadeAmount = 0.0f;
 
-            FadeColor(0.25f, false, false);
-            // foreach (var material in _topMaterials)
-            // {
-            //     material.color = _inactiveColor;
-            // }
-            //
-            // foreach (var material in _innerMaterials)
-            // {
-            //     material.color = _inactiveColor;
-            // }
+            if (fade)
+            {
+                FadeColor(_fadeDuration, false, false);
+            }
+            else
+            {
+                foreach (var material in _topMaterials)
+                {
+                    material.color = _inactiveColor;
+                }
+
+                foreach (var material in _innerMaterials)
+                {
+                    material.color = _inactiveColor;
+                }
+            }
         }
 
-        public void ResetColor()
+        public void ResetColor(bool fade = false)
         {
             _active = true;
             _fadeDirection = true;
             _colorChangeEnabled = false;
             _fadeAmount = 0.0f;
-            foreach (var material in _topMaterials)
-            {
-                material.color = _originalUnityTopColor;
-            }
 
-            foreach (var material in _innerMaterials)
+            if (fade)
             {
-                material.color = _originalUnityInnerColor;
+                FadeColor(_fadeDuration, false, true);
+            }
+            else
+            {
+                foreach (var material in _topMaterials)
+                {
+                    material.color = _originalUnityTopColor;
+                }
+
+                foreach (var material in _innerMaterials)
+                {
+                    material.color = _originalUnityInnerColor;
+                }
             }
         }
 
@@ -202,28 +215,31 @@ namespace YARG.Gameplay.Visuals
                 return;
             }
 
-            var rateAdjustment = _pulseOrFade ? 2 : 1;
+            var rateAdjustment = 1; //_pulseOrFade ? 2 : 1;
 
-            if (!_pulseOrFade && Time.time - _fadeStartTime >= _fadeDuration / rateAdjustment)
-            {
-                // Switch directions (
-                _fadeDirection = !_fadeDirection;
-                _fadeAmount = 0.0f;
-            }
+            // if (!_pulseOrFade && Time.time - _fadeStartTime >= _fadeDuration / rateAdjustment)
+            // {
+            //     // Switch directions
+            //     _fadeDirection = !_fadeDirection;
+            //     _fadeAmount = 0.0f;
+            //     _colorChangeEnabled = false;
+            //     return;
+            // }
 
             _fadeAmount += Time.deltaTime / (_fadeDuration / rateAdjustment);
+            var fadeIntensity = _pulseOrFade ? _fadeAmount : ((Mathf.Cos(Mathf.PI * _fadeAmount) / 2) * -1) + 1;
 
             if (_fadeDirection)
             {
                 // Fading in
                 foreach (var material in _topMaterials)
                 {
-                    material.color = UnityEngine.Color.Lerp(_inactiveColor, _originalUnityTopColor, _fadeAmount);
+                    material.color = UnityEngine.Color.Lerp(_inactiveColor, _originalUnityTopColor, fadeIntensity);
                 }
 
                 foreach (var material in _innerMaterials)
                 {
-                    material.color = UnityEngine.Color.Lerp(_inactiveColor, _originalUnityTopColor, _fadeAmount);
+                    material.color = UnityEngine.Color.Lerp(_inactiveColor, _originalUnityTopColor, fadeIntensity);
                 }
             }
             else
@@ -231,12 +247,12 @@ namespace YARG.Gameplay.Visuals
                 // Fading out
                 foreach (var material in _topMaterials)
                 {
-                    material.color = UnityEngine.Color.Lerp(_originalUnityTopColor, _inactiveColor, _fadeAmount);
+                    material.color = UnityEngine.Color.Lerp(_originalUnityTopColor, _inactiveColor, fadeIntensity);
                 }
 
                 foreach (var material in _innerMaterials)
                 {
-                    material.color = UnityEngine.Color.Lerp(_originalUnityTopColor, _inactiveColor, _fadeAmount);
+                    material.color = UnityEngine.Color.Lerp(_originalUnityTopColor, _inactiveColor, fadeIntensity);
                 }
             }
 

--- a/Assets/Script/Gameplay/Visuals/Fret/Fret.cs
+++ b/Assets/Script/Gameplay/Visuals/Fret/Fret.cs
@@ -197,7 +197,7 @@ namespace YARG.Gameplay.Visuals
                 return;
             }
 
-            var rateAdjustment = pulse ? 2 : 1;
+            var rateAdjustment = 1; // pulse ? 2 : 1;
 
             _pulseOrFade = pulse;
             _fadeDuration = duration;

--- a/Assets/Script/Gameplay/Visuals/Fret/Fret.cs
+++ b/Assets/Script/Gameplay/Visuals/Fret/Fret.cs
@@ -43,7 +43,6 @@ namespace YARG.Gameplay.Visuals
         private bool  _pulseOrFade  = true;
         private float _fadeDuration = 0.25f;
         private float _fadeStartTime;
-        private float _fadeEndTime;
         private float _fadeAmount = 0.0f;
 
         public void Initialize(Color top, Color inner, Color particles)
@@ -197,17 +196,18 @@ namespace YARG.Gameplay.Visuals
                 return;
             }
 
-            var rateAdjustment = 1; // pulse ? 2 : 1;
-
             _pulseOrFade = pulse;
             _fadeDuration = duration;
             _fadeDirection = fadeDirection;
             _fadeStartTime = Time.time;
-            _fadeEndTime = Time.time + (_fadeDuration / rateAdjustment);
             _colorChangeEnabled = true;
             _fadeAmount = 0.0f;
         }
 
+        // TODO: Investigate whether we should be using a MaterialPropertyBlock to set the color
+        //  instead of setting the color directly so that draw call batching is possible
+        //  (I think it doesn't actually matter much since there's only 10 of these materials active at a time,
+        //   but every bit helps, I guess?)
         public void UpdateColor()
         {
             if (!_colorChangeEnabled)
@@ -216,15 +216,6 @@ namespace YARG.Gameplay.Visuals
             }
 
             var rateAdjustment = 1; //_pulseOrFade ? 2 : 1;
-
-            // if (!_pulseOrFade && Time.time - _fadeStartTime >= _fadeDuration / rateAdjustment)
-            // {
-            //     // Switch directions
-            //     _fadeDirection = !_fadeDirection;
-            //     _fadeAmount = 0.0f;
-            //     _colorChangeEnabled = false;
-            //     return;
-            // }
 
             _fadeAmount += Time.deltaTime / (_fadeDuration / rateAdjustment);
             var fadeIntensity = _pulseOrFade ? _fadeAmount : ((Mathf.Cos(Mathf.PI * _fadeAmount) / 2) * -1) + 1;
@@ -266,23 +257,6 @@ namespace YARG.Gameplay.Visuals
                     _colorChangeEnabled = false;
                     _fadeAmount = 0.0f;
                 }
-
-                // This seems like it shouldn't be necessary, but even when _fadeAmount is 1.0f we still aren't quite
-                // all the way to the inactive color.
-                // if (_fadeDirection)
-                // {
-                //     return;
-                // }
-                //
-                // foreach (var material in _topMaterials)
-                // {
-                //     material.color = _inactiveColor;
-                // }
-                //
-                // foreach (var material in _innerMaterials)
-                // {
-                //     material.color = _inactiveColor;
-                // }
             }
         }
     }

--- a/Assets/Script/Gameplay/Visuals/Fret/FretArray.cs
+++ b/Assets/Script/Gameplay/Visuals/Fret/FretArray.cs
@@ -178,7 +178,8 @@ namespace YARG.Gameplay.Visuals
                 {
                     continue;
                 }
-                _frets[i].FadeColor(_pulseDuration, true);
+                // TODO: Switch fade direction back to true
+                _frets[i].FadeColor(_pulseDuration, true, false);
             }
         }
 

--- a/Assets/Script/Gameplay/Visuals/Fret/FretArray.cs
+++ b/Assets/Script/Gameplay/Visuals/Fret/FretArray.cs
@@ -31,6 +31,7 @@ namespace YARG.Gameplay.Visuals
 
         private bool[] _activeFrets;
         private bool[] _pulsingFrets;
+        private float  _pulseDuration;
 
         public void Initialize(ThemePreset themePreset, GameMode gameMode,
             ColorProfile.IFretColorProvider fretColorProvider, bool leftyFlip)
@@ -165,24 +166,19 @@ namespace YARG.Gameplay.Visuals
 
         public void SetFretColorPulse(int fretIndex, bool pulse, float duration)
         {
+            _pulseDuration = duration;
             _pulsingFrets[fretIndex] = pulse;
         }
 
         public void PulseFretColors(Beatline beat)
         {
-            // if (beat.Type == BeatlineType.Weak)
-            // {
-            //     return;
-            // }
-
             for (int i = 0; i < _pulsingFrets.Length; i++)
             {
                 if (!_pulsingFrets[i] || _activeFrets[i])
                 {
                     continue;
                 }
-
-                _frets[i].FadeColor(0.5f, true);
+                _frets[i].FadeColor(_pulseDuration, true);
             }
         }
 
@@ -199,11 +195,11 @@ namespace YARG.Gameplay.Visuals
             {
                 if (frets[i])
                 {
-                    _frets[i].ResetColor();
+                    _frets[i].ResetColor(true);
                 }
                 else
                 {
-                    _frets[i].DimColor();
+                    _frets[i].DimColor(true);
                 }
                 _activeFrets[i] = frets[i];
             }

--- a/Assets/Script/Gameplay/Visuals/Fret/FretArray.cs
+++ b/Assets/Script/Gameplay/Visuals/Fret/FretArray.cs
@@ -1,7 +1,9 @@
 ﻿using System.Collections.Generic;
 using UnityEngine;
 using YARG.Core;
+using YARG.Core.Chart;
 using YARG.Core.Game;
+using YARG.Core.Logging;
 using YARG.Themes;
 
 namespace YARG.Gameplay.Visuals
@@ -26,6 +28,9 @@ namespace YARG.Gameplay.Visuals
 
         private readonly List<Fret> _frets = new();
         private readonly List<KickFret> _kickFrets = new();
+
+        private bool[] _activeFrets;
+        private bool[] _pulsingFrets;
 
         public void Initialize(ThemePreset themePreset, GameMode gameMode,
             ColorProfile.IFretColorProvider fretColorProvider, bool leftyFlip)
@@ -77,6 +82,13 @@ namespace YARG.Gameplay.Visuals
             }
 
             InitializeColor(fretColorProvider, leftyFlip);
+            _activeFrets = new bool[FretCount];
+            _pulsingFrets = new bool[FretCount];
+            // Start with all frets active, they will be set inactive once TrackPlayer figures itself out
+            for (int i = 0; i < FretCount; i++)
+            {
+                _activeFrets[i] = true;
+            }
         }
 
         public void InitializeColor(ColorProfile.IFretColorProvider fretColorProvider, bool leftyFlip)
@@ -148,6 +160,54 @@ namespace YARG.Gameplay.Visuals
             foreach (var fret in _frets)
             {
                 fret.SetSustained(false);
+            }
+        }
+
+        public void SetFretColorPulse(int fretIndex, bool pulse)
+        {
+            _pulsingFrets[fretIndex] = pulse;
+        }
+
+        public void PulseFretColors(Beatline beat)
+        {
+            // if (beat.Type == BeatlineType.Weak)
+            // {
+            //     return;
+            // }
+
+            for (int i = 0; i < _pulsingFrets.Length; i++)
+            {
+                if (!_pulsingFrets[i] || _activeFrets[i])
+                {
+                    continue;
+                }
+
+                _frets[i].PulseColor(0.5f);
+            }
+        }
+
+        public void UpdateFretActiveState(bool[] frets)
+        {
+            // We should always receive the same number of frets that we actually have, but...
+            if (frets.Length != _frets.Count)
+            {
+                YargLogger.LogFormatDebug("Received inconsistent fret array. Got {0} flags, but we have {1} frets.", frets.Length, _frets.Count);
+                return;
+            }
+
+            // TODO: Implement a means of pulsing the color
+
+            for (int i = 0; i < _frets.Count; i++)
+            {
+                if (frets[i])
+                {
+                    _frets[i].ResetColor();
+                }
+                else
+                {
+                    _frets[i].DimColor();
+                }
+                _activeFrets[i] = frets[i];
             }
         }
     }

--- a/Assets/Script/Gameplay/Visuals/Fret/FretArray.cs
+++ b/Assets/Script/Gameplay/Visuals/Fret/FretArray.cs
@@ -178,7 +178,7 @@ namespace YARG.Gameplay.Visuals
                 {
                     continue;
                 }
-                // TODO: Switch fade direction back to true
+
                 _frets[i].FadeColor(_pulseDuration, true, false);
             }
         }

--- a/Assets/Script/Gameplay/Visuals/Fret/FretArray.cs
+++ b/Assets/Script/Gameplay/Visuals/Fret/FretArray.cs
@@ -194,6 +194,11 @@ namespace YARG.Gameplay.Visuals
 
             for (int i = 0; i < _frets.Count; i++)
             {
+                if (_activeFrets[i] == frets[i])
+                {
+                    continue;
+                }
+
                 if (frets[i])
                 {
                     _frets[i].ResetColor(true);

--- a/Assets/Script/Gameplay/Visuals/Fret/FretArray.cs
+++ b/Assets/Script/Gameplay/Visuals/Fret/FretArray.cs
@@ -163,7 +163,7 @@ namespace YARG.Gameplay.Visuals
             }
         }
 
-        public void SetFretColorPulse(int fretIndex, bool pulse)
+        public void SetFretColorPulse(int fretIndex, bool pulse, float duration)
         {
             _pulsingFrets[fretIndex] = pulse;
         }
@@ -182,7 +182,7 @@ namespace YARG.Gameplay.Visuals
                     continue;
                 }
 
-                _frets[i].PulseColor(0.5f);
+                _frets[i].FadeColor(0.5f, true);
             }
         }
 
@@ -194,8 +194,6 @@ namespace YARG.Gameplay.Visuals
                 YargLogger.LogFormatDebug("Received inconsistent fret array. Got {0} flags, but we have {1} frets.", frets.Length, _frets.Count);
                 return;
             }
-
-            // TODO: Implement a means of pulsing the color
 
             for (int i = 0; i < _frets.Count; i++)
             {

--- a/Assets/Script/Gameplay/Visuals/TrackElements/Guitar/GuitarRangeIndicatorElement.cs
+++ b/Assets/Script/Gameplay/Visuals/TrackElements/Guitar/GuitarRangeIndicatorElement.cs
@@ -1,0 +1,45 @@
+﻿using UnityEngine;
+using YARG.Gameplay.Player;
+using YARG.Helpers;
+
+namespace YARG.Gameplay.Visuals
+{
+    public class GuitarRangeIndicatorElement : TrackElement<FiveFretPlayer>
+    {
+        public        FiveFretRangeShift RangeShift;
+
+        private const float SCALE_DENOMINATOR    = 5f;
+        private const float RANGE_Y_SCALE        = 0.12f;
+
+        private static readonly int _color = Shader.PropertyToID("_Color");
+
+        public override double ElementTime => RangeShift.Time;
+
+        [SerializeField]
+        private MeshRenderer _meshRenderer;
+
+        protected override void InitializeElement()
+        {
+            transform.localPosition = Vector3.zero;
+
+            var cachedTransform = _meshRenderer.transform;
+            var newXScale = (RangeShift.Size / SCALE_DENOMINATOR) * 2;
+
+            // TODO: There has got to be a better way to calculate this
+            var sign = RangeShift.Range < 2 ? -1 : 1;
+            var xPos = ((2 - newXScale) / 2) * (RangeShift.Range == 2 && RangeShift.Size == 3 ? 0f : sign);
+
+            cachedTransform.localScale = new Vector3(newXScale, RANGE_Y_SCALE, transform.localScale.z);
+            cachedTransform.localPosition = new Vector3(xPos, 0.002f, cachedTransform.localPosition.z);
+        }
+
+        protected override void UpdateElement()
+        {
+        }
+
+        protected override void HideElement()
+        {
+        }
+
+    }
+}

--- a/Assets/Script/Gameplay/Visuals/TrackElements/Guitar/GuitarRangeIndicatorElement.cs.meta
+++ b/Assets/Script/Gameplay/Visuals/TrackElements/Guitar/GuitarRangeIndicatorElement.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 50e27ecabe214d549c66e50a02d48609
+timeCreated: 1740537140

--- a/Assets/Script/Gameplay/Visuals/TrackElements/Guitar/GuitarShiftIndicatorElement.cs
+++ b/Assets/Script/Gameplay/Visuals/TrackElements/Guitar/GuitarShiftIndicatorElement.cs
@@ -5,15 +5,23 @@ namespace YARG.Gameplay.Visuals
 {
     public class GuitarShiftIndicatorElement : TrackElement<FiveFretPlayer>
     {
-        public FiveFretPlayer.RangeShiftIndicator RangeShiftIndicator;
+        // TODO: These constants will only work for a five fret track, so work will be required to
+        //  make it work with six fret if that ever becomes a thing
+        private const float                              WIDTH_NUMERATOR                  = 2f;
+        private const float                              WIDTH_DENOMINATOR                = 5f;
+        private const float                              SHIFT_INDICATOR_DEFAULT_POSITION = 1f;
+        public        FiveFretPlayer.RangeShiftIndicator RangeShiftIndicator;
 
         public override double ElementTime => RangeShiftIndicator.Time;
 
         protected override void InitializeElement()
         {
             var cachedTransform = transform;
-            cachedTransform.localScale = cachedTransform.localScale
-                .WithX(RangeShiftIndicator.LeftSide ? -1f : 1f);
+            var sign = RangeShiftIndicator.LeftSide ? -1f : 1f;
+            var xPosition = ((WIDTH_NUMERATOR / WIDTH_DENOMINATOR) * RangeShiftIndicator.Offset) * sign;
+
+            cachedTransform.localScale = cachedTransform.localScale.WithX(sign);
+            cachedTransform.localPosition = cachedTransform.localPosition.WithX(xPosition);
         }
 
         protected override void UpdateElement()

--- a/Assets/Script/Gameplay/Visuals/TrackElements/Guitar/GuitarShiftIndicatorElement.cs
+++ b/Assets/Script/Gameplay/Visuals/TrackElements/Guitar/GuitarShiftIndicatorElement.cs
@@ -1,0 +1,27 @@
+﻿using UnityEngine;
+using YARG.Gameplay.Player;
+
+namespace YARG.Gameplay.Visuals
+{
+    public class GuitarShiftIndicatorElement : TrackElement<FiveFretPlayer>
+    {
+        public FiveFretPlayer.RangeShiftIndicator RangeShiftIndicator;
+
+        public override double ElementTime => RangeShiftIndicator.Time;
+
+        protected override void InitializeElement()
+        {
+            var cachedTransform = transform;
+            cachedTransform.localScale = cachedTransform.localScale
+                .WithX(RangeShiftIndicator.LeftSide ? -1f : 1f);
+        }
+
+        protected override void UpdateElement()
+        {
+        }
+
+        protected override void HideElement()
+        {
+        }
+    }
+}

--- a/Assets/Script/Gameplay/Visuals/TrackElements/Guitar/GuitarShiftIndicatorElement.cs.meta
+++ b/Assets/Script/Gameplay/Visuals/TrackElements/Guitar/GuitarShiftIndicatorElement.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: bf614b13bedd4614b7002d57c143bdaa
+timeCreated: 1738298532

--- a/Assets/Script/Helpers/FiveFretRangeShift.cs
+++ b/Assets/Script/Helpers/FiveFretRangeShift.cs
@@ -1,0 +1,107 @@
+﻿using System.Collections.Generic;
+using YARG.Core;
+using YARG.Core.Chart;
+using YARG.Core.Logging;
+
+namespace YARG.Helpers
+{
+    // TODO: Figure out a better place to put this
+    public class FiveFretRangeShift
+    {
+        public double Time  { get; private set; }
+        public int    Range { get; private set; }
+        public int    Size  { get; private set; }
+        public bool   Shown = false;
+
+        private FiveFretRangeShift(double time, int range, int size)
+        {
+            Time = time;
+            Range = range;
+            Size = size;
+        }
+
+        public static List<FiveFretRangeShift> GetRangeShiftEvents(List<TextEvent> textEvents, Difficulty playerDifficulty)
+        {
+            var shiftEvents = new List<FiveFretRangeShift>();
+            var eventDifficulty = (int?) GetRangeDifficultyForChartDifficulty(playerDifficulty);
+
+            // We can't do anything with this, so log an error and return an empty list
+            if (eventDifficulty == null)
+            {
+                YargLogger.LogFormatDebug("Unable to find range shift difficulty for chart difficulty {0}", playerDifficulty);
+                return shiftEvents;
+            }
+
+            foreach (var textEvent in textEvents)
+            {
+                if (!textEvent.Text.StartsWith("ld_range_shift"))
+                {
+                    continue;
+                }
+
+                // Validate the event and add it to the list
+                // My natural inclination here would be to use a regex, but they're not really used
+                // anywhere else in YARG, so...
+                var splitEvent = textEvent.Text.Split(' ');
+                if (splitEvent.Length != 4)
+                {
+                    YargLogger.LogFormatDebug("Unable to parse range shift event: {0}", textEvent.Text);
+                    continue;
+                }
+
+                // TODO: Consider merging this with the above, though I feel like this way is more readable
+                if (!(int.TryParse(splitEvent[1], out int difficulty) &&
+                      int.TryParse(splitEvent[2], out int range) &&
+                      int.TryParse(splitEvent[3], out int size)))
+                {
+                    YargLogger.LogFormatDebug("Unable to parse range shift event: {0}", textEvent.Text);
+                    continue;
+                }
+
+                // Further validation
+                // 1) Is the range index valid
+                if (range < 1 || range > 5)
+                {
+                    YargLogger.LogFormatDebug("Invalid range index in range shift event: {0}", textEvent.Text);
+                    continue;
+                }
+
+                // 2) Is the size valid for the range index
+                if (range + size > 6)
+                {
+                    YargLogger.LogFormatDebug("Invalid range size (too large for index) in shift event: {0}", textEvent.Text);
+                    continue;
+                }
+
+                // TODO: Range probably needs to be adjusted since visual frets are zero indexed (I think)
+                //  and the chart fret is one indexed since zero is an open note
+
+                if (difficulty == eventDifficulty)
+                {
+                    shiftEvents.Add(new FiveFretRangeShift(textEvent.Time, range, size));
+                }
+            }
+            return shiftEvents;
+        }
+
+        private static RangeDifficulty? GetRangeDifficultyForChartDifficulty(Difficulty difficulty)
+        {
+            return difficulty switch
+            {
+                Difficulty.Easy   => RangeDifficulty.Easy,
+                Difficulty.Medium => RangeDifficulty.Medium,
+                Difficulty.Hard   => RangeDifficulty.Hard,
+                Difficulty.Expert => RangeDifficulty.Expert,
+                _                 => null,
+            };
+        }
+
+        private enum RangeDifficulty
+        {
+            Easy   = 0,
+            Medium  = 1,
+            Hard   = 2,
+            Expert  = 3,
+        }
+    }
+}

--- a/Assets/Script/Helpers/FiveFretRangeShift.cs
+++ b/Assets/Script/Helpers/FiveFretRangeShift.cs
@@ -75,9 +75,6 @@ namespace YARG.Helpers
                     continue;
                 }
 
-                // TODO: Range probably needs to be adjusted since visual frets are zero indexed (I think)
-                //  and the chart fret is one indexed since zero is an open note
-
                 if (difficulty == eventDifficulty)
                 {
                     shiftEvents.Add(new FiveFretRangeShift(textEvent.Time, range, size));

--- a/Assets/Script/Helpers/FiveFretRangeShift.cs
+++ b/Assets/Script/Helpers/FiveFretRangeShift.cs
@@ -8,9 +8,11 @@ namespace YARG.Helpers
     // TODO: Figure out a better place to put this
     public class FiveFretRangeShift
     {
-        public double Time  { get; private set; }
-        public int    Range { get; private set; }
-        public int    Size  { get; private set; }
+        public double Time         { get; private set; }
+        public int    Range        { get; private set; }
+        public int    Size         { get; private set; }
+        public double BeatDuration { get; set; }
+
         public bool   Shown = false;
 
         private FiveFretRangeShift(double time, int range, int size)

--- a/Assets/Script/Helpers/FiveFretRangeShift.cs.meta
+++ b/Assets/Script/Helpers/FiveFretRangeShift.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 47bb9f47a5df4e6085abb6e842a5a64f
+timeCreated: 1738272352


### PR DESCRIPTION
This PR adds support for shift indicators on five fret instruments, using range shift text events found in some of the YARG setlist songs.

During initialization the list of text events attached to the note track is scanned for events with the form `[ld_range_shift d r s]` where d is the difficulty, r is the 1 indexed range, and s is the number of frets in the range. Any frets not in the initial range are grayed out.

![inactive fret](https://github.com/user-attachments/assets/01eeac19-aab1-4710-88d3-43bd8ea6c844)

When a range shift event occurs, range shift markers are shown at the four preceding beat lines on the track and the currently inactive frets coming into use flash at each range shift marker.

Shift marker, currently identical to the pro keys range shift marker:
![shift marker](https://github.com/user-attachments/assets/6af7e5ea-fb7f-4c11-a6db-3691e1b5854e)

Fading out from the beat line flash:
![mid flash](https://github.com/user-attachments/assets/9c51b046-50b5-4af3-aeaf-3908437d8156)

Once the event has passed, the now active frets are colored and the now inactive frets fade to gray.

![inactive flipped](https://github.com/user-attachments/assets/e27318fc-cc06-4a9e-b501-b87c61eae4ac)
