### PR TITLE
Add NoPercussion vocal modifier

### DIFF
--- a/Assets/StreamingAssets/lang/en-US.json
+++ b/Assets/StreamingAssets/lang/en-US.json
@@ -59,7 +59,8 @@
             "NoKicks": "No Kicks",
             "TapsToHopos": "Taps to HOPOs",
             "UnpitchedOnly": "Unpitched Only",
-            "NoDynamics": "No Dynamics"
+            "NoDynamics": "No Dynamics",
+            "NoPercussion": "No Percussion"
         },
         "SortAttribute": {
             "Album": "Album",

--- a/Assets/StreamingAssets/lang/es-ES.json
+++ b/Assets/StreamingAssets/lang/es-ES.json
@@ -58,7 +58,8 @@
             "NoteShuffle": "Note Shuffle",
             "NoKicks": "No Kicks",
             "TapsToHopos": "Taps to HOPOs",
-            "UnpitchedOnly": "Unpitched Only"
+            "UnpitchedOnly": "Unpitched Only",
+            "NoPercussion": "No Percussion"
         },
         "SortAttribute": {
             "Album": "Album",

--- a/Assets/StreamingAssets/lang/ja-JP.json
+++ b/Assets/StreamingAssets/lang/ja-JP.json
@@ -58,7 +58,8 @@
             "NoteShuffle": "Note Shuffle",
             "NoKicks": "No Kicks",
             "TapsToHopos": "Taps to HOPOs",
-            "UnpitchedOnly": "Unpitched Only"
+            "UnpitchedOnly": "Unpitched Only",
+            "NoPercussion": "No Percussion"
         },
         "SortAttribute": {
             "Album": "Album",

--- a/Assets/StreamingAssets/lang/pt-BR.json
+++ b/Assets/StreamingAssets/lang/pt-BR.json
@@ -58,7 +58,8 @@
             "NoteShuffle": "Note Shuffle",
             "NoKicks": "No Kicks",
             "TapsToHopos": "Taps to HOPOs",
-            "UnpitchedOnly": "Unpitched Only"
+            "UnpitchedOnly": "Unpitched Only",
+            "NoPercussion": "No Percussion"
         },
         "SortAttribute": {
             "Album": "Album",

--- a/Assets/StreamingAssets/lang/pt-PT.json
+++ b/Assets/StreamingAssets/lang/pt-PT.json
@@ -58,7 +58,8 @@
             "NoteShuffle": "Note Shuffle",
             "NoKicks": "No Kicks",
             "TapsToHopos": "Taps to HOPOs",
-            "UnpitchedOnly": "Unpitched Only"
+            "UnpitchedOnly": "Unpitched Only",
+            "NoPercussion": "No Percussion"
         },
         "SortAttribute": {
             "Album": "Album",


### PR DESCRIPTION
This PR adds the localization entries for the "No Percussion" vocal modifier. This relies on PR https://github.com/YARC-Official/YARG.Core/pull/238 to add the underlying functionality.

Issue: #969 