### PR TITLE
don't add favorites playlist to list of user-created playlists

### DIFF
--- a/Assets/Script/Playlists/PlaylistContainer.cs
+++ b/Assets/Script/Playlists/PlaylistContainer.cs
@@ -78,7 +78,7 @@ namespace YARG.Playlists
                 }
 
                 var playlist = LoadPlaylist(file);
-                if (playlist is not null)
+                if (playlist is not null && playlist.Id != FavoritesPlaylist.Id)
                 {
                     _playlists.Add(playlist);
                 }


### PR DESCRIPTION
Fixes display bug causing favorites playlist to appear as both a system playlist and user created playlist.