### PR TITLE
Fix some text sometimes not visible in opengl mode

### DIFF
--- a/Assets/Art/Fonts/RedHatDisplay/RedHatDisplay-SemiBold.asset
+++ b/Assets/Art/Fonts/RedHatDisplay/RedHatDisplay-SemiBold.asset
@@ -5620,7 +5620,7 @@ Material:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: RedHatDisplay-SemiBold SDF Material
-  m_Shader: {fileID: 4800000, guid: 68e6db2ebdc24f95958faec2be5558d6, type: 3}
+  m_Shader: {fileID: 4800000, guid: dd89cf5b9246416f84610a006f916af7, type: 3}
   m_ValidKeywords: []
   m_InvalidKeywords: []
   m_LightmapFlags: 4

--- a/Assets/Art/Fonts/RedHatDisplay/RedHatDisplay-SemiBoldItalic.asset
+++ b/Assets/Art/Fonts/RedHatDisplay/RedHatDisplay-SemiBoldItalic.asset
@@ -5664,7 +5664,7 @@ Material:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: RedHatDisplay-SemiBoldItalic SDF Material
-  m_Shader: {fileID: 4800000, guid: 68e6db2ebdc24f95958faec2be5558d6, type: 3}
+  m_Shader: {fileID: 4800000, guid: dd89cf5b9246416f84610a006f916af7, type: 3}
   m_ValidKeywords:
   - GLOW_ON
   m_InvalidKeywords: []

--- a/Assets/Art/Fonts/RedHatDisplay/RedHatDisplay.asset
+++ b/Assets/Art/Fonts/RedHatDisplay/RedHatDisplay.asset
@@ -5660,7 +5660,7 @@ Material:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: RedHatDisplay-Regular Atlas Material
-  m_Shader: {fileID: 4800000, guid: 68e6db2ebdc24f95958faec2be5558d6, type: 3}
+  m_Shader: {fileID: 4800000, guid: dd89cf5b9246416f84610a006f916af7, type: 3}
   m_ValidKeywords: []
   m_InvalidKeywords: []
   m_LightmapFlags: 4

--- a/Assets/Art/Fonts/Unbounded Outline.mat
+++ b/Assets/Art/Fonts/Unbounded Outline.mat
@@ -8,7 +8,7 @@ Material:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: Unbounded Outline
-  m_Shader: {fileID: 4800000, guid: 68e6db2ebdc24f95958faec2be5558d6, type: 3}
+  m_Shader: {fileID: 4800000, guid: dd89cf5b9246416f84610a006f916af7, type: 3}
   m_ValidKeywords: []
   m_InvalidKeywords: []
   m_LightmapFlags: 4


### PR DESCRIPTION
By changing shader used to an `overlay` variant that will always render on top. The Distance Field and Distance Field Overlay shaders are two nearly-identical variants of the TextMesh Pro signed distance field (SDF)shader. The difference between the two is that the Distance Field Overlay variant always renders the TextMesh Pro object on top of everything else in the Scene, while the Distance Field variant renders the Scene normally—objects in front of the TextMesh Pro object are rendered on top of the text.

There is no case currently where we need non-overlay variant and apparently according to user reports it causes some text not being visible in certain situations. Likely due to some depth collision/z-fighting.