### PR TITLE
Fix bug with score database high score query.

### DIFF
--- a/Assets/Script/Scores/ScoreDatabase.cs
+++ b/Assets/Script/Scores/ScoreDatabase.cs
@@ -219,18 +219,21 @@ namespace YARG.Scores
             bool highestDifficultyOnly
         )
         {
-            string query =
-                @"SELECT *, MAX(Score) FROM PlayerScores
-                INNER JOIN GameRecords
-                    ON PlayerScores.GameRecordId = GameRecords.Id
-                WHERE PlayerId = ?
-                    AND Instrument = ?
-                GROUP BY GameRecords.SongChecksum";
-
+            string difficultyClause = "";
             if (highestDifficultyOnly)
             {
-                query += " HAVING Difficulty = MAX(Difficulty)";
+                difficultyClause = "Difficulty DESC,";
             }
+
+            string query = $@"SELECT * FROM (
+                SELECT * FROM PlayerScores
+                    INNER JOIN GameRecords
+                ON PlayerScores.GameRecordId = GameRecords.Id
+                WHERE PlayerId = ?
+                    AND Instrument = ?
+                ORDER BY {difficultyClause} Score DESC
+              )
+              GROUP BY SongChecksum";
 
             return Query<PlayerScoreRecord>(
                 query,
@@ -245,24 +248,28 @@ namespace YARG.Scores
             bool highestDifficultyOnly
         )
         {
-            string query =
-                @"SELECT *, MAX(Percent) FROM PlayerScores
-                INNER JOIN GameRecords
-                    ON PlayerScores.GameRecordId = GameRecords.Id
-                WHERE PlayerId = ?
-                    AND Instrument = ?
-                GROUP BY GameRecords.SongChecksum";
-
+            string difficultyClause = "";
             if (highestDifficultyOnly)
             {
-                query += " HAVING Difficulty = MAX(Difficulty)";
+                difficultyClause = "Difficulty DESC,";
             }
 
-            return Query<PlayerScoreRecord>(
+            string query = $@"SELECT * FROM (
+                SELECT * FROM PlayerScores
+                    INNER JOIN GameRecords
+                ON PlayerScores.GameRecordId = GameRecords.Id
+                WHERE PlayerId = ?
+                    AND Instrument = ?
+                ORDER BY {difficultyClause} Percent DESC
+              )
+              GROUP BY SongChecksum";
+
+            var result = Query<PlayerScoreRecord>(
                 query,
                 playerId,
                 (int) instrument
             );
+            return result;
         }
 
         public PlayerScoreRecord QueryPlayerSongHighScore(


### PR DESCRIPTION
Songs that have only been played on one difficulty currently always show the first score record when score display is set to "highest difficulty only". This PR fixes the issue by using a different SQL query.

The new query [provided by goulart](https://discord.com/channels/1086048856678084609/1086052453801283624/1333068169551810560) when the current query was originally implemented uses a subselect, but returns the correct values. 

On my score database, goulart's query is about 0.7ms slower averaged over 1000 repetitions of the high score query. This shouldn't be an issue since all songs are loaded at once and the results are cached.

Relevant bug reports are [here](https://discord.com/channels/1086048856678084609/1345827528501100637) and [here](https://discord.com/channels/1086048856678084609/1347039075420340297)