### PR TITLE
Generate extra beatlines after the end of a chart

### DIFF
--- a/Assets/Script/Gameplay/GameManager.Loading.cs
+++ b/Assets/Script/Gameplay/GameManager.Loading.cs
@@ -282,9 +282,6 @@ namespace YARG.Gameplay
 
         private void FinalizeChart()
         {
-            BeatEventHandler = new BeatEventHandler(Chart.SyncTrack);
-            _chartLoaded?.Invoke(Chart);
-
             double audioLength = _mixer.Length;
             double chartLength = Chart.GetEndTime();
             double endTime = Chart.GetEndEvent()?.Time ?? -1;
@@ -305,6 +302,13 @@ namespace YARG.Gameplay
             {
                 SongLength = endTime;
             }
+
+            // Make sure enough beatlines have been generated to cover the song end delay
+            Chart.SyncTrack.GenerateBeatlines(SongLength + SONG_END_DELAY, true);
+
+            BeatEventHandler = new BeatEventHandler(Chart.SyncTrack);
+            _chartLoaded?.Invoke(Chart);
+
             _songLoaded?.Invoke();
         }
 


### PR DESCRIPTION
This PR generates extra beatlines to cover the entire song length plus end delay so that beat events continue to fire until the score screen is displayed. The primary motivation for this so that the 5GS progress pulsing of the star meter doesn't end before we go to the score screen.

GameManager.FinalizeChart calls SyncTrack.GenerateBeatlines once the complete length of the song has been determined.

Requires YARG.Core PR YARC-Official/YARG.Core#252