### PR TITLE
Add multiplier glow effects

### DIFF
--- a/Assets/Art/Materials/Gameplay/Track/TrackComboSunburst.mat
+++ b/Assets/Art/Materials/Gameplay/Track/TrackComboSunburst.mat
@@ -112,7 +112,7 @@ Material:
     - _ZWrite: 1
     m_Colors:
     - _BaseColor: {r: 1, g: 1, b: 1, a: 1}
-    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _Color: {r: 0, g: 0.8509804, b: 1, a: 1}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
     - _Flip: {r: 1, g: 1, b: 1, a: 1}
     - _RendererColor: {r: 1, g: 1, b: 1, a: 1}

--- a/Assets/Art/Textures/Gameplay/Track_Combo_Sunburst.png
+++ b/Assets/Art/Textures/Gameplay/Track_Combo_Sunburst.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:af1a1236b02ccfddda48e9dc11e42459f0ff590d6416d6c9ea0bf4624fc9f361
-size 552608
+oid sha256:6e68f707499f8d5bf10de9e3e38ce8115cd36011ec3a2ff09a8fb86dc81bca3c
+size 288100

--- a/Assets/Prefabs/Gameplay/Visual/BaseVisual.prefab
+++ b/Assets/Prefabs/Gameplay/Visual/BaseVisual.prefab
@@ -1130,10 +1130,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 42974416b948ada45a2fd1534af7341c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _grooveSunburstEffect: {fileID: 8360053433170138951}
-  _grooveLightEffect: {fileID: 1811260302183972900}
-  _starpowerSunburstEffect: {fileID: 3797275969015020249}
-  _starpowerLightEffect: {fileID: 2166581194060232035}
+  _sunburstEffect: {fileID: 8360053433170138951}
+  _lightEffect: {fileID: 1811260302183972900}
+  _grooveSunburstColor: {r: 0, g: 0.8509804, b: 1, a: 1}
+  _grooveLightColor: {r: 0, g: 0.5372549, b: 1, a: 1}
+  _starpowerSunburstColor: {r: 1, g: 0.9882353, b: 0.5647059, a: 1}
+  _starpowerLightColor: {r: 1, g: 0.8745098, b: 0, a: 1}
 --- !u!1 &4315058809814086876
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Script/Gameplay/Player/TrackPlayer.cs
+++ b/Assets/Script/Gameplay/Player/TrackPlayer.cs
@@ -267,7 +267,7 @@ namespace YARG.Gameplay.Player
 
             ComboMeter.SetCombo(stats.ScoreMultiplier, maxMultiplier, stats.Combo);
             StarpowerBar.SetStarpower(currentStarPowerAmount, stats.IsStarPowerActive);
-            SunburstEffects.SetSunburstEffects(groove, stats.IsStarPowerActive);
+            SunburstEffects.SetSunburstEffects(groove, stats.IsStarPowerActive, _currentMultiplier);
 
             TrackView.UpdateNoteStreak(stats.Combo);
 

--- a/Assets/Script/Gameplay/Visuals/SunburstEffects.cs
+++ b/Assets/Script/Gameplay/Visuals/SunburstEffects.cs
@@ -198,6 +198,12 @@ namespace YARG.Gameplay.Visuals
 
         private void ActivateGrooveSunburst(bool forceLight = false)
         {
+            // Ensure that the disable tween isn't still running
+            if (_sunburstDisableSequence.IsPlaying())
+            {
+                _sunburstDisableSequence.Complete(false);
+            }
+
             // If _starpower is set that means we are coming out of starpower, so we just want to run the sequence
             if (_starpower)
             {
@@ -231,6 +237,12 @@ namespace YARG.Gameplay.Visuals
                 // If we're in groove, we don't want to reset scale and such
                 _starpowerStartSequence.Restart();
                 return;
+            }
+
+            // Ensure that the disable tween isn't still running
+            if (_sunburstDisableSequence.IsPlaying())
+            {
+                _sunburstDisableSequence.Complete(false);
             }
 
             // We need to make sure that we're set up for starpower before we start the sequence

--- a/Assets/Script/Gameplay/Visuals/SunburstEffects.cs
+++ b/Assets/Script/Gameplay/Visuals/SunburstEffects.cs
@@ -1,9 +1,11 @@
+using DG.Tweening;
 using UnityEngine;
+using YARG.Core.Chart;
 using YARG.Settings;
 
 namespace YARG.Gameplay.Visuals
 {
-    public class SunburstEffects : MonoBehaviour
+    public class SunburstEffects : GameplayBehaviour
     {
         [SerializeField]
         private GameObject _grooveSunburstEffect;
@@ -16,6 +18,16 @@ namespace YARG.Gameplay.Visuals
         [SerializeField]
         private GameObject _starpowerLightEffect;
 
+        private Tweener _grooveTween;
+        private Tweener _starpowerTween;
+        private Vector3 _originalScale;
+
+        protected override void GameplayAwake()
+        {
+            GameManager.BeatEventHandler.Subscribe(PulseSunburst);
+            _originalScale = _grooveSunburstEffect.transform.localScale;
+        }
+
         public void SetSunburstEffects(bool groove, bool starpower)
         {
             starpower &= SettingsManager.Settings.StarPowerHighwayFx.Value != StarPowerHighwayFxMode.Off;
@@ -25,12 +37,42 @@ namespace YARG.Gameplay.Visuals
 
             _starpowerSunburstEffect.SetActive(starpower);
             _starpowerLightEffect.SetActive(starpower);
+
+            _grooveTween ??= _grooveSunburstEffect.transform.DOScale(_originalScale * 0.85f, 0.25f).SetAutoKill(false)
+                .SetEase(Ease.OutSine).Pause();
+
+            _starpowerTween ??= _starpowerSunburstEffect.transform.DOScale(_originalScale * 0.85f, 0.25f).SetAutoKill(false)
+                .SetEase(Ease.InSine).Pause();
         }
 
         private void Update()
         {
             _grooveSunburstEffect.transform.Rotate(0f, 0f, Time.deltaTime * -25f);
             _starpowerSunburstEffect.transform.Rotate(0f, 0f, Time.deltaTime * -25f);
+        }
+
+        private void PulseSunburst(Beatline beatline)
+        {
+            if (_grooveSunburstEffect.activeInHierarchy)
+            {
+                // Snap to full size and tween to smaller size
+                _grooveSunburstEffect.transform.localScale = _originalScale;
+                _grooveTween?.Restart();
+            }
+
+            if (_starpowerSunburstEffect.activeInHierarchy)
+            {
+                // Snap to full size and tween to smaller size
+                _starpowerSunburstEffect.transform.localScale = _originalScale;
+                _starpowerTween?.Restart();
+            }
+        }
+
+        protected override void GameplayDestroy()
+        {
+            _grooveTween?.Kill();
+            _starpowerTween?.Kill();
+            GameManager.BeatEventHandler.Unsubscribe(PulseSunburst);
         }
     }
 }

--- a/Assets/Script/Gameplay/Visuals/SunburstEffects.cs
+++ b/Assets/Script/Gameplay/Visuals/SunburstEffects.cs
@@ -8,70 +8,255 @@ namespace YARG.Gameplay.Visuals
     public class SunburstEffects : GameplayBehaviour
     {
         [SerializeField]
-        private GameObject _grooveSunburstEffect;
+        private GameObject _sunburstEffect;
         [SerializeField]
-        private GameObject _grooveLightEffect;
+        private GameObject _lightEffect;
 
         [Space]
         [SerializeField]
-        private GameObject _starpowerSunburstEffect;
+        private Color _grooveSunburstColor;
         [SerializeField]
-        private GameObject _starpowerLightEffect;
+        private Color _grooveLightColor;
 
-        private Tweener _grooveTween;
-        private Tweener _starpowerTween;
-        private Vector3 _originalScale;
+        [Space]
+        [SerializeField]
+        private Color _starpowerSunburstColor;
+        [SerializeField]
+        private Color _starpowerLightColor;
+
+        private Tweener  _sunburstPulseTween;
+        private Sequence _multiplierIncreaseSequence;
+        private Sequence _multiplierDecreaseSequence;
+        private Sequence _grooveStartSequence;
+        private Sequence _starpowerStartSequence;
+        private Sequence _sunburstDisableSequence;
+        private Vector3  _originalScale;
+        private int      _previousMultiplier;
+
+        private Material _sunburstMaterial;
+        private Color    _grooveSunburstMaterialColor;
+        private Color    _grooveSunburstLightColor;
+        private Light    _light;
+        private float    _lightIntensity;
+
+        private bool _groove;
+        private bool _starpower;
+
+        private const float TRANSITION_DURATION = 0.433f;
 
         protected override void GameplayAwake()
         {
+
             GameManager.BeatEventHandler.Subscribe(PulseSunburst);
-            _originalScale = _grooveSunburstEffect.transform.localScale;
+
+            // Get the components we'll need to manipulate later
+            _sunburstMaterial = _sunburstEffect.GetComponent<SpriteRenderer>().material;
+            _light = _lightEffect.GetComponent<Light>();
+
+            // Save original state so we can return to it later if necessary
+            _originalScale = _sunburstEffect.transform.localScale;
+            _grooveSunburstMaterialColor = _sunburstMaterial.color;
+            _grooveSunburstLightColor = _light.color;
+            _lightIntensity = _light.intensity;
+
+            // Set up tweens for later use
+            _sunburstPulseTween = _sunburstEffect.transform.DOScale(_originalScale * 0.85f, 0.25f).SetAutoKill(false)
+                .SetEase(Ease.OutSine).Pause();
+
+            _multiplierIncreaseSequence = DOTween.Sequence(_sunburstEffect).SetAutoKill(false).Pause();
+            _multiplierIncreaseSequence.Append(_sunburstEffect.transform.DOScale(0.045f, TRANSITION_DURATION).SetEase(Ease.InSine)).
+                Join(_light.DOIntensity(0.0f, TRANSITION_DURATION).SetEase(Ease.InCubic)).
+                AppendCallback(SetGrooveSunburst);
+
+            _multiplierDecreaseSequence = DOTween.Sequence(_sunburstEffect).SetAutoKill(false).Pause();
+            _multiplierDecreaseSequence.Append(_light.DOColor(Color.red, 0.000001f)).
+                Join(_sunburstMaterial.DOColor(Color.red, 0.000001f)).
+                Append(_sunburstEffect.transform.DOScale(0.045f, TRANSITION_DURATION).SetEase(Ease.InSine)).
+                Join(_light.DOIntensity(0.0f, TRANSITION_DURATION).SetEase(Ease.InCubic)).
+                AppendCallback(SetGrooveSunburst);
+
+            _grooveStartSequence = DOTween.Sequence(_sunburstEffect).SetAutoKill(false).Pause();
+            _grooveStartSequence.Append(_sunburstEffect.transform.DOScale(_originalScale, TRANSITION_DURATION)).
+                Join(_sunburstMaterial.DOColor(_grooveSunburstColor, TRANSITION_DURATION)).
+                Join(_light.DOColor(_grooveLightColor, TRANSITION_DURATION)).
+                Join(_light.DOIntensity(_lightIntensity, TRANSITION_DURATION));
+
+            _starpowerStartSequence = DOTween.Sequence(_sunburstEffect).SetAutoKill(false).Pause();
+            _starpowerStartSequence.Append(_sunburstEffect.transform.DOScale(_originalScale, TRANSITION_DURATION)).
+                Join(_sunburstMaterial.DOColor(_starpowerSunburstColor, TRANSITION_DURATION)).
+                Join(_light.DOColor(_starpowerLightColor, TRANSITION_DURATION)).
+                Join(_light.DOIntensity(_lightIntensity, TRANSITION_DURATION));
+
+            _sunburstDisableSequence = DOTween.Sequence(_sunburstEffect).SetAutoKill(false).Pause();
+            _sunburstDisableSequence.Append(_sunburstEffect.transform.DOScale(_originalScale * 0.4f, TRANSITION_DURATION))
+                .Join(_light.DOIntensity(0.0f, TRANSITION_DURATION)).
+                AppendCallback(DisableSunburst);
+
+            // Disable the sunburst effect in case it is already on
+            _sunburstEffect.SetActive(false);
+            _lightEffect.SetActive(false);
         }
 
-        public void SetSunburstEffects(bool groove, bool starpower)
+        public void SetSunburstEffects(bool groove, bool starpower, int multiplier)
         {
             starpower &= SettingsManager.Settings.StarPowerHighwayFx.Value != StarPowerHighwayFxMode.Off;
 
-            _grooveSunburstEffect.SetActive(groove && !starpower);
-            _grooveLightEffect.SetActive(groove && !starpower);
+            // Handle going in and out of starpower
+            if (starpower != _starpower)
+            {
+                if (starpower)
+                {
+                    ActivateStarpowerSunburst();
+                }
+                else if (groove)
+                {
+                    ActivateGrooveSunburst();
+                }
+                else
+                {
+                    _sunburstDisableSequence.Restart();
+                }
 
-            _starpowerSunburstEffect.SetActive(starpower);
-            _starpowerLightEffect.SetActive(starpower);
+                _groove = groove;
+                _starpower = starpower;
+                _previousMultiplier = multiplier;
+                return;
+            }
 
-            _grooveTween ??= _grooveSunburstEffect.transform.DOScale(_originalScale * 0.85f, 0.25f).SetAutoKill(false)
-                .SetEase(Ease.OutSine).Pause();
+            _groove = groove;
+            _starpower = starpower;
 
-            _starpowerTween ??= _starpowerSunburstEffect.transform.DOScale(_originalScale * 0.85f, 0.25f).SetAutoKill(false)
-                .SetEase(Ease.InSine).Pause();
+            // Handle multiplier changes not connected to starpower activation
+            if (multiplier > _previousMultiplier && multiplier > 1)
+            {
+                if (!starpower && groove)
+                {
+                    ActivateGrooveSunburst();
+                    _grooveStartSequence.Restart();
+                }
+                else if (!starpower)
+                {
+                    ActivateGrooveSunburst();
+                    _multiplierIncreaseSequence.Restart();
+                }
+            }
+
+            // If groove is set, that means the decrease was due to starpower expiring, so we don't want
+            // to run the sequence even though the multiplier has decreased.
+            if (!groove && multiplier < _previousMultiplier && _previousMultiplier > 1)
+            {
+                // If we're in starpower, don't do anything
+                if (!starpower)
+                {
+                    ActivateGrooveSunburst(true);
+                    _multiplierDecreaseSequence.Restart();
+                }
+            }
+
+            _previousMultiplier = multiplier;
         }
 
         private void Update()
         {
-            _grooveSunburstEffect.transform.Rotate(0f, 0f, Time.deltaTime * -25f);
-            _starpowerSunburstEffect.transform.Rotate(0f, 0f, Time.deltaTime * -25f);
+            _sunburstEffect.transform.Rotate(0f, 0f, Time.deltaTime * -25f);
         }
 
         private void PulseSunburst(Beatline beatline)
         {
-            if (_grooveSunburstEffect.activeInHierarchy)
+            if (!_groove && !_starpower)
             {
-                // Snap to full size and tween to smaller size
-                _grooveSunburstEffect.transform.localScale = _originalScale;
-                _grooveTween?.Restart();
+                return;
             }
 
-            if (_starpowerSunburstEffect.activeInHierarchy)
+            if (_sunburstEffect.activeInHierarchy)
             {
                 // Snap to full size and tween to smaller size
-                _starpowerSunburstEffect.transform.localScale = _originalScale;
-                _starpowerTween?.Restart();
+                _sunburstEffect.transform.localScale = _originalScale;
+                _sunburstPulseTween?.Restart();
             }
+        }
+
+        private void SetGrooveSunburst()
+        {
+            _sunburstEffect.transform.localScale = _originalScale;
+            _sunburstMaterial.color = _grooveSunburstMaterialColor;
+            _light.color = _grooveSunburstLightColor;
+            _light.intensity = _lightIntensity;
+            _sunburstEffect.SetActive(_groove);
+            _lightEffect.SetActive(_groove);
+        }
+
+        private void SetStarpowerSunburst()
+        {
+            _sunburstEffect.transform.localScale = _originalScale;
+            _sunburstMaterial.color = _starpowerSunburstColor;
+            _light.color = _starpowerLightColor;
+            _light.intensity = _lightIntensity;
+            _sunburstEffect.SetActive(_starpower);
+            _lightEffect.SetActive(_starpower);
+        }
+
+        private void ActivateGrooveSunburst(bool forceLight = false)
+        {
+            // If _starpower is set that means we are coming out of starpower, so we just want to run the sequence
+            if (_starpower)
+            {
+                _grooveStartSequence.Restart();
+                return;
+            }
+
+            if (_groove)
+            {
+                _sunburstEffect.transform.localScale = _originalScale * 0.5f;
+                _sunburstMaterial.color = _grooveSunburstColor;
+                _light.intensity = 0f;
+                _light.color = _grooveSunburstLightColor;
+            }
+            else
+            {
+                _sunburstMaterial.color = Color.white;
+                _light.color = Color.white;
+                _light.intensity = 0.75f;
+                _sunburstEffect.transform.localScale = _originalScale * 0.65f;
+            }
+            _sunburstEffect.SetActive(true);
+            _lightEffect.SetActive(_groove || forceLight);
+            // This one doesn't start the sequence because there are multiple sequence options that could be run
+        }
+
+        private void ActivateStarpowerSunburst()
+        {
+            if (_groove)
+            {
+                // If we're in groove, we don't want to reset scale and such
+                _starpowerStartSequence.Restart();
+                return;
+            }
+
+            // We need to make sure that we're set up for starpower before we start the sequence
+            _sunburstEffect.transform.localScale = _originalScale * 0.5f;
+            _sunburstMaterial.color = _starpowerSunburstColor;
+            _light.color = _starpowerLightColor;
+            _light.intensity = 0f;
+            _sunburstEffect.SetActive(true);
+            _lightEffect.SetActive(true);
+            _starpowerStartSequence.Restart();
+        }
+
+        private void DisableSunburst()
+        {
+            _sunburstEffect.SetActive(false);
+            _lightEffect.SetActive(false);
         }
 
         protected override void GameplayDestroy()
         {
-            _grooveTween?.Kill();
-            _starpowerTween?.Kill();
+            _sunburstPulseTween?.Kill();
+            _multiplierIncreaseSequence?.Kill();
+            _multiplierDecreaseSequence?.Kill();
+            _grooveStartSequence?.Kill();
+            _starpowerStartSequence?.Kill();
+            _sunburstDisableSequence?.Kill();
             GameManager.BeatEventHandler.Unsubscribe(PulseSunburst);
         }
     }


### PR DESCRIPTION
This PR adds visual effects when the score multiplier changes.

- When multiplier increases, the sunburst effect "flashes" to more clearly indicate that the multiplier has changed
- When multiplier drops, the track light flashes red to more clearly indicate that the player did something wrong
- When at maximum multiplier, the sunburst pulses in size at every beat
- When transitioning to/from max multiplier, the sunburst and track light effects are eased instead of instantly changing state


https://github.com/user-attachments/assets/e0a57a28-94a5-447d-9876-5ac7c1f43db6

~~Currently marked as draft because, while it was discussed on Discord, Kadu has not yet given specific approval.~~

