### PR TITLE
Expand the light manager in general

### DIFF
--- a/Assets/Script/Venue/Lights/LightManager.Cues.cs
+++ b/Assets/Script/Venue/Lights/LightManager.Cues.cs
@@ -104,14 +104,14 @@ namespace YARG.Venue
 			else if (location == VenueLightLocation.Center)
 			{
 				target = Color.white;
-				targetint = 0.5f;
+				targetint = 0.1f;
 			}
 			else
 			{
-				current.Intensity = Mathf.Lerp(current.Intensity, 0f, Time.deltaTime * speed);
+				targetint = 0f;
 			}
-			current.Color = Color.Lerp(current.Color ?? Color.white, target, Time.deltaTime * 25f);
-			current.Intensity = Mathf.Lerp(current.Intensity, targetint, Time.deltaTime * 30f);
+			current.Color = Color.Lerp(current.Color ?? Color.white, target, Time.deltaTime * speed);
+			current.Intensity = Mathf.Lerp(current.Intensity, targetint, Time.deltaTime * speed);
 			return current;
         }
 

--- a/Assets/Script/Venue/Lights/LightManager.Cues.cs
+++ b/Assets/Script/Venue/Lights/LightManager.Cues.cs
@@ -4,6 +4,9 @@ namespace YARG.Venue
 {
     public partial class LightManager
     {
+		private Color target;
+		private float targetint;
+		
 		private LightState Default(LightState current, VenueLightLocation location, Gradient gradient)
         {
 			if (AnimationFrame < 1)
@@ -30,7 +33,8 @@ namespace YARG.Venue
 					_							=> gradient.Evaluate(Mathf.Repeat(AnimationFrame+1,2)/2f)
 				};
 			}
-			current.Intensity = 1f;
+			targetint = 1f;
+			current.Intensity = Mathf.Lerp(current.Intensity, targetint, Time.deltaTime * 60f);
 
             current.Delta += Time.deltaTime * _gradientLightingSpeed;
             if (current.Delta > 1f)
@@ -45,11 +49,11 @@ namespace YARG.Venue
         {
 			if (AnimationFrame < 1)
 			{
-				current.Color = gradient.Evaluate(current.Delta);
+				target = gradient.Evaluate(current.Delta);
 			}
 			else
 			{
-				current.Color = location switch
+				target = location switch
 				{
 					VenueLightLocation.Right or
 					VenueLightLocation.Left or
@@ -57,7 +61,9 @@ namespace YARG.Venue
 					_							=> gradient.Evaluate(Mathf.Repeat(AnimationFrame,2)/2f)
 				};
 			}
-			current.Intensity = 1f;
+			targetint = 1f;
+			current.Color = Color.Lerp(current.Color ?? Color.white, target, Time.deltaTime * 40f);
+			current.Intensity = Mathf.Lerp(current.Intensity, targetint, Time.deltaTime * 60f);
 
             current.Delta += Time.deltaTime * _gradientLightingSpeed;
             if (current.Delta > 1f)
@@ -92,18 +98,20 @@ namespace YARG.Venue
         {
 			if (location == VenueLightLocation.Front)
 			{
-				current.Color = _silhouetteColor;
-				current.Intensity = 1f;
+				target = _silhouetteColor;
+				targetint = 1f;
 			}
 			else if (location == VenueLightLocation.Center)
 			{
-				current.Color = Color.white;
-				current.Intensity = 0.5f;
+				target = Color.white;
+				targetint = 0.5f;
 			}
 			else
 			{
 				current.Intensity = Mathf.Lerp(current.Intensity, 0f, Time.deltaTime * speed);
 			}
+			current.Color = Color.Lerp(current.Color ?? Color.white, target, Time.deltaTime * 40f);
+			current.Intensity = Mathf.Lerp(current.Intensity, targetint, Time.deltaTime * 60f);
 			return current;
         }
 
@@ -116,15 +124,19 @@ namespace YARG.Venue
 
         private LightState Strobe(LightState current)
         {
-			current.Color = Color.white;
-            current.Intensity = AnimationFrame % 2 == 0 ? 1f : 0f;
+			target = Color.white;
+            targetint = AnimationFrame % 2 == 0 ? 1f : 0f;
+			current.Color = Color.Lerp(current.Color ?? Color.white, target, Time.deltaTime * 80f);
+			current.Intensity = Mathf.Lerp(current.Intensity, targetint, Time.deltaTime * 80f);
             return current;
         }
 		
         private LightState Stomp(LightState current, Gradient gradient)
         {
-			current.Color = ((gradient.Evaluate(current.Delta) + Color.white) * 0.5f);
-            current.Intensity = AnimationFrame % 2 == 0 ? 1f : 0f;
+			target = ((gradient.Evaluate(current.Delta) + Color.white) * 0.5f);
+            targetint = AnimationFrame % 2 == 0 ? 1f : 0f;
+			current.Color = Color.Lerp(current.Color ?? Color.white, target, Time.deltaTime * 40f);
+			current.Intensity = Mathf.Lerp(current.Intensity, targetint, Time.deltaTime * 60f);
             return current;
         }
 		
@@ -132,14 +144,15 @@ namespace YARG.Venue
         {
             if (location == VenueLightLocation.Back)
             {
-                current.Intensity = 1f;
-                current.Color = _silhouetteColor;
+                targetint = 1f;
+                target = _silhouetteColor;
             }
             else
             {
-                current.Intensity = 0f;
+                targetint = 0f;
             }
-
+			current.Color = Color.Lerp(current.Color ?? Color.white, target, Time.deltaTime * 40f);
+			current.Intensity = Mathf.Lerp(current.Intensity, targetint, Time.deltaTime * 60f);
             return current;
         }
 
@@ -147,31 +160,35 @@ namespace YARG.Venue
         {
             if (location == VenueLightLocation.Crowd || location == VenueLightLocation.Front || location == VenueLightLocation.Center)
             {
-                current.Intensity = 0f;
+                targetint = 0f;
             }
             else
             {
-                current.Intensity = 1f;
-                current.Color = location switch
+                targetint = 1f;
+                target = location switch
                 {
                     VenueLightLocation.Back => Color.white,
                     _                         => _silhouetteColor
                 };
             }
-
+			current.Color = Color.Lerp(current.Color ?? Color.white, target, Time.deltaTime * 40f);
+			current.Intensity = Mathf.Lerp(current.Intensity, targetint, Time.deltaTime * 60f);
             return current;
         }
 
         private LightState Searchlights(LightState current, VenueLightLocation location,
             Gradient gradient)
         {
-            current.Intensity = 1f;
-            current.Color = location switch
+            targetint = 1f;
+            target = location switch
             {
                 VenueLightLocation.Right or
                 VenueLightLocation.Left  => Color.white,
                 _                        => gradient.Evaluate(current.Delta),
             };
+			
+			current.Color = Color.Lerp(current.Color ?? Color.white, target, Time.deltaTime * 40f);
+			current.Intensity = Mathf.Lerp(current.Intensity, targetint, Time.deltaTime * 60f);
 			
 			current.Delta += Time.deltaTime * _gradientLightingSpeed;
             if (current.Delta > 1f)

--- a/Assets/Script/Venue/Lights/LightManager.Cues.cs
+++ b/Assets/Script/Venue/Lights/LightManager.Cues.cs
@@ -34,7 +34,7 @@ namespace YARG.Venue
 				};
 			}
 			targetint = 1f;
-			current.Intensity = Mathf.Lerp(current.Intensity, targetint, Time.deltaTime * 60f);
+			current.Intensity = Mathf.Lerp(current.Intensity, targetint, Time.deltaTime * 30f);
 
             current.Delta += Time.deltaTime * _gradientLightingSpeed;
             if (current.Delta > 1f)
@@ -62,8 +62,8 @@ namespace YARG.Venue
 				};
 			}
 			targetint = 1f;
-			current.Color = Color.Lerp(current.Color ?? Color.white, target, Time.deltaTime * 40f);
-			current.Intensity = Mathf.Lerp(current.Intensity, targetint, Time.deltaTime * 60f);
+			current.Color = Color.Lerp(current.Color ?? Color.white, target, Time.deltaTime * 25f);
+			current.Intensity = Mathf.Lerp(current.Intensity, targetint, Time.deltaTime * 30f);
 
             current.Delta += Time.deltaTime * _gradientLightingSpeed;
             if (current.Delta > 1f)
@@ -110,8 +110,8 @@ namespace YARG.Venue
 			{
 				current.Intensity = Mathf.Lerp(current.Intensity, 0f, Time.deltaTime * speed);
 			}
-			current.Color = Color.Lerp(current.Color ?? Color.white, target, Time.deltaTime * 40f);
-			current.Intensity = Mathf.Lerp(current.Intensity, targetint, Time.deltaTime * 60f);
+			current.Color = Color.Lerp(current.Color ?? Color.white, target, Time.deltaTime * 25f);
+			current.Intensity = Mathf.Lerp(current.Intensity, targetint, Time.deltaTime * 30f);
 			return current;
         }
 
@@ -126,8 +126,8 @@ namespace YARG.Venue
         {
 			target = Color.white;
             targetint = AnimationFrame % 2 == 0 ? 1f : 0f;
-			current.Color = Color.Lerp(current.Color ?? Color.white, target, Time.deltaTime * 80f);
-			current.Intensity = Mathf.Lerp(current.Intensity, targetint, Time.deltaTime * 80f);
+			current.Color = Color.Lerp(current.Color ?? Color.white, target, Time.deltaTime * 50f);
+			current.Intensity = Mathf.Lerp(current.Intensity, targetint, Time.deltaTime * 50f);
             return current;
         }
 		
@@ -135,8 +135,8 @@ namespace YARG.Venue
         {
 			target = ((gradient.Evaluate(current.Delta) + Color.white) * 0.5f);
             targetint = AnimationFrame % 2 == 0 ? 1f : 0f;
-			current.Color = Color.Lerp(current.Color ?? Color.white, target, Time.deltaTime * 40f);
-			current.Intensity = Mathf.Lerp(current.Intensity, targetint, Time.deltaTime * 60f);
+			current.Color = Color.Lerp(current.Color ?? Color.white, target, Time.deltaTime * 25f);
+			current.Intensity = Mathf.Lerp(current.Intensity, targetint, Time.deltaTime * 30f);
             return current;
         }
 		
@@ -151,8 +151,8 @@ namespace YARG.Venue
             {
                 targetint = 0f;
             }
-			current.Color = Color.Lerp(current.Color ?? Color.white, target, Time.deltaTime * 40f);
-			current.Intensity = Mathf.Lerp(current.Intensity, targetint, Time.deltaTime * 60f);
+			current.Color = Color.Lerp(current.Color ?? Color.white, target, Time.deltaTime * 25f);
+			current.Intensity = Mathf.Lerp(current.Intensity, targetint, Time.deltaTime * 30f);
             return current;
         }
 
@@ -171,8 +171,8 @@ namespace YARG.Venue
                     _                         => _silhouetteColor
                 };
             }
-			current.Color = Color.Lerp(current.Color ?? Color.white, target, Time.deltaTime * 40f);
-			current.Intensity = Mathf.Lerp(current.Intensity, targetint, Time.deltaTime * 60f);
+			current.Color = Color.Lerp(current.Color ?? Color.white, target, Time.deltaTime * 25f);
+			current.Intensity = Mathf.Lerp(current.Intensity, targetint, Time.deltaTime * 30f);
             return current;
         }
 
@@ -187,8 +187,8 @@ namespace YARG.Venue
                 _                        => gradient.Evaluate(current.Delta),
             };
 			
-			current.Color = Color.Lerp(current.Color ?? Color.white, target, Time.deltaTime * 40f);
-			current.Intensity = Mathf.Lerp(current.Intensity, targetint, Time.deltaTime * 60f);
+			current.Color = Color.Lerp(current.Color ?? Color.white, target, Time.deltaTime * 25f);
+			current.Intensity = Mathf.Lerp(current.Intensity, targetint, Time.deltaTime * 30f);
 			
 			current.Delta += Time.deltaTime * _gradientLightingSpeed;
             if (current.Delta > 1f)

--- a/Assets/Script/Venue/Lights/LightManager.Cues.cs
+++ b/Assets/Script/Venue/Lights/LightManager.Cues.cs
@@ -7,6 +7,7 @@ namespace YARG.Venue
         private LightState AutoGradient(LightState current, Gradient gradient)
         {
             current.Color = gradient.Evaluate(current.Delta);
+			current.Intensity = 1f;
 
             current.Delta += Time.deltaTime * _gradientLightingSpeed;
             if (current.Delta > 1f)

--- a/Assets/Script/Venue/Lights/LightManager.Cues.cs
+++ b/Assets/Script/Venue/Lights/LightManager.Cues.cs
@@ -4,7 +4,44 @@ namespace YARG.Venue
 {
     public partial class LightManager
     {
-        private LightState AutoGradient(LightState current, VenueLightLocation location, Gradient gradient)
+		private LightState Default(LightState current, VenueLightLocation location, Gradient gradient)
+        {
+			if (AnimationFrame < 1)
+			{
+				current.Color = null;
+			}
+			else if (AnimationFrame % 2 == 0)
+			{
+				current.Color = location switch
+				{
+					VenueLightLocation.Right or
+					VenueLightLocation.Left or
+					VenueLightLocation.Crowd 	=> gradient.Evaluate(Mathf.Repeat(AnimationFrame+1,2)/2f),
+					_							=> null
+				};
+			}
+			else
+			{
+				current.Color = location switch
+				{
+					VenueLightLocation.Right or
+					VenueLightLocation.Left or
+					VenueLightLocation.Crowd 	=> null,
+					_							=> gradient.Evaluate(Mathf.Repeat(AnimationFrame+1,2)/2f)
+				};
+			}
+			current.Intensity = 1f;
+
+            current.Delta += Time.deltaTime * _gradientLightingSpeed;
+            if (current.Delta > 1f)
+            {
+                current.Delta = 0f;
+            }
+
+            return current;
+        }
+		
+		private LightState AutoGradient(LightState current, VenueLightLocation location, Gradient gradient)
         {
 			if (AnimationFrame < 1)
 			{
@@ -53,7 +90,7 @@ namespace YARG.Venue
 
         private LightState Flare(LightState current, float speed)
         {
-            current.Intensity = Mathf.Lerp(current.Intensity, 1f, Time.deltaTime * speed);
+            current.Intensity = Mathf.Lerp(current.Intensity, 2f, Time.deltaTime * speed);
             current.Color = Color.Lerp(current.Color ?? Color.white, Color.white, Time.deltaTime * speed);
             return current;
         }
@@ -66,7 +103,7 @@ namespace YARG.Venue
 
         private LightState Silhouette(LightState current, VenueLightLocation location)
         {
-            if (location == VenueLightLocation.Crowd)
+            if (location == VenueLightLocation.Crowd || location == VenueLightLocation.Front)
             {
                 current.Intensity = 0f;
             }

--- a/Assets/Script/Venue/Lights/LightManager.Cues.cs
+++ b/Assets/Script/Venue/Lights/LightManager.Cues.cs
@@ -1,143 +1,315 @@
-﻿using UnityEngine;
+using System.Collections.Generic;
+using UnityEngine;
+using YARG.Core.Chart;
+using YARG.Core.Extensions;
+using YARG.Gameplay;
+using YARG.Playback;
+using Random = UnityEngine.Random;
 
 namespace YARG.Venue
 {
-    public partial class LightManager
+    public partial class LightManager : GameplayBehaviour
     {
-		private LightState Default(LightState current, VenueLightLocation location, Gradient gradient)
+        public struct LightState
         {
-			if (AnimationFrame < 1)
-			{
-				current.Color = null;
-			}
-			else if (AnimationFrame % 2 == 0)
-			{
-				current.Color = location switch
-				{
-					VenueLightLocation.Right or
-					VenueLightLocation.Left or
-					VenueLightLocation.Crowd 	=> gradient.Evaluate(Mathf.Repeat(AnimationFrame+1,2)/2f),
-					_							=> null
-				};
-			}
-			else
-			{
-				current.Color = location switch
-				{
-					VenueLightLocation.Right or
-					VenueLightLocation.Left or
-					VenueLightLocation.Crowd 	=> null,
-					_							=> gradient.Evaluate(Mathf.Repeat(AnimationFrame+1,2)/2f)
-				};
-			}
-			current.Intensity = 1f;
+            /// <summary>
+            /// The intensity of the light between <c>0</c> and <c>1</c>. <c>1</c> is the default value.
+            /// </summary>
+            public float Intensity;
 
-            current.Delta += Time.deltaTime * _gradientLightingSpeed;
-            if (current.Delta > 1f)
-            {
-                current.Delta = 0f;
-            }
+            /// <summary>
+            /// The color of the light. <see cref="Intensity"/> should be taken into consideration.
+            /// <c>null</c> indicates default.
+            /// </summary>
+            public Color? Color;
 
-            return current;
+            public float Delta;
         }
+
+        public LightingType Animation { get; private set; }
+        public int AnimationFrame { get; private set; }
+
+        private LightState[] _lightStates;
+        public LightState GenericLightState => _lightStates[(int) VenueLightLocation.Generic];
+		public LightState LeftLightState => _lightStates[(int) VenueLightLocation.Left];
+		public LightState RightLightState => _lightStates[(int) VenueLightLocation.Right];
+		public LightState FrontLightState => _lightStates[(int) VenueLightLocation.Front];
+		public LightState BackLightState => _lightStates[(int) VenueLightLocation.Back];
+		public LightState CenterLightState => _lightStates[(int) VenueLightLocation.Center];
+		public LightState CrowdLightState => _lightStates[(int) VenueLightLocation.Crowd];
+
+        [SerializeField]
+        private float _gradientLightingSpeed = 0.125f;
 		
-		private LightState AutoGradient(LightState current, VenueLightLocation location, Gradient gradient)
-        {
-			if (AnimationFrame < 1)
-			{
-				current.Color = gradient.Evaluate(current.Delta);
-			}
-			else
-			{
-				current.Color = location switch
-				{
-					VenueLightLocation.Right or
-					VenueLightLocation.Left or
-					VenueLightLocation.Crowd 	=> gradient.Evaluate(Mathf.Repeat(AnimationFrame+1,2)/2f),
-					_							=> gradient.Evaluate(Mathf.Repeat(AnimationFrame,2)/2f)
-				};
-			}
-			current.Intensity = 1f;
+		private float _initialGradientSpeed;
+		
+        [SerializeField]
+        private float _gradientRandomness = 0.5f;
 
-            current.Delta += Time.deltaTime * _gradientLightingSpeed;
-            if (current.Delta > 1f)
+        [Space]
+        [SerializeField]
+        private Color[] _warmColors;
+        [SerializeField]
+        private Color[] _coolColors;
+        [SerializeField]
+        private Color[] _dissonantColors;
+        [SerializeField]
+        private Color[] _harmoniousColors;
+        [SerializeField]
+        private Color _silhouetteColor;
+
+        private List<LightingEvent> _lightingEvents;
+
+        private Gradient _warmGradient;
+        private Gradient _coolGradient;
+        private Gradient _dissonantGradient;
+        private Gradient _harmoniousGradient;
+
+        private int _lightingEventIndex;
+        private int _beatIndex;
+
+        protected override void OnChartLoaded(SongChart chart)
+        {
+            _lightStates = new LightState[EnumExtensions<VenueLightLocation>.Count];
+
+            _lightingEvents = chart.VenueTrack.Lighting;
+
+            // If the color arrays are empty, add basic ones for safety
+
+            if (_warmColors is not { Length: > 0 })
             {
-                current.Delta = 0f;
-            }
-
-            return current;
-        }
-
-        private LightState AutoGradientSplit(LightState current, VenueLightLocation location,
-            Gradient innerGradient, Gradient outerGradient)
-        {
-            var gradient = location switch
-            {
-                VenueLightLocation.Right or
-                VenueLightLocation.Left or
-                VenueLightLocation.Crowd => outerGradient,
-                _                        => innerGradient,
-            };
-
-            return AutoGradient(current, location, gradient);
-        }
-
-        private LightState BlackOut(LightState current, float speed)
-        {
-            current.Intensity = Mathf.Lerp(current.Intensity, 0f, Time.deltaTime * speed);
-            return current;
-        }
-
-        private LightState Flare(LightState current, float speed)
-        {
-            current.Intensity = Mathf.Lerp(current.Intensity, 2f, Time.deltaTime * speed);
-            current.Color = Color.Lerp(current.Color ?? Color.white, Color.white, Time.deltaTime * speed);
-            return current;
-        }
-
-        private LightState Strobe(LightState current)
-        {
-            current.Intensity = AnimationFrame % 2 == 0 ? 1f : 0f;
-            return current;
-        }
-
-        private LightState Silhouette(LightState current, VenueLightLocation location)
-        {
-            if (location == VenueLightLocation.Crowd || location == VenueLightLocation.Front)
-            {
-                current.Intensity = 0f;
-            }
-            else
-            {
-                current.Intensity = 1f;
-                current.Color = location switch
+                _warmColors = new[]
                 {
-                    VenueLightLocation.Center => Color.white,
-                    _                         => _silhouetteColor
+                    Color.red,
+                    Color.yellow
                 };
             }
 
-            return current;
-        }
-
-        private LightState Searchlights(LightState current, VenueLightLocation location,
-            Gradient gradient)
-        {
-            current.Intensity = 1f;
-            current.Color = location switch
+            if (_coolColors is not { Length: > 0 })
             {
-                VenueLightLocation.Right or
-                VenueLightLocation.Left  => Color.white,
-                _                        => gradient.Evaluate(current.Delta),
-            };
-			
-			current.Delta += Time.deltaTime * _gradientLightingSpeed;
-            if (current.Delta > 1f)
-            {
-                current.Delta = 0f;
+                _coolColors = new[]
+                {
+                    Color.blue,
+                    Color.green
+                };
             }
 
-            return current;
+            if (_dissonantColors is not { Length: > 0 })
+            {
+                _dissonantColors = new[]
+                {
+                    Color.red,
+                    Color.green,
+                    Color.blue,
+                };
+            }
+
+            if (_harmoniousColors is not { Length: > 0 })
+            {
+                _harmoniousColors = new[]
+                {
+                    Color.yellow,
+                    Color.red,
+                    Color.blue,
+                };
+            }			
+		
+			// Store gradient speed for temporary Frenzy/BRE speedup
+			_initialGradientSpeed = _gradientLightingSpeed;
+
+            // Setup gradients
+            _warmGradient = CreateGradient(_warmColors);
+            _coolGradient = CreateGradient(_coolColors);
+            _dissonantGradient = CreateGradient(_dissonantColors);
+            _harmoniousGradient = CreateGradient(_harmoniousColors);
+
+            // 1/8th of a beat is a 32nd note
+            GameManager.BeatEventHandler.Subscribe(UpdateLightAnimation, 1f / 8f, mode: TempoMapEventMode.Quarter);
+        }
+
+        protected override void GameplayDestroy()
+        {
+            GameManager.BeatEventHandler.Unsubscribe(UpdateLightAnimation);
+        }
+
+        private void Update()
+        {
+            // Look for new lighting events
+            while (_lightingEventIndex < _lightingEvents.Count &&
+                _lightingEvents[_lightingEventIndex].Time <= GameManager.VisualTime)
+            {
+                var current = _lightingEvents[_lightingEventIndex];
+
+                switch (current.Type)
+                {
+                    case LightingType.KeyframeNext:
+                        AnimationFrame++;
+                        break;
+                    case LightingType.KeyframePrevious:
+                        AnimationFrame--;
+                        break;
+                    case LightingType.KeyframeFirst:
+                        AnimationFrame = 0;
+                        break;
+                    case LightingType.WarmAutomatic:
+                    case LightingType.WarmManual:
+                    case LightingType.CoolAutomatic:
+                    case LightingType.CoolManual:
+                    case LightingType.Verse:
+                    case LightingType.Chorus:
+					case LightingType.Searchlights:
+                        // Add a slight randomness to colored cues
+                        for (int i = 0; i < _lightStates.Length; i++)
+                        {
+                            _lightStates[i].Delta = Random.Range(0f, _gradientRandomness);
+                        }
+
+                        goto default;
+                    default:
+                        Animation = current.Type;
+                        AnimationFrame = 0;
+                        break;
+                }
+
+                _lightingEventIndex++;
+            }
+
+            UpdateLightStates();
+        }
+
+        private void UpdateLightAnimation()
+        {
+            _beatIndex++;
+
+            switch (Animation)
+            {
+                case LightingType.StrobeFast:
+                    AnimationFrame++;
+                    break;
+                case LightingType.StrobeSlow:
+                    if (_beatIndex % 2 == 1)
+                    {
+                        AnimationFrame++;
+                    }
+
+                    break;
+            }
+        }
+
+        private void UpdateLightStates()
+        {
+            for (int i = 0; i < _lightStates.Length; i++)
+            {
+                var location = (VenueLightLocation) i;
+
+                switch (Animation)
+                {
+					case LightingType.Default:
+						_lightStates[i] = Default(_lightStates[i], location, _harmoniousGradient);
+						break;
+                    case LightingType.Verse:
+                        _lightStates[i] = AutoGradientSplit(_lightStates[i], location, _harmoniousGradient, _dissonantGradient);
+						_gradientLightingSpeed = _initialGradientSpeed;
+                        break;
+                    case LightingType.Chorus:
+                        _lightStates[i] = AutoGradientSplit(_lightStates[i], location, _warmGradient, _coolGradient);
+						_gradientLightingSpeed = _initialGradientSpeed;
+                        break;
+                    case LightingType.BlackoutFast:
+                        _lightStates[i] = BlackOut(_lightStates[i], 40f);
+                        break;
+                    case LightingType.BlackoutSlow:
+                        _lightStates[i] = BlackOut(_lightStates[i], 8f);
+                        break;
+                    case LightingType.BlackoutSpotlight:
+                        _lightStates[i] = BlackOutSpot(_lightStates[i], 40f, location);
+                        break;
+                    case LightingType.Dischord:
+						_lightStates[i] = AutoGradient(_lightStates[i], location, _dissonantGradient);
+						_gradientLightingSpeed = _initialGradientSpeed;
+						break;
+                    case LightingType.BigRockEnding:
+                        _lightStates[i] = AutoGradientSplit(_lightStates[i], location, _dissonantGradient, _harmoniousGradient);
+						_gradientLightingSpeed = _initialGradientSpeed*16f;
+                        break;
+                    case LightingType.Frenzy:
+                        _lightStates[i] = AutoGradientSplit(_lightStates[i], location, _dissonantGradient, _harmoniousGradient);
+						_gradientLightingSpeed = _initialGradientSpeed*8f;
+                        break;
+                    case LightingType.CoolAutomatic:
+                    case LightingType.CoolManual:
+					case LightingType.Sweep:
+                        _lightStates[i] = AutoGradient(_lightStates[i], location, _coolGradient);
+						_gradientLightingSpeed = _initialGradientSpeed;
+                        break;
+                    case LightingType.FlareFast:
+                        _lightStates[i] = Flare(_lightStates[i], 40f);
+                        break;
+                    case LightingType.FlareSlow:
+                        _lightStates[i] = Flare(_lightStates[i], 8f);
+                        break;
+                    case LightingType.Harmony:
+                        _lightStates[i] = AutoGradient(_lightStates[i], location, _harmoniousGradient);
+						_gradientLightingSpeed = _initialGradientSpeed;
+                        break;
+                    case LightingType.Silhouettes:
+                        _lightStates[i] = Silhouette(_lightStates[i], location);
+                        break;
+                    case LightingType.SilhouettesSpotlight:
+                        _lightStates[i] = SilhouetteSpot(_lightStates[i], location);
+                        break;
+					case LightingType.Searchlights:
+						_lightStates[i] = Searchlights(_lightStates[i], location, _warmGradient);
+						_gradientLightingSpeed = _initialGradientSpeed;
+						break;
+                    case LightingType.StrobeFast:
+                    case LightingType.StrobeSlow:
+                        _lightStates[i] = Strobe(_lightStates[i]);
+                        break;
+                    case LightingType.Stomp:
+						_lightStates[i] = Stomp(_lightStates[i], _warmGradient);
+						break;
+                    case LightingType.WarmAutomatic:
+                    case LightingType.WarmManual:
+                        _lightStates[i] = AutoGradient(_lightStates[i], location, _warmGradient);
+						_gradientLightingSpeed = _initialGradientSpeed;
+                        break;
+                    default:
+                        _lightStates[i].Intensity = 1f;
+                        _lightStates[i].Color = null;
+                        _lightStates[i].Delta = 0f;
+                        break; 
+                }
+            }
+        }
+
+        public LightState GetLightStateFor(VenueLightLocation location)
+        {
+            return _lightStates[(int) location];
+        }
+
+        private static Gradient CreateGradient(Color[] colors)
+        {
+            var gradient = new Gradient();
+
+            var keys = new GradientColorKey[colors.Length + 1];
+
+            // Make the gradient loop nice without snapping
+            keys[0] = new GradientColorKey(colors[^1], 0f);
+
+            // Add the rest of the colors
+            for (int i = 1; i < keys.Length; i++)
+            {
+                keys[i] = new GradientColorKey(colors[i - 1], 1f / colors.Length * i);
+            }
+
+            // No alpha for gradient
+            gradient.SetKeys(keys, new[]
+            {
+                new GradientAlphaKey(1f, 0f)
+            });
+
+            return gradient;
         }
     }
 }

--- a/Assets/Script/Venue/Lights/LightManager.Cues.cs
+++ b/Assets/Script/Venue/Lights/LightManager.Cues.cs
@@ -4,9 +4,22 @@ namespace YARG.Venue
 {
     public partial class LightManager
     {
-        private LightState AutoGradient(LightState current, Gradient gradient)
+        private LightState AutoGradient(LightState current, VenueLightLocation location, Gradient gradient)
         {
-            current.Color = gradient.Evaluate(current.Delta);
+			if (AnimationFrame < 1)
+			{
+				current.Color = gradient.Evaluate(current.Delta);
+			}
+			else
+			{
+				current.Color = location switch
+				{
+					VenueLightLocation.Right or
+					VenueLightLocation.Left or
+					VenueLightLocation.Crowd 	=> gradient.Evaluate(Mathf.Repeat(AnimationFrame+1,2)/2f),
+					_							=> gradient.Evaluate(Mathf.Repeat(AnimationFrame,2)/2f)
+				};
+			}
 			current.Intensity = 1f;
 
             current.Delta += Time.deltaTime * _gradientLightingSpeed;
@@ -29,7 +42,7 @@ namespace YARG.Venue
                 _                        => innerGradient,
             };
 
-            return AutoGradient(current, gradient);
+            return AutoGradient(current, location, gradient);
         }
 
         private LightState BlackOut(LightState current, float speed)
@@ -65,6 +78,26 @@ namespace YARG.Venue
                     VenueLightLocation.Center => Color.white,
                     _                         => _silhouetteColor
                 };
+            }
+
+            return current;
+        }
+
+        private LightState Searchlights(LightState current, VenueLightLocation location,
+            Gradient gradient)
+        {
+            current.Intensity = 1f;
+            current.Color = location switch
+            {
+                VenueLightLocation.Right or
+                VenueLightLocation.Left  => Color.white,
+                _                        => gradient.Evaluate(current.Delta),
+            };
+			
+			current.Delta += Time.deltaTime * _gradientLightingSpeed;
+            if (current.Delta > 1f)
+            {
+                current.Delta = 0f;
             }
 
             return current;

--- a/Assets/Script/Venue/Lights/LightManager.cs
+++ b/Assets/Script/Venue/Lights/LightManager.cs
@@ -142,19 +142,19 @@ namespace YARG.Venue
 
                 switch (current.Type)
                 {
-                    case LightingType.Keyframe_Next:
+                    case LightingType.KeyframeNext:
                         AnimationFrame++;
                         break;
-                    case LightingType.Keyframe_Previous:
+                    case LightingType.KeyframePrevious:
                         AnimationFrame--;
                         break;
-                    case LightingType.Keyframe_First:
+                    case LightingType.KeyframeFirst:
                         AnimationFrame = 0;
                         break;
-                    case LightingType.Warm_Automatic:
-                    case LightingType.Warm_Manual:
-                    case LightingType.Cool_Automatic:
-                    case LightingType.Cool_Manual:
+                    case LightingType.WarmAutomatic:
+                    case LightingType.WarmManual:
+                    case LightingType.CoolAutomatic:
+                    case LightingType.CoolManual:
                     case LightingType.Verse:
                     case LightingType.Chorus:
 					case LightingType.Searchlights:
@@ -183,10 +183,10 @@ namespace YARG.Venue
 
             switch (Animation)
             {
-                case LightingType.Strobe_Fast:
+                case LightingType.StrobeFast:
                     AnimationFrame++;
                     break;
-                case LightingType.Strobe_Slow:
+                case LightingType.StrobeSlow:
                     if (_beatIndex % 2 == 1)
                     {
                         AnimationFrame++;
@@ -212,10 +212,10 @@ namespace YARG.Venue
                         _lightStates[i] = AutoGradientSplit(_lightStates[i], location, _warmGradient, _coolGradient);
 						_gradientLightingSpeed = _initialGradientSpeed;
                         break;
-                    case LightingType.Blackout_Fast:
+                    case LightingType.BlackoutFast:
                         _lightStates[i] = BlackOut(_lightStates[i], 15f);
                         break;
-                    case LightingType.Blackout_Slow:
+                    case LightingType.BlackoutSlow:
                         _lightStates[i] = BlackOut(_lightStates[i], 10f);
                         break;
                     case LightingType.Dischord:
@@ -230,16 +230,16 @@ namespace YARG.Venue
                         _lightStates[i] = AutoGradientSplit(_lightStates[i], location, _dissonantGradient, _harmoniousGradient);
 						_gradientLightingSpeed = _initialGradientSpeed*4f;
                         break;
-                    case LightingType.Cool_Automatic:
-                    case LightingType.Cool_Manual:
+                    case LightingType.CoolAutomatic:
+                    case LightingType.CoolManual:
 					case LightingType.Sweep:
                         _lightStates[i] = AutoGradient(_lightStates[i], location, _coolGradient);
 						_gradientLightingSpeed = _initialGradientSpeed;
                         break;
-                    case LightingType.Flare_Fast:
+                    case LightingType.FlareFast:
                         _lightStates[i] = Flare(_lightStates[i], 15f);
                         break;
-                    case LightingType.Flare_Slow:
+                    case LightingType.FlareSlow:
                         _lightStates[i] = Flare(_lightStates[i], 10f);
                         break;
                     case LightingType.Harmony:
@@ -247,19 +247,19 @@ namespace YARG.Venue
 						_gradientLightingSpeed = _initialGradientSpeed;
                         break;
                     case LightingType.Silhouettes:
-                    case LightingType.Silhouettes_Spotlight:
+                    case LightingType.SilhouettesSpotlight:
                         _lightStates[i] = Silhouette(_lightStates[i], location);
                         break;
 					case LightingType.Searchlights:
 						_lightStates[i] = Searchlights(_lightStates[i], location, _warmGradient);
 						break;
-                    case LightingType.Strobe_Fast:
-                    case LightingType.Strobe_Slow:
+                    case LightingType.StrobeFast:
+                    case LightingType.StrobeSlow:
                     case LightingType.Stomp:
                         _lightStates[i] = Strobe(_lightStates[i]);
                         break;
-                    case LightingType.Warm_Automatic:
-                    case LightingType.Warm_Manual:
+                    case LightingType.WarmAutomatic:
+                    case LightingType.WarmManual:
                         _lightStates[i] = AutoGradient(_lightStates[i], location, _warmGradient);
 						_gradientLightingSpeed = _initialGradientSpeed;
                         break;
@@ -267,7 +267,7 @@ namespace YARG.Venue
                         _lightStates[i].Intensity = 1f;
                         _lightStates[i].Color = null;
                         _lightStates[i].Delta = 0f;
-                        break;
+                        break; 
                 }
             }
         }

--- a/Assets/Script/Venue/Lights/LightManager.cs
+++ b/Assets/Script/Venue/Lights/LightManager.cs
@@ -216,13 +216,13 @@ namespace YARG.Venue
 						_gradientLightingSpeed = _initialGradientSpeed;
                         break;
                     case LightingType.BlackoutFast:
-                        _lightStates[i] = BlackOut(_lightStates[i], 60f);
+                        _lightStates[i] = BlackOut(_lightStates[i], 30f);
                         break;
                     case LightingType.BlackoutSlow:
                         _lightStates[i] = BlackOut(_lightStates[i], 5f);
                         break;
                     case LightingType.BlackoutSpotlight:
-                        _lightStates[i] = BlackOutSpot(_lightStates[i], 60f, location);
+                        _lightStates[i] = BlackOutSpot(_lightStates[i], 30f, location);
                         break;
                     case LightingType.Dischord:
 						_lightStates[i] = AutoGradient(_lightStates[i], location, _dissonantGradient);
@@ -243,7 +243,7 @@ namespace YARG.Venue
 						_gradientLightingSpeed = _initialGradientSpeed;
                         break;
                     case LightingType.FlareFast:
-                        _lightStates[i] = Flare(_lightStates[i], 60f);
+                        _lightStates[i] = Flare(_lightStates[i], 30f);
                         break;
                     case LightingType.FlareSlow:
                         _lightStates[i] = Flare(_lightStates[i], 5f);

--- a/Assets/Script/Venue/Lights/LightManager.cs
+++ b/Assets/Script/Venue/Lights/LightManager.cs
@@ -204,8 +204,11 @@ namespace YARG.Venue
 
                 switch (Animation)
                 {
+					case LightingType.Default:
+						_lightStates[i] = Default(_lightStates[i], location, _harmoniousGradient);
+						break;
                     case LightingType.Verse:
-                        _lightStates[i] = AutoGradientSplit(_lightStates[i], location, _coolGradient, _warmGradient);
+                        _lightStates[i] = AutoGradientSplit(_lightStates[i], location, _harmoniousGradient, _dissonantGradient);
 						_gradientLightingSpeed = _initialGradientSpeed;
                         break;
                     case LightingType.Chorus:
@@ -213,10 +216,10 @@ namespace YARG.Venue
 						_gradientLightingSpeed = _initialGradientSpeed;
                         break;
                     case LightingType.BlackoutFast:
-                        _lightStates[i] = BlackOut(_lightStates[i], 15f);
+                        _lightStates[i] = BlackOut(_lightStates[i], 40f);
                         break;
                     case LightingType.BlackoutSlow:
-                        _lightStates[i] = BlackOut(_lightStates[i], 10f);
+                        _lightStates[i] = BlackOut(_lightStates[i], 8f);
                         break;
                     case LightingType.Dischord:
 						_lightStates[i] = AutoGradient(_lightStates[i], location, _dissonantGradient);
@@ -224,11 +227,11 @@ namespace YARG.Venue
 						break;
                     case LightingType.BigRockEnding:
                         _lightStates[i] = AutoGradientSplit(_lightStates[i], location, _dissonantGradient, _harmoniousGradient);
-						_gradientLightingSpeed = _initialGradientSpeed*8f;
+						_gradientLightingSpeed = _initialGradientSpeed*16f;
                         break;
                     case LightingType.Frenzy:
                         _lightStates[i] = AutoGradientSplit(_lightStates[i], location, _dissonantGradient, _harmoniousGradient);
-						_gradientLightingSpeed = _initialGradientSpeed*4f;
+						_gradientLightingSpeed = _initialGradientSpeed*8f;
                         break;
                     case LightingType.CoolAutomatic:
                     case LightingType.CoolManual:
@@ -237,10 +240,10 @@ namespace YARG.Venue
 						_gradientLightingSpeed = _initialGradientSpeed;
                         break;
                     case LightingType.FlareFast:
-                        _lightStates[i] = Flare(_lightStates[i], 15f);
+                        _lightStates[i] = Flare(_lightStates[i], 40f);
                         break;
                     case LightingType.FlareSlow:
-                        _lightStates[i] = Flare(_lightStates[i], 10f);
+                        _lightStates[i] = Flare(_lightStates[i], 8f);
                         break;
                     case LightingType.Harmony:
                         _lightStates[i] = AutoGradient(_lightStates[i], location, _harmoniousGradient);
@@ -249,9 +252,11 @@ namespace YARG.Venue
                     case LightingType.Silhouettes:
                     case LightingType.SilhouettesSpotlight:
                         _lightStates[i] = Silhouette(_lightStates[i], location);
+						_gradientLightingSpeed = _initialGradientSpeed;
                         break;
 					case LightingType.Searchlights:
 						_lightStates[i] = Searchlights(_lightStates[i], location, _warmGradient);
+						_gradientLightingSpeed = _initialGradientSpeed;
 						break;
                     case LightingType.StrobeFast:
                     case LightingType.StrobeSlow:

--- a/Assets/Script/Venue/Lights/LightManager.cs
+++ b/Assets/Script/Venue/Lights/LightManager.cs
@@ -216,13 +216,13 @@ namespace YARG.Venue
 						_gradientLightingSpeed = _initialGradientSpeed;
                         break;
                     case LightingType.BlackoutFast:
-                        _lightStates[i] = BlackOut(_lightStates[i], 40f);
+                        _lightStates[i] = BlackOut(_lightStates[i], 60f);
                         break;
                     case LightingType.BlackoutSlow:
-                        _lightStates[i] = BlackOut(_lightStates[i], 8f);
+                        _lightStates[i] = BlackOut(_lightStates[i], 5f);
                         break;
                     case LightingType.BlackoutSpotlight:
-                        _lightStates[i] = BlackOutSpot(_lightStates[i], 40f, location);
+                        _lightStates[i] = BlackOutSpot(_lightStates[i], 60f, location);
                         break;
                     case LightingType.Dischord:
 						_lightStates[i] = AutoGradient(_lightStates[i], location, _dissonantGradient);
@@ -243,10 +243,10 @@ namespace YARG.Venue
 						_gradientLightingSpeed = _initialGradientSpeed;
                         break;
                     case LightingType.FlareFast:
-                        _lightStates[i] = Flare(_lightStates[i], 40f);
+                        _lightStates[i] = Flare(_lightStates[i], 60f);
                         break;
                     case LightingType.FlareSlow:
-                        _lightStates[i] = Flare(_lightStates[i], 8f);
+                        _lightStates[i] = Flare(_lightStates[i], 5f);
                         break;
                     case LightingType.Harmony:
                         _lightStates[i] = AutoGradient(_lightStates[i], location, _harmoniousGradient);

--- a/Assets/Script/Venue/Lights/LightManager.cs
+++ b/Assets/Script/Venue/Lights/LightManager.cs
@@ -34,8 +34,8 @@ namespace YARG.Venue
 		public LightState LeftLightState => _lightStates[(int) VenueLightLocation.Left];
 		public LightState RightLightState => _lightStates[(int) VenueLightLocation.Right];
 		public LightState FrontLightState => _lightStates[(int) VenueLightLocation.Front];
-		public LightState BackLightState => _lightStates[(int) VenueLightLocation.Center];
-		public LightState CenterLightState => _lightStates[(int) VenueLightLocation.Back];
+		public LightState BackLightState => _lightStates[(int) VenueLightLocation.Back];
+		public LightState CenterLightState => _lightStates[(int) VenueLightLocation.Center];
 		public LightState CrowdLightState => _lightStates[(int) VenueLightLocation.Crowd];
 
         [SerializeField]

--- a/Assets/Script/Venue/Lights/LightManager.cs
+++ b/Assets/Script/Venue/Lights/LightManager.cs
@@ -31,6 +31,12 @@ namespace YARG.Venue
 
         private LightState[] _lightStates;
         public LightState GenericLightState => _lightStates[(int) VenueLightLocation.Generic];
+		public LightState LeftLightState => _lightStates[(int) VenueLightLocation.Left];
+		public LightState RightLightState => _lightStates[(int) VenueLightLocation.Right];
+		public LightState FrontLightState => _lightStates[(int) VenueLightLocation.Front];
+		public LightState BackLightState => _lightStates[(int) VenueLightLocation.Center];
+		public LightState CenterLightState => _lightStates[(int) VenueLightLocation.Back];
+		public LightState CrowdLightState => _lightStates[(int) VenueLightLocation.Crowd];
 
         [SerializeField]
         private float _gradientLightingSpeed = 0.125f;

--- a/Assets/Script/Venue/Lights/LightManager.cs
+++ b/Assets/Script/Venue/Lights/LightManager.cs
@@ -221,6 +221,9 @@ namespace YARG.Venue
                     case LightingType.BlackoutSlow:
                         _lightStates[i] = BlackOut(_lightStates[i], 8f);
                         break;
+                    case LightingType.BlackoutSpotlight:
+                        _lightStates[i] = BlackOutSpot(_lightStates[i], 40f, location);
+                        break;
                     case LightingType.Dischord:
 						_lightStates[i] = AutoGradient(_lightStates[i], location, _dissonantGradient);
 						_gradientLightingSpeed = _initialGradientSpeed;
@@ -250,9 +253,10 @@ namespace YARG.Venue
 						_gradientLightingSpeed = _initialGradientSpeed;
                         break;
                     case LightingType.Silhouettes:
-                    case LightingType.SilhouettesSpotlight:
                         _lightStates[i] = Silhouette(_lightStates[i], location);
-						_gradientLightingSpeed = _initialGradientSpeed;
+                        break;
+                    case LightingType.SilhouettesSpotlight:
+                        _lightStates[i] = SilhouetteSpot(_lightStates[i], location);
                         break;
 					case LightingType.Searchlights:
 						_lightStates[i] = Searchlights(_lightStates[i], location, _warmGradient);
@@ -260,9 +264,11 @@ namespace YARG.Venue
 						break;
                     case LightingType.StrobeFast:
                     case LightingType.StrobeSlow:
-                    case LightingType.Stomp:
                         _lightStates[i] = Strobe(_lightStates[i]);
                         break;
+                    case LightingType.Stomp:
+						_lightStates[i] = Stomp(_lightStates[i], _warmGradient);
+						break;
                     case LightingType.WarmAutomatic:
                     case LightingType.WarmManual:
                         _lightStates[i] = AutoGradient(_lightStates[i], location, _warmGradient);

--- a/Assets/Script/Venue/Lights/LightManager.cs
+++ b/Assets/Script/Venue/Lights/LightManager.cs
@@ -40,6 +40,9 @@ namespace YARG.Venue
 
         [SerializeField]
         private float _gradientLightingSpeed = 0.125f;
+		
+		private float _initialGradientSpeed;
+		
         [SerializeField]
         private float _gradientRandomness = 0.5f;
 
@@ -109,7 +112,10 @@ namespace YARG.Venue
                     Color.red,
                     Color.blue,
                 };
-            }
+            }			
+		
+			// Store gradient speed for temporary Frenzy/BRE speedup
+			_initialGradientSpeed = _gradientLightingSpeed;
 
             // Setup gradients
             _warmGradient = CreateGradient(_warmColors);
@@ -136,21 +142,22 @@ namespace YARG.Venue
 
                 switch (current.Type)
                 {
-                    case LightingType.KeyframeNext:
+                    case LightingType.Keyframe_Next:
                         AnimationFrame++;
                         break;
-                    case LightingType.KeyframePrevious:
+                    case LightingType.Keyframe_Previous:
                         AnimationFrame--;
                         break;
-                    case LightingType.KeyframeFirst:
+                    case LightingType.Keyframe_First:
                         AnimationFrame = 0;
                         break;
-                    case LightingType.WarmAutomatic:
-                    case LightingType.WarmManual:
-                    case LightingType.CoolAutomatic:
-                    case LightingType.CoolManual:
+                    case LightingType.Warm_Automatic:
+                    case LightingType.Warm_Manual:
+                    case LightingType.Cool_Automatic:
+                    case LightingType.Cool_Manual:
                     case LightingType.Verse:
                     case LightingType.Chorus:
+					case LightingType.Searchlights:
                         // Add a slight randomness to colored cues
                         for (int i = 0; i < _lightStates.Length; i++)
                         {
@@ -176,10 +183,10 @@ namespace YARG.Venue
 
             switch (Animation)
             {
-                case LightingType.StrobeFast:
+                case LightingType.Strobe_Fast:
                     AnimationFrame++;
                     break;
-                case LightingType.StrobeSlow:
+                case LightingType.Strobe_Slow:
                     if (_beatIndex % 2 == 1)
                     {
                         AnimationFrame++;
@@ -199,46 +206,62 @@ namespace YARG.Venue
                 {
                     case LightingType.Verse:
                         _lightStates[i] = AutoGradientSplit(_lightStates[i], location, _coolGradient, _warmGradient);
+						_gradientLightingSpeed = _initialGradientSpeed;
                         break;
                     case LightingType.Chorus:
                         _lightStates[i] = AutoGradientSplit(_lightStates[i], location, _warmGradient, _coolGradient);
+						_gradientLightingSpeed = _initialGradientSpeed;
                         break;
-                    case LightingType.BlackoutFast:
+                    case LightingType.Blackout_Fast:
                         _lightStates[i] = BlackOut(_lightStates[i], 15f);
                         break;
-                    case LightingType.BlackoutSlow:
+                    case LightingType.Blackout_Slow:
                         _lightStates[i] = BlackOut(_lightStates[i], 10f);
                         break;
-                    case LightingType.BigRockEnding:
                     case LightingType.Dischord:
+						_lightStates[i] = AutoGradient(_lightStates[i], location, _dissonantGradient);
+						_gradientLightingSpeed = _initialGradientSpeed;
+						break;
+                    case LightingType.BigRockEnding:
+                        _lightStates[i] = AutoGradientSplit(_lightStates[i], location, _dissonantGradient, _harmoniousGradient);
+						_gradientLightingSpeed = _initialGradientSpeed*8f;
+                        break;
                     case LightingType.Frenzy:
-                        _lightStates[i] = AutoGradient(_lightStates[i], _dissonantGradient);
+                        _lightStates[i] = AutoGradientSplit(_lightStates[i], location, _dissonantGradient, _harmoniousGradient);
+						_gradientLightingSpeed = _initialGradientSpeed*4f;
                         break;
-                    case LightingType.CoolAutomatic:
-                    case LightingType.CoolManual:
-                        _lightStates[i] = AutoGradient(_lightStates[i], _coolGradient);
+                    case LightingType.Cool_Automatic:
+                    case LightingType.Cool_Manual:
+					case LightingType.Sweep:
+                        _lightStates[i] = AutoGradient(_lightStates[i], location, _coolGradient);
+						_gradientLightingSpeed = _initialGradientSpeed;
                         break;
-                    case LightingType.FlareFast:
+                    case LightingType.Flare_Fast:
                         _lightStates[i] = Flare(_lightStates[i], 15f);
                         break;
-                    case LightingType.FlareSlow:
+                    case LightingType.Flare_Slow:
                         _lightStates[i] = Flare(_lightStates[i], 10f);
                         break;
                     case LightingType.Harmony:
-                        _lightStates[i] = AutoGradient(_lightStates[i], _harmoniousGradient);
+                        _lightStates[i] = AutoGradient(_lightStates[i], location, _harmoniousGradient);
+						_gradientLightingSpeed = _initialGradientSpeed;
                         break;
                     case LightingType.Silhouettes:
-                    case LightingType.SilhouettesSpotlight:
+                    case LightingType.Silhouettes_Spotlight:
                         _lightStates[i] = Silhouette(_lightStates[i], location);
                         break;
-                    case LightingType.StrobeFast:
-                    case LightingType.StrobeSlow:
+					case LightingType.Searchlights:
+						_lightStates[i] = Searchlights(_lightStates[i], location, _warmGradient);
+						break;
+                    case LightingType.Strobe_Fast:
+                    case LightingType.Strobe_Slow:
                     case LightingType.Stomp:
                         _lightStates[i] = Strobe(_lightStates[i]);
                         break;
-                    case LightingType.WarmAutomatic:
-                    case LightingType.WarmManual:
-                        _lightStates[i] = AutoGradient(_lightStates[i], _warmGradient);
+                    case LightingType.Warm_Automatic:
+                    case LightingType.Warm_Manual:
+                        _lightStates[i] = AutoGradient(_lightStates[i], location, _warmGradient);
+						_gradientLightingSpeed = _initialGradientSpeed;
                         break;
                     default:
                         _lightStates[i].Intensity = 1f;

--- a/Assets/Script/Venue/Lights/NeonLightManager.cs
+++ b/Assets/Script/Venue/Lights/NeonLightManager.cs
@@ -68,86 +68,37 @@ namespace YARG.Venue
                 {
                 if (_neonMaterialsFullColor[i].Location == VenueLightLocation.Generic)
                 {
-					if (lightState.Color == null)
-					{
-						_neonMaterialsFullColor[i].Material.SetColor(_emissionColor, _neonMaterialsFullColor[i].InitialColor);
-					}
-					else
-					{
-						_neonMaterialsFullColor[i].Material.SetColor(_emissionColor, lightState.Color.Value);
-					}
+					_neonMaterialsFullColor[i].Material.SetColor(_emissionColor, lightState.Color ?? _neonMaterialsFullColor[i].InitialColor);
 					_neonMaterialsFullColor[i].Material.SetFloat(_emissionMultiplier, lightState.Intensity);
                 }
 				else if (_neonMaterialsFullColor[i].Location == VenueLightLocation.Left)
                 {
-					if (lightStateLeft.Color == null)
-					{
-						_neonMaterialsFullColor[i].Material.SetColor(_emissionColor, _neonMaterialsFullColor[i].InitialColor);
-					}
-					else
-					{
-						_neonMaterialsFullColor[i].Material.SetColor(_emissionColor, lightStateLeft.Color.Value);
-					}
+					_neonMaterialsFullColor[i].Material.SetColor(_emissionColor, lightStateLeft.Color ?? _neonMaterialsFullColor[i].InitialColor);
 					_neonMaterialsFullColor[i].Material.SetFloat(_emissionMultiplier, lightStateLeft.Intensity);
                 }
                 else if (_neonMaterialsFullColor[i].Location == VenueLightLocation.Right)
                 {
-					if (lightStateRight.Color == null)
-					{
-						_neonMaterialsFullColor[i].Material.SetColor(_emissionColor, _neonMaterialsFullColor[i].InitialColor);
-					}
-					else
-					{
-						_neonMaterialsFullColor[i].Material.SetColor(_emissionColor, lightStateRight.Color.Value);
-					}
+					_neonMaterialsFullColor[i].Material.SetColor(_emissionColor, lightStateRight.Color ?? _neonMaterialsFullColor[i].InitialColor);
 					_neonMaterialsFullColor[i].Material.SetFloat(_emissionMultiplier, lightStateRight.Intensity);
                 }
                 else if (_neonMaterialsFullColor[i].Location == VenueLightLocation.Front)
                 {
-					if (lightStateFront.Color == null)
-					{
-						_neonMaterialsFullColor[i].Material.SetColor(_emissionColor, _neonMaterialsFullColor[i].InitialColor);
-					}
-					else
-					{
-						_neonMaterialsFullColor[i].Material.SetColor(_emissionColor, lightStateFront.Color.Value);
-					}
+					_neonMaterialsFullColor[i].Material.SetColor(_emissionColor, lightStateFront.Color ?? _neonMaterialsFullColor[i].InitialColor);
 					_neonMaterialsFullColor[i].Material.SetFloat(_emissionMultiplier, lightStateFront.Intensity);
                 }
                 else if (_neonMaterialsFullColor[i].Location == VenueLightLocation.Back)
                 {
-					if (lightStateBack.Color == null)
-					{
-						_neonMaterialsFullColor[i].Material.SetColor(_emissionColor, _neonMaterialsFullColor[i].InitialColor);
-					}
-					else
-					{
-						_neonMaterialsFullColor[i].Material.SetColor(_emissionColor, lightStateBack.Color.Value);
-					}
+					_neonMaterialsFullColor[i].Material.SetColor(_emissionColor, lightStateBack.Color ?? _neonMaterialsFullColor[i].InitialColor);
 					_neonMaterialsFullColor[i].Material.SetFloat(_emissionMultiplier, lightStateBack.Intensity);
                 }
                 else if (_neonMaterialsFullColor[i].Location == VenueLightLocation.Center)
                 {
-					if (lightStateCenter.Color == null)
-					{
-						_neonMaterialsFullColor[i].Material.SetColor(_emissionColor, _neonMaterialsFullColor[i].InitialColor);
-					}
-					else
-					{
-						_neonMaterialsFullColor[i].Material.SetColor(_emissionColor, lightStateCenter.Color.Value);
-					}
+					_neonMaterialsFullColor[i].Material.SetColor(_emissionColor, lightStateCenter.Color ?? _neonMaterialsFullColor[i].InitialColor);
 					_neonMaterialsFullColor[i].Material.SetFloat(_emissionMultiplier, lightStateCenter.Intensity);
                 }
                 else if (_neonMaterialsFullColor[i].Location == VenueLightLocation.Crowd)
                 {
-					if (lightStateCrowd.Color == null)
-					{
-						_neonMaterialsFullColor[i].Material.SetColor(_emissionColor, _neonMaterialsFullColor[i].InitialColor);
-					}
-					else
-					{
-						_neonMaterialsFullColor[i].Material.SetColor(_emissionColor, lightStateCrowd.Color.Value);
-					}
+					_neonMaterialsFullColor[i].Material.SetColor(_emissionColor, lightStateCrowd.Color ?? _neonMaterialsFullColor[i].InitialColor);
 					_neonMaterialsFullColor[i].Material.SetFloat(_emissionMultiplier, lightStateCrowd.Intensity);
                 }
             }

--- a/Assets/Script/Venue/Lights/NeonLightManager.cs
+++ b/Assets/Script/Venue/Lights/NeonLightManager.cs
@@ -12,33 +12,185 @@ namespace YARG.Venue
     {
         private static readonly int _emissionMultiplier = Shader.PropertyToID("_Emission_Multiplier");
         private static readonly int _emissionSecondaryColor = Shader.PropertyToID("_Emission_Secondary_Color");
+        private static readonly int _emissionColor = Shader.PropertyToID("_EmissionColor");
 
         [SerializeField]
         private Material[] _neonMaterials;
+		[SerializeField]
+		private Material[] _neonLeftMaterials;
+		[SerializeField]
+		private Material[] _neonRightMaterials;
+		[SerializeField]
+		private Material[] _neonFrontMaterials;
+		[SerializeField]
+		private Material[] _neonBackMaterials;
+		[SerializeField]
+		private Material[] _neonCenterMaterials;
+		[SerializeField]
+		private Material[] _neonCrowdMaterials;
 
         private LightManager _lightManager;
+		private Color _defaultColorLeft;
+		private Color _defaultColorRight;
+		private Color _defaultColorFront;
+		private Color _defaultColorBack;
+		private Color _defaultColorCenter;
+		private Color _defaultColorCrowd;
 
         private void Awake()
         {
             _lightManager = FindObjectOfType<LightManager>();
+			
+			foreach (var material in _neonLeftMaterials)
+			{
+				_defaultColorLeft = material.GetColor(_emissionColor);
+			}
+			
+			foreach (var material in _neonRightMaterials)
+			{
+				_defaultColorRight = material.GetColor(_emissionColor);
+			}
+			
+			foreach (var material in _neonFrontMaterials)
+			{
+				_defaultColorFront = material.GetColor(_emissionColor);
+			}
+			
+			foreach (var material in _neonBackMaterials)
+			{
+				_defaultColorBack = material.GetColor(_emissionColor);
+			}
+			
+			foreach (var material in _neonCenterMaterials)
+			{
+				_defaultColorCenter = material.GetColor(_emissionColor);
+			}
+			
+			foreach (var material in _neonCrowdMaterials)
+			{
+				_defaultColorCrowd = material.GetColor(_emissionColor);
+			}
+			
         }
 
         private void Update()
         {
-            var lightState = _lightManager.GenericLightState;
+            
 
             // Update all of the materials
             foreach (var material in _neonMaterials)
             {
-                material.SetFloat(_emissionMultiplier, lightState.Intensity);
+                var lightState = _lightManager.GenericLightState;
+				material.SetFloat(_emissionMultiplier, lightState.Intensity);
 
                 if (lightState.Color == null)
                 {
-                    material.SetColor(_emissionSecondaryColor, Color.white);
+					material.SetColor(_emissionSecondaryColor, Color.white);
                 }
                 else
                 {
-                    material.SetColor(_emissionSecondaryColor, lightState.Color.Value);
+					material.SetColor(_emissionSecondaryColor, lightState.Color.Value);
+                }
+            }
+			
+			
+
+            foreach (var material in _neonLeftMaterials)
+            {
+                var lightState = _lightManager.LeftLightState;
+				material.SetFloat(_emissionMultiplier, lightState.Intensity);
+
+                if (lightState.Color == null)
+                {
+                    material.SetColor(_emissionColor, _defaultColorLeft);
+                }
+                else
+                {
+					material.SetColor(_emissionColor, lightState.Color.Value);
+                }
+            }
+			
+			
+
+            foreach (var material in _neonRightMaterials)
+            {
+                var lightState = _lightManager.RightLightState;
+				material.SetFloat(_emissionMultiplier, lightState.Intensity);
+
+                if (lightState.Color == null)
+                {
+                    material.SetColor(_emissionColor, _defaultColorRight);
+                }
+                else
+                {
+					material.SetColor(_emissionColor, lightState.Color.Value);
+                }
+            }
+			
+
+            foreach (var material in _neonFrontMaterials)
+            {
+				var lightState = _lightManager.FrontLightState;
+				material.SetFloat(_emissionMultiplier, lightState.Intensity);
+
+                if (lightState.Color == null)
+                {
+                    material.SetColor(_emissionColor, _defaultColorFront);
+                }
+                else
+                {
+					material.SetColor(_emissionColor, lightState.Color.Value);
+                }
+            }
+			
+			
+
+            foreach (var material in _neonBackMaterials)
+            {
+                var lightState = _lightManager.BackLightState;
+				material.SetFloat(_emissionMultiplier, lightState.Intensity);
+
+                if (lightState.Color == null)
+                {
+                    material.SetColor(_emissionColor, _defaultColorBack);
+                }
+                else
+                {
+					material.SetColor(_emissionColor, lightState.Color.Value);
+                }
+            }
+			
+			
+
+            foreach (var material in _neonCenterMaterials)
+            {
+                var lightState = _lightManager.CenterLightState;
+				material.SetFloat(_emissionMultiplier, lightState.Intensity);
+
+                if (lightState.Color == null)
+                {
+                    material.SetColor(_emissionColor, _defaultColorCenter);
+                }
+                else
+                {
+					material.SetColor(_emissionColor, lightState.Color.Value);
+                }
+			}
+			
+			
+
+            foreach (var material in _neonCrowdMaterials)
+            {
+                var lightState = _lightManager.CrowdLightState;
+				material.SetFloat(_emissionMultiplier, lightState.Intensity);
+
+                if (lightState.Color == null)
+                {
+                    material.SetColor(_emissionColor, _defaultColorCrowd);
+                }
+                else
+                {
+					material.SetColor(_emissionColor, lightState.Color.Value);
                 }
             }
         }

--- a/Assets/Script/Venue/Lights/NeonLightManager.cs
+++ b/Assets/Script/Venue/Lights/NeonLightManager.cs
@@ -21,7 +21,7 @@ namespace YARG.Venue
 		public class NeonFullColor {
 			public Material Material;
 			public VenueLightLocation Location;
-			[System.NonSerialized] 
+			// [System.NonSerialized] 
 			public Color InitialColor;
 		}
 		
@@ -41,12 +41,17 @@ namespace YARG.Venue
 
         private void Update()
         {
-            
+			var lightState = _lightManager.GenericLightState;
+			var lightStateLeft = _lightManager.LeftLightState;
+			var lightStateRight = _lightManager.RightLightState;
+			var lightStateFront = _lightManager.FrontLightState;
+			var lightStateBack = _lightManager.BackLightState;
+			var lightStateCenter = _lightManager.CenterLightState;
+			var lightStateCrowd = _lightManager.CrowdLightState;
 
             // Update all of the materials
             foreach (var material in _neonMaterials)
             {
-                var lightState = _lightManager.GenericLightState;
 				material.SetFloat(_emissionMultiplier, lightState.Intensity);
 
                 if (lightState.Color == null)
@@ -59,52 +64,90 @@ namespace YARG.Venue
                 }
             } 
 			
-            for (int i = 0; i < _neonMaterialsFullColor.Length; i++) {
-				var lightState = _lightManager.GenericLightState;
-                var lightStateLeft = _lightManager.LeftLightState;
-				var lightStateRight = _lightManager.RightLightState;
-				var lightStateFront = _lightManager.FrontLightState;
-				var lightStateBack = _lightManager.BackLightState;
-				var lightStateCenter = _lightManager.CenterLightState;
-				var lightStateCrowd = _lightManager.CrowdLightState;
-
-                if (lightState.Color == null)
+            for (int i = 0; i < _neonMaterialsFullColor.Length; i++) 
                 {
-                    _neonMaterialsFullColor[i].Material.SetColor(_emissionColor, _neonMaterialsFullColor[i].InitialColor);
-                }
-                else if (_neonMaterialsFullColor[i].Location == VenueLightLocation.Generic)
+                if (_neonMaterialsFullColor[i].Location == VenueLightLocation.Generic)
                 {
-					_neonMaterialsFullColor[i].Material.SetColor(_emissionColor, lightState.Color.Value);
+					if (lightState.Color == null)
+					{
+						_neonMaterialsFullColor[i].Material.SetColor(_emissionColor, _neonMaterialsFullColor[i].InitialColor);
+					}
+					else
+					{
+						_neonMaterialsFullColor[i].Material.SetColor(_emissionColor, lightState.Color.Value);
+					}
 					_neonMaterialsFullColor[i].Material.SetFloat(_emissionMultiplier, lightState.Intensity);
                 }
 				else if (_neonMaterialsFullColor[i].Location == VenueLightLocation.Left)
                 {
-					_neonMaterialsFullColor[i].Material.SetColor(_emissionColor, lightStateLeft.Color.Value);
+					if (lightStateLeft.Color == null)
+					{
+						_neonMaterialsFullColor[i].Material.SetColor(_emissionColor, _neonMaterialsFullColor[i].InitialColor);
+					}
+					else
+					{
+						_neonMaterialsFullColor[i].Material.SetColor(_emissionColor, lightStateLeft.Color.Value);
+					}
 					_neonMaterialsFullColor[i].Material.SetFloat(_emissionMultiplier, lightStateLeft.Intensity);
                 }
                 else if (_neonMaterialsFullColor[i].Location == VenueLightLocation.Right)
                 {
-					_neonMaterialsFullColor[i].Material.SetColor(_emissionColor, lightStateRight.Color.Value);
+					if (lightStateRight.Color == null)
+					{
+						_neonMaterialsFullColor[i].Material.SetColor(_emissionColor, _neonMaterialsFullColor[i].InitialColor);
+					}
+					else
+					{
+						_neonMaterialsFullColor[i].Material.SetColor(_emissionColor, lightStateRight.Color.Value);
+					}
 					_neonMaterialsFullColor[i].Material.SetFloat(_emissionMultiplier, lightStateRight.Intensity);
                 }
                 else if (_neonMaterialsFullColor[i].Location == VenueLightLocation.Front)
                 {
-					_neonMaterialsFullColor[i].Material.SetColor(_emissionColor, lightStateFront.Color.Value);
+					if (lightStateFront.Color == null)
+					{
+						_neonMaterialsFullColor[i].Material.SetColor(_emissionColor, _neonMaterialsFullColor[i].InitialColor);
+					}
+					else
+					{
+						_neonMaterialsFullColor[i].Material.SetColor(_emissionColor, lightStateFront.Color.Value);
+					}
 					_neonMaterialsFullColor[i].Material.SetFloat(_emissionMultiplier, lightStateFront.Intensity);
                 }
                 else if (_neonMaterialsFullColor[i].Location == VenueLightLocation.Back)
                 {
-					_neonMaterialsFullColor[i].Material.SetColor(_emissionColor, lightStateBack.Color.Value);
+					if (lightStateBack.Color == null)
+					{
+						_neonMaterialsFullColor[i].Material.SetColor(_emissionColor, _neonMaterialsFullColor[i].InitialColor);
+					}
+					else
+					{
+						_neonMaterialsFullColor[i].Material.SetColor(_emissionColor, lightStateBack.Color.Value);
+					}
 					_neonMaterialsFullColor[i].Material.SetFloat(_emissionMultiplier, lightStateBack.Intensity);
                 }
                 else if (_neonMaterialsFullColor[i].Location == VenueLightLocation.Center)
                 {
-					_neonMaterialsFullColor[i].Material.SetColor(_emissionColor, lightStateCenter.Color.Value);
+					if (lightStateCenter.Color == null)
+					{
+						_neonMaterialsFullColor[i].Material.SetColor(_emissionColor, _neonMaterialsFullColor[i].InitialColor);
+					}
+					else
+					{
+						_neonMaterialsFullColor[i].Material.SetColor(_emissionColor, lightStateCenter.Color.Value);
+					}
 					_neonMaterialsFullColor[i].Material.SetFloat(_emissionMultiplier, lightStateCenter.Intensity);
                 }
                 else if (_neonMaterialsFullColor[i].Location == VenueLightLocation.Crowd)
                 {
-					_neonMaterialsFullColor[i].Material.SetColor(_emissionColor, lightStateCrowd.Color.Value);
+					if (lightStateCrowd.Color == null)
+					{
+						_neonMaterialsFullColor[i].Material.SetColor(_emissionColor, _neonMaterialsFullColor[i].InitialColor);
+					}
+					else
+					{
+						_neonMaterialsFullColor[i].Material.SetColor(_emissionColor, lightStateCrowd.Color.Value);
+					}
 					_neonMaterialsFullColor[i].Material.SetFloat(_emissionMultiplier, lightStateCrowd.Intensity);
                 }
             }

--- a/Assets/Script/Venue/Lights/NeonLightManager.cs
+++ b/Assets/Script/Venue/Lights/NeonLightManager.cs
@@ -30,7 +30,7 @@ namespace YARG.Venue
 
         private LightManager _lightManager;
 
-        private void Awake()
+        private void Start()
         {
             _lightManager = FindObjectOfType<LightManager>();
 			

--- a/Assets/Script/Venue/Lights/NeonLightManager.cs
+++ b/Assets/Script/Venue/Lights/NeonLightManager.cs
@@ -21,7 +21,7 @@ namespace YARG.Venue
 		public class NeonFullColor {
 			public Material Material;
 			public VenueLightLocation Location;
-			// [System.NonSerialized] 
+			[System.NonSerialized] 
 			public Color InitialColor;
 		}
 		

--- a/Assets/Script/Venue/Lights/NeonLightManager.cs
+++ b/Assets/Script/Venue/Lights/NeonLightManager.cs
@@ -22,7 +22,6 @@ namespace YARG.Venue
 		public struct NeonFullColor {
 			public Material Material;
 			public VenueLightLocation Location;
-			public VenueSpotLightLocation SpotLocation;
 			[System.NonSerialized] 
 			public Color InitialColor;
 		}

--- a/Assets/Script/Venue/Lights/NeonLightManager.cs
+++ b/Assets/Script/Venue/Lights/NeonLightManager.cs
@@ -16,61 +16,27 @@ namespace YARG.Venue
 
         [SerializeField]
         private Material[] _neonMaterials;
+		
+		[System.Serializable]
+		public class NeonFullColor {
+			public Material Material;
+			public VenueLightLocation Location;
+			[System.NonSerialized] 
+			public Color InitialColor;
+		}
+		
 		[SerializeField]
-		private Material[] _neonLeftMaterials;
-		[SerializeField]
-		private Material[] _neonRightMaterials;
-		[SerializeField]
-		private Material[] _neonFrontMaterials;
-		[SerializeField]
-		private Material[] _neonBackMaterials;
-		[SerializeField]
-		private Material[] _neonCenterMaterials;
-		[SerializeField]
-		private Material[] _neonCrowdMaterials;
+		private NeonFullColor[] _neonMaterialsFullColor;
 
         private LightManager _lightManager;
-		private Color _defaultColorLeft;
-		private Color _defaultColorRight;
-		private Color _defaultColorFront;
-		private Color _defaultColorBack;
-		private Color _defaultColorCenter;
-		private Color _defaultColorCrowd;
 
         private void Awake()
         {
             _lightManager = FindObjectOfType<LightManager>();
 			
-			foreach (var material in _neonLeftMaterials)
-			{
-				_defaultColorLeft = material.GetColor(_emissionColor);
+			for (int i = 0; i < _neonMaterialsFullColor.Length; i++) {
+				_neonMaterialsFullColor[i].InitialColor = (_neonMaterialsFullColor[i].Material.GetColor(_emissionColor));
 			}
-			
-			foreach (var material in _neonRightMaterials)
-			{
-				_defaultColorRight = material.GetColor(_emissionColor);
-			}
-			
-			foreach (var material in _neonFrontMaterials)
-			{
-				_defaultColorFront = material.GetColor(_emissionColor);
-			}
-			
-			foreach (var material in _neonBackMaterials)
-			{
-				_defaultColorBack = material.GetColor(_emissionColor);
-			}
-			
-			foreach (var material in _neonCenterMaterials)
-			{
-				_defaultColorCenter = material.GetColor(_emissionColor);
-			}
-			
-			foreach (var material in _neonCrowdMaterials)
-			{
-				_defaultColorCrowd = material.GetColor(_emissionColor);
-			}
-			
         }
 
         private void Update()
@@ -91,106 +57,55 @@ namespace YARG.Venue
                 {
 					material.SetColor(_emissionSecondaryColor, lightState.Color.Value);
                 }
-            }
+            } 
 			
-			
-
-            foreach (var material in _neonLeftMaterials)
-            {
-                var lightState = _lightManager.LeftLightState;
-				material.SetFloat(_emissionMultiplier, lightState.Intensity);
+            for (int i = 0; i < _neonMaterialsFullColor.Length; i++) {
+				var lightState = _lightManager.GenericLightState;
+                var lightStateLeft = _lightManager.LeftLightState;
+				var lightStateRight = _lightManager.RightLightState;
+				var lightStateFront = _lightManager.FrontLightState;
+				var lightStateBack = _lightManager.BackLightState;
+				var lightStateCenter = _lightManager.CenterLightState;
+				var lightStateCrowd = _lightManager.CrowdLightState;
 
                 if (lightState.Color == null)
                 {
-                    material.SetColor(_emissionColor, _defaultColorLeft);
+                    _neonMaterialsFullColor[i].Material.SetColor(_emissionColor, _neonMaterialsFullColor[i].InitialColor);
                 }
-                else
+                else if (_neonMaterialsFullColor[i].Location == VenueLightLocation.Generic)
                 {
-					material.SetColor(_emissionColor, lightState.Color.Value);
+					_neonMaterialsFullColor[i].Material.SetColor(_emissionColor, lightState.Color.Value);
+					_neonMaterialsFullColor[i].Material.SetFloat(_emissionMultiplier, lightState.Intensity);
                 }
-            }
-			
-			
-
-            foreach (var material in _neonRightMaterials)
-            {
-                var lightState = _lightManager.RightLightState;
-				material.SetFloat(_emissionMultiplier, lightState.Intensity);
-
-                if (lightState.Color == null)
+				else if (_neonMaterialsFullColor[i].Location == VenueLightLocation.Left)
                 {
-                    material.SetColor(_emissionColor, _defaultColorRight);
+					_neonMaterialsFullColor[i].Material.SetColor(_emissionColor, lightStateLeft.Color.Value);
+					_neonMaterialsFullColor[i].Material.SetFloat(_emissionMultiplier, lightStateLeft.Intensity);
                 }
-                else
+                else if (_neonMaterialsFullColor[i].Location == VenueLightLocation.Right)
                 {
-					material.SetColor(_emissionColor, lightState.Color.Value);
+					_neonMaterialsFullColor[i].Material.SetColor(_emissionColor, lightStateRight.Color.Value);
+					_neonMaterialsFullColor[i].Material.SetFloat(_emissionMultiplier, lightStateRight.Intensity);
                 }
-            }
-			
-
-            foreach (var material in _neonFrontMaterials)
-            {
-				var lightState = _lightManager.FrontLightState;
-				material.SetFloat(_emissionMultiplier, lightState.Intensity);
-
-                if (lightState.Color == null)
+                else if (_neonMaterialsFullColor[i].Location == VenueLightLocation.Front)
                 {
-                    material.SetColor(_emissionColor, _defaultColorFront);
+					_neonMaterialsFullColor[i].Material.SetColor(_emissionColor, lightStateFront.Color.Value);
+					_neonMaterialsFullColor[i].Material.SetFloat(_emissionMultiplier, lightStateFront.Intensity);
                 }
-                else
+                else if (_neonMaterialsFullColor[i].Location == VenueLightLocation.Back)
                 {
-					material.SetColor(_emissionColor, lightState.Color.Value);
+					_neonMaterialsFullColor[i].Material.SetColor(_emissionColor, lightStateBack.Color.Value);
+					_neonMaterialsFullColor[i].Material.SetFloat(_emissionMultiplier, lightStateBack.Intensity);
                 }
-            }
-			
-			
-
-            foreach (var material in _neonBackMaterials)
-            {
-                var lightState = _lightManager.BackLightState;
-				material.SetFloat(_emissionMultiplier, lightState.Intensity);
-
-                if (lightState.Color == null)
+                else if (_neonMaterialsFullColor[i].Location == VenueLightLocation.Center)
                 {
-                    material.SetColor(_emissionColor, _defaultColorBack);
+					_neonMaterialsFullColor[i].Material.SetColor(_emissionColor, lightStateCenter.Color.Value);
+					_neonMaterialsFullColor[i].Material.SetFloat(_emissionMultiplier, lightStateCenter.Intensity);
                 }
-                else
+                else if (_neonMaterialsFullColor[i].Location == VenueLightLocation.Crowd)
                 {
-					material.SetColor(_emissionColor, lightState.Color.Value);
-                }
-            }
-			
-			
-
-            foreach (var material in _neonCenterMaterials)
-            {
-                var lightState = _lightManager.CenterLightState;
-				material.SetFloat(_emissionMultiplier, lightState.Intensity);
-
-                if (lightState.Color == null)
-                {
-                    material.SetColor(_emissionColor, _defaultColorCenter);
-                }
-                else
-                {
-					material.SetColor(_emissionColor, lightState.Color.Value);
-                }
-			}
-			
-			
-
-            foreach (var material in _neonCrowdMaterials)
-            {
-                var lightState = _lightManager.CrowdLightState;
-				material.SetFloat(_emissionMultiplier, lightState.Intensity);
-
-                if (lightState.Color == null)
-                {
-                    material.SetColor(_emissionColor, _defaultColorCrowd);
-                }
-                else
-                {
-					material.SetColor(_emissionColor, lightState.Color.Value);
+					_neonMaterialsFullColor[i].Material.SetColor(_emissionColor, lightStateCrowd.Color.Value);
+					_neonMaterialsFullColor[i].Material.SetFloat(_emissionMultiplier, lightStateCrowd.Intensity);
                 }
             }
         }

--- a/Assets/Script/Venue/Lights/NeonLightManager.cs
+++ b/Assets/Script/Venue/Lights/NeonLightManager.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using YARG.Core.Logging;
 
 namespace YARG.Venue
 {
@@ -18,9 +19,10 @@ namespace YARG.Venue
         private Material[] _neonMaterials;
 		
 		[System.Serializable]
-		public class NeonFullColor {
+		public struct NeonFullColor {
 			public Material Material;
 			public VenueLightLocation Location;
+			public VenueSpotLightLocation SpotLocation;
 			[System.NonSerialized] 
 			public Color InitialColor;
 		}
@@ -41,17 +43,10 @@ namespace YARG.Venue
 
         private void Update()
         {
-			var lightState = _lightManager.GenericLightState;
-			var lightStateLeft = _lightManager.LeftLightState;
-			var lightStateRight = _lightManager.RightLightState;
-			var lightStateFront = _lightManager.FrontLightState;
-			var lightStateBack = _lightManager.BackLightState;
-			var lightStateCenter = _lightManager.CenterLightState;
-			var lightStateCrowd = _lightManager.CrowdLightState;
-
             // Update all of the materials
             foreach (var material in _neonMaterials)
             {
+				var lightState = _lightManager.GenericLightState;
 				material.SetFloat(_emissionMultiplier, lightState.Intensity);
 
                 if (lightState.Color == null)
@@ -64,43 +59,58 @@ namespace YARG.Venue
                 }
             } 
 			
-            for (int i = 0; i < _neonMaterialsFullColor.Length; i++) 
-                {
-                if (_neonMaterialsFullColor[i].Location == VenueLightLocation.Generic)
-                {
-					_neonMaterialsFullColor[i].Material.SetColor(_emissionColor, lightState.Color ?? _neonMaterialsFullColor[i].InitialColor);
-					_neonMaterialsFullColor[i].Material.SetFloat(_emissionMultiplier, lightState.Intensity);
-                }
-				else if (_neonMaterialsFullColor[i].Location == VenueLightLocation.Left)
-                {
-					_neonMaterialsFullColor[i].Material.SetColor(_emissionColor, lightStateLeft.Color ?? _neonMaterialsFullColor[i].InitialColor);
-					_neonMaterialsFullColor[i].Material.SetFloat(_emissionMultiplier, lightStateLeft.Intensity);
-                }
-                else if (_neonMaterialsFullColor[i].Location == VenueLightLocation.Right)
-                {
-					_neonMaterialsFullColor[i].Material.SetColor(_emissionColor, lightStateRight.Color ?? _neonMaterialsFullColor[i].InitialColor);
-					_neonMaterialsFullColor[i].Material.SetFloat(_emissionMultiplier, lightStateRight.Intensity);
-                }
-                else if (_neonMaterialsFullColor[i].Location == VenueLightLocation.Front)
-                {
-					_neonMaterialsFullColor[i].Material.SetColor(_emissionColor, lightStateFront.Color ?? _neonMaterialsFullColor[i].InitialColor);
-					_neonMaterialsFullColor[i].Material.SetFloat(_emissionMultiplier, lightStateFront.Intensity);
-                }
-                else if (_neonMaterialsFullColor[i].Location == VenueLightLocation.Back)
-                {
-					_neonMaterialsFullColor[i].Material.SetColor(_emissionColor, lightStateBack.Color ?? _neonMaterialsFullColor[i].InitialColor);
-					_neonMaterialsFullColor[i].Material.SetFloat(_emissionMultiplier, lightStateBack.Intensity);
-                }
-                else if (_neonMaterialsFullColor[i].Location == VenueLightLocation.Center)
-                {
-					_neonMaterialsFullColor[i].Material.SetColor(_emissionColor, lightStateCenter.Color ?? _neonMaterialsFullColor[i].InitialColor);
-					_neonMaterialsFullColor[i].Material.SetFloat(_emissionMultiplier, lightStateCenter.Intensity);
-                }
-                else if (_neonMaterialsFullColor[i].Location == VenueLightLocation.Crowd)
-                {
-					_neonMaterialsFullColor[i].Material.SetColor(_emissionColor, lightStateCrowd.Color ?? _neonMaterialsFullColor[i].InitialColor);
-					_neonMaterialsFullColor[i].Material.SetFloat(_emissionMultiplier, lightStateCrowd.Intensity);
-                }
+            for (int i = 0; i < _neonMaterialsFullColor.Length; i++)
+            {
+				var neon = _neonMaterialsFullColor[i];
+				
+				switch (neon.Location)
+				{
+					case VenueLightLocation.Generic:
+						var lightState = _lightManager.GenericLightState;
+						neon.Material.SetColor(_emissionColor, lightState.Color ?? neon.InitialColor);
+						neon.Material.SetFloat(_emissionMultiplier, lightState.Intensity);
+					break;
+					
+					case VenueLightLocation.Left:
+						var lightStateLeft = _lightManager.LeftLightState;
+						neon.Material.SetColor(_emissionColor, lightStateLeft.Color ?? neon.InitialColor);
+						neon.Material.SetFloat(_emissionMultiplier, lightStateLeft.Intensity);
+					break;
+					
+					case VenueLightLocation.Right:
+						var lightStateRight = _lightManager.RightLightState;
+						neon.Material.SetColor(_emissionColor, lightStateRight.Color ?? neon.InitialColor);
+						neon.Material.SetFloat(_emissionMultiplier, lightStateRight.Intensity);
+					break;
+					
+					case VenueLightLocation.Front:
+						var lightStateFront = _lightManager.FrontLightState;
+						neon.Material.SetColor(_emissionColor, lightStateFront.Color ?? neon.InitialColor);
+						neon.Material.SetFloat(_emissionMultiplier, lightStateFront.Intensity);
+					break;
+					
+					case VenueLightLocation.Back:
+						var lightStateBack = _lightManager.BackLightState;
+						neon.Material.SetColor(_emissionColor, lightStateBack.Color ?? neon.InitialColor);
+						neon.Material.SetFloat(_emissionMultiplier, lightStateBack.Intensity);
+					break;
+					
+					case VenueLightLocation.Center:
+						var lightStateCenter = _lightManager.CenterLightState;
+						neon.Material.SetColor(_emissionColor, lightStateCenter.Color ?? neon.InitialColor);
+						neon.Material.SetFloat(_emissionMultiplier, lightStateCenter.Intensity);
+					break;
+					
+					case VenueLightLocation.Crowd:
+						var lightStateCrowd = _lightManager.CrowdLightState;
+						neon.Material.SetColor(_emissionColor, lightStateCrowd.Color ?? neon.InitialColor);
+						neon.Material.SetFloat(_emissionMultiplier, lightStateCrowd.Intensity);
+					break;
+					
+					default:
+						YargLogger.LogDebug("Unknown location for neon light");
+					break;
+				}
             }
         }
     }


### PR DESCRIPTION
More exposed light colors from the main manager and an expanded version of the neon manager to use them and temporarily overwrite the emission color of materials not in the existing list, then set it back when there's not a specific color being sent.

Existing material set functionality left alone for compatibility, and to still have the option of the current behavior.

(If there's a more efficient way to code this though then by all means, there's hardly an impact from my measurements but, copy-pasting was the best I could figure out)