### PR TITLE
Add background to text notifications

### DIFF
--- a/Assets/Art/Textures/Gameplay/NotificationBackground.png
+++ b/Assets/Art/Textures/Gameplay/NotificationBackground.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fa67e81d0a5a87a98f3adeba4efd852800262efe782bbd395662577aaf11b03e
+size 23525

--- a/Assets/Art/Textures/Gameplay/NotificationBackground.png
+++ b/Assets/Art/Textures/Gameplay/NotificationBackground.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fa67e81d0a5a87a98f3adeba4efd852800262efe782bbd395662577aaf11b03e
-size 23525
+oid sha256:93e5625036b0dc81dd37886ca757516fec4d440ee51d6ddd4a636bd3299d8ff5
+size 23123

--- a/Assets/Art/Textures/Gameplay/NotificationBackground.png.meta
+++ b/Assets/Art/Textures/Gameplay/NotificationBackground.png.meta
@@ -49,7 +49,7 @@ TextureImporter:
   spritePivot: {x: 0.5, y: 0.5}
   spritePixelsToUnits: 100
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
-  spriteGenerateFallbackPhysicsShape: 1
+  spriteGenerateFallbackPhysicsShape: 0
   alphaUsage: 1
   alphaIsTransparency: 1
   spriteTessellationDetail: -1

--- a/Assets/Art/Textures/Gameplay/NotificationBackground.png.meta
+++ b/Assets/Art/Textures/Gameplay/NotificationBackground.png.meta
@@ -1,0 +1,111 @@
+fileFormatVersion: 2
+guid: c7147c6b9ad628f449281b361ce827cc
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 12
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMasterTextureLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 1
+    wrapV: 1
+    wrapW: 0
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  cookieLightType: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    nameFileIdTable: {}
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Gameplay/HUD/TrackView.prefab
+++ b/Assets/Prefabs/Gameplay/HUD/TrackView.prefab
@@ -204,7 +204,7 @@ RectTransform:
   m_GameObject: {fileID: 881258039788376651}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1.0000728, y: 1.0000728, z: 1}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 1
   m_Children:
   - {fileID: 2784863481168182611}
@@ -262,7 +262,7 @@ RectTransform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 1
   m_Children: []
-  m_Father: {fileID: 2784863481168182611}
+  m_Father: {fileID: 8448967496905679418}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0.5}
@@ -381,6 +381,55 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _text: {fileID: 8078771021002508975}
+  _containerRect: {fileID: 8448967496905679418}
+  _notificationBackground: {fileID: 1849009881569265160}
+--- !u!1 &2238794423646391257
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8448967496905679418}
+  - component: {fileID: 1350980346779679674}
+  m_Layer: 5
+  m_Name: Notification Container
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8448967496905679418
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2238794423646391257}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4959688482305672062}
+  - {fileID: 9014481999390702953}
+  m_Father: {fileID: 2784863481168182611}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 768, y: 86}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1350980346779679674
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2238794423646391257}
+  m_CullTransparentMesh: 1
 --- !u!1 &2870395719493184972
 GameObject:
   m_ObjectHideFlags: 0
@@ -673,7 +722,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 7754222893441328411}
-  - {fileID: 9014481999390702953}
+  - {fileID: 8448967496905679418}
   m_Father: {fileID: 83804126774381919}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -714,6 +763,82 @@ MonoBehaviour:
         m_CallState: 2
   _draggingDisplayPrefab: {fileID: 5730308542642054521, guid: 2a82983eb1a960843bd5603736f9b042,
     type: 3}
+--- !u!1 &4776451680015925056
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4959688482305672062}
+  - component: {fileID: 2361875951409195598}
+  - component: {fileID: 1849009881569265160}
+  m_Layer: 5
+  m_Name: Notification Box
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4959688482305672062
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4776451680015925056}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8448967496905679418}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0}
+  m_AnchorMax: {x: 0.5, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 768, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2361875951409195598
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4776451680015925056}
+  m_CullTransparentMesh: 1
+--- !u!114 &1849009881569265160
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4776451680015925056}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.14117648, g: 0.14117648, b: 0.14117648, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: c7147c6b9ad628f449281b361ce827cc, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!1 &4933759889059973123
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Gameplay/HUD/TrackView.prefab
+++ b/Assets/Prefabs/Gameplay/HUD/TrackView.prefab
@@ -832,7 +832,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: f8a49fcfe1dd7394f8bb7b2234982af6, type: 3}
+  m_Sprite: {fileID: 21300000, guid: c7147c6b9ad628f449281b361ce827cc, type: 3}
   m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1

--- a/Assets/Prefabs/Gameplay/HUD/TrackView.prefab
+++ b/Assets/Prefabs/Gameplay/HUD/TrackView.prefab
@@ -383,6 +383,9 @@ MonoBehaviour:
   _text: {fileID: 8078771021002508975}
   _containerRect: {fileID: 8448967496905679418}
   _notificationBackground: {fileID: 1849009881569265160}
+  _defaultColor: {r: 0.14117648, g: 0.14117648, b: 0.14117648, a: 1}
+  _starpowerColor: {r: 0.9882353, g: 0.8352941, b: 0.282353, a: 0.2509804}
+  _grooveColor: {r: 0, g: 0.4, b: 1, a: 0.2509804}
 --- !u!1 &2238794423646391257
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Gameplay/HUD/TrackView.prefab
+++ b/Assets/Prefabs/Gameplay/HUD/TrackView.prefab
@@ -383,9 +383,9 @@ MonoBehaviour:
   _text: {fileID: 8078771021002508975}
   _containerRect: {fileID: 8448967496905679418}
   _notificationBackground: {fileID: 1849009881569265160}
-  _defaultColor: {r: 0.14117648, g: 0.14117648, b: 0.14117648, a: 1}
-  _starpowerColor: {r: 0.9882353, g: 0.8352941, b: 0.282353, a: 0.2509804}
-  _grooveColor: {r: 0, g: 0.4, b: 1, a: 0.2509804}
+  _defaultColor: {r: 0.09411765, g: 0.09411765, b: 0.09411765, a: 1}
+  _starpowerColor: {r: 0.09411765, g: 0.09411765, b: 0.09411765, a: 1}
+  _grooveColor: {r: 0.09411765, g: 0.09411765, b: 0.09411765, a: 1}
 --- !u!1 &2238794423646391257
 GameObject:
   m_ObjectHideFlags: 0
@@ -423,7 +423,7 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 768, y: 86}
+  m_SizeDelta: {x: 768, y: 128}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &1350980346779679674
 CanvasRenderer:
@@ -825,14 +825,14 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 0.14117648, g: 0.14117648, b: 0.14117648, a: 1}
+  m_Color: {r: 0.09411765, g: 0.09411765, b: 0.09411765, a: 1}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: c7147c6b9ad628f449281b361ce827cc, type: 3}
+  m_Sprite: {fileID: 21300000, guid: f8a49fcfe1dd7394f8bb7b2234982af6, type: 3}
   m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1

--- a/Assets/Script/Gameplay/HUD/TextNotifications.cs
+++ b/Assets/Script/Gameplay/HUD/TextNotifications.cs
@@ -21,6 +21,12 @@ namespace YARG.Gameplay.HUD
         private RectTransform _containerRect;
         [SerializeField]
         private Image _notificationBackground;
+        [SerializeField]
+        private Color _defaultColor;
+        [SerializeField]
+        private Color _starpowerColor;
+        [SerializeField]
+        private Color _grooveColor;
 
         private int _streak;
         private int _nextStreakCount;
@@ -193,14 +199,14 @@ namespace YARG.Gameplay.HUD
             _containerRect.gameObject.SetActive(active);
         }
 
-        private static Color GetBackgroundColor(TextNotificationType type)
+        private Color GetBackgroundColor(TextNotificationType type)
         {
             return type switch
             {
-                TextNotificationType.FullCombo      => new Color(0.9882353f, 0.8352941f, 0.282353f, 0.25f),
-                TextNotificationType.BassGroove     => new Color(0.0f, 0.4f, 1.0f, 0.25f),
-                TextNotificationType.StarPowerReady => new Color(0.9882353f, 0.8352941f, 0.282353f, 0.25f),
-                _                                   => new Color(0.1411765f, 0.1411765f, 0.1411765f, 1.0f),
+                TextNotificationType.FullCombo      => _starpowerColor,
+                TextNotificationType.BassGroove     => _grooveColor,
+                TextNotificationType.StarPowerReady => _starpowerColor,
+                _                                   => _defaultColor,
             };
         }
     }

--- a/Assets/Script/Gameplay/HUD/TextNotifications.cs
+++ b/Assets/Script/Gameplay/HUD/TextNotifications.cs
@@ -42,6 +42,8 @@ namespace YARG.Gameplay.HUD
             _text.text = string.Empty;
             _coroutine = null;
             _containerRect.localScale = Vector3.zero;
+            _containerRect.gameObject.SetActive(true);
+            _notificationBackground.gameObject.SetActive(true);
         }
 
         private void OnDisable()
@@ -50,6 +52,9 @@ namespace YARG.Gameplay.HUD
             {
                 StopCoroutine(_coroutine);
             }
+
+            _notificationBackground.gameObject.SetActive(false);
+            _containerRect.gameObject.SetActive(false);
         }
 
         public void ShowNewHighScore()
@@ -74,7 +79,7 @@ namespace YARG.Gameplay.HUD
         public void ShowHotStart()
         {
             // Don't build up notifications during a solo
-            if (!gameObject.activeSelf) return;
+            if (!isActiveAndEnabled) return;
 
             _notificationQueue.Enqueue(new TextNotification(TextNotificationType.HotStart));
         }
@@ -82,7 +87,7 @@ namespace YARG.Gameplay.HUD
         public void ShowBassGroove()
         {
             // Don't build up notifications during a solo
-            if (!gameObject.activeSelf) return;
+            if (!isActiveAndEnabled) return;
 
             _notificationQueue.Enqueue(new TextNotification(TextNotificationType.BassGroove));
         }
@@ -90,7 +95,8 @@ namespace YARG.Gameplay.HUD
         public void ShowStarPowerReady()
         {
             // Don't build up notifications during a solo
-            if (!gameObject.activeSelf) return;
+            if (!isActiveAndEnabled) return;
+
 
             _notificationQueue.Enqueue(new TextNotification(TextNotificationType.StarPowerReady));
         }
@@ -98,7 +104,7 @@ namespace YARG.Gameplay.HUD
         public void UpdateNoteStreak(int streak)
         {
             // Don't build up notifications during a solo
-            if (!gameObject.activeSelf) return;
+            if (!isActiveAndEnabled) return;
 
             // Only push to the queue if there is a change to the streak
             if (streak == _streak) return;

--- a/Assets/Script/Gameplay/HUD/TextNotifications.cs
+++ b/Assets/Script/Gameplay/HUD/TextNotifications.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections;
 using TMPro;
 using UnityEngine;
+using UnityEngine.UI;
 using YARG.Settings;
 
 namespace YARG.Gameplay.HUD
@@ -16,6 +17,10 @@ namespace YARG.Gameplay.HUD
     {
         [SerializeField]
         private TextMeshProUGUI _text;
+        [SerializeField]
+        private RectTransform _containerRect;
+        [SerializeField]
+        private Image _notificationBackground;
 
         private int _streak;
         private int _nextStreakCount;
@@ -30,6 +35,7 @@ namespace YARG.Gameplay.HUD
         {
             _text.text = string.Empty;
             _coroutine = null;
+            _containerRect.localScale = Vector3.zero;
         }
 
         private void OnDisable()
@@ -120,6 +126,10 @@ namespace YARG.Gameplay.HUD
             if (_coroutine == null && _notificationQueue.Count > 0)
             {
                 var textNotification = _notificationQueue.Dequeue();
+
+                // Set the color of the text background image based on the notifcation type
+                _notificationBackground.color = GetBackgroundColor(textNotification.Type);
+
                 _coroutine = StartCoroutine(ShowNextNotification(textNotification.Text));
             }
         }
@@ -135,7 +145,7 @@ namespace YARG.Gameplay.HUD
                 _scaler.AnimTimeRemaining -= Time.deltaTime;
                 float scale = _scaler.PerformanceTextScale();
 
-                _text.transform.localScale = new Vector3(scale, scale, scale);
+                _containerRect.localScale = new Vector3(scale, scale, scale);
                 yield return null;
             }
 
@@ -176,6 +186,22 @@ namespace YARG.Gameplay.HUD
             _notificationQueue.Clear();
             _nextStreakCount = 0;
             _streak = 0;
+        }
+
+        public void SetActive(bool active)
+        {
+            _containerRect.gameObject.SetActive(active);
+        }
+
+        private static Color GetBackgroundColor(TextNotificationType type)
+        {
+            return type switch
+            {
+                TextNotificationType.FullCombo      => new Color(0.9882353f, 0.8352941f, 0.282353f, 0.25f),
+                TextNotificationType.BassGroove     => new Color(0.0f, 0.4f, 1.0f, 0.25f),
+                TextNotificationType.StarPowerReady => new Color(0.9882353f, 0.8352941f, 0.282353f, 0.25f),
+                _                                   => new Color(0.1411765f, 0.1411765f, 0.1411765f, 1.0f),
+            };
         }
     }
 }

--- a/Assets/Script/Gameplay/HUD/TrackView.cs
+++ b/Assets/Script/Gameplay/HUD/TrackView.cs
@@ -90,7 +90,7 @@ namespace YARG.Gameplay.HUD
             _soloBox.StartSolo(solo);
 
             // No text notifications during the solo
-            _textNotifications.gameObject.SetActive(false);
+            _textNotifications.SetActive(false);
         }
 
         public void EndSolo(int soloBonus)
@@ -98,7 +98,7 @@ namespace YARG.Gameplay.HUD
             _soloBox.EndSolo(soloBonus, () =>
             {
                 // Show text notifications again
-                _textNotifications.gameObject.SetActive(true);
+                _textNotifications.SetActive(true);
             });
         }
 
@@ -144,7 +144,7 @@ namespace YARG.Gameplay.HUD
 
         public void ForceReset()
         {
-            _textNotifications.gameObject.SetActive(true);
+            _textNotifications.SetActive(true);
 
             _soloBox.ForceReset();
             _textNotifications.ForceReset();


### PR DESCRIPTION
This PR adds a background to text notifications to make them more visible when using venues. The background is colored based on the type of notification. At present, only bass groove, star power ready, and full combo use colors.

### Default
![hot start](https://github.com/user-attachments/assets/d4c45661-d816-46f0-8cf8-c59da1454ea5)

### Bass Groove
![bass groove](https://github.com/user-attachments/assets/2442a2ac-c474-45a3-b236-5aae8d370353)

### Star Power
![star power](https://github.com/user-attachments/assets/fe85e874-20d0-4b45-8ad5-e7c4f6418d40)

Reference to Discord suggestion where this was discussed: https://discord.com/channels/1086048856678084609/1355248369269739732
