### PR TITLE
Force GC right before song starts

### DIFF
--- a/Assets/Script/Persistent/GlobalVariables.cs
+++ b/Assets/Script/Persistent/GlobalVariables.cs
@@ -163,6 +163,7 @@ namespace YARG
             {
                 LoadSceneAdditive(scene);
             }
+            GC.Collect();
         }
 
         // Due to the preprocessor, it doesn't know that an instance variable is being used

--- a/Assets/Script/Persistent/LoadingScreen.cs
+++ b/Assets/Script/Persistent/LoadingScreen.cs
@@ -128,6 +128,7 @@ namespace YARG
                     YargLogger.LogException(ex);
                 }
             }
+            GC.Collect();
         }
 
         public async void Dispose()


### PR DESCRIPTION
It's a common PR feedback to avoid generating garbage even in a library view or scene setup as it "may be collected during gameplay and cause stutter" To alleviate those concerns it seems natural to simply force garbage collection before song start so that any garbage generated during setup would be collected then.