### PR TITLE
Fixes long standing bug with blending.

### DIFF
--- a/Assets/Script/Integration/MasterLightingController.cs
+++ b/Assets/Script/Integration/MasterLightingController.cs
@@ -278,6 +278,7 @@ namespace YARG.Integration
             CurrentLightingCue = null;
             CurrentFogState = FogState.Off;
             CurrentStrobeState = StageKitStrobeSpeed.Off;
+            CurrentPostProcessing = new PostProcessingEvent(PostProcessingType.Default, 0, 0);
         }
     }
 }

--- a/Assets/Script/Integration/StageKit/StageKitInterpreter.cs
+++ b/Assets/Script/Integration/StageKit/StageKitInterpreter.cs
@@ -68,6 +68,11 @@ namespace YARG.Integration.StageKit
 
         private void ChangeCues(StageKitLightingCue cue)
         {
+            if (_currentLightingCue == cue)
+            {
+                return;
+            }
+
             if (_currentLightingCue != null)
             {
                 foreach (var primitive in _currentLightingCue.CuePrimitives)

--- a/Assets/Script/Integration/StageKit/StageKitLighting.Cues.cs
+++ b/Assets/Script/Integration/StageKit/StageKitLighting.Cues.cs
@@ -580,18 +580,14 @@ namespace YARG.Integration.StageKit
         private bool _blueOn = true;
         private bool _enableBlueLedVocals;
 
-        public SilhouetteSpot()
+        public override void Enable()
         {
             if (StageKitInterpreter.PreviousLightingCue is Intro)
             {
                 CuePrimitives.Add(new ListenPattern(new (StageKitLedColor, byte)[] { (BLUE, ALL) },
                     ListenTypes.RedFretDrums, true));
             }
-        }
-
-        public override void Enable()
-        {
-            if (StageKitInterpreter.PreviousLightingCue is Dischord)
+            else if (StageKitInterpreter.PreviousLightingCue is Dischord)
             {
                 StageKitInterpreter.Instance.SetLed(RED, NONE);
                 StageKitInterpreter.Instance.SetLed(YELLOW, NONE);


### PR DESCRIPTION
Since I never had metadata for rb3 stuff, I never noticed the addition of blending (calling the same cue again). Since our auto-gen follows magma which does blending, auto-gen songs were having strange bugs in the stage kit because of this. Solution? just ignore a cue if same as the current one.