### PR TITLE
Handle charts with missing initial range shift

### DIFF
--- a/Assets/Script/Gameplay/Player/FiveFretPlayer.cs
+++ b/Assets/Script/Gameplay/Player/FiveFretPlayer.cs
@@ -501,12 +501,10 @@ namespace YARG.Gameplay.Player
 
         private void InitializeRangeShift(double time = 0)
         {
+            var firstShiftAfterFirstNote = false;
             _rangeShiftEventQueue.Clear();
             // Default to all frets on
-            for (int i = 0; i < _fretArray.FretCount; i++)
-            {
-                _activeFrets[i] = true;
-            }
+            SetDefaultActiveFrets();
 
             // No range shifts, so just return
             if (_allRangeShiftEvents.Length < 1)
@@ -514,11 +512,22 @@ namespace YARG.Gameplay.Player
                 return;
             }
 
+            // Now that we know there is at least one range shift, figure out if it is after the first note
+            if (_allRangeShiftEvents[0].Time > Notes[0].Time)
+            {
+                firstShiftAfterFirstNote = true;
+            }
+
             if (_allRangeShiftEvents.Length == 1)
             {
                 // There are no actual shifts (or we aren't shifting because of range compression), but we should dim unused frets
                 CurrentRange = _allRangeShiftEvents[0];
-                SetActiveFretsForShiftEvent(CurrentRange);
+                // If the range shift is after the first note, leave all the frets on because chart is broke
+                if (!firstShiftAfterFirstNote)
+                {
+                    SetActiveFretsForShiftEvent(CurrentRange);
+                }
+
                 return;
             }
 
@@ -547,7 +556,15 @@ namespace YARG.Gameplay.Player
             }
 
             CurrentRange = mostRecentEvent;
-            SetActiveFretsForShiftEvent(CurrentRange);
+            if (time < mostRecentEvent.Time)
+            {
+                // If we get here, the only range shifts are in the future
+                SetDefaultActiveFrets();
+            }
+            else
+            {
+                SetActiveFretsForShiftEvent(CurrentRange);
+            }
 
             // Figure out where the indicators should go
             var beatlines = Beatlines
@@ -624,6 +641,17 @@ namespace YARG.Gameplay.Player
             {
                 newFrets[i] = true;
             }
+
+            if (!newFrets.SequenceEqual(_activeFrets))
+            {
+                _activeFrets = newFrets;
+                _fretArray.UpdateFretActiveState(_activeFrets);
+            }
+        }
+
+        private void SetDefaultActiveFrets()
+        {
+            bool[] newFrets = { true, true, true, true, true };
 
             if (!newFrets.SequenceEqual(_activeFrets))
             {

--- a/Assets/Script/Gameplay/Visuals/Fret/Fret.cs
+++ b/Assets/Script/Gameplay/Visuals/Fret/Fret.cs
@@ -289,10 +289,32 @@ namespace YARG.Gameplay.Visuals
                 _colorChangeEnabled = false;
                 _fadeAmount = 0.0f;
 
-                if (_fadeAmount >= 1.0f)
+                if (_fadeDirection)
                 {
-                    _colorChangeEnabled = false;
-                    _fadeAmount = 0.0f;
+                    // Fading in
+                    foreach (var material in _topMaterials)
+                    {
+                        material.color = _originalUnityTopColor;
+                    }
+
+                    foreach (var material in _innerMaterials)
+                    {
+                        // Why was this _originalUnityTopColor?
+                        material.color = _originalUnityInnerColor;
+                    }
+                }
+                else
+                {
+                    // Fading out
+                    foreach (var material in _topMaterials)
+                    {
+                        material.color = _inactiveColor;
+                    }
+
+                    foreach (var material in _innerMaterials)
+                    {
+                        material.color = _inactiveColor;
+                    }
                 }
             }
         }


### PR DESCRIPTION
It turns out that some of the YARG DLC charts have range shifts in the middle of the chart, but do not include one at the beginning.

This PR changes some logic in FiveFretPlayer so that no frets are dimmed until the first range shift if there is no range shift event prior to the first note of the chart.