### PR TITLE
Add "No Vocal Percussion" modifier

### DIFF
--- a/Assets/Art/Menu/Common/ModifierIcons.png
+++ b/Assets/Art/Menu/Common/ModifierIcons.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:36d49ec39a47442bcfb910f18ea4d6c0cabaced44f00556fe97b09f40d2b1535
-size 1846713
+oid sha256:ec9d19e6632b3fe1cc093789b252602c8ee006cbb33ab863f942d0d6685966f8
+size 1649174

--- a/Assets/Art/Menu/Common/ModifierIcons.png.meta
+++ b/Assets/Art/Menu/Common/ModifierIcons.png.meta
@@ -420,7 +420,7 @@ TextureImporter:
       edges: []
       weights: []
     - serializedVersion: 2
-      name: ModifierIcons_15
+      name: NoVocalPercussion
       rect:
         serializedVersion: 2
         x: 1536
@@ -458,13 +458,13 @@ TextureImporter:
       Ghosting: 960618387
       HoposToTaps: 1309754347
       InfiniteFrontEnd: -1660463282
-      ModifierIcons_15: 1841026791
       ModifierIcons_3: -1638818548
       ModifierIcons_4: 1692867385
       ModifierIcons_5: -1436843964
       ModifierIcons_6: 1497401919
       ModifierIcons_7: -1355680061
       NoKicks: -1200274759
+      NoVocalPercussion: 1841026791
       TapsToHopos: 1609936924
       UnpitchedOnly: -2147107449
   spritePackingTag: 

--- a/Assets/StreamingAssets/lang/en-US.json
+++ b/Assets/StreamingAssets/lang/en-US.json
@@ -59,7 +59,8 @@
             "NoKicks": "No Kicks",
             "TapsToHopos": "Taps to HOPOs",
             "UnpitchedOnly": "Unpitched Only",
-            "NoDynamics": "No Dynamics"
+            "NoDynamics": "No Dynamics",
+            "NoVocalPercussion" : "No Percussion"
         },
         "SortAttribute": {
             "Album": "Album",


### PR DESCRIPTION
This PR adds a new modifier for vocalists: "No Vocal Percussion", which removes all percussion (tambourine, cowbell, etc) notes from the vocals track. It is selectable from the modifiers menu.

This resolves multiple requests, including this one: https://discord.com/channels/1086048856678084609/1297003257088184330

NOTE: Included in this PR is a basic placeholder icon for this modifier, shown on the Results screen for players that have it enabled.

Requires YARG.Core PR: https://github.com/YARC-Official/YARG.Core/pull/244