### PR TITLE
Lyric Bar Enhancements

### DIFF
--- a/Assets/Script/Gameplay/HUD/LyricBar.cs
+++ b/Assets/Script/Gameplay/HUD/LyricBar.cs
@@ -194,7 +194,7 @@ namespace YARG.Gameplay.HUD
 
         private void UpdateUpcomingPhrase()
         {
-            const double MIN_PHRASE_LENGTH = 0.1;
+            const double MIN_PHRASE_LENGTH = 0.25;
             if (_upcomingLineSet)
             {
                 return;

--- a/Assets/Script/Gameplay/HUD/LyricBar.cs
+++ b/Assets/Script/Gameplay/HUD/LyricBar.cs
@@ -17,7 +17,7 @@ namespace YARG.Gameplay.HUD
 
     public class LyricBar : GameplayBehaviour
     {
-        private const double PHRASE_START_PADDING = 0.5;
+        private const double PHRASE_FADING = 0.5;
         private const double PHRASE_DISTANCE_THRESHOLD = 2.0;
 
         [SerializeField]
@@ -31,13 +31,12 @@ namespace YARG.Gameplay.HUD
         [SerializeField]
         private TextMeshProUGUI _upcomingLyricText;
 
-        private LyricsTrack _lyrics;
-
-        private double _upcomingLyricsThreshold;
-        private bool _upcomingLyricsSet;
+        private List<LyricsPhrase> _phrases;
+        private bool _upcomingLineSet = false;
 
         private int _currentPhraseIndex = 0;
-        private int _currentLyricIndex = 0;
+        private int _currentLyricIndex = -1;
+        private Utf16ValueStringBuilder _builder;
 
         protected override void GameplayAwake()
         {
@@ -49,6 +48,7 @@ namespace YARG.Gameplay.HUD
                 return;
             }
 
+            _builder = ZString.CreateStringBuilder(false);
             // Set the lyric background
             switch (lyricSetting)
             {
@@ -69,91 +69,89 @@ namespace YARG.Gameplay.HUD
             // Reset the lyrics
             _lyricText.text = string.Empty;
             _upcomingLyricText.text = string.Empty;
-
-            _upcomingLyricsThreshold = SettingsManager.Settings.UpcomingLyricsTime.Value;
         }
 
         protected override void OnChartLoaded(SongChart chart)
         {
-            _lyrics = chart.Lyrics;
-            if (_lyrics.Phrases.Count < 1)
+            _phrases = chart.Lyrics.Phrases;
+            if (_phrases.Count < 1)
             {
                 gameObject.SetActive(false);
             }
         }
 
+        protected override void GameplayDestroy()
+        {
+            if (!GameManager.IsPractice && SettingsManager.Settings.LyricDisplay.Value != LyricDisplayMode.Disabled)
+            {
+                _builder.Dispose();
+                return;
+            }
+        }
+
         private void Update()
         {
-            var phrases = _lyrics.Phrases;
-
-            // If the current phrase ended AND
-            while (_currentPhraseIndex < phrases.Count && phrases[_currentPhraseIndex].TimeEnd <= GameManager.SongTime &&
-                 // Was the last phrase
-                (_currentPhraseIndex + 1 == phrases.Count ||
-                 // OR if the next phrase is one second or more away (leading to an empty bar)
-                 phrases[_currentPhraseIndex + 1].Time - phrases[_currentPhraseIndex].TimeEnd >= PHRASE_DISTANCE_THRESHOLD ||
-                 // OR if the next phrase should be started
-                 phrases[_currentPhraseIndex + 1].Time <= GameManager.SongTime))
+            while (_currentPhraseIndex < _phrases.Count && _phrases[_currentPhraseIndex].TimeEnd <= GameManager.SongTime)
             {
+                // We don't want to immedately remove the current line if the next one is close enough
+                if (_currentPhraseIndex + 1 == _phrases.Count || _phrases[_currentPhraseIndex + 1].Time - _phrases[_currentPhraseIndex].TimeEnd >= PHRASE_DISTANCE_THRESHOLD)
+                {
+                    double fadeOut = GameManager.SongTime - _phrases[_currentPhraseIndex].TimeEnd;
+                    if (fadeOut < PHRASE_FADING)
+                    {
+                        float alpha = 1 - (float) (fadeOut / PHRASE_FADING);
+                        _lyricText.alpha = alpha;
+                        _upcomingLyricText.alpha = alpha;
+                        break;
+                    }
+                }
+                else if (GameManager.SongTime < _phrases[_currentPhraseIndex + 1].Time)
+                {
+                    break;
+                }
+
                 _currentPhraseIndex++;
                 _currentLyricIndex = -1;
-
                 _lyricText.text = string.Empty;
-
                 _upcomingLyricText.text = string.Empty;
-                _upcomingLyricsSet = false;
+                _upcomingLineSet = false;
             }
 
             // Exit if we've complete all phrases
-            if (_currentPhraseIndex == _lyrics.Phrases.Count)
+            if (_currentPhraseIndex == _phrases.Count)
             {
                 return;
             }
 
-            var lyrics = phrases[_currentPhraseIndex].Lyrics;
-
-            // If it's not time to show the lyrics...
-            if (GameManager.SongTime < phrases[_currentPhraseIndex].Time - PHRASE_START_PADDING)
+            if (GameManager.SongTime < _phrases[_currentPhraseIndex].Time)
             {
-                // Add it to the upcoming line, if the timing is right
-                if (!_upcomingLyricsSet &&
-                    GameManager.SongTime >= phrases[_currentPhraseIndex].Time - _upcomingLyricsThreshold)
+                double fadeIn = _phrases[_currentPhraseIndex].Time - GameManager.SongTime;
+                if (fadeIn >= PHRASE_FADING)
                 {
-                    SetUpcomingLyrics(lyrics);
+                    return;
                 }
-
-                // Exit
-                return;
+                float alpha = 1 - (float) (fadeIn / PHRASE_FADING);
+                _lyricText.alpha = alpha;
+                _upcomingLyricText.alpha = alpha;
+            }
+            // Fade-out could be occuring, so we can't just always set alpha to 1.0f here
+            else if (GameManager.SongTime < _phrases[_currentPhraseIndex].TimeEnd)
+            {
+                _lyricText.alpha = 1;
+                _upcomingLyricText.alpha = 1;
             }
 
-            // At this point, if the current lyric is being displayed (which happens below),
-            // then update the upcoming one (if it's not the last).
-            if (_currentPhraseIndex + 1 < phrases.Count)
-            {
-                var nextPhrase = phrases[_currentPhraseIndex + 1];
-                if (GameManager.SongTime >= nextPhrase.Time - _upcomingLyricsThreshold)
-                {
-                    if (!_upcomingLyricsSet)
-                    {
-                        SetUpcomingLyrics(nextPhrase.Lyrics);
-                    }
-                }
-                else
-                {
-                    _upcomingLyricText.text = string.Empty;
-                    _upcomingLyricsSet = false;
-                }
-            }
-            else
-            {
-                _upcomingLyricText.text = string.Empty;
-                _upcomingLyricsSet = false;
-            }
+            UpdateCurrentPhrase();
+            UpdateUpcomingPhrase();
+        }
+
+        private void UpdateCurrentPhrase()
+        {
+            var lyrics = _phrases[_currentPhraseIndex].Lyrics;
 
             // Update the lyric index
             int currIndex = _currentLyricIndex;
-            while (currIndex == -1 ||
-                (currIndex < lyrics.Count && lyrics[currIndex].Time <= GameManager.SongTime))
+            while (currIndex == -1 || (currIndex < lyrics.Count && lyrics[currIndex].Time <= GameManager.SongTime))
             {
                 currIndex++;
             }
@@ -164,55 +162,69 @@ namespace YARG.Gameplay.HUD
                 return;
             }
 
-            // Construct lyrics to be displayed
-            using var output = ZString.CreateStringBuilder(true);
-
+            _builder.Clear();
             // Highlighted words
-            output.Append("<color=#5CB9FF>");
+            _builder.Append("<color=#5CB9FF>");
             int i = 0;
             while (i < currIndex)
             {
                 var lyric = lyrics[i++];
-                output.Append(lyric.Text);
+                _builder.Append(lyric.Text);
                 if (!lyric.JoinWithNext && i < lyrics.Count)
                 {
-                    output.Append(' ');
+                    _builder.Append(' ');
                 }
             }
-            output.Append("</color>");
+            _builder.Append("</color>");
 
             // Non-highlighted words
             while (i < lyrics.Count)
             {
                 var lyric = lyrics[i++];
-                output.Append(lyric.Text);
+                _builder.Append(lyric.Text);
                 if (!lyric.JoinWithNext && i < lyrics.Count)
                 {
-                    output.Append(' ');
+                    _builder.Append(' ');
                 }
             }
 
             _currentLyricIndex = currIndex;
-            _lyricText.SetText(output);
+            _lyricText.SetText(_builder);
         }
 
-        private void SetUpcomingLyrics(IReadOnlyList<LyricEvent> lyrics)
+        private void UpdateUpcomingPhrase()
         {
-            using var output = ZString.CreateStringBuilder(false);
+            const double MIN_PHRASE_LENGTH = 0.1;
+            if (_upcomingLineSet)
+            {
+                return;
+            }
 
+            _upcomingLineSet = true;
+            // We only want the upcoming phrase show if the phrase starts within the phrase-to-phrase threshold.
+            // We also give an excpetion for very very very short phrases (usually for special effects).
+            if (_currentPhraseIndex + 1 == _phrases.Count
+            || _phrases[_currentPhraseIndex + 1].Time - _phrases[_currentPhraseIndex].TimeEnd >= PHRASE_DISTANCE_THRESHOLD
+            || _phrases[_currentPhraseIndex].TimeLength < MIN_PHRASE_LENGTH)
+            {
+                return;
+            }
+
+            var lyrics = _phrases[_currentPhraseIndex + 1].Lyrics;
+
+            _builder.Clear();
             int i = 0;
             while (i < lyrics.Count)
             {
                 var lyric = lyrics[i++];
-                output.Append(lyric.Text);
+                _builder.Append(lyric.Text);
                 if (!lyric.JoinWithNext && i < lyrics.Count)
                 {
-                    output.Append(' ');
+                    _builder.Append(' ');
                 }
             }
 
-            _upcomingLyricText.SetText(output);
-            _upcomingLyricsSet = true;
+            _upcomingLyricText.SetText(_builder);
         }
     }
 }

--- a/Assets/Script/Gameplay/HUD/LyricBar.cs
+++ b/Assets/Script/Gameplay/HUD/LyricBar.cs
@@ -85,7 +85,6 @@ namespace YARG.Gameplay.HUD
             if (!GameManager.IsPractice && SettingsManager.Settings.LyricDisplay.Value != LyricDisplayMode.Disabled)
             {
                 _builder.Dispose();
-                return;
             }
         }
 

--- a/Assets/Script/Settings/SettingsManager.Settings.cs
+++ b/Assets/Script/Settings/SettingsManager.Settings.cs
@@ -268,8 +268,6 @@ namespace YARG.Settings
                     LyricDisplayMode.Disabled
                 };
 
-            public SliderSetting UpcomingLyricsTime { get; } = new(3f, 0f, 10f);
-
             public DropdownSetting<SongProgressMode> SongTimeOnScoreBox { get; }
                 = new(SongProgressMode.CountUpOnly)
                 {

--- a/Assets/Script/Settings/SettingsManager.cs
+++ b/Assets/Script/Settings/SettingsManager.cs
@@ -142,7 +142,6 @@ namespace YARG.Settings
                 nameof(Settings.CountdownDisplay),
                 nameof(Settings.ShowPlayerNameWhenStartingSong),
                 nameof(Settings.LyricDisplay),
-                nameof(Settings.UpcomingLyricsTime),
                 nameof(Settings.SongTimeOnScoreBox),
                 nameof(Settings.GraphicalProgressOnScoreBox),
                 nameof(Settings.KeepSongInfoVisible),


### PR DESCRIPTION
+ Improve implementation of upcoming lyric bar: the style of how the current phrase appears in the lyric bar makes delaying upcoming phrase display feel off. Now, given that the next phrase connects with the current one, the upcoming phrase will always appear. The only exception being for upcoming phrases that have length shorter than a certain threshold - where they won't appear at all.
+ Add fadein and fadeout of both sets of lyrics.
+ Remove `UpcomingLyricsTime` setting.
+ Hold the stringbuilder as a member variable instead of creating a new one every time. Just have to clear it before constructing a line.