### PR TITLE
Fix bug with replay filename handling

### DIFF
--- a/Assets/Script/Menu/History/ViewTypes/ReplayViewType.cs
+++ b/Assets/Script/Menu/History/ViewTypes/ReplayViewType.cs
@@ -183,10 +183,9 @@ namespace YARG.Menu.History
                 return null;
             }
 
-            // Get the replay path
-            var path = Path.Combine(ScoreContainer.ScoreReplayDirectory, _record.ReplayFileName);
-            // Accounts the change to ReplayName to remove the ".replay"
-            path = Path.ChangeExtension(path, ".replay");
+            // Get the replay path, mirroring the serialization code
+            var path = Path.Combine(ScoreContainer.ScoreReplayDirectory, _record.ReplayFileName + ".replay");
+
             if (!File.Exists(path))
             {
                 DialogManager.Instance.ShowMessage(messageBoxTitle, "The replay for this song does not exist! It has probably been deleted!");


### PR DESCRIPTION
Changes replay loading path creation to concatenate ".replay" with the stored filename rather than trying to use Path.ChangeExtension.

This fixes #1008 by correctly handling filenames with multiple dots.