### PR TITLE
Play along with replay

### DIFF
--- a/Assets/Prefabs/Menu/History/HistoryMenu.prefab
+++ b/Assets/Prefabs/Menu/History/HistoryMenu.prefab
@@ -60,8 +60,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_Material: {fileID: 0}
   m_Color: {r: 0, g: 0.22745098, b: 0.41568628, a: 1}
   m_RaycastTarget: 1
@@ -90,8 +90,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 31a19414c41e5ae4aae2af33fee712f6, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_ShowMaskGraphic: 0
 --- !u!114 &8569649329610169560
 MonoBehaviour:
@@ -103,8 +103,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_IgnoreLayout: 0
   m_MinWidth: -1
   m_MinHeight: -1
@@ -123,8 +123,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: ea764c8f49ba4dfaba672be77de25f68, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   SelectedView: {fileID: 0}
   _innerViewContainer: {fileID: 7242423078743798783}
 --- !u!1 &1328902297093170595
@@ -240,8 +240,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_UiScaleMode: 1
   m_ReferencePixelsPerUnit: 100
   m_ScaleFactor: 1
@@ -263,8 +263,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_IgnoreReversedGraphics: 1
   m_BlockingObjects: 0
   m_BlockingMask:
@@ -280,8 +280,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: d8ace06a29e24742a57e7063a7345cf9, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   <Menu>k__BackingField: 7
   <HideBelow>k__BackingField: 1
 --- !u!114 &2297200881685797724
@@ -294,8 +294,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: e7989b6b69f34a19ba1dd8f2a53b202b, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   _viewObjectPrefab: {fileID: 4753457024697432023, guid: 170621276b777a744bd6c46aededed3f,
     type: 3}
   _viewObjectParent: {fileID: 7242423078743798783}
@@ -303,6 +303,7 @@ MonoBehaviour:
   _viewAligner: {fileID: 619021696685137995}
   _exportReplayButton: {fileID: 8577329528064569814}
   _importReplayButton: {fileID: 7535555724622063350}
+  _playWithReplayButton: {fileID: 0}
   _headerTabs: {fileID: 4155919010694207238}
 --- !u!1 &3868076950096473284
 GameObject:
@@ -352,8 +353,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 59f8146938fff824cb5fd77236b75775, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_Padding:
     m_Left: 0
     m_Right: 0
@@ -378,8 +379,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 3245ec927659c4140ac4f8d17403cc18, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_HorizontalFit: 0
   m_VerticalFit: 2
 --- !u!1001 &2797418370732063021
@@ -537,7 +538,7 @@ PrefabInstance:
     - target: {fileID: 7797295169623578800, guid: 39d10333b1c21384fa99cee4bf5e6ddc,
         type: 3}
       propertyPath: m_OnValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_Target
-      value: 
+      value:
       objectReference: {fileID: 2297200881685797724}
     - target: {fileID: 7797295169623578800, guid: 39d10333b1c21384fa99cee4bf5e6ddc,
         type: 3}
@@ -577,8 +578,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 2a4db7a114972834c8e4117be1d82ba3, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
 --- !u!1001 &5380931320726277251
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -599,7 +600,7 @@ PrefabInstance:
     - target: {fileID: 1245898288579793007, guid: 23b94837fb849574ebf1ad7d180706e3,
         type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
-      value: 
+      value:
       objectReference: {fileID: 2297200881685797724}
     - target: {fileID: 1245898288579793007, guid: 23b94837fb849574ebf1ad7d180706e3,
         type: 3}
@@ -769,7 +770,7 @@ PrefabInstance:
     - target: {fileID: 1245898288579793007, guid: 23b94837fb849574ebf1ad7d180706e3,
         type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
-      value: 
+      value:
       objectReference: {fileID: 2297200881685797724}
     - target: {fileID: 1245898288579793007, guid: 23b94837fb849574ebf1ad7d180706e3,
         type: 3}
@@ -939,7 +940,7 @@ PrefabInstance:
     - target: {fileID: 363344089001548003, guid: 0dab2d5fd611fdb4bb5ca54e023d39b7,
         type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
-      value: 
+      value:
       objectReference: {fileID: 4004993937793846201}
     - target: {fileID: 363344089001548003, guid: 0dab2d5fd611fdb4bb5ca54e023d39b7,
         type: 3}
@@ -1094,13 +1095,13 @@ PrefabInstance:
     - target: {fileID: 5245842211347915737, guid: 0dab2d5fd611fdb4bb5ca54e023d39b7,
         type: 3}
       propertyPath: _tabs.Array.data[0].Icon
-      value: 
+      value:
       objectReference: {fileID: -1967022677, guid: 0a16c58d433eacb44a1354456c1c8abd,
         type: 3}
     - target: {fileID: 5245842211347915737, guid: 0dab2d5fd611fdb4bb5ca54e023d39b7,
         type: 3}
       propertyPath: _tabs.Array.data[1].Icon
-      value: 
+      value:
       objectReference: {fileID: -345837708, guid: 0a16c58d433eacb44a1354456c1c8abd,
         type: 3}
     - target: {fileID: 5245842211347915737, guid: 0dab2d5fd611fdb4bb5ca54e023d39b7,
@@ -1131,8 +1132,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 7666ce39360a4330a733067d9e66b929, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   _localizationKey: Menu.History.Name
 --- !u!224 &3990723114228759297 stripped
 RectTransform:
@@ -1150,5 +1151,5 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: e198e729a591458fbdaef6827418428d, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:

--- a/Assets/Script/Gameplay/GameManager.Loading.cs
+++ b/Assets/Script/Gameplay/GameManager.Loading.cs
@@ -126,7 +126,35 @@ namespace YARG.Gameplay
                     global.LoadScene(SceneIndex.Menu);
                     return;
                 }
-                _replayController.gameObject.SetActive(true);
+
+                if (!GlobalVariables.State.PlayingWithReplay)
+                {
+                    _replayController.gameObject.SetActive(true);
+                }
+                else
+                {
+                    // var players = new YargPlayer[YargPlayers.Count + PlayerContainer.Players.Count];
+                    _replayController.gameObject.SetActive(false);
+                    var players = new List<YargPlayer>();
+                    players.AddRange(PlayerContainer.Players);
+                    for (int i = 0; i < YargPlayers.Count; i++)
+                    {
+                         // YargPlayers[i].ReplayIndex = i;
+                         players.Add(YargPlayers[i]);
+                    }
+
+                    YargPlayers = players.ToArray();
+                }
+
+                var replayIndex = 0;
+                foreach (var player in YargPlayers)
+                {
+                    if (player.IsReplay)
+                    {
+                        player.ReplayIndex = replayIndex;
+                        replayIndex++;
+                    }
+                }
             }
 
             context.Queue(UniTask.RunOnThreadPool(LoadChart), "Loading chart...");
@@ -322,7 +350,7 @@ namespace YARG.Gameplay
                 {
                     index++;
 
-                    if (ReplayInfo == null)
+                    if (!player.IsReplay)
                     {
                         // Reset microphone (resets channel buffers)
                         // We probably wanna do this no matter what, so put it up here
@@ -335,7 +363,7 @@ namespace YARG.Gameplay
                         continue;
                     }
 
-                    if (ReplayInfo == null)
+                    if (!player.IsReplay)
                     {
                         // Don't do this if it's a replay, because the replay
                         // would've already set its own presets at this point

--- a/Assets/Script/Gameplay/GameManager.cs
+++ b/Assets/Script/Gameplay/GameManager.cs
@@ -298,7 +298,7 @@ namespace YARG.Gameplay
         {
             if (showMenu)
             {
-                if (ReplayInfo != null)
+                if (!GlobalVariables.State.PlayingWithReplay && ReplayInfo != null)
                 {
                     _pauseMenu.PushMenu(PauseMenuManager.Menu.ReplayPause);
                 }
@@ -405,7 +405,7 @@ namespace YARG.Gameplay
                 return false;
             }
 
-            if (ReplayInfo != null)
+            if (!GlobalVariables.State.PlayingWithReplay && ReplayInfo != null)
             {
                 Pause(false);
                 return true;

--- a/Assets/Script/Gameplay/GameManager.cs
+++ b/Assets/Script/Gameplay/GameManager.cs
@@ -479,6 +479,7 @@ namespace YARG.Gameplay
                     NotesHit = player.BaseStats.NotesHit,
                     NotesMissed = player.BaseStats.NotesMissed,
                     IsFc = player.IsFc,
+                    IsReplay = player.Player.IsReplay,
 
                     Percent = player.BaseStats.Percent
                 });
@@ -500,7 +501,8 @@ namespace YARG.Gameplay
                 BandScore = BandScore,
                 BandStars = StarAmountHelper.GetStarsFromInt((int) BandStars),
 
-                SongSpeed = SongSpeed
+                SongSpeed = SongSpeed,
+                PlayedWithReplay = GlobalVariables.State.PlayingWithReplay,
             }, playerEntries);
         }
 

--- a/Assets/Script/Gameplay/HUD/HideCursor.cs
+++ b/Assets/Script/Gameplay/HUD/HideCursor.cs
@@ -34,7 +34,7 @@ namespace YARG.Gameplay.HUD
             float showCursorSetting = SettingsManager.Settings.ShowCursorTimer.Value;
 
             // Always show if paused, or if settings say so
-            if (GameManager.Paused || (GlobalVariables.State.PlayingWithReplay && GameManager.ReplayInfo != null))
+            if (GameManager.Paused || (!GlobalVariables.State.PlayingWithReplay && GameManager.ReplayInfo != null))
             {
                 Cursor.visible = true;
                 return;

--- a/Assets/Script/Gameplay/HUD/HideCursor.cs
+++ b/Assets/Script/Gameplay/HUD/HideCursor.cs
@@ -34,7 +34,7 @@ namespace YARG.Gameplay.HUD
             float showCursorSetting = SettingsManager.Settings.ShowCursorTimer.Value;
 
             // Always show if paused, or if settings say so
-            if (GameManager.Paused || GameManager.ReplayInfo != null)
+            if (GameManager.Paused || (GlobalVariables.State.PlayingWithReplay && GameManager.ReplayInfo != null))
             {
                 Cursor.visible = true;
                 return;

--- a/Assets/Script/Gameplay/Player/BasePlayer.cs
+++ b/Assets/Script/Gameplay/Player/BasePlayer.cs
@@ -31,7 +31,7 @@ namespace YARG.Gameplay.Player
                 // If we're in a replay, don't change the note speed (it should be like a video
                 // slowing down/speeding up). The actual song speed should be taken into account though,
                 // which is saved in the engine parameter override.
-                if (GameManager.ReplayInfo != null)
+                if (Player.IsReplay)
                 {
                     return noteSpeed / (float) Player.EngineParameterOverride.SongSpeed;
                 }
@@ -116,7 +116,7 @@ namespace YARG.Gameplay.Player
                 SantrollerHaptics = Player.Bindings.GetDevicesByType<ISantrollerHaptics>();
             }
 
-            if (GameManager.ReplayInfo == null)
+            if (!Player.IsReplay)
             {
                 SubscribeToInputEvents();
             }
@@ -138,9 +138,9 @@ namespace YARG.Gameplay.Player
 
             _noteSpeedDifficultyScale = Player.Profile.CurrentDifficulty.NoteSpeedScale();
 
-            if (GameManager.ReplayInfo != null)
+            if (Player.IsReplay && GameManager.ReplayInfo != null)
             {
-                _replayInputs = new List<GameInput>(GameManager.ReplayData.Frames[index].Inputs);
+                _replayInputs = new List<GameInput>(GameManager.ReplayData.Frames[player.ReplayIndex].Inputs);
                 YargLogger.LogFormatDebug("Initialized replay inputs with {0} inputs", _replayInputs.Count);
             }
 
@@ -206,7 +206,7 @@ namespace YARG.Gameplay.Player
 
         protected override void GameplayDestroy()
         {
-            if (GameManager.ReplayInfo == null)
+            if (!Player.IsReplay)
             {
                 UnsubscribeFromInputEvents();
             }
@@ -224,7 +224,7 @@ namespace YARG.Gameplay.Player
             // Video offset is already accounted for
             time += InputCalibration;
 
-            if (GameManager.ReplayInfo != null)
+            if (Player.IsReplay && GameManager.ReplayInfo != null)
             {
                 while (_replayInputIndex < ReplayInputs.Count)
                 {

--- a/Assets/Script/Gameplay/Player/DrumsPlayer.cs
+++ b/Assets/Script/Gameplay/Player/DrumsPlayer.cs
@@ -65,7 +65,7 @@ namespace YARG.Gameplay.Player
                 _                        => throw new Exception("Unreachable.")
             };
 
-            if (GameManager.ReplayInfo == null)
+            if (!Player.IsReplay)
             {
                 // Create the engine params from the engine preset
                 EngineParams = Player.EnginePreset.Drums.Create(StarMultiplierThresholds, mode);

--- a/Assets/Script/Gameplay/Player/FiveFretPlayer.cs
+++ b/Assets/Script/Gameplay/Player/FiveFretPlayer.cs
@@ -75,7 +75,7 @@ namespace YARG.Gameplay.Player
                 StarMultiplierThresholds = BassStarMultiplierThresholds;
             }
 
-            if (GameManager.ReplayInfo == null)
+            if (!Player.IsReplay)
             {
                 // Create the engine params from the engine preset
                 EngineParams = Player.EnginePreset.FiveFretGuitar.Create(StarMultiplierThresholds, isBass);

--- a/Assets/Script/Gameplay/Player/ProKeysPlayer.cs
+++ b/Assets/Script/Gameplay/Player/ProKeysPlayer.cs
@@ -84,7 +84,7 @@ namespace YARG.Gameplay.Player
 
         protected override ProKeysEngine CreateEngine()
         {
-            if (GameManager.ReplayInfo == null)
+            if (!Player.IsReplay)
             {
                 // Create the engine params from the engine preset
                 EngineParams = Player.EnginePreset.ProKeys.Create(StarMultiplierThresholds);

--- a/Assets/Script/Gameplay/Player/TrackPlayer.cs
+++ b/Assets/Script/Gameplay/Player/TrackPlayer.cs
@@ -191,7 +191,7 @@ namespace YARG.Gameplay.Player
             {
                 Engine.SetSpeed(GameManager.SongSpeed >= 1 ? GameManager.SongSpeed : 1);
             }
-            else if (GameManager.ReplayInfo != null)
+            else if (Player.IsReplay)
             {
                 // If it's a replay, the "SongSpeed" parameter should be set properly
                 // when it gets deserialized. Transfer this over to the engine.

--- a/Assets/Script/Gameplay/Player/VocalsPlayer.cs
+++ b/Assets/Script/Gameplay/Player/VocalsPlayer.cs
@@ -111,7 +111,7 @@ namespace YARG.Gameplay.Player
             _hud.ShowPlayerName(player, needleIndex);
 
             // Create and start an input context for the mic
-            if (GameManager.ReplayInfo == null && player.Bindings.Microphone != null)
+            if (!Player.IsReplay && player.Bindings.Microphone != null)
             {
                 _inputContext = new MicInputContext(player.Bindings.Microphone, GameManager);
                 _inputContext.Start();
@@ -154,7 +154,7 @@ namespace YARG.Gameplay.Player
 
         protected VocalsEngine CreateEngine()
         {
-            if (GameManager.ReplayInfo == null)
+            if (!Player.IsReplay)
             {
                 var singToActivateStarPower = SettingsManager.Settings.VoiceActivatedVocalStarPower.Value;
 
@@ -251,7 +251,7 @@ namespace YARG.Gameplay.Player
         protected override void UpdateInputs(double time)
         {
             // Push all inputs from mic
-            if (GameManager.ReplayInfo == null && _inputContext != null)
+            if (!Player.IsReplay && _inputContext != null)
             {
                 foreach (var input in _inputContext.GetInputsFromMic())
                 {

--- a/Assets/Script/Menu/History/HistoryMenu.cs
+++ b/Assets/Script/Menu/History/HistoryMenu.cs
@@ -63,6 +63,8 @@ namespace YARG.Menu.History
                     Back),
                 new NavigationScheme.Entry(MenuAction.Yellow, "Menu.History.Analyze",
                     () => CurrentSelection?.Shortcut1()),
+                new NavigationScheme.Entry(MenuAction.Orange, "Menu.History.PlayWithReplay",
+                    () => CurrentSelection?.PlayWithReplayClick())
             }, false));
 
             _headerTabs.TabChanged += OnTabChanged;

--- a/Assets/Script/Menu/History/ViewTypes/ReplayViewType.cs
+++ b/Assets/Script/Menu/History/ViewTypes/ReplayViewType.cs
@@ -164,6 +164,17 @@ namespace YARG.Menu.History
             FileExplorerHelper.OpenSaveFile(null, _entry!.ReplayName, "replay", path => File.Copy(_entry.FilePath, path, true));
         }
 
+        public override void PlayWithReplayClick()
+        {
+            _entry ??= LoadReplay("Cannot Play Replay");
+            if (_entry == null)
+            {
+                return;
+            }
+
+            PlayWithReplay(_entry, _songEntry);
+        }
+
         public override GameInfo? GetGameInfo()
         {
             return _gameInfo;

--- a/Assets/Script/Menu/History/ViewTypes/ViewType.cs
+++ b/Assets/Script/Menu/History/ViewTypes/ViewType.cs
@@ -21,6 +21,11 @@ namespace YARG.Menu.History
 
         }
 
+        public virtual void PlayWithReplayClick()
+        {
+
+        }
+
         public virtual void Shortcut1()
         {
 
@@ -39,6 +44,18 @@ namespace YARG.Menu.History
         public virtual GameInfo? GetGameInfo()
         {
             return null;
+        }
+
+        protected static void PlayWithReplay(ReplayInfo replay, SongEntry song)
+        {
+            GlobalVariables.State = PersistentState.Default;
+
+            GlobalVariables.State.CurrentSong = song;
+            GlobalVariables.State.CurrentReplay = replay;
+            GlobalVariables.State.PlayingWithReplay = true;
+
+            // GlobalVariables.Instance.LoadScene(SceneIndex.Gameplay);
+            MenuManager.Instance.PushMenu(MenuManager.Menu.DifficultySelect);
         }
 
         protected static void LoadIntoReplay(ReplayInfo replay, SongEntry song)

--- a/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
+++ b/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
@@ -181,6 +181,7 @@ namespace YARG.Menu.MusicLibrary
             // Set IsPractice as well
             GlobalVariables.State.IsPractice = LibraryMode == MusicLibraryMode.Practice;
             GlobalVariables.State.CurrentReplay = null;
+            GlobalVariables.State.PlayingWithReplay = false;
 
             // Show no player warning
             _noPlayerWarning.SetActive(PlayerContainer.Players.Count <= 0);

--- a/Assets/Script/Menu/ScoreScreen/ScoreCards/ScoreCard.cs
+++ b/Assets/Script/Menu/ScoreScreen/ScoreCards/ScoreCard.cs
@@ -92,6 +92,19 @@ namespace YARG.Menu.ScoreScreen
                 _colorizer.SetCardColor(ScoreCardColorizer.ScoreCardColor.Gray);
                 ShowTag("Bot");
             }
+            else if (Player.IsReplay)
+            {
+                if (Stats.MaxCombo == Stats.TotalNotes)
+                {
+                    _colorizer.SetCardColor(ScoreCardColorizer.ScoreCardColor.Gold);
+                }
+                else
+                {
+                    _colorizer.SetCardColor(ScoreCardColorizer.ScoreCardColor.Blue);
+                }
+
+                ShowTag("Replay");
+            }
             else if (Stats.MaxCombo == Stats.TotalNotes)
             {
                 _colorizer.SetCardColor(ScoreCardColorizer.ScoreCardColor.Gold);
@@ -101,11 +114,6 @@ namespace YARG.Menu.ScoreScreen
             {
                 _colorizer.SetCardColor(ScoreCardColorizer.ScoreCardColor.Blue);
                 ShowTag("High Score");
-            }
-            else if (Player.IsReplay)
-            {
-                _colorizer.SetCardColor(ScoreCardColorizer.ScoreCardColor.Blue);
-                ShowTag("Replay");
             }
             else
             {

--- a/Assets/Script/Menu/ScoreScreen/ScoreCards/ScoreCard.cs
+++ b/Assets/Script/Menu/ScoreScreen/ScoreCards/ScoreCard.cs
@@ -102,6 +102,11 @@ namespace YARG.Menu.ScoreScreen
                 _colorizer.SetCardColor(ScoreCardColorizer.ScoreCardColor.Blue);
                 ShowTag("High Score");
             }
+            else if (Player.IsReplay)
+            {
+                _colorizer.SetCardColor(ScoreCardColorizer.ScoreCardColor.Blue);
+                ShowTag("Replay");
+            }
             else
             {
                 _colorizer.SetCardColor(ScoreCardColorizer.ScoreCardColor.Blue);

--- a/Assets/Script/Persistent/PersistentState.cs
+++ b/Assets/Script/Persistent/PersistentState.cs
@@ -21,7 +21,8 @@ namespace YARG
 
         public float SongSpeed;
 
-        public bool IsPractice;
+        public          bool IsPractice;
         public readonly bool IsReplay => CurrentReplay is not null;
+        public          bool PlayingWithReplay;
     }
 }

--- a/Assets/Script/Player/YargPlayer.cs
+++ b/Assets/Script/Player/YargPlayer.cs
@@ -31,6 +31,9 @@ namespace YARG.Player
         public CameraPreset  CameraPreset  { get; private set; }
         public HighwayPreset HighwayPreset { get; private set; }
 
+        public bool IsReplay { get; private set; }
+        public int ReplayIndex = -1;
+
         /// <summary>
         /// Overrides the engine parameters in the gameplay player.
         /// This is only used when loading replays.
@@ -44,6 +47,7 @@ namespace YARG.Player
         {
             Profile = profile;
             Bindings = bindings;
+            IsReplay = false;
         }
 
         public YargPlayer(ReplayFrame frame, ReplayData replay)
@@ -51,6 +55,7 @@ namespace YARG.Player
             Profile = frame.Profile;
             Bindings = null;
             EngineParameterOverride = frame.EngineParameters;
+            IsReplay = true;
 
             EnginePreset = CustomContentManager.EnginePresets.GetPresetById(Profile.EnginePreset)
                 ?? EnginePreset.Default;

--- a/Assets/Script/Scores/GameRecord.cs
+++ b/Assets/Script/Scores/GameRecord.cs
@@ -32,6 +32,7 @@ namespace YARG.Scores
         public int        BandScore { get; set; }
         public StarAmount BandStars { get; set; }
 
-        public float SongSpeed { get; set; }
+        public float SongSpeed        { get; set; }
+        public bool  PlayedWithReplay { get; set; }
     }
 }

--- a/Assets/Script/Scores/PlayerScoreRecord.cs
+++ b/Assets/Script/Scores/PlayerScoreRecord.cs
@@ -32,6 +32,7 @@ namespace YARG.Scores
         public int  NotesHit    { get; set; }
         public int  NotesMissed { get; set; }
         public bool IsFc        { get; set; }
+        public bool IsReplay    { get; set; }
 
         /// <remarks>
         /// This property was added afterwards, so it is nullable.

--- a/Assets/Script/Scores/ScoreContainer.cs
+++ b/Assets/Script/Scores/ScoreContainer.cs
@@ -122,10 +122,13 @@ namespace YARG.Scores
                 foreach (var playerEntry in playerEntries)
                 {
                     playerEntry.GameRecordId = gameRecord.Id;
-
                     // Record the player's info in the "Players" table
-                    string name = PlayerContainer.GetProfileById(playerEntry.PlayerId).Name;
-                    RecordPlayerInfo(playerEntry.PlayerId, name);
+
+                    if (!playerEntry.IsReplay)
+                    {
+                        string name = PlayerContainer.GetProfileById(playerEntry.PlayerId).Name;
+                        RecordPlayerInfo(playerEntry.PlayerId, name);
+                    }
                 }
 
                 _db.InsertSoloRecords(playerEntries);

--- a/Assets/StreamingAssets/lang/en-US.json
+++ b/Assets/StreamingAssets/lang/en-US.json
@@ -225,7 +225,8 @@
                 "MoreThanYear": "More Than A Year"
             },
 
-            "Analyze": "Analyze"
+            "Analyze": "Analyze",
+            "PlayWithReplay": "Play With Replay"
         },
         "Main": {
             "MessageOfTheDay": "<align=center><size=32><b>Welcome to the v0.13 Nightly!</b></size></align>\n\nv0.13 adds Pro Keys to the game, as well as reintroducing Pro Guitar/Bass after it was removed in v0.12 due to time constraints. Please let us know how these instruments feel, as well as any bugs you find and missing features.\n\nInstrument engine code has once again gone through major changes to facilitate producing replays with 1:1 results to the original gameplay. <b>If you encounter any inconsistent replay results, report it to the YARG team on Discord or GitHub.</b>\n\nIf you previously played on the v0.12 nightly, all of your settings will be reset. This is due to nightly builds now using a separate location for data storage. Your nightly settings/scores will not persist to stable versions of YARG, and vice versa.\n\nAs we previously announced, <b>we do not recommend playing nightly full time, instead only for testing.</b> Nightly is now going to be much more unstable with many more bugs and unfinished systems.\n\n<b>If you have any feedback, please let us know on Discord or GitHub.</b>\n\nHave fun!",


### PR DESCRIPTION
This PR adds a feature allowing users to play along with a selected replay by selecting a replay from the history screen and pressing the orange menu button. This launches into the usual difficulty select screen. Upon completion, the score screen is shown and the combined replay is saved as a new replay, allowing for a single player to build up a full band playthrough one instrument at a time.

~~Draft because this has so far only been tested with five fret and drums.~~