### PR TITLE
fix spurious hot start message on early SP activation

### DIFF
--- a/Assets/Script/Gameplay/Player/TrackPlayer.cs
+++ b/Assets/Script/Gameplay/Player/TrackPlayer.cs
@@ -271,7 +271,11 @@ namespace YARG.Gameplay.Player
 
             TrackView.UpdateNoteStreak(stats.Combo);
 
-            if (!_isHotStartChecked && stats.ScoreMultiplier == 4)
+
+            // Could be if (!_isHotStartChecked && groove), but that would make it so hot start doesn't show
+            // for bass until 6x.
+            if (!_isHotStartChecked &&
+                ((stats.ScoreMultiplier == 4 && !stats.IsStarPowerActive) || stats.ScoreMultiplier == 8))
             {
                 _isHotStartChecked = true;
 

--- a/Assets/Script/Gameplay/Player/TrackPlayer.cs
+++ b/Assets/Script/Gameplay/Player/TrackPlayer.cs
@@ -274,8 +274,7 @@ namespace YARG.Gameplay.Player
 
             // Could be if (!_isHotStartChecked && groove), but that would make it so hot start doesn't show
             // for bass until 6x.
-            if (!_isHotStartChecked &&
-                ((stats.ScoreMultiplier == 4 && !stats.IsStarPowerActive) || stats.ScoreMultiplier == 8))
+            if (!_isHotStartChecked && stats.ScoreMultiplier == (!stats.IsStarPowerActive ? 4 : 8))
             {
                 _isHotStartChecked = true;
 


### PR DESCRIPTION
Per a bug report on Discord (I'd link, but the Discord client has gone stupid at the moment and won't copy thread links), hot start is displayed when activating SP at 2x multiplier.

This PR adds a condition to the hot start check to ensure that hot start is not displayed until 8x when SP is active.