### PR TITLE
Limit delay before score screen at end of song

### DIFF
--- a/Assets/Script/Audio/Bass/BassStemMixer.cs
+++ b/Assets/Script/Audio/Bass/BassStemMixer.cs
@@ -224,6 +224,17 @@ namespace YARG.Audio.BASS
             return data;
         }
 
+        protected override int GetLevel_Internal(float[] level)
+        {
+            bool status = Bass.ChannelGetLevel(_mixerHandle, level, 0.2f, LevelRetrievalFlags.Mono | LevelRetrievalFlags.RMS);
+            if (!status)
+            {
+                return (int) Bass.LastError;
+            }
+
+            return (int) ManagedBass.Errors.OK;
+        }
+
         protected override void SetSpeed_Internal(float speed, bool shiftPitch)
         {
             speed = (float) Math.Clamp(speed, 0.05, 50);

--- a/Assets/Script/Gameplay/GameManager.Audio.cs
+++ b/Assets/Script/Gameplay/GameManager.Audio.cs
@@ -3,16 +3,17 @@ using System.Linq;
 using UnityEngine;
 using YARG.Core.Audio;
 using YARG.Core.Chart;
+using YARG.Core.Logging;
 using YARG.Settings;
 
 namespace YARG.Gameplay
 {
     public partial class GameManager
     {
-        private const double DEFAULT_VOLUME    = 1.0;
-        private const double MAX_END_SILENCE   = 0.333;
-        // This should equate to -65.22dBFS.
-        private const float  SILENCE_THRESHOLD = 16;
+        private const    double DEFAULT_VOLUME         = 1.0;
+        private const    double MAX_END_SILENCE        = 0.333;
+        private const    float  SILENCE_THRESHOLD_DBFS = -65.22f;
+        private readonly float  _silenceThreshold      = Mathf.Pow(10, SILENCE_THRESHOLD_DBFS / 20);
 
         private double _lastAudioCheck;
         private double _silenceLength;
@@ -214,7 +215,7 @@ namespace YARG.Gameplay
                 return false;
             }
 
-            if (audioLevel[0] > SILENCE_THRESHOLD)
+            if (audioLevel[0] > _silenceThreshold)
             {
                 return false;
             }

--- a/Assets/Script/Gameplay/GameManager.Audio.cs
+++ b/Assets/Script/Gameplay/GameManager.Audio.cs
@@ -11,8 +11,8 @@ namespace YARG.Gameplay
     {
         private const double DEFAULT_VOLUME    = 1.0;
         private const double MAX_END_SILENCE   = 0.333;
-        // The silence threshold value is just a guess. An empirically tested guess, but still a guess.
-        private const float  SILENCE_THRESHOLD = 0.1f;
+        // This should equate to -65.22dBFS.
+        private const float  SILENCE_THRESHOLD = 16;
 
         private double _lastAudioCheck;
         private double _silenceLength;
@@ -205,26 +205,16 @@ namespace YARG.Gameplay
 
         private bool CheckForSilence(double silenceTime = MAX_END_SILENCE)
         {
-            var ret = _mixer.GetData(_fftData);
-            var hasSound = false;
-            if (ret == -1)
+            var audioLevel = new float[1];
+            var status = _mixer.GetLevel(audioLevel);
+
+            if (status == -1)
             {
                 // There was an error, so do the safe thing and don't indicate silence
                 return false;
             }
 
-            // See if any of the FFT bins have any significant energy
-            for (var i = 0; i < _fftData.Length; i++)
-            {
-                if (_fftData[i] > SILENCE_THRESHOLD)
-                {
-                    hasSound = true;
-                    _silenceLength = 0;
-                    break;
-                }
-            }
-
-            if (hasSound)
+            if (audioLevel[0] > SILENCE_THRESHOLD)
             {
                 return false;
             }

--- a/Assets/Script/Gameplay/GameManager.cs
+++ b/Assets/Script/Gameplay/GameManager.cs
@@ -140,7 +140,9 @@ namespace YARG.Gameplay
         private StemMixer _mixer;
 
         // Default to SONG_END_DELAY, but this may get reset given certain conditions
-        private double _realEndDelay = SONG_END_DELAY;
+        // private double _realEndDelay = SONG_END_DELAY;
+        private double  _lastNoteEndTime;
+        private bool    _endIsAudioEnd = false;
 
         private void Awake()
         {
@@ -256,6 +258,16 @@ namespace YARG.Gameplay
                     return;
                 }
             }
+
+            // End early for silence after the last note
+            if (_endIsAudioEnd && _songRunner.SongTime >= _lastNoteEndTime + SONG_END_DELAY && CheckForSilence())
+            {
+                YargLogger.LogFormatDebug("Ending song early at {0} due to silence.", _songRunner.SongTime);
+                if (EndSong(true))
+                {
+                    return;
+                }
+            }
         }
 
         public void SetSongTime(double time, double delayTime = SONG_START_DELAY)
@@ -338,7 +350,7 @@ namespace YARG.Gameplay
             }
 
             _pauseMenu.PopAllMenus();
-            if (_songRunner.SongTime >= SongLength + _realEndDelay)
+            if (_songRunner.SongTime >= SongLength)
             {
                 return;
             }
@@ -395,7 +407,7 @@ namespace YARG.Gameplay
         public double GetCalibratedRelativeInputTime(double timeFromInputSystem)
             => _songRunner.GetCalibratedRelativeInputTime(timeFromInputSystem);
 
-        private bool EndSong()
+        private bool EndSong(bool earlyEnd = false)
         {
             if (IsPractice)
             {
@@ -403,13 +415,13 @@ namespace YARG.Gameplay
                 return false;
             }
 
-            if (_songRunner.SongTime < SongLength + _realEndDelay)
+            if (_songRunner.SongTime < SongLength && !earlyEnd)
             {
                 return false;
             }
 
-            // If we're ending before the end of the audio, fade out the audio
-            if (_songRunner.SongTime < _mixer.Length)
+            // If we're ending before the end of the audio, fade out the audio (unless we're ending due to silence)
+            if (_songRunner.SongTime < _mixer.Length && !earlyEnd)
             {
                 _mixer.FadeOut(0.5);
             }

--- a/Assets/Script/Gameplay/GameManager.cs
+++ b/Assets/Script/Gameplay/GameManager.cs
@@ -139,6 +139,9 @@ namespace YARG.Gameplay
 
         private StemMixer _mixer;
 
+        // Default to SONG_END_DELAY, but this may get reset given certain conditions
+        private double _realEndDelay = SONG_END_DELAY;
+
         private void Awake()
         {
             // Set references
@@ -335,7 +338,7 @@ namespace YARG.Gameplay
             }
 
             _pauseMenu.PopAllMenus();
-            if (_songRunner.SongTime >= SongLength + SONG_END_DELAY)
+            if (_songRunner.SongTime >= SongLength + _realEndDelay)
             {
                 return;
             }
@@ -400,9 +403,15 @@ namespace YARG.Gameplay
                 return false;
             }
 
-            if (_songRunner.SongTime < SongLength + SONG_END_DELAY)
+            if (_songRunner.SongTime < SongLength + _realEndDelay)
             {
                 return false;
+            }
+
+            // If we're ending before the end of the audio, fade out the audio
+            if (_songRunner.SongTime < _mixer.Length)
+            {
+                _mixer.FadeOut(0.5);
             }
 
             if (ReplayInfo != null)


### PR DESCRIPTION
There is currently an excessive delay before showing the score screen at the end of many songs. This is because there is a fixed two second delay after the end of the greater of the chart end time, the audio end time, or the end event time. In many cases this can lead to 5+ seconds of sitting in silence awaiting the score screen.

This PR changes the delay to be adaptive, with a minimum of two seconds wait after the last charted note for any instrument before showing the score screen, thus eliminating the excessive delay.

SongLength is set depending on whether an end event is charted (endTime is the time of the end event):
- With an end event SongLength = Max(lastNoteTime, endTime)
- With no end event SongLength = Max(lastNoteTime, audioLength)

The song ending again depends on whether an end event is charted:
- With an end event the song ends at the greater of lastNoteTime + SONG_END_DELAY and endTime
- With no end event the song ends at the greater of lastNoteTime + SONG_END_DELAY and audioLength

~~The only exception is if the end_events tag is set in song.ini and an end event exists. In that case, the end event is respected precisely with no delay, regardless of any other considerations.~~

Additionally, silence detection is run on the StemMixer output once lastNoteTime + SONG_END_DELAY has elapsed when there is no end event and SongLength is being controlled by audioLength. This is to avoid long waits for audio tracks with excessive trailing silence.

Requires [YARG.Core PR #242](https://github.com/YARC-Official/YARG.Core/pull/242)


