### PR TITLE
Update Active Player List instrument icons on device connect/disconnect

### DIFF
--- a/Assets/Script/Menu/Persistent/ActivePlayerList.cs
+++ b/Assets/Script/Menu/Persistent/ActivePlayerList.cs
@@ -1,6 +1,7 @@
 ﻿using System.Linq;
 using UnityEngine;
 using YARG.Helpers.Extensions;
+using YARG.Input;
 using YARG.Player;
 
 namespace YARG.Menu.Persistent
@@ -16,6 +17,13 @@ namespace YARG.Menu.Persistent
 
         [SerializeField]
         private int _maxShownPlayerNames = 3;
+
+        private void Start()
+        {
+            // Refresh player list to display "No controller" instrument icon correctly.
+            InputManager.DeviceAdded += (device) => UpdatePlayerList();
+            InputManager.DeviceRemoved += (device) => UpdatePlayerList();
+        }
 
         public void UpdatePlayerList()
         {


### PR DESCRIPTION
This PR refreshes the active player (or more specifically the instrument icon) list whenever an input device is connected or disconnected. This fixes an issue where the list would display the "device not connected" red instrument icon for a player even after that player's device is connected after the game starts up.