### PR TITLE
Harmonies: Don't hide lyrics in Three Lyric Lane mode

### DIFF
--- a/Assets/Script/Gameplay/Player/Vocals/VocalLyricContainer.cs
+++ b/Assets/Script/Gameplay/Player/Vocals/VocalLyricContainer.cs
@@ -1,4 +1,4 @@
-using UnityEngine;
+﻿using UnityEngine;
 using YARG.Core.Chart;
 using YARG.Gameplay.Visuals;
 using YARG.Settings;
@@ -51,8 +51,9 @@ namespace YARG.Gameplay.Player
             double length = probableNotePair?.TotalTimeLength ?? 0;
 
             // Spawn the vocal lyric
+            bool allowHiding = harmIndex != 0 && combineHarmonyLyrics;
             var obj = (VocalLyricElement) _pools[lane].TakeWithoutEnabling();
-            obj.Initialize(lyric, _lastLyricEdgeTime[lane], length, isStarpower, harmIndex);
+            obj.Initialize(lyric, _lastLyricEdgeTime[lane], length, isStarpower, harmIndex, allowHiding);
             obj.EnableFromPool();
 
             // Set the edge time

--- a/Assets/Script/Gameplay/Visuals/VocalElements/VocalLyricElement.cs
+++ b/Assets/Script/Gameplay/Visuals/VocalElements/VocalLyricElement.cs
@@ -14,6 +14,7 @@ namespace YARG.Gameplay.Visuals
         private bool _isStarpower;
 
         private int _harmonyIndex;
+        private bool _allowHiding;
 
         public override double ElementTime => Math.Max(_lyricRef.Time, _minimumTime);
 
@@ -23,7 +24,7 @@ namespace YARG.Gameplay.Visuals
         public float Width => _lyricText.GetPreferredValues().x;
 
         public void Initialize(LyricEvent lyric, double minTime, double lyricLength,
-            bool isStarpower, int harmonyIndex)
+            bool isStarpower, int harmonyIndex, bool allowHiding)
         {
             _lyricRef = lyric;
             _lyricLength = lyricLength;
@@ -32,11 +33,12 @@ namespace YARG.Gameplay.Visuals
             _isStarpower = isStarpower;
 
             _harmonyIndex = harmonyIndex;
+            _allowHiding = allowHiding;
         }
 
         protected override void InitializeElement()
         {
-            if (_lyricRef.HarmonyHidden && _harmonyIndex != 0)
+            if (_lyricRef.HarmonyHidden && _allowHiding)
             {
                 _lyricText.text = string.Empty;
             }


### PR DESCRIPTION
This PR adds functionality to ignore the "Hidden" attribute for vocal lyrics when it isn't needed - such as when the _Use Three Lyric Lanes In Harmony_  setting is enabled. With this setting enabled, each harmony part has its own lyric bar, but YARG will still respect the "Hidden" attribute, despite having plenty of room to display those lyrics.

![YARG-Old-3Lane](https://github.com/user-attachments/assets/1b71ef89-33e4-45e0-a0ee-da3efc36a301)

With this PR, the "Hidden" attribute is only applied in Two Lyric Lanes mode, as seen below. Note that HARM1 lyrics are *never* hidden, even if marked as such, and this PR does not affect this rule.

![YARG-New-2Lane](https://github.com/user-attachments/assets/3eb23b50-51f3-49b0-a2ed-b9e1bafb5439)
_Two Lyric Lane mode. Note how the HARM3 lyrics are hidden._

![YARG-New-3Lane](https://github.com/user-attachments/assets/cfc9deeb-28ff-4448-8bc5-a3720d060828)
_Three Lyric Lane mode. Note how the HARM3 lyrics are shown, despite being marked as hidden._


