### PR TITLE
Cache combo meter's text meshes

### DIFF
--- a/Assets/Script/Gameplay/Player/TrackPlayer.cs
+++ b/Assets/Script/Gameplay/Player/TrackPlayer.cs
@@ -88,7 +88,6 @@ namespace YARG.Gameplay.Player
 
             var preset = player.EnginePreset;
             IndicatorStripes.Initialize(preset);
-            ComboMeter.Initialize(preset);
 
             // Set fade information and highway length
             ZeroFadePosition = DEFAULT_ZERO_FADE_POS * Player.Profile.HighwayLength;
@@ -185,6 +184,8 @@ namespace YARG.Gameplay.Player
             Notes = NoteTrack.Notes;
 
             Engine = CreateEngine();
+
+            base.ComboMeter.Initialize(player.EnginePreset, Engine.BaseParameters.MaxMultiplier);
 
             if (GameManager.IsPractice)
             {

--- a/Assets/Script/Gameplay/Visuals/ComboMeter.cs
+++ b/Assets/Script/Gameplay/Visuals/ComboMeter.cs
@@ -25,8 +25,20 @@ namespace YARG.Gameplay.Visuals
         [SerializeField]
         private Material _noFcRingMaterial;
 
-        public void Initialize(EnginePreset preset)
+        private TextMeshPro[] _textCache;
+
+        public void Initialize(EnginePreset preset, int maxMultiplier)
         {
+            _multiplierText.enabled = false;
+            _multiplierText.text = string.Empty;
+            _textCache = new TextMeshPro[maxMultiplier * 2 - 1];
+            _textCache[0] = _multiplierText;
+            for(int i = 0; i < _textCache.Length; ++i)
+            {
+                _textCache[i] = Instantiate(_multiplierText, _multiplierText.transform.parent, true);
+                _textCache[i].SetTextFormat("{0}<sub>x</sub>", i + 2);
+            }
+
             // Skip if the preset is a default one
             if (EnginePreset.Defaults.Contains(preset)) return;
 
@@ -36,10 +48,12 @@ namespace YARG.Gameplay.Visuals
 
         public void SetCombo(int multiplier, int maxMultiplier, int combo)
         {
-            if (multiplier != 1)
-                _multiplierText.SetTextFormat("{0}<sub>x</sub>", multiplier);
-            else
-                _multiplierText.text = string.Empty;
+            _multiplierText.enabled = false;
+            if (multiplier > 1)
+            {
+                _multiplierText = _textCache[multiplier - 2];
+                _multiplierText.enabled = true;
+            }
 
             int index = combo % 10;
             if (combo != 0 && index == 0)
@@ -56,7 +70,7 @@ namespace YARG.Gameplay.Visuals
 
         public void SetFullCombo(bool isFc)
         {
-            _ringMesh.material = isFc ? _fcRingMaterial : _noFcRingMaterial;
+            _ringMesh.sharedMaterial = isFc ? _fcRingMaterial : _noFcRingMaterial;
         }
     }
 }


### PR DESCRIPTION
Currently text onto meter is set every frame and every frame it (re) generates the mesh. Its not that expensive but on my low power old mac it adds up to 1ms with 4 players

Pre-generate all meter meshes since there is only a few and display the needed one.

I suspect my changes in TrackPlayer classes are wrong so hopefully someone will give a nudge in the right direction for that part.