### PR TITLE
Fix particle effect background blending

### DIFF
--- a/Assets/Art/Materials/Gameplay/Frets/ParticleTransparent.mat
+++ b/Assets/Art/Materials/Gameplay/Frets/ParticleTransparent.mat
@@ -10,7 +10,6 @@ Material:
   m_Name: ParticleTransparent
   m_Shader: {fileID: 4800000, guid: b7839dad95683814aa64166edc107ae2, type: 3}
   m_ValidKeywords:
-  - _ALPHAPREMULTIPLY_ON
   - _SURFACE_TYPE_TRANSPARENT
   m_InvalidKeywords:
   - _FLIPBOOKBLENDING_OFF
@@ -86,7 +85,7 @@ Material:
     m_Floats:
     - _AlphaClip: 0
     - _AlphaToMask: 0
-    - _Blend: 1
+    - _Blend: 0
     - _BlendModePreserveSpecular: 0
     - _BlendOp: 0
     - _BumpScale: 1
@@ -124,7 +123,7 @@ Material:
     - _SoftParticlesFarFadeDistance: 1
     - _SoftParticlesNearFadeDistance: 0
     - _SpecularHighlights: 1
-    - _SrcBlend: 1
+    - _SrcBlend: 5
     - _SrcBlendAlpha: 1
     - _Surface: 1
     - _WorkflowMode: 1


### PR DESCRIPTION
This fixes their background not being fully transparent

before:
![image](https://github.com/user-attachments/assets/f4fc63b3-8571-4b0e-8559-be8152436c54)
![image](https://github.com/user-attachments/assets/da385a51-2add-49ce-aaaa-7de7509b001a)

after:
![image](https://github.com/user-attachments/assets/aa8dc473-0428-4134-8588-e13d26058ef4)
![image](https://github.com/user-attachments/assets/4a41ea62-3b7a-459f-8387-680529e3ded4)
