### PR TITLE
Video calibration

### DIFF
--- a/Assets/Scenes/CalibrationScene.unity
+++ b/Assets/Scenes/CalibrationScene.unity
@@ -123,6 +123,142 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1 &51138883
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 51138884}
+  - component: {fileID: 51138886}
+  - component: {fileID: 51138885}
+  m_Layer: 5
+  m_Name: '"Detected" Text'
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &51138884
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 51138883}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 506060379}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -212}
+  m_SizeDelta: {x: 1920, y: 85}
+  m_Pivot: {x: 0.5, y: 0.49999982}
+--- !u!114 &51138885
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 51138883}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: ' '
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 69b34e9e884c55947b52d9bbbd4258d7, type: 2}
+  m_sharedMaterial: {fileID: 4264900350419322127, guid: 69b34e9e884c55947b52d9bbbd4258d7,
+    type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 64
+  m_fontSizeBase: 64
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &51138886
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 51138883}
+  m_CullTransparentMesh: 1
 --- !u!1 &321642868
 GameObject:
   m_ObjectHideFlags: 0
@@ -242,12 +378,12 @@ GameObject:
   m_Component:
   - component: {fileID: 506060379}
   m_Layer: 5
-  m_Name: Audio Calibration
+  m_Name: Calibration Text
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &506060379
 RectTransform:
   m_ObjectHideFlags: 0
@@ -261,6 +397,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 1475276001}
+  - {fileID: 51138884}
   m_Father: {fileID: 1322027747}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -327,7 +464,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: Calibrate Audio
+  m_text: Calibrate Video
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
   m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
@@ -437,11 +574,11 @@ RectTransform:
   m_Children:
   - {fileID: 530648844}
   m_Father: {fileID: 1532234720}
-  m_RootOrder: 0
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: -100}
   m_SizeDelta: {x: 500, y: 64}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &924377149
@@ -489,8 +626,8 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls:
       - m_Target: {fileID: 1617527340}
-        m_TargetAssemblyTypeName: YARG.Calibrator, Assembly-CSharp
-        m_MethodName: StartAudioMode
+        m_TargetAssemblyTypeName: YARG.Menu.Calibrator.Calibrator, Assembly-CSharp
+        m_MethodName: StartVideoMode
         m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -576,6 +713,140 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: -80}
   m_SizeDelta: {x: 0, y: -160}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &1417324740
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1417324741}
+  - component: {fileID: 1417324744}
+  - component: {fileID: 1417324743}
+  - component: {fileID: 1417324742}
+  m_Layer: 5
+  m_Name: Button
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1417324741
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1417324740}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1493378020}
+  m_Father: {fileID: 1532234720}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 500, y: 64}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1417324742
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1417324740}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1417324743}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1617527340}
+        m_TargetAssemblyTypeName: YARG.Calibrator, Assembly-CSharp
+        m_MethodName: StartAudioMode
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &1417324743
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1417324740}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1417324744
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1417324740}
+  m_CullTransparentMesh: 1
 --- !u!1 &1475276000
 GameObject:
   m_ObjectHideFlags: 0
@@ -712,6 +983,141 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1475276000}
   m_CullTransparentMesh: 1
+--- !u!1 &1493378019
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1493378020}
+  - component: {fileID: 1493378022}
+  - component: {fileID: 1493378021}
+  m_Layer: 5
+  m_Name: Text (TMP)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1493378020
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1493378019}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1417324741}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1493378021
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1493378019}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Calibrate Audio
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4281479730
+  m_fontColor: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 36
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &1493378022
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1493378019}
+  m_CullTransparentMesh: 1
 --- !u!1 &1532234719
 GameObject:
   m_ObjectHideFlags: 0
@@ -740,6 +1146,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
+  - {fileID: 1417324741}
   - {fileID: 924377148}
   m_Father: {fileID: 1322027747}
   m_RootOrder: 0
@@ -867,8 +1274,9 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _startingStateContainer: {fileID: 1532234719}
-  _audioCalibrateContainer: {fileID: 506060378}
-  _audioCalibrateText: {fileID: 1475276002}
+  _calibrateContainer: {fileID: 506060378}
+  _infoText: {fileID: 1475276002}
+  _detectedText: {fileID: 51138885}
 --- !u!114 &1617527341
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Script/Menu/Calibrator/Calibrator.cs
+++ b/Assets/Script/Menu/Calibrator/Calibrator.cs
@@ -24,6 +24,9 @@ namespace YARG.Menu.Calibrator
         private enum State
         {
             Starting,
+            VideoWaiting,
+            Video,
+            VideoDone,
             AudioWaiting,
             Audio,
             AudioDone
@@ -33,11 +36,14 @@ namespace YARG.Menu.Calibrator
         private GameObject _startingStateContainer;
 
         [SerializeField]
-        private GameObject _audioCalibrateContainer;
+        private GameObject _calibrateContainer;
 
         [Space]
         [SerializeField]
-        private TextMeshProUGUI _audioCalibrateText;
+        private TextMeshProUGUI _infoText;
+
+        [SerializeField]
+        private TextMeshProUGUI _detectedText;
 
         private State _state = State.Starting;
         private readonly List<double> _calibrationTimes = new();
@@ -47,6 +53,7 @@ namespace YARG.Menu.Calibrator
         private StemMixer? _mixer;
         private double _time;
 #nullable disable
+        private uint _timerCount = 0;
 
         private void Start()
         {
@@ -78,17 +85,23 @@ namespace YARG.Menu.Calibrator
 
             switch (_state)
             {
+                case State.VideoWaiting:
+                    _state = State.Video;
+                    UpdateForState();
+                    break;
                 case State.AudioWaiting:
                     _state = State.Audio;
                     UpdateForState();
                     break;
+                case State.Video:
                 case State.Audio:
-                    _audioCalibrateText.color = Color.green;
-                    _audioCalibrateText.text = Localize.Key("Menu.Calibrator.Detected");
-
                     _calibrationTimes.Add(Time.realtimeSinceStartupAsDouble - _time);
+
+                    _detectedText.color = Color.green;
+                    _detectedText.text = Localize.Key("Menu.Calibrator.Detected");
                     break;
                 case State.Starting:
+                case State.VideoDone:
                 case State.AudioDone:
                     if (input.GetAction<MenuAction>() == MenuAction.Red)
                     {
@@ -100,13 +113,28 @@ namespace YARG.Menu.Calibrator
 
         private void Update()
         {
+            var color = Color.white;
             switch (_state)
             {
+                case State.Video:
+                    // Fade out text
+                    color = _infoText.color;
+                    color.a -= Time.deltaTime * 9f;
+                    _infoText.color = color;
+
+                    color = _detectedText.color;
+                    color.a -= Time.deltaTime * 3f;
+                    _detectedText.color = color;
+                    break;
                 case State.Audio:
                     // Fade out text
-                    var color = _audioCalibrateText.color;
+                    color = _infoText.color;
                     color.a -= Time.deltaTime * 3f;
-                    _audioCalibrateText.color = color;
+                    _infoText.color = color;
+
+                    color = _detectedText.color;
+                    color.a -= Time.deltaTime * 3f;
+                    _detectedText.color = color;
                     break;
             }
         }
@@ -117,26 +145,66 @@ namespace YARG.Menu.Calibrator
             _mixer = null;
 
             StopAllCoroutines();
+            CancelInvoke();
 
             _startingStateContainer.SetActive(false);
-            _audioCalibrateContainer.SetActive(false);
+            _calibrateContainer.SetActive(false);
+
+            _infoText.fontSize = 64;
+
+            int calibration = -10000;
 
             switch (_state)
             {
                 case State.Starting:
                     _startingStateContainer.SetActive(true);
                     break;
-                case State.AudioWaiting:
-                    _audioCalibrateContainer.SetActive(true);
+
+                case State.VideoWaiting:
+                    _calibrateContainer.SetActive(true);
                     _player = null;
 
-                    _audioCalibrateText.color = Color.white;
-                    _audioCalibrateText.text =
+                    _infoText.color = Color.white;
+                    _infoText.text =
+                        "Press any button on each circle you see.\n" +
+                        "Press any button when you are ready.";
+                    break;
+                case State.Video:
+                    _calibrateContainer.SetActive(true);
+                    _calibrationTimes.Clear();
+
+                    _timerCount = 0;
+                    _time = Time.realtimeSinceStartupAsDouble;
+                    InvokeRepeating("VideoCalibrationTimer", SECONDS_PER_BEAT, SECONDS_PER_BEAT);
+                    break;
+                case State.VideoDone:
+                    _calibrateContainer.SetActive(true);
+                    _detectedText.text = "";
+
+                    calibration = CalculateLatency();
+                    if (calibration > -10000)
+                    {
+                        SettingsManager.Settings.VideoCalibration.Value = calibration;
+
+                        // Set text
+                        _infoText.color = Color.green;
+                        _infoText.text =
+                            $"Calibration set to {calibration}ms!\n" +
+                            "Press back to exit.";
+                    }
+                    break;
+
+                case State.AudioWaiting:
+                    _calibrateContainer.SetActive(true);
+                    _player = null;
+
+                    _infoText.color = Color.white;
+                    _infoText.text =
                         "Press any button on each tick you hear.\n" +
                         "Press any button when you are ready.";
                     break;
                 case State.Audio:
-                    _audioCalibrateContainer.SetActive(true);
+                    _calibrateContainer.SetActive(true);
                     _calibrationTimes.Clear();
 
                     const float SPEED = 1f;
@@ -149,13 +217,27 @@ namespace YARG.Menu.Calibrator
                     StartCoroutine(AudioCalibrateCoroutine());
                     break;
                 case State.AudioDone:
-                    _audioCalibrateContainer.SetActive(true);
-                    CalculateAudioLatency();
+                    _calibrateContainer.SetActive(true);
+                    _detectedText.text = "";
+
+                    calibration = CalculateLatency();
+                    if (calibration > -10000)
+                    {
+                        if (SettingsManager.Settings.AccountForHardwareLatency.Value)
+                            calibration -= GlobalAudioHandler.PlaybackLatency;
+                        SettingsManager.Settings.AudioCalibration.Value = calibration;
+
+                        // Set text
+                        _infoText.color = Color.green;
+                        _infoText.text =
+                            $"Calibration set to {calibration}ms!\n" +
+                            "Press back to exit.";
+                    }
                     break;
             }
         }
 
-        private void CalculateAudioLatency()
+        private int CalculateLatency()
         {
             // Drop all discrepancies
             for (int i = _calibrationTimes.Count - 1; i > 1; i--)
@@ -169,9 +251,9 @@ namespace YARG.Menu.Calibrator
             // If there isn't enough data, RIP
             if (_calibrationTimes.Count <= 8)
             {
-                _audioCalibrateText.color = Color.red;
-                _audioCalibrateText.text = Localize.Key("Menu.Calibrator.NotEnoughData");
-                return;
+                _infoText.color = Color.red;
+                _infoText.text = Localize.Key("Menu.Calibrator.NotEnoughData");
+                return -10000;
             }
 
             // Get the deviations
@@ -217,35 +299,63 @@ namespace YARG.Menu.Calibrator
             int mid = diffs.Count / 2;
             double median = diffs.Count % 2 != 0 ? diffs[mid] : (diffs[mid] + diffs[mid - 1]) / 2f;
 
-            // Set calibration
-            int calibration = (int)Math.Round(median * 1000);
-            if (SettingsManager.Settings.AccountForHardwareLatency.Value)
-                calibration -= GlobalAudioHandler.PlaybackLatency;
-            SettingsManager.Settings.AudioCalibration.Value = calibration;
+            // return median
+            return (int)Math.Round(median * 1000);
+        }
 
-            // Set text
-            _audioCalibrateText.color = Color.green;
-            _audioCalibrateText.text =
-                $"Calibration set to {calibration}ms!\n" +
-                "Press back to exit.";
+        private void VideoCalibrationTimer()
+        {
+            _infoText.fontSize = 64;
+            _infoText.color = Color.white;
+            switch (_timerCount)
+            {
+                case 0:
+                    _infoText.text = "4";
+                    break;
+                case 1:
+                    _infoText.text = "3";
+                    break;
+                case 2:
+                    _infoText.text = "2";
+                    break;
+                case 3:
+                    _infoText.text = "1";
+                    break;
+                case < 20:
+                    _infoText.fontSize = 256;
+                    // black circle
+                    _infoText.text = "\u25CF";
+                    break;
+                default:
+                    _state = State.VideoDone;
+                    UpdateForState();
+                    break;
+            }
+            ++_timerCount;
         }
 
         private IEnumerator AudioCalibrateCoroutine()
         {
-            _audioCalibrateText.color = Color.white;
-            _audioCalibrateText.text = "1";
+            _infoText.color = Color.white;
+            _infoText.text = "4";
 
             yield return new WaitUntil(() => _mixer.GetPosition() >= SECONDS_PER_BEAT * 1f);
-            _audioCalibrateText.color = Color.white;
-            _audioCalibrateText.text = "2";
+            _infoText.color = Color.white;
+            _infoText.text = "3";
 
             yield return new WaitUntil(() => _mixer.GetPosition() >= SECONDS_PER_BEAT * 2f);
-            _audioCalibrateText.color = Color.white;
-            _audioCalibrateText.text = "3";
+            _infoText.color = Color.white;
+            _infoText.text = "2";
 
             yield return new WaitUntil(() => _mixer.GetPosition() >= SECONDS_PER_BEAT * 3f);
-            _audioCalibrateText.color = Color.white;
-            _audioCalibrateText.text = "4";
+            _infoText.color = Color.white;
+            _infoText.text = "1";
+        }
+
+        public void StartVideoMode()
+        {
+            _state = State.VideoWaiting;
+            UpdateForState();
         }
 
         public void StartAudioMode()


### PR DESCRIPTION
This is the first half/part of https://yarg.youtrack.cloud/issue/YARG-187/Rework-calibration-tool-to-allow-calibrating-video-and-input-delay i.e. to add video calibration. I intend to improve the calibrator further, this is just the "dipping my toes in game development" PR. For the further improvements, I'll open a proposal on Discord first.

As for the changes here, they are fairly simplistic, mainly copy/pasting what has been done for audio calibration. The latency calculation (median) is also reused. I used invoke instead of a coroutine because apparently it is more accurate (https://www.tantzygames.com/blog/most-accurate-timer-in-unity/)