### PR TITLE
Fix FC bug in library score display

### DIFF
--- a/Assets/Script/Scores/ScoreDatabase.cs
+++ b/Assets/Script/Scores/ScoreDatabase.cs
@@ -260,7 +260,7 @@ namespace YARG.Scores
                 ON PlayerScores.GameRecordId = GameRecords.Id
                 WHERE PlayerId = ?
                     AND Instrument = ?
-                ORDER BY {difficultyClause} Percent DESC
+                ORDER BY {difficultyClause} Percent DESC, IsFc DESC
               )
               GROUP BY SongChecksum";
 
@@ -323,11 +323,11 @@ namespace YARG.Scores
 
             if (highestDifficultyOnly)
             {
-                query += " ORDER BY PlayerScores.Difficulty DESC, PlayerScores.Percent DESC";
+                query += " ORDER BY PlayerScores.Difficulty DESC, PlayerScores.Percent DESC, IsFc DESC";
             }
             else
             {
-                query += " ORDER BY PlayerScores.Percent DESC";
+                query += " ORDER BY PlayerScores.Percent DESC, IsFc DESC";
             }
 
             query += " LIMIT 1";


### PR DESCRIPTION
This fixes a bug causing the percentage display FC color to not be used if the player first had a 100% with an overstrum/overhit and only later got an FC.