### PR TITLE
Add support for user-supplied song sources

### DIFF
--- a/Assets/Script/Song/SongSources.cs
+++ b/Assets/Script/Song/SongSources.cs
@@ -14,6 +14,7 @@ using YARG.Core.Logging;
 using YARG.Core.Song;
 using YARG.Helpers;
 using YARG.Helpers.Extensions;
+using YARG.Settings.Customization;
 
 namespace YARG.Song
 {
@@ -50,7 +51,7 @@ namespace YARG.Song
 
         public class ParsedSource
         {
-            private readonly string _icon;
+            public string _icon;
             private readonly Dictionary<string, string> _names;
 #nullable enable
             private Sprite? _sprite;
@@ -122,6 +123,7 @@ namespace YARG.Song
 #else
         public static readonly string SourcesFolder = Path.Combine(PathHelper.StreamingAssetsPath, "sources");
 #endif
+        public static readonly string CustomSourcesFolder = Path.Combine(CustomContentManager.CustomizationDirectory, "icons");
 
         private static readonly string[] SourceTypes =
         {
@@ -130,6 +132,7 @@ namespace YARG.Song
 
         private static readonly string[] SourceRoots =
         {
+            CustomSourcesFolder, // Prioritize user-supplied sources
             Path.Combine(SourcesFolder, SOURCE_REPO_FOLDER, "base", "icons"),
             Path.Combine(SourcesFolder, SOURCE_REPO_FOLDER, "extra", "icons"),
         };
@@ -282,32 +285,25 @@ namespace YARG.Song
 
         private static void ReadSources()
         {
+            // Read custom sources - they are read first so user replacements are prioritized
+            // Create the folder if it doesn't exist
+            Directory.CreateDirectory(CustomSourcesFolder);
+            // Read index.json if it exists; otherwise fallback to reading PNGs individually later on
+            string customIndexPath = Path.Combine(CustomSourcesFolder, "index.json");
+            var customSourcesRead = false;
+            if (File.Exists(customIndexPath))
+            {
+                ReadIndexPath(customIndexPath);
+                customSourcesRead = true;
+            }
+
+            // Read regular sources
             foreach (var index in SourceTypes)
             {
                 try
                 {
                     var indexPath = Path.Combine(SourcesFolder, SOURCE_REPO_FOLDER, index, "index.json");
-                    var sources = JsonConvert.DeserializeObject<SourceIndex>(File.ReadAllText(indexPath));
-
-                    foreach (var source in sources.sources)
-                    {
-                        var parsed = new ParsedSource(source.icon, source.names, source.type switch
-                        {
-                            "game"    => SourceType.Game,
-                            "charter" => SourceType.Charter,
-                            "rb"      => SourceType.RB,
-                            "gh"      => SourceType.GH,
-                            _         => SourceType.Custom
-                        });
-
-                        foreach (var id in source.ids)
-                        {
-                            if (_sources.TryAdd(id, parsed) && id == DEFAULT_KEY)
-                            {
-                                _default = parsed;
-                            }
-                        }
-                    }
+                    ReadIndexPath(indexPath);
                 }
                 catch (Exception e)
                 {
@@ -319,6 +315,56 @@ namespace YARG.Song
                         YargLogger.LogError("Skipping and creating a backup source.");
                         CreateBackupSource();
                         return;
+                    }
+                }
+            }
+
+            // Read individual PNGs (this is done after reading regular sources, so their icons can be replaced if needed)
+            if (!customSourcesRead) {
+                PathHelper.SafeEnumerateFiles(CustomSourcesFolder, "*.png", true, (path) =>
+                {
+                    // Filename will be used for all values (id, name, icon path).
+                    var icon = Path.GetFileNameWithoutExtension(path);
+                    var names = new Dictionary<string, string> {
+                        { "en-US", icon }
+                    };
+                    var parsed = new ParsedSource(icon, names, SourceType.Custom);
+                    if (_sources.TryAdd(icon, parsed))
+                    {
+                        if (icon == DEFAULT_KEY)
+                        {
+                            _default = parsed;
+                        }
+                    }
+                    else // Source already exists; override its icon
+                    {
+                        _sources[icon]._icon = icon;
+                    }
+                    return true;
+                });
+            }
+        }
+
+        private static void ReadIndexPath(String indexPath)
+        {
+            var sources = JsonConvert.DeserializeObject<SourceIndex>(File.ReadAllText(indexPath));
+
+            foreach (var source in sources.sources)
+            {
+                var parsed = new ParsedSource(source.icon, source.names, source.type switch
+                {
+                    "game"    => SourceType.Game,
+                    "charter" => SourceType.Charter,
+                    "rb"      => SourceType.RB,
+                    "gh"      => SourceType.GH,
+                    _         => SourceType.Custom
+                });
+
+                foreach (var id in source.ids)
+                {
+                    if (_sources.TryAdd(id, parsed) && id == DEFAULT_KEY)
+                    {
+                        _default = parsed;
                     }
                 }
             }

--- a/Assets/Script/Song/SongSources.cs
+++ b/Assets/Script/Song/SongSources.cs
@@ -290,7 +290,7 @@ namespace YARG.Song
             Directory.CreateDirectory(CustomSourcesFolder);
             // Read index.json if it exists; otherwise fallback to reading PNGs individually later on
             string customIndexPath = Path.Combine(CustomSourcesFolder, "index.json");
-            var customSourcesRead = false;
+            bool customSourcesRead = false;
             if (File.Exists(customIndexPath))
             {
                 ReadIndexPath(customIndexPath);
@@ -320,11 +320,12 @@ namespace YARG.Song
             }
 
             // Read individual PNGs (this is done after reading regular sources, so their icons can be replaced if needed)
-            if (!customSourcesRead) {
+            if (!customSourcesRead)
+            {
                 PathHelper.SafeEnumerateFiles(CustomSourcesFolder, "*.png", true, (path) =>
                 {
                     // Filename will be used for all values (id, name, icon path).
-                    var icon = Path.GetFileNameWithoutExtension(path);
+                    string icon = Path.GetFileNameWithoutExtension(path);
                     var names = new Dictionary<string, string> {
                         { "en-US", icon }
                     };
@@ -336,7 +337,7 @@ namespace YARG.Song
                             _default = parsed;
                         }
                     }
-                    else // Source already exists; override its icon
+                    else // Source already exists; override its icon only (preserving metadata)
                     {
                         _sources[icon]._icon = icon;
                     }
@@ -360,7 +361,7 @@ namespace YARG.Song
                     _         => SourceType.Custom
                 });
 
-                foreach (var id in source.ids)
+                foreach (string id in source.ids)
                 {
                     if (_sources.TryAdd(id, parsed) && id == DEFAULT_KEY)
                     {

--- a/Assets/Script/Song/SongSources.cs
+++ b/Assets/Script/Song/SongSources.cs
@@ -51,7 +51,7 @@ namespace YARG.Song
 
         public class ParsedSource
         {
-            public string _icon;
+            public string IconName { get; set; }
             private readonly Dictionary<string, string> _names;
 #nullable enable
             private Sprite? _sprite;
@@ -65,7 +65,7 @@ namespace YARG.Song
 
             public ParsedSource(string icon, Dictionary<string, string> names, SourceType type)
             {
-                _icon = icon;
+                IconName = icon;
                 _names = names;
                 Type = type;
             }
@@ -88,7 +88,7 @@ namespace YARG.Song
 #nullable disable
                 foreach (var root in SourceRoots)
                 {
-                    string file = Path.Combine(root, $"{_icon}.png");
+                    string file = Path.Combine(root, $"{IconName}.png");
                     if (File.Exists(file))
                     {
                         using var image = await UniTask.RunOnThreadPool(() => YARGImage.Load(file));
@@ -105,7 +105,7 @@ namespace YARG.Song
 
                 if (texture == null)
                 {
-                    YargLogger.LogFormatWarning("Failed to find source icon `{0}`! Does it exist?", _icon);
+                    YargLogger.LogFormatWarning("Failed to find source icon `{0}`! Does it exist?", IconName);
                     return;
                 }
 
@@ -339,7 +339,7 @@ namespace YARG.Song
                     }
                     else // Source already exists; override its icon only (preserving metadata)
                     {
-                        _sources[icon]._icon = icon;
+                        _sources[icon].IconName = icon;
                     }
                     return true;
                 });


### PR DESCRIPTION
- Custom sources are prioritized, so user-provided replacements supersede the official ones;
- The location is `persistent data path / custom / icons`. To avoid duplicate code, the `CustomContentManager.CustomizationDirectory` variable is used;
- If there's an `index.json` there, that is used (similar to OpenSource sourced sources). It's up to the user to maintain that file;
- Otherwise, `.png`s are read individually. If it's a new source, the filename is used as its id/name/etc.
  - If a source already exists for a given PNG's filename, the existing source will be modified to use the custom icon instead. This is done so the metadata for existing sources aren't lost.