### PR TITLE
fix range indicator being positioned wrongly

### DIFF
--- a/Assets/Script/Gameplay/Player/FiveFretPlayer.cs
+++ b/Assets/Script/Gameplay/Player/FiveFretPlayer.cs
@@ -603,7 +603,7 @@ namespace YARG.Gameplay.Player
                         Time = beatlines[realIndex].Time,
                         LeftSide = shiftLeft,
                         Offset = shiftLeft ? ((shift.Position + shift.Size) - 6) * -1 : shift.Position - 1,
-                        RangeIndicator = i == 1 && shift.Position != lastShiftRange.Position,
+                        RangeIndicator = i == 1 && !(shift.Position == lastShiftRange.Position && shift.Size == lastShiftRange.Size),
                     });
                 }
 

--- a/Assets/Script/Gameplay/Visuals/TrackElements/Guitar/GuitarRangeIndicatorElement.cs
+++ b/Assets/Script/Gameplay/Visuals/TrackElements/Guitar/GuitarRangeIndicatorElement.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿using System;
+using UnityEngine;
 using YARG.Gameplay.Player;
 using YARG.Helpers;
 
@@ -8,8 +9,11 @@ namespace YARG.Gameplay.Visuals
     {
         public        FiveFretRangeShift RangeShift;
 
-        private const float SCALE_DENOMINATOR    = 5f;
-        private const float RANGE_Y_SCALE        = 0.12f;
+        private const float SCALE_DENOMINATOR = 5f;
+        private const float TRACK_WIDTH       = 2f;
+        private const float FRET_SIZE         = TRACK_WIDTH / SCALE_DENOMINATOR;
+        private const float TRACK_MIDDLE      = 0f;
+        private const float RANGE_Y_SCALE     = 0.12f;
 
         private static readonly int _color = Shader.PropertyToID("_Color");
 
@@ -24,10 +28,7 @@ namespace YARG.Gameplay.Visuals
 
             var cachedTransform = _meshRenderer.transform;
             var newXScale = (RangeShift.Size / SCALE_DENOMINATOR) * 2;
-
-            // TODO: There has got to be a better way to calculate this
-            var sign = RangeShift.Position < 2 ? -1 : 1;
-            var xPos = ((2 - newXScale) / 2) * (RangeShift.Position == 2 && RangeShift.Size == 3 ? 0f : sign);
+            var xPos = -1 + (RangeShift.Size * (FRET_SIZE / 2)) + (RangeShift.Position - 1) * FRET_SIZE;
 
             cachedTransform.localScale = new Vector3(newXScale, RANGE_Y_SCALE, transform.localScale.z);
             cachedTransform.localPosition = new Vector3(xPos, 0.002f, cachedTransform.localPosition.z);


### PR DESCRIPTION
Fixing [YARG.Core #254](https://github.com/YARC-Official/YARG.Core/issues/254) revealed that range indicators were being positioned incorrectly for 1 and 2 fret ranges. This PR fixes that issue using a much simplified x position calculation and fixes another issue causing range indicators to not spawn when a range shift event called for a change in size without a change in position.

Note: This PR does not depend on the associated YARG.Core PR.