### PR TITLE
Fix Circular HOPO Note Flares not scaling with FOV (Approximate scaling math to target Circular preset/60°)

### DIFF
--- a/Assets/Script/Gameplay/Visuals/TrackElements/NoteFlare.cs
+++ b/Assets/Script/Gameplay/Visuals/TrackElements/NoteFlare.cs
@@ -11,7 +11,6 @@ namespace YARG.Gameplay.Visuals
 
         [SerializeField]
         private float _scaleConstant = 4.25f;
-
         private LensFlareComponentSRP _flare;
 
         private float _fadeFullPosition;
@@ -54,10 +53,11 @@ namespace YARG.Gameplay.Visuals
             // We use "EaseInOutCubic" as the track fade also uses that
             _flare.intensity = EaseInOutCubic(Mathf.Clamp01(intensity));
 
-            // Update flare scale based on distance from camera
+            // Update flare scale based on distance from camera and attempt to normalize for FOV, includes tangent/cotangent for accurate FOV scaling
 
-            _flare.scale = _scaleConstant /
-                Vector3.Distance(transform.position, TrackPlayer.TrackCamera.transform.position);
+            float fovScale = (2.6f / Mathf.Tan(0.0126f * TrackPlayer.TrackCamera.fieldOfView - .046f)) + 1.223f;
+			_flare.scale = fovScale / Vector3.Distance(transform.position, TrackPlayer.TrackCamera.transform.position);
+
         }
 
         private static float EaseInOutCubic(float x)


### PR DESCRIPTION
Currently, on both Nightly and Stable, HOPO note lens flare effects on the Circular note shape do not scale with the perceptual distance change that comes with a change of FOV. The current code for Note Flares only accounts for the *physical distance* to the camera object. This makes them tiny on low FOV, and notably, Michael Bay levels of flare on high FOV.

Attached are some screenshots to demonstrate the intended effect, a 120fov profile, and after the linear function patch is applied
### 60FOV Circular Preset, target appearance
![60FOV Circular Preset, target appearance](https://github.com/user-attachments/assets/12143edc-b856-427e-b159-0fc2141e006a)
### 120FOV profile, pre-patch
![120FOV profile, pre-patch](https://github.com/user-attachments/assets/da25be0c-10dd-415d-bf9f-64f62009d200)
### The same profile, after the patch
![sameprofilepatch](https://github.com/user-attachments/assets/31a68189-dc63-4028-b970-ac9246e1e9cb)

The function might need some tweaking, but it does make higher FOV camera presets usable with the Circular note shape option.