### PR TITLE
Use much more aggresive prewarming for track element pools

### DIFF
--- a/Assets/Prefabs/Gameplay/Visual/BaseVisual.prefab
+++ b/Assets/Prefabs/Gameplay/Visual/BaseVisual.prefab
@@ -84,7 +84,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   <Prefab>k__BackingField: {fileID: 6252920090088018630, guid: b19c1dd36da7bd24593970f089eee836,
     type: 3}
-  _prewarmAmount: 10
+  _prewarmAmount: 100
   _objectCap: 100
 --- !u!1 &539331920876373676
 GameObject:
@@ -996,7 +996,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   <Prefab>k__BackingField: {fileID: 0}
-  _prewarmAmount: 15
+  _prewarmAmount: 150
   _objectCap: 500
 --- !u!1 &3797275969015020249
 GameObject:

--- a/Assets/Script/Gameplay/Pool.cs
+++ b/Assets/Script/Gameplay/Pool.cs
@@ -22,7 +22,7 @@ namespace YARG.Gameplay
         public GameObject Prefab { get; private set; }
 
         [SerializeField]
-        private int _prewarmAmount = 15;
+        private int _prewarmAmount = 300;
         [SerializeField]
         private int _objectCap = 500;
 


### PR DESCRIPTION
When a pool is depleted creating new elements is expensive and total memory used is only couple mb anyway
Cost to create them is pretty significant (profiling on steam deck)
![image](https://github.com/user-attachments/assets/9456eced-37c4-4a5b-bc0d-db59a4a5ec2d)
