### PR TITLE
Play A Show

### DIFF
--- a/Assets/Art/Menu/Dialog.meta
+++ b/Assets/Art/Menu/Dialog.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 56e44ddd5ec00e74ab7473963ab79e80
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Art/Menu/Dialog/StatusCircleEmpty.png
+++ b/Assets/Art/Menu/Dialog/StatusCircleEmpty.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:97b421caca25d1d309af2638870232c54cbe1335f30e15f5088c0d20b541c86f
+size 7372

--- a/Assets/Art/Menu/Dialog/StatusCircleEmpty.png.meta
+++ b/Assets/Art/Menu/Dialog/StatusCircleEmpty.png.meta
@@ -1,0 +1,111 @@
+fileFormatVersion: 2
+guid: 1233d02de0abf284e88f252d9653242c
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 12
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMasterTextureLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 1
+    wrapV: 1
+    wrapW: 0
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  cookieLightType: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    nameFileIdTable: {}
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Art/Menu/Dialog/StatusCircleFilled.png
+++ b/Assets/Art/Menu/Dialog/StatusCircleFilled.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:92cfb1e9271280e162e530ca725665126742adff7ea348945e7005c8a499c6d6
+size 4638

--- a/Assets/Art/Menu/Dialog/StatusCircleFilled.png.meta
+++ b/Assets/Art/Menu/Dialog/StatusCircleFilled.png.meta
@@ -1,0 +1,111 @@
+fileFormatVersion: 2
+guid: 660296780c54ee9499e788cc09f6465b
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 12
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMasterTextureLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 1
+    wrapV: 1
+    wrapW: 0
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  cookieLightType: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    nameFileIdTable: {}
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Art/UI/ShowDialog.meta
+++ b/Assets/Art/UI/ShowDialog.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9dbf7d0655794eb4fb08c6159bbbfad3
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Art/UI/ShowDialog/CountdownMeter.png
+++ b/Assets/Art/UI/ShowDialog/CountdownMeter.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:43298fb5f988aaf3bf9c27732b9e2f794a80c9be82e4d2e83c6c8734087d619a
+size 487

--- a/Assets/Art/UI/ShowDialog/CountdownMeter.png.meta
+++ b/Assets/Art/UI/ShowDialog/CountdownMeter.png.meta
@@ -1,0 +1,111 @@
+fileFormatVersion: 2
+guid: d82ad8edd81c4db42a00d5f84c3a64e2
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 12
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  ignoreMasterTextureLimit: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 1
+    aniso: 1
+    mipBias: 0
+    wrapU: 1
+    wrapV: 1
+    wrapW: 0
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 100
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  cookieLightType: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+    nameFileIdTable: {}
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Gameplay/HUD/Pause/SetlistPause.prefab
+++ b/Assets/Prefabs/Gameplay/HUD/Pause/SetlistPause.prefab
@@ -64,6 +64,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6846856529861592900, guid: 0e2af23c2e7465444a3fb84a06d425ae,
         type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6846856529861592900, guid: 0e2af23c2e7465444a3fb84a06d425ae,
+        type: 3}
       propertyPath: m_AnchorMax.x
       value: 0
       objectReference: {fileID: 0}
@@ -126,6 +131,21 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6846856529861592900, guid: 0e2af23c2e7465444a3fb84a06d425ae,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6846856529861592900, guid: 0e2af23c2e7465444a3fb84a06d425ae,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6846856529861592900, guid: 0e2af23c2e7465444a3fb84a06d425ae,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6846856529861592900, guid: 0e2af23c2e7465444a3fb84a06d425ae,
         type: 3}
@@ -711,6 +731,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6846856529861592900, guid: 0e2af23c2e7465444a3fb84a06d425ae,
         type: 3}
+      propertyPath: m_RootOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 6846856529861592900, guid: 0e2af23c2e7465444a3fb84a06d425ae,
+        type: 3}
       propertyPath: m_AnchorMax.x
       value: 0
       objectReference: {fileID: 0}
@@ -867,6 +892,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_RootOrder
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6846856529861592900, guid: 0e2af23c2e7465444a3fb84a06d425ae,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 6846856529861592900, guid: 0e2af23c2e7465444a3fb84a06d425ae,
         type: 3}

--- a/Assets/Prefabs/Gameplay/HUD/Pause/SetlistPause.prefab
+++ b/Assets/Prefabs/Gameplay/HUD/Pause/SetlistPause.prefab
@@ -65,7 +65,7 @@ PrefabInstance:
     - target: {fileID: 6846856529861592900, guid: 0e2af23c2e7465444a3fb84a06d425ae,
         type: 3}
       propertyPath: m_RootOrder
-      value: 1
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 6846856529861592900, guid: 0e2af23c2e7465444a3fb84a06d425ae,
         type: 3}
@@ -135,17 +135,17 @@ PrefabInstance:
     - target: {fileID: 6846856529861592900, guid: 0e2af23c2e7465444a3fb84a06d425ae,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 6846856529861592900, guid: 0e2af23c2e7465444a3fb84a06d425ae,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 6846856529861592900, guid: 0e2af23c2e7465444a3fb84a06d425ae,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 6846856529861592900, guid: 0e2af23c2e7465444a3fb84a06d425ae,
         type: 3}
@@ -176,6 +176,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_Name
       value: Skip
+      objectReference: {fileID: 0}
+    - target: {fileID: 6846856529861592903, guid: 0e2af23c2e7465444a3fb84a06d425ae,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6846856529861592903, guid: 0e2af23c2e7465444a3fb84a06d425ae,
         type: 3}
@@ -732,7 +737,7 @@ PrefabInstance:
     - target: {fileID: 6846856529861592900, guid: 0e2af23c2e7465444a3fb84a06d425ae,
         type: 3}
       propertyPath: m_RootOrder
-      value: 3
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 6846856529861592900, guid: 0e2af23c2e7465444a3fb84a06d425ae,
         type: 3}
@@ -896,7 +901,7 @@ PrefabInstance:
     - target: {fileID: 6846856529861592900, guid: 0e2af23c2e7465444a3fb84a06d425ae,
         type: 3}
       propertyPath: m_RootOrder
-      value: 2
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6846856529861592900, guid: 0e2af23c2e7465444a3fb84a06d425ae,
         type: 3}

--- a/Assets/Prefabs/Menu/Common/Dialogs/SongPickerListDialog.prefab
+++ b/Assets/Prefabs/Menu/Common/Dialogs/SongPickerListDialog.prefab
@@ -7,6 +7,36 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 17132938336351373, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 17132938336351373, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 17132938336351373, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 17132938336351373, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 17132938336351373, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 17132938336351373, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 64143011112911990, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
         type: 3}
       propertyPath: m_AnchorMax.y
@@ -33,6 +63,36 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 64143011112911990, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 159138732694668233, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 159138732694668233, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 159138732694668233, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 159138732694668233, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 159138732694668233, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 159138732694668233, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
@@ -67,6 +127,56 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 414481647415226995, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 414481647415226995, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 414481647415226995, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 414481647415226995, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 414481647415226995, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 414481647415226995, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 553751291006282775, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 553751291006282775, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 553751291006282775, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 553751291006282775, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 1166245827849443697, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
         type: 3}
       propertyPath: m_AnchorMax.y
@@ -123,6 +233,96 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1873803922046637929, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1940988218695608468, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1940988218695608468, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1940988218695608468, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1940988218695608468, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1940988218695608468, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1940988218695608468, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2097007857018738990, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2097007857018738990, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2097007857018738990, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2097007857018738990, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2097007857018738990, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2097007857018738990, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2239291827523202666, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2239291827523202666, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2239291827523202666, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2239291827523202666, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2239291827523202666, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2239291827523202666, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
@@ -262,6 +462,31 @@ PrefabInstance:
       propertyPath: m_Name
       value: SongPickerListDialog
       objectReference: {fileID: 0}
+    - target: {fileID: 2847283638568521407, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2847283638568521407, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2847283638568521407, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2847283638568521407, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2847283638568521407, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 2854289831005170819, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
         type: 3}
       propertyPath: m_AnchorMax.y
@@ -493,6 +718,31 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4047676686493816516, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4083880024458073176, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4083880024458073176, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4083880024458073176, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4083880024458073176, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4083880024458073176, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
@@ -532,6 +782,31 @@ PrefabInstance:
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 5168994331911331421, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5168994331911331421, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5168994331911331421, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5168994331911331421, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5168994331911331421, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 5210293236603985443, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
         type: 3}
       propertyPath: m_AnchorMax.y
@@ -592,6 +867,26 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 5440083984957791298, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5440083984957791298, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5440083984957791298, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5440083984957791298, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 5547492458093607615, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
         type: 3}
       propertyPath: m_AnchorMax.y
@@ -648,6 +943,86 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6002729474902729990, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6182302717869592941, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6182302717869592941, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6182302717869592941, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6182302717869592941, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6182302717869592941, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6257076215338178419, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6257076215338178419, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6257076215338178419, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6257076215338178419, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6257076215338178419, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7347879303275078289, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7347879303275078289, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7347879303275078289, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7347879303275078289, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7347879303275078289, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7347879303275078289, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
@@ -732,6 +1107,146 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 7803644422433898722, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7803644422433898722, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7803644422433898722, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7803644422433898722, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7803644422433898722, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7803644422433898722, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7880163546696298936, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7880163546696298936, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7880163546696298936, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7880163546696298936, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7880163546696298936, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7880163546696298936, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7945929488152082342, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7945929488152082342, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7945929488152082342, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7945929488152082342, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7945929488152082342, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7945929488152082342, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8021605253040965372, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8021605253040965372, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8021605253040965372, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8021605253040965372, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8021605253040965372, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8021605253040965372, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8132497045449875843, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8132497045449875843, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8132497045449875843, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8132497045449875843, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 8207996329488046963, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
         type: 3}
       propertyPath: m_AnchorMax.y
@@ -758,6 +1273,36 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8207996329488046963, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8401047377958792127, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8401047377958792127, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8401047377958792127, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8401047377958792127, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8401047377958792127, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8401047377958792127, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
@@ -792,6 +1337,36 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 8613396176923684257, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8613396176923684257, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8613396176923684257, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8613396176923684257, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8613396176923684257, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8613396176923684257, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 8960125481155028985, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
         type: 3}
       propertyPath: m_AnchorMax.y
@@ -813,6 +1388,36 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8960125481155028985, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9016892680062601676, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9016892680062601676, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9016892680062601676, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9016892680062601676, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9016892680062601676, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9016892680062601676, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
@@ -843,6 +1448,36 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 9086791058779123844, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9163683514498498184, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9163683514498498184, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9163683514498498184, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9163683514498498184, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9163683514498498184, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9163683514498498184, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
         type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0

--- a/Assets/Prefabs/Menu/Common/Dialogs/SongPickerListDialog.prefab
+++ b/Assets/Prefabs/Menu/Common/Dialogs/SongPickerListDialog.prefab
@@ -7,6 +7,11 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 13638125696851306, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 17132938336351373, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
         type: 3}
       propertyPath: m_AnchorMax.y
@@ -95,6 +100,16 @@ PrefabInstance:
     - target: {fileID: 159138732694668233, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
         type: 3}
       propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 297836273580791843, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 297836273580791843, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 298923438396872770, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
@@ -265,6 +280,11 @@ PrefabInstance:
     - target: {fileID: 1940988218695608468, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
         type: 3}
       propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1952186292314990134, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_IsActive
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2097007857018738990, guid: 0a237e5e84df70342aba8aab3b3e5d6b,

--- a/Assets/Prefabs/Menu/Common/Dialogs/SongPickerListDialog.prefab
+++ b/Assets/Prefabs/Menu/Common/Dialogs/SongPickerListDialog.prefab
@@ -1,0 +1,851 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &1228179817024030325
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 64143011112911990, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 64143011112911990, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 64143011112911990, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 64143011112911990, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 64143011112911990, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 64143011112911990, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 298923438396872770, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 298923438396872770, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 298923438396872770, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 298923438396872770, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 298923438396872770, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 298923438396872770, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1166245827849443697, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1166245827849443697, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1166245827849443697, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1166245827849443697, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1166245827849443697, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1166245827849443697, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1873803922046637929, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1873803922046637929, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1873803922046637929, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1873803922046637929, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1873803922046637929, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1873803922046637929, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2754269841017782208, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2754269841017782208, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2754269841017782208, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2754269841017782208, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2754269841017782208, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2827624170477580929, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2827624170477580929, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2827624170477580929, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2827624170477580929, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2827624170477580929, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2827624170477580929, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2827624170477580929, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2827624170477580929, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2827624170477580929, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2827624170477580929, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2827624170477580929, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2827624170477580929, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2827624170477580929, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2827624170477580929, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2827624170477580929, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2827624170477580929, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2827624170477580929, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2827624170477580929, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2827624170477580929, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2827624170477580929, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2827624170477580929, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2827624170477580938, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_Name
+      value: SongPickerListDialog
+      objectReference: {fileID: 0}
+    - target: {fileID: 2854289831005170819, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2854289831005170819, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2854289831005170819, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2854289831005170819, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2854289831005170819, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2854289831005170819, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3046135385789577302, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3046135385789577302, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3046135385789577302, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3046135385789577302, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3046135385789577302, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3046135385789577302, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3241019600124577347, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3241019600124577347, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3241019600124577347, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3241019600124577347, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3241019600124577347, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3241019600124577347, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3464443973800507582, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3464443973800507582, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3464443973800507582, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3464443973800507582, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3464443973800507582, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3464443973800507582, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3614199070660146502, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3614199070660146502, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3614199070660146502, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3614199070660146502, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3614199070660146502, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3614199070660146502, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3700223882773493400, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3700223882773493400, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3700223882773493400, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3700223882773493400, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3700223882773493400, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3700223882773493400, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3705845526608255939, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3705845526608255939, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3705845526608255939, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3705845526608255939, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3705845526608255939, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3705845526608255939, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4047676686493816516, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4047676686493816516, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4047676686493816516, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4047676686493816516, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4047676686493816516, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4466160273990341578, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4466160273990341578, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4466160273990341578, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4466160273990341578, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4466160273990341578, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4466160273990341578, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4930811357176253962, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5210293236603985443, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5210293236603985443, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5210293236603985443, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5210293236603985443, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5210293236603985443, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5210293236603985443, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5416641163753286082, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5416641163753286082, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5416641163753286082, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5416641163753286082, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5416641163753286082, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5416641163753286082, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5547492458093607615, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5547492458093607615, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5547492458093607615, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5547492458093607615, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5547492458093607615, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5547492458093607615, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6002729474902729990, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6002729474902729990, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6002729474902729990, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6002729474902729990, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6002729474902729990, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6002729474902729990, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7481822010884482250, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7481822010884482250, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7481822010884482250, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7481822010884482250, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7481822010884482250, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7496216710138728107, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7496216710138728107, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7496216710138728107, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7496216710138728107, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7496216710138728107, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7554922061874968159, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7554922061874968159, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7554922061874968159, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7554922061874968159, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7554922061874968159, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7554922061874968159, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8207996329488046963, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8207996329488046963, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8207996329488046963, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8207996329488046963, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8207996329488046963, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8207996329488046963, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8521810611960328972, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8521810611960328972, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8521810611960328972, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8521810611960328972, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8521810611960328972, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8521810611960328972, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8960125481155028985, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8960125481155028985, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8960125481155028985, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8960125481155028985, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8960125481155028985, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9086791058779123844, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9086791058779123844, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9086791058779123844, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9086791058779123844, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9086791058779123844, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9086791058779123844, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 0a237e5e84df70342aba8aab3b3e5d6b, type: 3}

--- a/Assets/Prefabs/Menu/Common/Dialogs/SongPickerListDialog.prefab.meta
+++ b/Assets/Prefabs/Menu/Common/Dialogs/SongPickerListDialog.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 8d3ad97e1da01634f9197d1a11dea1e8
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Menu/MusicLibrary/PlayAShow.meta
+++ b/Assets/Prefabs/Menu/MusicLibrary/PlayAShow.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6433514d5878adb488700d1aa947a25f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Menu/MusicLibrary/PlayAShow/ShowCategory.prefab
+++ b/Assets/Prefabs/Menu/MusicLibrary/PlayAShow/ShowCategory.prefab
@@ -1,0 +1,1034 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &844474878944335737
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6543757098159971903}
+  - component: {fileID: 8201268154056683657}
+  - component: {fileID: 7170216627743103387}
+  m_Layer: 5
+  m_Name: Category Background
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6543757098159971903
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 844474878944335737}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2746511049277439700}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &8201268154056683657
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 844474878944335737}
+  m_CullTransparentMesh: 1
+--- !u!114 &7170216627743103387
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 844474878944335737}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 1d1676b47e9f31e489a52d8804289bfb, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &1197906609552337957
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4462853425559794875}
+  - component: {fileID: 6544116703681456313}
+  - component: {fileID: 2911591811179863411}
+  m_Layer: 5
+  m_Name: Selected Background
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &4462853425559794875
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1197906609552337957}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2746511049277439700}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &6544116703681456313
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1197906609552337957}
+  m_CullTransparentMesh: 1
+--- !u!114 &2911591811179863411
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1197906609552337957}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 4e58ccb20b1b1fa43b7acc5341e83c13, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &2146586724478461365
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8829135385835151069}
+  - component: {fileID: 3001677230138055486}
+  m_Layer: 5
+  m_Name: Container
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8829135385835151069
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2146586724478461365}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7409450936394283947}
+  - {fileID: 602748328894825681}
+  - {fileID: 7267166965990280431}
+  m_Father: {fileID: 6792463089375337342}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 45, y: 0}
+  m_SizeDelta: {x: -110, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &3001677230138055486
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2146586724478461365}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 30649d3a9faa99c48a7b1166b86bf2a0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Padding:
+    m_Left: 0
+    m_Right: 0
+    m_Top: 0
+    m_Bottom: 0
+  m_ChildAlignment: 0
+  m_Spacing: 10
+  m_ChildForceExpandWidth: 1
+  m_ChildForceExpandHeight: 1
+  m_ChildControlWidth: 1
+  m_ChildControlHeight: 1
+  m_ChildScaleWidth: 0
+  m_ChildScaleHeight: 0
+  m_ReverseArrangement: 0
+--- !u!1 &2501435170046897687
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6198024405023087915}
+  - component: {fileID: 2315977907229298525}
+  - component: {fileID: 3691326486322328978}
+  m_Layer: 5
+  m_Name: Normal Background
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &6198024405023087915
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2501435170046897687}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2746511049277439700}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2315977907229298525
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2501435170046897687}
+  m_CullTransparentMesh: 1
+--- !u!114 &3691326486322328978
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2501435170046897687}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 4c7c7c93d136fdc449978d533b752369, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &4425254306641889520
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 602748328894825681}
+  - component: {fileID: 4603392985084315001}
+  - component: {fileID: 8784775627586518841}
+  - component: {fileID: 4415212389471246496}
+  m_Layer: 5
+  m_Name: Side Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &602748328894825681
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4425254306641889520}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8829135385835151069}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 10, y: -30}
+  m_SizeDelta: {x: 0, y: 60}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4603392985084315001
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4425254306641889520}
+  m_CullTransparentMesh: 1
+--- !u!114 &8784775627586518841
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4425254306641889520}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Side Text
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: ae170e91fd29a90479e906ddffb1d8ee, type: 2}
+  m_sharedMaterial: {fileID: -5480317595949376055, guid: ae170e91fd29a90479e906ddffb1d8ee,
+    type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 11400000, guid: 4fe54f44a04e7364db2baafd68cda60c, type: 2}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 30
+  m_fontSizeBase: 30
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 4
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 0
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 1
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!114 &4415212389471246496
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4425254306641889520}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreLayout: 0
+  m_MinWidth: -1
+  m_MinHeight: -1
+  m_PreferredWidth: -1
+  m_PreferredHeight: -1
+  m_FlexibleWidth: -1
+  m_FlexibleHeight: -1
+  m_LayoutPriority: 1
+--- !u!1 &7391721178182959868
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7409450936394283947}
+  - component: {fileID: 5221002622847433171}
+  - component: {fileID: 7373445800776221851}
+  m_Layer: 5
+  m_Name: Group_SongName
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7409450936394283947
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7391721178182959868}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8935335792748373938}
+  m_Father: {fileID: 8829135385835151069}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &5221002622847433171
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7391721178182959868}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 30649d3a9faa99c48a7b1166b86bf2a0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Padding:
+    m_Left: 0
+    m_Right: 0
+    m_Top: 0
+    m_Bottom: 0
+  m_ChildAlignment: 0
+  m_Spacing: 5
+  m_ChildForceExpandWidth: 0
+  m_ChildForceExpandHeight: 1
+  m_ChildControlWidth: 1
+  m_ChildControlHeight: 1
+  m_ChildScaleWidth: 0
+  m_ChildScaleHeight: 0
+  m_ReverseArrangement: 0
+--- !u!114 &7373445800776221851
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7391721178182959868}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreLayout: 0
+  m_MinWidth: 0
+  m_MinHeight: -1
+  m_PreferredWidth: 0
+  m_PreferredHeight: -1
+  m_FlexibleWidth: 1000000
+  m_FlexibleHeight: -1
+  m_LayoutPriority: 1
+--- !u!1 &7795967901779201422
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2746511049277439700}
+  m_Layer: 5
+  m_Name: Backgrounds
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2746511049277439700
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7795967901779201422}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 6198024405023087915}
+  - {fileID: 4462853425559794875}
+  - {fileID: 6543757098159971903}
+  m_Father: {fileID: 6792463089375337342}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &8388571864023119118
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6792463089375337342}
+  - component: {fileID: 1325348845442263549}
+  - component: {fileID: 3200710889995212794}
+  - component: {fileID: 1615909499665393770}
+  - component: {fileID: 3104792467088138150}
+  m_Layer: 5
+  m_Name: ShowCategory
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6792463089375337342
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8388571864023119118}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2746511049277439700}
+  - {fileID: 8829135385835151069}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 60}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1325348845442263549
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8388571864023119118}
+  m_CullTransparentMesh: 1
+--- !u!114 &3200710889995212794
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8388571864023119118}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!225 &1615909499665393770
+CanvasGroup:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8388571864023119118}
+  m_Enabled: 1
+  m_Alpha: 1
+  m_Interactable: 1
+  m_BlocksRaycasts: 1
+  m_IgnoreParentGroups: 0
+--- !u!114 &3104792467088138150
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8388571864023119118}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 981e6dcb8ea0456b86bd1874ac3a01fb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  CategoryText: {fileID: 1441989783758997294}
+  _pickerButton: {fileID: 1553656265950647833}
+--- !u!1 &9194467094468163488
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8935335792748373938}
+  - component: {fileID: 8773159673931162984}
+  - component: {fileID: 1441989783758997294}
+  - component: {fileID: 3184991458172422570}
+  - component: {fileID: 1286240698596734913}
+  m_Layer: 5
+  m_Name: CategoryText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8935335792748373938
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9194467094468163488}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7409450936394283947}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &8773159673931162984
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9194467094468163488}
+  m_CullTransparentMesh: 1
+--- !u!114 &1441989783758997294
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9194467094468163488}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: A Song From The 1990s
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: ae170e91fd29a90479e906ddffb1d8ee, type: 2}
+  m_sharedMaterial: {fileID: -5480317595949376055, guid: ae170e91fd29a90479e906ddffb1d8ee,
+    type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294042673
+  m_fontColor: {r: 0.19215687, g: 0.89411765, b: 0.94509804, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 35
+  m_fontSizeBase: 35
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 0
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 1
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!114 &3184991458172422570
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9194467094468163488}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreLayout: 0
+  m_MinWidth: 550
+  m_MinHeight: -1
+  m_PreferredWidth: 768
+  m_PreferredHeight: -1
+  m_FlexibleWidth: -1
+  m_FlexibleHeight: -1
+  m_LayoutPriority: 1
+--- !u!114 &1286240698596734913
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9194467094468163488}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1441989783758997294}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 0}
+        m_TargetAssemblyTypeName: YARG.Menu.MusicLibrary.SongView, Assembly-CSharp
+        m_MethodName: PrimaryTextClick
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!1001 &3499400066238214358
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 8829135385835151069}
+    m_Modifications:
+    - target: {fileID: 4008179247140915981, guid: 5fb045b8ffcc8614ebf0c963996ffa35,
+        type: 3}
+      propertyPath: m_Name
+      value: ShowPickerButton
+      objectReference: {fileID: 0}
+    - target: {fileID: 6073794641953995833, guid: 5fb045b8ffcc8614ebf0c963996ffa35,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6073794641953995833, guid: 5fb045b8ffcc8614ebf0c963996ffa35,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6073794641953995833, guid: 5fb045b8ffcc8614ebf0c963996ffa35,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 6073794641953995833, guid: 5fb045b8ffcc8614ebf0c963996ffa35,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6073794641953995833, guid: 5fb045b8ffcc8614ebf0c963996ffa35,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6073794641953995833, guid: 5fb045b8ffcc8614ebf0c963996ffa35,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6073794641953995833, guid: 5fb045b8ffcc8614ebf0c963996ffa35,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6073794641953995833, guid: 5fb045b8ffcc8614ebf0c963996ffa35,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6073794641953995833, guid: 5fb045b8ffcc8614ebf0c963996ffa35,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6073794641953995833, guid: 5fb045b8ffcc8614ebf0c963996ffa35,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6073794641953995833, guid: 5fb045b8ffcc8614ebf0c963996ffa35,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6073794641953995833, guid: 5fb045b8ffcc8614ebf0c963996ffa35,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6073794641953995833, guid: 5fb045b8ffcc8614ebf0c963996ffa35,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6073794641953995833, guid: 5fb045b8ffcc8614ebf0c963996ffa35,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6073794641953995833, guid: 5fb045b8ffcc8614ebf0c963996ffa35,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6073794641953995833, guid: 5fb045b8ffcc8614ebf0c963996ffa35,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6073794641953995833, guid: 5fb045b8ffcc8614ebf0c963996ffa35,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6073794641953995833, guid: 5fb045b8ffcc8614ebf0c963996ffa35,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6073794641953995833, guid: 5fb045b8ffcc8614ebf0c963996ffa35,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6073794641953995833, guid: 5fb045b8ffcc8614ebf0c963996ffa35,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6073794641953995833, guid: 5fb045b8ffcc8614ebf0c963996ffa35,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 5fb045b8ffcc8614ebf0c963996ffa35, type: 3}
+--- !u!114 &1553656265950647833 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2675120542315914959, guid: 5fb045b8ffcc8614ebf0c963996ffa35,
+    type: 3}
+  m_PrefabInstance: {fileID: 3499400066238214358}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 04f17c63d7ee4fe5be74e8374cf824bb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!224 &7267166965990280431 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 6073794641953995833, guid: 5fb045b8ffcc8614ebf0c963996ffa35,
+    type: 3}
+  m_PrefabInstance: {fileID: 3499400066238214358}
+  m_PrefabAsset: {fileID: 0}

--- a/Assets/Prefabs/Menu/MusicLibrary/PlayAShow/ShowCategory.prefab
+++ b/Assets/Prefabs/Menu/MusicLibrary/PlayAShow/ShowCategory.prefab
@@ -681,6 +681,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   CategoryText: {fileID: 1441989783758997294}
   _pickerButton: {fileID: 1553656265950647833}
+  _unselectedVisual: {fileID: 844474878944335737}
+  _selectedVisual: {fileID: 1197906609552337957}
 --- !u!1 &9194467094468163488
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Menu/MusicLibrary/PlayAShow/ShowCategory.prefab.meta
+++ b/Assets/Prefabs/Menu/MusicLibrary/PlayAShow/ShowCategory.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 7818c92215fed744f8c884bbf94c062e
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Menu/MusicLibrary/PlayAShow/ShowDialog.prefab
+++ b/Assets/Prefabs/Menu/MusicLibrary/PlayAShow/ShowDialog.prefab
@@ -1,0 +1,3389 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1852554208043748149
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7404975268562146615}
+  m_Layer: 5
+  m_Name: Content
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7404975268562146615
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1852554208043748149}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7482369732977593590}
+  m_Father: {fileID: 2827624170578181746}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 12.5}
+  m_SizeDelta: {x: -100, y: -275}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &1861923782178262702
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6408872993087179763}
+  - component: {fileID: 2794188701718389493}
+  - component: {fileID: 3270959754787510129}
+  m_Layer: 5
+  m_Name: Tint
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6408872993087179763
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1861923782178262702}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2827624170477580929}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2794188701718389493
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1861923782178262702}
+  m_CullTransparentMesh: 1
+--- !u!114 &3270959754787510129
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1861923782178262702}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 0.5019608}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &2298417957289621295
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 993958795601597550}
+  - component: {fileID: 1627061717528705264}
+  - component: {fileID: 2590132184541579595}
+  m_Layer: 5
+  m_Name: Handle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &993958795601597550
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2298417957289621295}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7503160694415057862}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 20, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1627061717528705264
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2298417957289621295}
+  m_CullTransparentMesh: 1
+--- !u!114 &2590132184541579595
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2298417957289621295}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10913, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &2376430295443659671
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5929123335480378528}
+  m_Layer: 5
+  m_Name: Fill Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5929123335480378528
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2376430295443659671}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 297836273580791843}
+  m_Father: {fileID: 2768940004618745430}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.25}
+  m_AnchorMax: {x: 1, y: 0.75}
+  m_AnchoredPosition: {x: -2.5, y: 0}
+  m_SizeDelta: {x: 5, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &2720885964934567665
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6730295334324542441}
+  - component: {fileID: 1921772313527037638}
+  - component: {fileID: 6739635422437149631}
+  m_Layer: 5
+  m_Name: Dialog Button Container
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &6730295334324542441
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2720885964934567665}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3234128249276097235}
+  m_Father: {fileID: 6931926890766530907}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 660, y: -50}
+  m_SizeDelta: {x: 1220, y: 50}
+  m_Pivot: {x: 0.5, y: 0}
+--- !u!114 &1921772313527037638
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2720885964934567665}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 30649d3a9faa99c48a7b1166b86bf2a0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Padding:
+    m_Left: 0
+    m_Right: 0
+    m_Top: 0
+    m_Bottom: 0
+  m_ChildAlignment: 3
+  m_Spacing: 25
+  m_ChildForceExpandWidth: 1
+  m_ChildForceExpandHeight: 1
+  m_ChildControlWidth: 1
+  m_ChildControlHeight: 1
+  m_ChildScaleWidth: 0
+  m_ChildScaleHeight: 0
+  m_ReverseArrangement: 0
+--- !u!114 &6739635422437149631
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2720885964934567665}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7792aa537b804208a803f971074a1a45, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _defaultGroup: 1
+  _canBeCurrent: 1
+  _addAllChildrenOnAwake: 0
+  _selectFirst: 0
+--- !u!1 &2774088838925057647
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5440083984957791298}
+  - component: {fileID: 7299824747575105198}
+  - component: {fileID: 4242869603074947390}
+  m_Layer: 5
+  m_Name: ButtonSideText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5440083984957791298
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2774088838925057647}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6931926890766530907}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 74, y: 34}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &7299824747575105198
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2774088838925057647}
+  m_CullTransparentMesh: 1
+--- !u!114 &4242869603074947390
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2774088838925057647}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: I've Had Enough!
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: ae170e91fd29a90479e906ddffb1d8ee, type: 2}
+  m_sharedMaterial: {fileID: -5480317595949376055, guid: ae170e91fd29a90479e906ddffb1d8ee,
+    type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 30
+  m_fontSizeBase: 30
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 16
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 0
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &2827624170477580938
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2827624170477580929}
+  - component: {fileID: 6162491671344219383}
+  m_Layer: 5
+  m_Name: ShowDialog
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2827624170477580929
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2827624170477580938}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 6408872993087179763}
+  - {fileID: 2827624170578181746}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &6162491671344219383
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2827624170477580938}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0a00be65e63445aa916cf62e06461c23, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _dialogButtonContainer: {fileID: 6730295334324542441}
+  _navigationGroup: {fileID: 6739635422437149631}
+  _dialogButtonPrefab: {fileID: 7773415494866034796}
+  <Title>k__BackingField: {fileID: 5876607721882585704}
+  _showCategoryViews:
+  - {fileID: 2350367649076024757}
+  - {fileID: 2558120278655013803}
+  - {fileID: 5969037656885758567}
+  - {fileID: 5618528895710040192}
+  - {fileID: 3669916413828962949}
+  _selectButton: {fileID: 110889079661771637}
+  _countdownSlider: {fileID: 9204053419736488386}
+  MusicLibrary: {fileID: 0}
+--- !u!1 &2827624170578181747
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2827624170578181746}
+  - component: {fileID: 2827624170578181740}
+  - component: {fileID: 2827624170578181741}
+  m_Layer: 5
+  m_Name: Base
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2827624170578181746
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2827624170578181747}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5233747177197680253}
+  - {fileID: 7404975268562146615}
+  - {fileID: 6931926890766530907}
+  m_Father: {fileID: 2827624170477580929}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: -600, y: -400}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2827624170578181740
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2827624170578181747}
+  m_CullTransparentMesh: 1
+--- !u!114 &2827624170578181741
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2827624170578181747}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: b5fdd80ad07111944b1a8a7336ca6727, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &4413511118123464845
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4759447697453872956}
+  - component: {fileID: 1671808937895087908}
+  - component: {fileID: 3928729212007995292}
+  m_Layer: 5
+  m_Name: Background
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4759447697453872956
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4413511118123464845}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2768940004618745430}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.25}
+  m_AnchorMax: {x: 1, y: 0.75}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1671808937895087908
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4413511118123464845}
+  m_CullTransparentMesh: 1
+--- !u!114 &3928729212007995292
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4413511118123464845}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: d82ad8edd81c4db42a00d5f84c3a64e2, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &4690427978830287430
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2768940004618745430}
+  - component: {fileID: 9204053419736488386}
+  m_Layer: 5
+  m_Name: CountdownTimer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2768940004618745430
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4690427978830287430}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5929123335480378528}
+  - {fileID: 4759447697453872956}
+  - {fileID: 7503160694415057862}
+  m_Father: {fileID: 553751291006282775}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 0.5}
+  m_AnchorMax: {x: 1, y: 0.5}
+  m_AnchoredPosition: {x: -200, y: 0}
+  m_SizeDelta: {x: 400, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &9204053419736488386
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4690427978830287430}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 0
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 0
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 0
+  m_TargetGraphic: {fileID: 2590132184541579595}
+  m_FillRect: {fileID: 297836273580791843}
+  m_HandleRect: {fileID: 993958795601597550}
+  m_Direction: 0
+  m_MinValue: 0
+  m_MaxValue: 1
+  m_WholeNumbers: 0
+  m_Value: 1
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!1 &5412126697378115904
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6931926890766530907}
+  - component: {fileID: 5682976143497057828}
+  m_Layer: 5
+  m_Name: BottomContainer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6931926890766530907
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5412126697378115904}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 6730295334324542441}
+  - {fileID: 8132497045449875843}
+  - {fileID: 5440083984957791298}
+  - {fileID: 553751291006282775}
+  m_Father: {fileID: 2827624170578181746}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 0}
+  m_AnchoredPosition: {x: 0, y: 50}
+  m_SizeDelta: {x: 0, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &5682976143497057828
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5412126697378115904}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 30649d3a9faa99c48a7b1166b86bf2a0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Padding:
+    m_Left: 50
+    m_Right: 0
+    m_Top: 0
+    m_Bottom: 0
+  m_ChildAlignment: 3
+  m_Spacing: 20
+  m_ChildForceExpandWidth: 0
+  m_ChildForceExpandHeight: 1
+  m_ChildControlWidth: 0
+  m_ChildControlHeight: 0
+  m_ChildScaleWidth: 0
+  m_ChildScaleHeight: 0
+  m_ReverseArrangement: 0
+--- !u!1 &6999224760296791664
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5233747177197680253}
+  - component: {fileID: 1625917551618021366}
+  - component: {fileID: 5876607721882585704}
+  m_Layer: 5
+  m_Name: Title
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5233747177197680253
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6999224760296791664}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2827624170578181746}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: -50}
+  m_SizeDelta: {x: -100, y: 75}
+  m_Pivot: {x: 0.5, y: 1}
+--- !u!222 &1625917551618021366
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6999224760296791664}
+  m_CullTransparentMesh: 1
+--- !u!114 &5876607721882585704
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6999224760296791664}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Choose Your Fate
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 65a8a6500dc773741bd815e54cd7c1ec, type: 2}
+  m_sharedMaterial: {fileID: -8996134669666270778, guid: 65a8a6500dc773741bd815e54cd7c1ec,
+    type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 36
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 16
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &7256023865006557718
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7482369732977593590}
+  - component: {fileID: 7207391788727554370}
+  - component: {fileID: 4037238654596423073}
+  m_Layer: 5
+  m_Name: List
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7482369732977593590
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7256023865006557718}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3932764644072689167}
+  m_Father: {fileID: 7404975268562146615}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: -20}
+  m_SizeDelta: {x: 0, y: -40}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &7207391788727554370
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7256023865006557718}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1aa08ab6e0800fa44ae55d278d1423e3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Content: {fileID: 4930811357176253962}
+  m_Horizontal: 0
+  m_Vertical: 1
+  m_MovementType: 2
+  m_Elasticity: 0.1
+  m_Inertia: 1
+  m_DecelerationRate: 0.135
+  m_ScrollSensitivity: 10
+  m_Viewport: {fileID: 3932764644072689167}
+  m_HorizontalScrollbar: {fileID: 0}
+  m_VerticalScrollbar: {fileID: 0}
+  m_HorizontalScrollbarVisibility: 2
+  m_VerticalScrollbarVisibility: 2
+  m_HorizontalScrollbarSpacing: -3
+  m_VerticalScrollbarSpacing: 3
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &4037238654596423073
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7256023865006557718}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fdd9b8927526f3b48b28b39a10d1b380, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &7318957847414337894
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7503160694415057862}
+  m_Layer: 5
+  m_Name: Handle Slide Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &7503160694415057862
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7318957847414337894}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 993958795601597550}
+  m_Father: {fileID: 2768940004618745430}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: -20, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &7464762023556607642
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3932764644072689167}
+  - component: {fileID: 7104820706259956215}
+  m_Layer: 5
+  m_Name: Viewport
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3932764644072689167
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7464762023556607642}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4930811357176253962}
+  m_Father: {fileID: 7482369732977593590}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: -18, y: 0}
+  m_Pivot: {x: 0, y: 1}
+--- !u!114 &7104820706259956215
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7464762023556607642}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3312d7739989d2b4e91e6319e9a96d76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Padding: {x: 0, y: 0, z: 0, w: 0}
+  m_Softness: {x: 0, y: 0}
+--- !u!1 &7959167632773694437
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 553751291006282775}
+  m_Layer: 5
+  m_Name: TimerContainer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &553751291006282775
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7959167632773694437}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2768940004618745430}
+  m_Father: {fileID: 6931926890766530907}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 1000, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &8114605822811179985
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4930811357176253962}
+  - component: {fileID: 7379177540684338613}
+  - component: {fileID: 8354918600737256761}
+  - component: {fileID: 5420957149693875267}
+  - component: {fileID: 8494258171690340139}
+  m_Layer: 5
+  m_Name: Content
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &4930811357176253962
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8114605822811179985}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 6182302717869592941}
+  - {fileID: 6257076215338178419}
+  - {fileID: 2847283638568521407}
+  - {fileID: 4083880024458073176}
+  - {fileID: 5168994331911331421}
+  m_Father: {fileID: 3932764644072689167}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0, y: 1}
+--- !u!222 &7379177540684338613
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8114605822811179985}
+  m_CullTransparentMesh: 1
+--- !u!114 &8354918600737256761
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8114605822811179985}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &5420957149693875267
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8114605822811179985}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 59f8146938fff824cb5fd77236b75775, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Padding:
+    m_Left: 0
+    m_Right: 0
+    m_Top: 10
+    m_Bottom: 10
+  m_ChildAlignment: 0
+  m_Spacing: 10
+  m_ChildForceExpandWidth: 1
+  m_ChildForceExpandHeight: 1
+  m_ChildControlWidth: 1
+  m_ChildControlHeight: 0
+  m_ChildScaleWidth: 0
+  m_ChildScaleHeight: 0
+  m_ReverseArrangement: 0
+--- !u!114 &8494258171690340139
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8114605822811179985}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3245ec927659c4140ac4f8d17403cc18, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_HorizontalFit: 0
+  m_VerticalFit: 2
+--- !u!1 &8571342555104006670
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 297836273580791843}
+  - component: {fileID: 2462960068212833992}
+  - component: {fileID: 7818037066119688614}
+  m_Layer: 5
+  m_Name: Fill
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &297836273580791843
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8571342555104006670}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5929123335480378528}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 2.5, y: 0}
+  m_SizeDelta: {x: -5, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &2462960068212833992
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8571342555104006670}
+  m_CullTransparentMesh: 1
+--- !u!114 &7818037066119688614
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8571342555104006670}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.32132694, g: 1, b: 0, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1001 &618739841347898381
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 4930811357176253962}
+    m_Modifications:
+    - target: {fileID: 602748328894825681, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 602748328894825681, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 602748328894825681, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 602748328894825681, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 602748328894825681, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 602748328894825681, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1301332380285371449, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1301332380285371449, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1301332380285371449, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1301332380285371449, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1301332380285371449, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1301332380285371449, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1441989783758997294, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_text
+      value: A Brutal Song
+      objectReference: {fileID: 0}
+    - target: {fileID: 1553656265950647833, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: _dialog
+      value: 
+      objectReference: {fileID: 6162491671344219383}
+    - target: {fileID: 3830606908955517198, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 6162491671344219383}
+    - target: {fileID: 3830606908955517198, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: OnRedButton
+      objectReference: {fileID: 0}
+    - target: {fileID: 3830606908955517198, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: YARG.Menu.Dialogs.SongPickerListDialog, Assembly-CSharp
+      objectReference: {fileID: 0}
+    - target: {fileID: 6423867115392018672, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7267166965990280431, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7267166965990280431, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7267166965990280431, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7267166965990280431, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7267166965990280431, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7267166965990280431, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7409450936394283947, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7409450936394283947, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7409450936394283947, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7409450936394283947, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7409450936394283947, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7409450936394283947, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8388571864023119118, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_Name
+      value: RedSong
+      objectReference: {fileID: 0}
+    - target: {fileID: 8929720893787002541, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_Color.b
+      value: 0.21568628
+      objectReference: {fileID: 0}
+    - target: {fileID: 8929720893787002541, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.16862746
+      objectReference: {fileID: 0}
+    - target: {fileID: 8929720893787002541, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.9529412
+      objectReference: {fileID: 0}
+    - target: {fileID: 8935335792748373938, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8935335792748373938, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8935335792748373938, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8935335792748373938, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8935335792748373938, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8935335792748373938, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7818c92215fed744f8c884bbf94c062e, type: 3}
+--- !u!114 &2558120278655013803 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 3104792467088138150, guid: 7818c92215fed744f8c884bbf94c062e,
+    type: 3}
+  m_PrefabInstance: {fileID: 618739841347898381}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 981e6dcb8ea0456b86bd1874ac3a01fb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!224 &6257076215338178419 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+    type: 3}
+  m_PrefabInstance: {fileID: 618739841347898381}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &831018172682848787
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 4930811357176253962}
+    m_Modifications:
+    - target: {fileID: 508823298876259291, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 602748328894825681, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 602748328894825681, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 602748328894825681, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 602748328894825681, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 602748328894825681, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 602748328894825681, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1301332380285371449, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1301332380285371449, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1301332380285371449, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1301332380285371449, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1301332380285371449, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1301332380285371449, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1553656265950647833, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: _dialog
+      value: 
+      objectReference: {fileID: 6162491671344219383}
+    - target: {fileID: 1616292577503295714, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3830606908955517198, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3830606908955517198, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3830606908955517198, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 6162491671344219383}
+    - target: {fileID: 3830606908955517198, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 3830606908955517198, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: OnGreenButton
+      objectReference: {fileID: 0}
+    - target: {fileID: 3830606908955517198, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: YARG.Menu.Dialogs.SongPickerListDialog, Assembly-CSharp
+      objectReference: {fileID: 0}
+    - target: {fileID: 3830606908955517198, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[1].m_TargetAssemblyTypeName
+      value: YARG.Menu.Dialogs.SongPickerListDialog, Assembly-CSharp
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7256936975803730948, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7267166965990280431, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7267166965990280431, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7267166965990280431, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7267166965990280431, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7267166965990280431, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7267166965990280431, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7409450936394283947, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7409450936394283947, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7409450936394283947, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7409450936394283947, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7409450936394283947, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7409450936394283947, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8388571864023119118, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_Name
+      value: GreenSong
+      objectReference: {fileID: 0}
+    - target: {fileID: 8935335792748373938, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8935335792748373938, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8935335792748373938, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8935335792748373938, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8935335792748373938, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8935335792748373938, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7818c92215fed744f8c884bbf94c062e, type: 3}
+--- !u!114 &2350367649076024757 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 3104792467088138150, guid: 7818c92215fed744f8c884bbf94c062e,
+    type: 3}
+  m_PrefabInstance: {fileID: 831018172682848787}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 981e6dcb8ea0456b86bd1874ac3a01fb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!224 &6182302717869592941 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+    type: 3}
+  m_PrefabInstance: {fileID: 831018172682848787}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1871344344858772771
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 4930811357176253962}
+    m_Modifications:
+    - target: {fileID: 602748328894825681, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 602748328894825681, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 602748328894825681, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 602748328894825681, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 602748328894825681, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 602748328894825681, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1301332380285371449, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1301332380285371449, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1301332380285371449, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1301332380285371449, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1301332380285371449, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1301332380285371449, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1441989783758997294, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_text
+      value: A Song From The Album SUMMERTIDE
+      objectReference: {fileID: 0}
+    - target: {fileID: 1553656265950647833, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: _dialog
+      value: 
+      objectReference: {fileID: 6162491671344219383}
+    - target: {fileID: 3830606908955517198, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 6162491671344219383}
+    - target: {fileID: 3830606908955517198, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: OnOrangeButton
+      objectReference: {fileID: 0}
+    - target: {fileID: 3830606908955517198, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: YARG.Menu.Dialogs.SongPickerListDialog, Assembly-CSharp
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 4
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7267166965990280431, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7267166965990280431, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7267166965990280431, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7267166965990280431, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7267166965990280431, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7267166965990280431, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7409450936394283947, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7409450936394283947, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7409450936394283947, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7409450936394283947, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7409450936394283947, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7409450936394283947, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8388571864023119118, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_Name
+      value: OrangeSong
+      objectReference: {fileID: 0}
+    - target: {fileID: 8929720893787002541, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_Color.b
+      value: 0.07450981
+      objectReference: {fileID: 0}
+    - target: {fileID: 8929720893787002541, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.5176471
+      objectReference: {fileID: 0}
+    - target: {fileID: 8929720893787002541, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8935335792748373938, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8935335792748373938, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8935335792748373938, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8935335792748373938, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8935335792748373938, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8935335792748373938, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7818c92215fed744f8c884bbf94c062e, type: 3}
+--- !u!114 &3669916413828962949 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 3104792467088138150, guid: 7818c92215fed744f8c884bbf94c062e,
+    type: 3}
+  m_PrefabInstance: {fileID: 1871344344858772771}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 981e6dcb8ea0456b86bd1874ac3a01fb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!224 &5168994331911331421 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+    type: 3}
+  m_PrefabInstance: {fileID: 1871344344858772771}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2636324260479671738
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 6931926890766530907}
+    m_Modifications:
+    - target: {fileID: 412450321716482520, guid: 5fb045b8ffcc8614ebf0c963996ffa35,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 6162491671344219383}
+    - target: {fileID: 412450321716482520, guid: 5fb045b8ffcc8614ebf0c963996ffa35,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: OnSelectButton
+      objectReference: {fileID: 0}
+    - target: {fileID: 412450321716482520, guid: 5fb045b8ffcc8614ebf0c963996ffa35,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: YARG.Menu.Dialogs.SongPickerListDialog, Assembly-CSharp
+      objectReference: {fileID: 0}
+    - target: {fileID: 440116509921864197, guid: 5fb045b8ffcc8614ebf0c963996ffa35,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 440116509921864197, guid: 5fb045b8ffcc8614ebf0c963996ffa35,
+        type: 3}
+      propertyPath: m_Padding.m_Left
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2675120542315914959, guid: 5fb045b8ffcc8614ebf0c963996ffa35,
+        type: 3}
+      propertyPath: ButtonText
+      value: 
+      objectReference: {fileID: 4242869603074947390}
+    - target: {fileID: 2809793550742734900, guid: 5fb045b8ffcc8614ebf0c963996ffa35,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4008179247140915981, guid: 5fb045b8ffcc8614ebf0c963996ffa35,
+        type: 3}
+      propertyPath: m_Name
+      value: SelectButton
+      objectReference: {fileID: 0}
+    - target: {fileID: 5439468768656205435, guid: 5fb045b8ffcc8614ebf0c963996ffa35,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: 0d0c4a6295bcbdb448b5fc427b924038,
+        type: 3}
+    - target: {fileID: 5439468768656205435, guid: 5fb045b8ffcc8614ebf0c963996ffa35,
+        type: 3}
+      propertyPath: m_Color.b
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5439468768656205435, guid: 5fb045b8ffcc8614ebf0c963996ffa35,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5439468768656205435, guid: 5fb045b8ffcc8614ebf0c963996ffa35,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6073794641953995833, guid: 5fb045b8ffcc8614ebf0c963996ffa35,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6073794641953995833, guid: 5fb045b8ffcc8614ebf0c963996ffa35,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6073794641953995833, guid: 5fb045b8ffcc8614ebf0c963996ffa35,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6073794641953995833, guid: 5fb045b8ffcc8614ebf0c963996ffa35,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6073794641953995833, guid: 5fb045b8ffcc8614ebf0c963996ffa35,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6073794641953995833, guid: 5fb045b8ffcc8614ebf0c963996ffa35,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6073794641953995833, guid: 5fb045b8ffcc8614ebf0c963996ffa35,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6073794641953995833, guid: 5fb045b8ffcc8614ebf0c963996ffa35,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 74
+      objectReference: {fileID: 0}
+    - target: {fileID: 6073794641953995833, guid: 5fb045b8ffcc8614ebf0c963996ffa35,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 34
+      objectReference: {fileID: 0}
+    - target: {fileID: 6073794641953995833, guid: 5fb045b8ffcc8614ebf0c963996ffa35,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6073794641953995833, guid: 5fb045b8ffcc8614ebf0c963996ffa35,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6073794641953995833, guid: 5fb045b8ffcc8614ebf0c963996ffa35,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6073794641953995833, guid: 5fb045b8ffcc8614ebf0c963996ffa35,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6073794641953995833, guid: 5fb045b8ffcc8614ebf0c963996ffa35,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6073794641953995833, guid: 5fb045b8ffcc8614ebf0c963996ffa35,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6073794641953995833, guid: 5fb045b8ffcc8614ebf0c963996ffa35,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6073794641953995833, guid: 5fb045b8ffcc8614ebf0c963996ffa35,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6073794641953995833, guid: 5fb045b8ffcc8614ebf0c963996ffa35,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6073794641953995833, guid: 5fb045b8ffcc8614ebf0c963996ffa35,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6073794641953995833, guid: 5fb045b8ffcc8614ebf0c963996ffa35,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6073794641953995833, guid: 5fb045b8ffcc8614ebf0c963996ffa35,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 5fb045b8ffcc8614ebf0c963996ffa35, type: 3}
+--- !u!114 &110889079661771637 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2675120542315914959, guid: 5fb045b8ffcc8614ebf0c963996ffa35,
+    type: 3}
+  m_PrefabInstance: {fileID: 2636324260479671738}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 04f17c63d7ee4fe5be74e8374cf824bb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!224 &8132497045449875843 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 6073794641953995833, guid: 5fb045b8ffcc8614ebf0c963996ffa35,
+    type: 3}
+  m_PrefabInstance: {fileID: 2636324260479671738}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &7417276920968531750
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 4930811357176253962}
+    m_Modifications:
+    - target: {fileID: 602748328894825681, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 602748328894825681, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 602748328894825681, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 602748328894825681, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 602748328894825681, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 602748328894825681, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1301332380285371449, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1301332380285371449, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1301332380285371449, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1301332380285371449, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1301332380285371449, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1301332380285371449, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1441989783758997294, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_text
+      value: A Song Beginning With Q
+      objectReference: {fileID: 0}
+    - target: {fileID: 1553656265950647833, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: _dialog
+      value: 
+      objectReference: {fileID: 6162491671344219383}
+    - target: {fileID: 3830606908955517198, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 6162491671344219383}
+    - target: {fileID: 3830606908955517198, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: OnBlueButton
+      objectReference: {fileID: 0}
+    - target: {fileID: 3830606908955517198, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: YARG.Menu.Dialogs.SongPickerListDialog, Assembly-CSharp
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7267166965990280431, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7267166965990280431, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7267166965990280431, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7267166965990280431, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7267166965990280431, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7267166965990280431, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7409450936394283947, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7409450936394283947, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7409450936394283947, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7409450936394283947, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7409450936394283947, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7409450936394283947, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8388571864023119118, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_Name
+      value: BlueSong
+      objectReference: {fileID: 0}
+    - target: {fileID: 8929720893787002541, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_Color.b
+      value: 0.9764706
+      objectReference: {fileID: 0}
+    - target: {fileID: 8929720893787002541, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.5176471
+      objectReference: {fileID: 0}
+    - target: {fileID: 8929720893787002541, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.21568628
+      objectReference: {fileID: 0}
+    - target: {fileID: 8935335792748373938, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8935335792748373938, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8935335792748373938, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8935335792748373938, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8935335792748373938, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8935335792748373938, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7818c92215fed744f8c884bbf94c062e, type: 3}
+--- !u!224 &4083880024458073176 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+    type: 3}
+  m_PrefabInstance: {fileID: 7417276920968531750}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &5618528895710040192 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 3104792467088138150, guid: 7818c92215fed744f8c884bbf94c062e,
+    type: 3}
+  m_PrefabInstance: {fileID: 7417276920968531750}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 981e6dcb8ea0456b86bd1874ac3a01fb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1001 &8571935286636477722
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 6730295334324542441}
+    m_Modifications:
+    - target: {fileID: 4580038255989718011, guid: 1391aeff5bdd1ce40b9b1a76d237c1eb,
+        type: 3}
+      propertyPath: m_text
+      value: Close
+      objectReference: {fileID: 0}
+    - target: {fileID: 4580038255989718011, guid: 1391aeff5bdd1ce40b9b1a76d237c1eb,
+        type: 3}
+      propertyPath: m_fontColor.b
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4580038255989718011, guid: 1391aeff5bdd1ce40b9b1a76d237c1eb,
+        type: 3}
+      propertyPath: m_fontColor.g
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4580038255989718011, guid: 1391aeff5bdd1ce40b9b1a76d237c1eb,
+        type: 3}
+      propertyPath: m_fontColor.r
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4580038255989718011, guid: 1391aeff5bdd1ce40b9b1a76d237c1eb,
+        type: 3}
+      propertyPath: m_fontColor32.rgba
+      value: 4294967295
+      objectReference: {fileID: 0}
+    - target: {fileID: 5373295246384972792, guid: 1391aeff5bdd1ce40b9b1a76d237c1eb,
+        type: 3}
+      propertyPath: m_Name
+      value: Close
+      objectReference: {fileID: 0}
+    - target: {fileID: 6490900081354612681, guid: 1391aeff5bdd1ce40b9b1a76d237c1eb,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6490900081354612681, guid: 1391aeff5bdd1ce40b9b1a76d237c1eb,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 1.0000005
+      objectReference: {fileID: 0}
+    - target: {fileID: 6490900081354612681, guid: 1391aeff5bdd1ce40b9b1a76d237c1eb,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6490900081354612681, guid: 1391aeff5bdd1ce40b9b1a76d237c1eb,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6490900081354612681, guid: 1391aeff5bdd1ce40b9b1a76d237c1eb,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6490900081354612681, guid: 1391aeff5bdd1ce40b9b1a76d237c1eb,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6490900081354612681, guid: 1391aeff5bdd1ce40b9b1a76d237c1eb,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6490900081354612681, guid: 1391aeff5bdd1ce40b9b1a76d237c1eb,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 1220
+      objectReference: {fileID: 0}
+    - target: {fileID: 6490900081354612681, guid: 1391aeff5bdd1ce40b9b1a76d237c1eb,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 50
+      objectReference: {fileID: 0}
+    - target: {fileID: 6490900081354612681, guid: 1391aeff5bdd1ce40b9b1a76d237c1eb,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6490900081354612681, guid: 1391aeff5bdd1ce40b9b1a76d237c1eb,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6490900081354612681, guid: 1391aeff5bdd1ce40b9b1a76d237c1eb,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6490900081354612681, guid: 1391aeff5bdd1ce40b9b1a76d237c1eb,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6490900081354612681, guid: 1391aeff5bdd1ce40b9b1a76d237c1eb,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6490900081354612681, guid: 1391aeff5bdd1ce40b9b1a76d237c1eb,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6490900081354612681, guid: 1391aeff5bdd1ce40b9b1a76d237c1eb,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6490900081354612681, guid: 1391aeff5bdd1ce40b9b1a76d237c1eb,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 610
+      objectReference: {fileID: 0}
+    - target: {fileID: 6490900081354612681, guid: 1391aeff5bdd1ce40b9b1a76d237c1eb,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0.000022888184
+      objectReference: {fileID: 0}
+    - target: {fileID: 6490900081354612681, guid: 1391aeff5bdd1ce40b9b1a76d237c1eb,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6490900081354612681, guid: 1391aeff5bdd1ce40b9b1a76d237c1eb,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6490900081354612681, guid: 1391aeff5bdd1ce40b9b1a76d237c1eb,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8784880082956110221, guid: 1391aeff5bdd1ce40b9b1a76d237c1eb,
+        type: 3}
+      propertyPath: m_Color.b
+      value: 0.21568628
+      objectReference: {fileID: 0}
+    - target: {fileID: 8784880082956110221, guid: 1391aeff5bdd1ce40b9b1a76d237c1eb,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.16862746
+      objectReference: {fileID: 0}
+    - target: {fileID: 8784880082956110221, guid: 1391aeff5bdd1ce40b9b1a76d237c1eb,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 0.9529412
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 1391aeff5bdd1ce40b9b1a76d237c1eb, type: 3}
+--- !u!224 &3234128249276097235 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 6490900081354612681, guid: 1391aeff5bdd1ce40b9b1a76d237c1eb,
+    type: 3}
+  m_PrefabInstance: {fileID: 8571935286636477722}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &7773415494866034796 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2095609304296693110, guid: 1391aeff5bdd1ce40b9b1a76d237c1eb,
+    type: 3}
+  m_PrefabInstance: {fileID: 8571935286636477722}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b6738045cff16e840b711505d125696f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1001 &8773074003847009729
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 4930811357176253962}
+    m_Modifications:
+    - target: {fileID: 602748328894825681, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 602748328894825681, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 602748328894825681, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 602748328894825681, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 602748328894825681, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 602748328894825681, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1301332380285371449, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1301332380285371449, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1301332380285371449, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1301332380285371449, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1301332380285371449, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1301332380285371449, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1441989783758997294, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_text
+      value: A Song I've Never Played Before
+      objectReference: {fileID: 0}
+    - target: {fileID: 1553656265950647833, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: _dialog
+      value: 
+      objectReference: {fileID: 6162491671344219383}
+    - target: {fileID: 3830606908955517198, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 6162491671344219383}
+    - target: {fileID: 3830606908955517198, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: OnYellowButton
+      objectReference: {fileID: 0}
+    - target: {fileID: 3830606908955517198, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: YARG.Menu.Dialogs.SongPickerListDialog, Assembly-CSharp
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 60
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7267166965990280431, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7267166965990280431, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7267166965990280431, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7267166965990280431, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7267166965990280431, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7267166965990280431, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7409450936394283947, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7409450936394283947, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7409450936394283947, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7409450936394283947, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7409450936394283947, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7409450936394283947, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8388571864023119118, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_Name
+      value: YellowSong
+      objectReference: {fileID: 0}
+    - target: {fileID: 8929720893787002541, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_Color.b
+      value: 0.050980393
+      objectReference: {fileID: 0}
+    - target: {fileID: 8929720893787002541, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_Color.g
+      value: 0.73333335
+      objectReference: {fileID: 0}
+    - target: {fileID: 8929720893787002541, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_Color.r
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8935335792748373938, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8935335792748373938, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8935335792748373938, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8935335792748373938, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8935335792748373938, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8935335792748373938, guid: 7818c92215fed744f8c884bbf94c062e,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7818c92215fed744f8c884bbf94c062e, type: 3}
+--- !u!224 &2847283638568521407 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 6792463089375337342, guid: 7818c92215fed744f8c884bbf94c062e,
+    type: 3}
+  m_PrefabInstance: {fileID: 8773074003847009729}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &5969037656885758567 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 3104792467088138150, guid: 7818c92215fed744f8c884bbf94c062e,
+    type: 3}
+  m_PrefabInstance: {fileID: 8773074003847009729}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 981e6dcb8ea0456b86bd1874ac3a01fb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/Prefabs/Menu/MusicLibrary/PlayAShow/ShowDialog.prefab
+++ b/Assets/Prefabs/Menu/MusicLibrary/PlayAShow/ShowDialog.prefab
@@ -1,5 +1,145 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1334357290031955801
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3564976322284513629}
+  - component: {fileID: 898410363895519703}
+  - component: {fileID: 3584757944650969520}
+  m_Layer: 5
+  m_Name: Image
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &3564976322284513629
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1334357290031955801}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 709190914221093347}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 610, y: -25}
+  m_SizeDelta: {x: 40, y: 40}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &898410363895519703
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1334357290031955801}
+  m_CullTransparentMesh: 1
+--- !u!114 &3584757944650969520
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1334357290031955801}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 1233d02de0abf284e88f252d9653242c, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &1582435374060711086
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 709190914221093347}
+  - component: {fileID: 6319225215275365284}
+  m_Layer: 5
+  m_Name: DotContainer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &709190914221093347
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1582435374060711086}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3564976322284513629}
+  m_Father: {fileID: 7404975268562146615}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 0}
+  m_AnchoredPosition: {x: 0, y: -25}
+  m_SizeDelta: {x: 0, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &6319225215275365284
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1582435374060711086}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 30649d3a9faa99c48a7b1166b86bf2a0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Padding:
+    m_Left: 0
+    m_Right: 0
+    m_Top: 0
+    m_Bottom: 0
+  m_ChildAlignment: 4
+  m_Spacing: 10
+  m_ChildForceExpandWidth: 0
+  m_ChildForceExpandHeight: 0
+  m_ChildControlWidth: 0
+  m_ChildControlHeight: 0
+  m_ChildScaleWidth: 0
+  m_ChildScaleHeight: 0
+  m_ReverseArrangement: 0
 --- !u!1 &1852554208043748149
 GameObject:
   m_ObjectHideFlags: 0
@@ -29,6 +169,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 7482369732977593590}
+  - {fileID: 709190914221093347}
   m_Father: {fileID: 2827624170578181746}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -506,7 +647,10 @@ MonoBehaviour:
   - {fileID: 3669916413828962949}
   _selectButton: {fileID: 110889079661771637}
   _countdownSlider: {fileID: 9204053419736488386}
-  MusicLibrary: {fileID: 0}
+  _dotContainer: {fileID: 1582435374060711086}
+  _dotImage: {fileID: 1334357290031955801}
+  _emptyDot: {fileID: 21300000, guid: 1233d02de0abf284e88f252d9653242c, type: 3}
+  _filledDot: {fileID: 21300000, guid: 660296780c54ee9499e788cc09f6465b, type: 3}
 --- !u!1 &2827624170578181747
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Prefabs/Menu/MusicLibrary/PlayAShow/ShowDialog.prefab.meta
+++ b/Assets/Prefabs/Menu/MusicLibrary/PlayAShow/ShowDialog.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 0a237e5e84df70342aba8aab3b3e5d6b
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Menu/MusicLibrary/PlayAShow/ShowPickerButton.prefab
+++ b/Assets/Prefabs/Menu/MusicLibrary/PlayAShow/ShowPickerButton.prefab
@@ -1,0 +1,415 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &2809793550742734900
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2919596403338703147}
+  - component: {fileID: 1996683174773469899}
+  - component: {fileID: 5189735305709361124}
+  m_Layer: 5
+  m_Name: Button Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2919596403338703147
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2809793550742734900}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 9154763036977806440}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1996683174773469899
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2809793550742734900}
+  m_CullTransparentMesh: 1
+--- !u!114 &5189735305709361124
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2809793550742734900}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: _
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 19b7115073766a24aa48ceca884dcbf5, type: 2}
+  m_sharedMaterial: {fileID: 4249517445589659644, guid: 19b7115073766a24aa48ceca884dcbf5,
+    type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 22
+  m_fontSizeBase: 22
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 0
+  m_fontSizeMax: 999
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 4096
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &4008179247140915981
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6073794641953995833}
+  - component: {fileID: 412450321716482520}
+  - component: {fileID: 2675120542315914959}
+  - component: {fileID: 440116509921864197}
+  - component: {fileID: 5387409240223291895}
+  - component: {fileID: 7617404234607777830}
+  m_Layer: 5
+  m_Name: ShowPickerButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6073794641953995833
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4008179247140915981}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 9154763036977806440}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 74, y: 34}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &412450321716482520
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4008179247140915981}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 0
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 2
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 1, g: 0.8895351, b: 0, a: 1}
+    m_PressedColor: {r: 0.7075472, g: 0.56108844, b: 0.130162, a: 1}
+    m_SelectedColor: {r: 1, g: 1, b: 1, a: 1}
+    m_DisabledColor: {r: 0.6603774, g: 0.6603774, b: 0.6603774, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 21300000, guid: d3b0f548d717a64409a784af245a58cf,
+      type: 3}
+    m_PressedSprite: {fileID: 21300000, guid: b511bbfffd0ea184ba6ffda09d17f88c, type: 3}
+    m_SelectedSprite: {fileID: 21300000, guid: d3b0f548d717a64409a784af245a58cf, type: 3}
+    m_DisabledSprite: {fileID: 21300000, guid: b511bbfffd0ea184ba6ffda09d17f88c, type: 3}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 5439468768656205435}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 0}
+        m_TargetAssemblyTypeName: YARG.Menu.HelpBarButton, Assembly-CSharp
+        m_MethodName: OnClick
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 1
+--- !u!114 &2675120542315914959
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4008179247140915981}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 04f17c63d7ee4fe5be74e8374cf824bb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _buttonImage: {fileID: 5439468768656205435}
+  _buttonBackground: {fileID: 7617404234607777830}
+  _button: {fileID: 412450321716482520}
+  _dialog: {fileID: 0}
+--- !u!114 &440116509921864197
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4008179247140915981}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 30649d3a9faa99c48a7b1166b86bf2a0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Padding:
+    m_Left: 94
+    m_Right: 0
+    m_Top: 0
+    m_Bottom: 0
+  m_ChildAlignment: 0
+  m_Spacing: 0
+  m_ChildForceExpandWidth: 1
+  m_ChildForceExpandHeight: 1
+  m_ChildControlWidth: 1
+  m_ChildControlHeight: 1
+  m_ChildScaleWidth: 0
+  m_ChildScaleHeight: 0
+  m_ReverseArrangement: 0
+--- !u!222 &5387409240223291895
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4008179247140915981}
+  m_CullTransparentMesh: 1
+--- !u!114 &7617404234607777830
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4008179247140915981}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 0d800d674d4c3bc43a6a61be9aec873b, type: 3}
+  m_Type: 2
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &6063406863896460498
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 9154763036977806440}
+  - component: {fileID: 6427275014526108492}
+  - component: {fileID: 5439468768656205435}
+  - component: {fileID: 411124567397154946}
+  m_Layer: 5
+  m_Name: Button Image
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &9154763036977806440
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6063406863896460498}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 1
+  m_Children:
+  - {fileID: 2919596403338703147}
+  m_Father: {fileID: 6073794641953995833}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -37, y: 0}
+  m_SizeDelta: {x: 74, y: 54}
+  m_Pivot: {x: 0, y: 0.5}
+--- !u!222 &6427275014526108492
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6063406863896460498}
+  m_CullTransparentMesh: 1
+--- !u!114 &5439468768656205435
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6063406863896460498}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.09019608, g: 0.8862745, b: 0.5372549, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: b511bbfffd0ea184ba6ffda09d17f88c, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &411124567397154946
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6063406863896460498}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreLayout: 1
+  m_MinWidth: -1
+  m_MinHeight: -1
+  m_PreferredWidth: -1
+  m_PreferredHeight: -1
+  m_FlexibleWidth: -1
+  m_FlexibleHeight: 1
+  m_LayoutPriority: 1

--- a/Assets/Prefabs/Menu/MusicLibrary/PlayAShow/ShowPickerButton.prefab.meta
+++ b/Assets/Prefabs/Menu/MusicLibrary/PlayAShow/ShowPickerButton.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 5fb045b8ffcc8614ebf0c963996ffa35
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Menu/MusicLibrary/PlayAShow/ShowSelectButton.prefab
+++ b/Assets/Prefabs/Menu/MusicLibrary/PlayAShow/ShowSelectButton.prefab
@@ -1,0 +1,415 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &2809793550742734900
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2919596403338703147}
+  - component: {fileID: 1996683174773469899}
+  - component: {fileID: 5189735305709361124}
+  m_Layer: 5
+  m_Name: Button Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2919596403338703147
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2809793550742734900}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 9154763036977806440}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1996683174773469899
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2809793550742734900}
+  m_CullTransparentMesh: 1
+--- !u!114 &5189735305709361124
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2809793550742734900}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: _
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 19b7115073766a24aa48ceca884dcbf5, type: 2}
+  m_sharedMaterial: {fileID: 4249517445589659644, guid: 19b7115073766a24aa48ceca884dcbf5,
+    type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 22
+  m_fontSizeBase: 22
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 0
+  m_fontSizeMax: 999
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 4096
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &4008179247140915981
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6073794641953995833}
+  - component: {fileID: 412450321716482520}
+  - component: {fileID: 2675120542315914959}
+  - component: {fileID: 440116509921864197}
+  - component: {fileID: 5387409240223291895}
+  - component: {fileID: 7617404234607777830}
+  m_Layer: 5
+  m_Name: ShowSelectButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &6073794641953995833
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4008179247140915981}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 9154763036977806440}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 74, y: 34}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &412450321716482520
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4008179247140915981}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 0
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 2
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 1, g: 0.8895351, b: 0, a: 1}
+    m_PressedColor: {r: 0.7075472, g: 0.56108844, b: 0.130162, a: 1}
+    m_SelectedColor: {r: 1, g: 1, b: 1, a: 1}
+    m_DisabledColor: {r: 0.6603774, g: 0.6603774, b: 0.6603774, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 21300000, guid: d3b0f548d717a64409a784af245a58cf,
+      type: 3}
+    m_PressedSprite: {fileID: 21300000, guid: b511bbfffd0ea184ba6ffda09d17f88c, type: 3}
+    m_SelectedSprite: {fileID: 21300000, guid: d3b0f548d717a64409a784af245a58cf, type: 3}
+    m_DisabledSprite: {fileID: 21300000, guid: b511bbfffd0ea184ba6ffda09d17f88c, type: 3}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 5439468768656205435}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 0}
+        m_TargetAssemblyTypeName: YARG.Menu.HelpBarButton, Assembly-CSharp
+        m_MethodName: OnClick
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 1
+--- !u!114 &2675120542315914959
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4008179247140915981}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 04f17c63d7ee4fe5be74e8374cf824bb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _buttonImage: {fileID: 5439468768656205435}
+  _buttonBackground: {fileID: 7617404234607777830}
+  _button: {fileID: 412450321716482520}
+  _dialog: {fileID: 0}
+--- !u!114 &440116509921864197
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4008179247140915981}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 30649d3a9faa99c48a7b1166b86bf2a0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Padding:
+    m_Left: 94
+    m_Right: 0
+    m_Top: 0
+    m_Bottom: 0
+  m_ChildAlignment: 0
+  m_Spacing: 0
+  m_ChildForceExpandWidth: 1
+  m_ChildForceExpandHeight: 1
+  m_ChildControlWidth: 1
+  m_ChildControlHeight: 1
+  m_ChildScaleWidth: 0
+  m_ChildScaleHeight: 0
+  m_ReverseArrangement: 0
+--- !u!222 &5387409240223291895
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4008179247140915981}
+  m_CullTransparentMesh: 1
+--- !u!114 &7617404234607777830
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4008179247140915981}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 0d800d674d4c3bc43a6a61be9aec873b, type: 3}
+  m_Type: 2
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &6063406863896460498
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 9154763036977806440}
+  - component: {fileID: 6427275014526108492}
+  - component: {fileID: 5439468768656205435}
+  - component: {fileID: 411124567397154946}
+  m_Layer: 5
+  m_Name: Button Image
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &9154763036977806440
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6063406863896460498}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 1
+  m_Children:
+  - {fileID: 2919596403338703147}
+  m_Father: {fileID: 6073794641953995833}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -37, y: 0}
+  m_SizeDelta: {x: 74, y: 54}
+  m_Pivot: {x: 0, y: 0.5}
+--- !u!222 &6427275014526108492
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6063406863896460498}
+  m_CullTransparentMesh: 1
+--- !u!114 &5439468768656205435
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6063406863896460498}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 0d0c4a6295bcbdb448b5fc427b924038, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &411124567397154946
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6063406863896460498}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreLayout: 1
+  m_MinWidth: -1
+  m_MinHeight: -1
+  m_PreferredWidth: -1
+  m_PreferredHeight: -1
+  m_FlexibleWidth: -1
+  m_FlexibleHeight: 1
+  m_LayoutPriority: 1

--- a/Assets/Prefabs/Menu/MusicLibrary/PlayAShow/ShowSelectButton.prefab.meta
+++ b/Assets/Prefabs/Menu/MusicLibrary/PlayAShow/ShowSelectButton.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 947b138c4b3b45c4e9b04251b6013f5e
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/Gameplay.unity
+++ b/Assets/Scenes/Gameplay.unity
@@ -4924,22 +4924,22 @@ PrefabInstance:
     - target: {fileID: 2933889975780695480, guid: f8c143f8514898b4fb85fbadc18550c0,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2933889975780695480, guid: f8c143f8514898b4fb85fbadc18550c0,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 2933889975780695480, guid: f8c143f8514898b4fb85fbadc18550c0,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 0
+      value: 30.000036
       objectReference: {fileID: 0}
     - target: {fileID: 2933889975780695480, guid: f8c143f8514898b4fb85fbadc18550c0,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: 0
+      value: -32
       objectReference: {fileID: 0}
     - target: {fileID: 5322898957872382039, guid: f8c143f8514898b4fb85fbadc18550c0,
         type: 3}

--- a/Assets/Scenes/Gameplay.unity
+++ b/Assets/Scenes/Gameplay.unity
@@ -4924,22 +4924,22 @@ PrefabInstance:
     - target: {fileID: 2933889975780695480, guid: f8c143f8514898b4fb85fbadc18550c0,
         type: 3}
       propertyPath: m_AnchorMax.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2933889975780695480, guid: f8c143f8514898b4fb85fbadc18550c0,
         type: 3}
       propertyPath: m_AnchorMin.y
-      value: 1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2933889975780695480, guid: f8c143f8514898b4fb85fbadc18550c0,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 30.000036
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 2933889975780695480, guid: f8c143f8514898b4fb85fbadc18550c0,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -32
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5322898957872382039, guid: f8c143f8514898b4fb85fbadc18550c0,
         type: 3}

--- a/Assets/Scenes/PersistentScene.unity
+++ b/Assets/Scenes/PersistentScene.unity
@@ -235,6 +235,8 @@ MonoBehaviour:
     type: 3}
   _colorPickerDialog: {fileID: 6710161102796530923, guid: 5b1c5ee7b42f2b04bad86eaac460548a,
     type: 3}
+  _playAShowDialog: {fileID: 6162491671344219383, guid: 0a237e5e84df70342aba8aab3b3e5d6b,
+    type: 3}
 --- !u!1 &227771748
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Script/Menu/Common/Dialogs/Dialog.cs
+++ b/Assets/Script/Menu/Common/Dialogs/Dialog.cs
@@ -59,7 +59,7 @@ namespace YARG.Menu.Dialogs
             return button;
         }
 
-        public ColoredButton AddDialogButton(string localizeKey, Color backgroundColor, UnityAction action)
+        public virtual ColoredButton AddDialogButton(string localizeKey, Color backgroundColor, UnityAction action)
         {
             var button = AddDialogButton(localizeKey, action);
 

--- a/Assets/Script/Menu/Common/Dialogs/SongPickerListDialog.cs
+++ b/Assets/Script/Menu/Common/Dialogs/SongPickerListDialog.cs
@@ -189,7 +189,14 @@ namespace YARG.Menu.Dialogs
             _votedPlayers.Clear();
             Array.Clear(_votes, 0, _votes.Length);
             MusicLibrary.ShowPlaylist.AddSong(_categories[selectedIndex].Song);
-            Refresh();
+            HighlightSelectedSong(selectedIndex);
+            DOVirtual.DelayedCall(0.5f, Refresh);
+        }
+
+        private void HighlightSelectedSong(int selectedIndex)
+        {
+            // Highlight the background of the selected category
+            _showCategoryViews[selectedIndex].SetSelected(true);
         }
 
         private void CloseDialog(NavigationContext ctx)
@@ -217,6 +224,7 @@ namespace YARG.Menu.Dialogs
             _categories = _showCategoriesProvider.GetCategories();
             for (int i = 0; i < _showCategoryViews.Length; i++)
             {
+                _showCategoryViews[i].SetSelected(false);
                 _showCategoryViews[i].CategoryText.text = _categories[i].CategoryText;
             }
 

--- a/Assets/Script/Menu/Common/Dialogs/SongPickerListDialog.cs
+++ b/Assets/Script/Menu/Common/Dialogs/SongPickerListDialog.cs
@@ -1,0 +1,245 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using DG.Tweening;
+using UnityEngine;
+using UnityEngine.Events;
+using UnityEngine.Serialization;
+using UnityEngine.UI;
+using YARG.Core.Input;
+using YARG.Localization;
+using YARG.Menu.MusicLibrary;
+using YARG.Menu.Navigation;
+using YARG.Menu.Persistent;
+using YARG.Player;
+
+namespace YARG.Menu.Dialogs
+{
+    /// <summary>
+    /// Play A Show dialog, note that it works with only exactly five entries and eventually times out on its own
+    /// </summary>
+    public class SongPickerListDialog : Dialog
+    {
+        [FormerlySerializedAs("_showCategories")]
+        [SerializeField]
+        private ShowCategoryView[] _showCategoryViews;
+        [SerializeField]
+        private ShowPickerButton _selectButton;
+        [SerializeField]
+        private Slider _countdownSlider;
+
+        private ShowCategories.ShowCategory[] _categories;
+        private ShowCategories                _showCategoriesProvider;
+        private List<YargPlayer>              _players;
+        private List<YargPlayer>              _votedPlayers;
+        private int                           _voteCount;
+        private int[]                         _votes;
+        public  MusicLibraryMenu              MusicLibrary;
+
+        private Sequence _timerSequence;
+
+        public void Initialize(MusicLibraryMenu musicLibrary)
+        {
+            MusicLibrary = musicLibrary;
+            _showCategoriesProvider = new ShowCategories(musicLibrary);
+            _categories = _showCategoriesProvider.GetCategories();
+            _players = PlayerContainer.Players.Where(e => !e.Profile.IsBot).ToList();
+            _votedPlayers = new List<YargPlayer>();
+            _votes = new int[_categories.Length];
+
+            _selectButton.ButtonText.text = Localize.Key("Menu.Dialog.ShowDialog.Select");
+            Title.text = Localize.Key("Menu.Dialog.ShowDialog.Title");
+
+            for (int i = 0; i < _showCategoryViews.Length; i++)
+            {
+                _showCategoryViews[i].CategoryText.text = _categories[i].CategoryText;
+            }
+
+            // _timeoutTween = DOVirtual.DelayedCall(10.0f, TallyVotes, true);
+            _timerSequence = DOTween.Sequence(_countdownSlider).SetAutoKill(false);
+            _timerSequence.Append(_countdownSlider.DOValue(1.0f, 0.01f)).
+                Join(_countdownSlider.DOValue(0.0f, 10.0f)).
+                AppendCallback(TallyVotes);
+        }
+
+        protected override NavigationScheme GetNavigationScheme()
+        {
+            // Need an empty scheme here, because we don't want the navigation logic
+            return new NavigationScheme(new()
+            {
+                new NavigationScheme.Entry(MenuAction.Select, "That's Enough!", OnSelectButton),
+                new NavigationScheme.Entry(MenuAction.Green, "", ChooseSongAction),
+                new NavigationScheme.Entry(MenuAction.Red, "", ChooseSongAction),
+                new NavigationScheme.Entry(MenuAction.Yellow, "", ChooseSongAction),
+                new NavigationScheme.Entry(MenuAction.Blue, "", ChooseSongAction),
+                new NavigationScheme.Entry(MenuAction.Orange, "", ChooseSongAction),
+            }, true, true);
+        }
+
+        private void ChooseSongAction(NavigationContext ctx)
+        {
+            // Figure out which player and which button
+            var player = ctx.Player;
+            var button = ctx.Action;
+
+            switch (button)
+            {
+                case MenuAction.Green:
+                    AddVote(player, 0);
+                    break;
+                case MenuAction.Red:
+                    AddVote(player, 1);
+                    break;
+                case MenuAction.Yellow:
+                    AddVote(player, 2);
+                    break;
+                case MenuAction.Blue:
+                    AddVote(player, 3);
+                    break;
+                case MenuAction.Orange:
+                    AddVote(player, 4);
+                    break;
+            }
+        }
+
+        private void AddVote(YargPlayer player, int vote)
+        {
+            if (_votedPlayers.Contains(player))
+            {
+                return;
+            }
+
+            _votedPlayers.Add(player);
+            _votes[vote]++;
+
+            if (_votedPlayers.Count == _players.Count)
+            {
+                // All players have voted
+                _timerSequence.Pause();
+                TallyVotes();
+            }
+        }
+
+        private void TallyVotes()
+        {
+            // If no players voted, just give a new set of choices
+            if (_votedPlayers.Count == 0)
+            {
+                _votedPlayers.Clear();
+                Array.Clear(_votes, 0, _votes.Length);
+                Refresh();
+                return;
+            }
+
+            // Find the highest vote total and deal with the case where there is a tie
+            int highestVote = -1;
+            List<int> highestVotes = new();
+            for (int i = 0; i < _votes.Length; i++)
+            {
+                if (_votes[i] > highestVote)
+                {
+                    highestVote = _votes[i];
+                    highestVotes.Clear();
+                    highestVotes.Add(i);
+                }
+                else if (_votes[i] == highestVote)
+                {
+                    highestVotes.Add(i);
+                }
+            }
+
+            int selectedIndex;
+            if (highestVotes.Count > 1)
+            {
+                // Randomly select one of the highest votes
+                int randomIndex = UnityEngine.Random.Range(0, highestVotes.Count);
+                selectedIndex = highestVotes[randomIndex];
+            }
+            else
+            {
+                selectedIndex = highestVotes[0];
+            }
+
+            _votedPlayers.Clear();
+            Array.Clear(_votes, 0, _votes.Length);
+            MusicLibrary.ShowPlaylist.AddSong(_categories[selectedIndex].Song);
+            Refresh();
+        }
+
+        private void CloseDialog(NavigationContext ctx)
+        {
+            // Close the dialog
+            DialogManager.Instance.SubmitAndClearDialog();
+        }
+
+        private void Refresh()
+        {
+            // Minimize the chance of a race condition
+            if (_timerSequence.IsPlaying())
+            {
+                _timerSequence.Pause();
+            }
+
+            MusicLibrary.RefreshAndReselect();
+            _showCategoriesProvider.Refresh();
+            _categories = _showCategoriesProvider.GetCategories();
+            for (int i = 0; i < _showCategoryViews.Length; i++)
+            {
+                _showCategoryViews[i].CategoryText.text = _categories[i].CategoryText;
+            }
+
+            _timerSequence.Restart();
+        }
+
+
+        // The On[Color]Button methods are used only for mouse clicks. Since clicks aren't associated
+        // with a player, we short circuit the vote logic and add the song directly.
+        public void OnGreenButton()
+        {
+            MusicLibrary.ShowPlaylist.AddSong(_categories[0].Song);
+            Refresh();
+        }
+
+        public void OnRedButton()
+        {
+            MusicLibrary.ShowPlaylist.AddSong(_categories[1].Song);
+            Refresh();
+        }
+
+        public void OnYellowButton()
+        {
+            MusicLibrary.ShowPlaylist.AddSong(_categories[2].Song);
+            Refresh();
+        }
+
+        public void OnBlueButton()
+        {
+            MusicLibrary.ShowPlaylist.AddSong(_categories[3].Song);
+            Refresh();
+        }
+
+        public void OnOrangeButton()
+        {
+            MusicLibrary.ShowPlaylist.AddSong(_categories[4].Song);
+            Refresh();
+        }
+
+        public void OnSelectButton()
+        {
+            DialogManager.Instance.SubmitAndClearDialog();
+        }
+
+        public override void Submit()
+        {
+            _timerSequence.Kill();
+            MusicLibrary.RefreshAndReselect();
+            DialogManager.Instance.ClearDialog();
+        }
+
+        public override ColoredButton AddDialogButton(string localizeKey, Color backgroundColor, UnityAction action)
+        {
+            // We're living dangerously here, because we don't want to add any buttons to this dialog
+            return null;
+        }
+    }
+}

--- a/Assets/Script/Menu/Common/Dialogs/SongPickerListDialog.cs.meta
+++ b/Assets/Script/Menu/Common/Dialogs/SongPickerListDialog.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 0a00be65e63445aa916cf62e06461c23
+timeCreated: 1748630358

--- a/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.Playlist.cs
+++ b/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.Playlist.cs
@@ -1,0 +1,410 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using YARG.Core.Input;
+using YARG.Core.Song;
+using YARG.Localization;
+using YARG.Menu.Navigation;
+using YARG.Menu.Persistent;
+using YARG.Playlists;
+using YARG.Settings;
+using YARG.Song;
+
+namespace YARG.Menu.MusicLibrary
+{
+    public partial class MusicLibraryMenu
+    {
+        public struct ShowCategory
+        {
+            public ShowCategoryType Category;
+            public SongEntry        Song;
+        }
+
+        public Playlist       ShowPlaylist   { get; set; }         = new(true);
+        public ShowCategory[] ShowCategories { get; private set; } = new ShowCategory[5];
+
+        private List<ViewType> CreatePlaylistSelectViewList()
+        {
+            SongCategory[] emptyCategory = Array.Empty<SongCategory>();
+            int id = BACK_ID + 1;
+            var list = new List<ViewType>
+            {
+                new ButtonViewType(Localize.Key("Menu.MusicLibrary.Back"),
+                    "MusicLibraryIcons[Back]", () =>
+                    {
+                        SelectedPlaylist = null;
+                        MenuState = MenuState.Library;
+                        Refresh();
+                    }, BACK_ID)
+            };
+
+            list.Add(new ButtonViewType("YARG", "MusicLibraryIcons[Playlists]", () => { }));
+
+            // Favorites is always on top
+            list.Add(new PlaylistViewType(
+                Localize.Key("Menu.MusicLibrary.Favorites"),
+                PlaylistContainer.FavoritesPlaylist,
+                () =>
+                {
+                    SelectedPlaylist = PlaylistContainer.FavoritesPlaylist;
+                    MenuState = MenuState.Playlist;
+                    Refresh();
+                }, PLAYLIST_ID));
+
+            list.Add(new ButtonViewType(Localize.Key("Menu.MusicLibrary.YourPlaylists"),
+                "MusicLibraryIcons[Playlists]", () => { }));
+
+            // Add the setlist "playlist" if there are any songs currently in it
+            if (ShowPlaylist.Count > 0)
+            {
+                list.Add(new PlaylistViewType(Localize.Key("Menu.MusicLibrary.CurrentSetlist"), ShowPlaylist,
+                    () =>
+                    {
+                        SelectedPlaylist = ShowPlaylist;
+                        MenuState = MenuState.Playlist;
+                        Refresh();
+                    }, id));
+                id++;
+            }
+
+            // Add any other user defined playlists
+            foreach (var playlist in PlaylistContainer.Playlists)
+            {
+                list.Add(new PlaylistViewType(playlist.Name, playlist, () =>
+                {
+                    SelectedPlaylist = playlist;
+                    MenuState = MenuState.Playlist;
+                    Refresh();
+                }, id));
+                id++;
+            }
+
+            return list;
+        }
+
+        private List<ViewType> CreatePlaylistViewList()
+        {
+            var list = new List<ViewType>
+            {
+                new ButtonViewType(Localize.Key("Menu.MusicLibrary.Back"),
+                    "MusicLibraryIcons[Back]", ExitPlaylistView, BACK_ID)
+            };
+
+            // If `_sortedSongs` is null, then this function is being called during very first initialization,
+            // which means the song list hasn't been constructed yet.
+            if (_sortedSongs is null || SongContainer.Count <= 0 ||
+                !_sortedSongs.Any(section => section.Songs.Length > 0))
+            {
+                return list;
+            }
+
+            bool allowdupes = SettingsManager.Settings.AllowDuplicateSongs.Value;
+            foreach (var section in _sortedSongs)
+            {
+                list.Add(new SortHeaderViewType(
+                    section.Category.ToUpperInvariant(),
+                    section.Songs.Length,
+                    section.CategoryGroup));
+
+                foreach (var song in section.Songs)
+                {
+                    if (allowdupes || !song.IsDuplicate)
+                    {
+                        list.Add(new SongViewType(this, song));
+                    }
+                }
+            }
+
+            CalculateCategoryHeaderIndices(list);
+            return list;
+        }
+
+        private List<ViewType> CreateShowViewList()
+        {
+            var list = new List<ViewType>
+            {
+                new ButtonViewType(Localize.Key("Menu.MusicLibrary.Back"),
+                    "MusicLibraryIcons[Back]", LeaveShowMode, BACK_ID),
+                new ButtonViewType("Show Setlist", "MusicLibraryIcons[Playlists]", () => { })
+            };
+
+            foreach (var song in ShowPlaylist.ToList())
+            {
+                list.Add(new SongViewType(this, song));
+            }
+
+            return list;
+        }
+
+        private void SetShowNavigationScheme(bool reset = false)
+        {
+            if (reset)
+            {
+                Navigator.Instance.PopScheme();
+            }
+
+            Navigator.Instance.PushScheme(new NavigationScheme(new()
+            {
+                new NavigationScheme.Entry(MenuAction.Up, "Menu.Common.Up",
+                    ctx =>
+                    {
+                        if (IsButtonHeldByPlayer(ctx.Player, MenuAction.Orange))
+                        {
+                            GoToPreviousSection();
+                        }
+                        else
+                        {
+                            SetWrapAroundState(!ctx.IsRepeat);
+                            SelectedIndex--;
+                        }
+                    }),
+                new NavigationScheme.Entry(MenuAction.Down, "Menu.Common.Down",
+                    ctx =>
+                    {
+                        if (IsButtonHeldByPlayer(ctx.Player, MenuAction.Orange))
+                        {
+                            GoToNextSection();
+                        }
+                        else
+                        {
+                            SetWrapAroundState(!ctx.IsRepeat);
+                            SelectedIndex++;
+                        }
+                    }),
+                new NavigationScheme.Entry(MenuAction.Green, "Menu.Common.Confirm",
+                    () => CurrentSelection?.PrimaryButtonClick()),
+                new NavigationScheme.Entry(MenuAction.Red, "Menu.Common.Back", Back),
+                new NavigationScheme.Entry(MenuAction.Yellow, "Play Me Show, Mateys!",
+                    OnPlayShowHit),
+                new NavigationScheme.Entry(MenuAction.Blue, "Menu.MusicLibrary.Search",
+                    () => _searchField.Focus()),
+                new NavigationScheme.Entry(MenuAction.Orange, "Menu.MusicLibrary.MoreOptions",
+                    OnButtonHit, OnButtonRelease),
+            }, false));
+        }
+
+        private void SetShowSelectNavigationScheme(bool reset = false)
+        {
+            if (reset)
+            {
+                Navigator.Instance.PopScheme();
+            }
+
+            Navigator.Instance.PushScheme(new NavigationScheme(new()
+            {
+                new NavigationScheme.Entry(MenuAction.Up, "Menu.Common.Up",
+                    ctx =>
+                    {
+                        if (IsButtonHeldByPlayer(ctx.Player, MenuAction.Orange))
+                        {
+                            GoToPreviousSection();
+                        }
+                        else
+                        {
+                            SetWrapAroundState(!ctx.IsRepeat);
+                            SelectedIndex--;
+                        }
+                    }),
+                new NavigationScheme.Entry(MenuAction.Down, "Menu.Common.Down",
+                    ctx =>
+                    {
+                        if (IsButtonHeldByPlayer(ctx.Player, MenuAction.Orange))
+                        {
+                            GoToNextSection();
+                        }
+                        else
+                        {
+                            SetWrapAroundState(!ctx.IsRepeat);
+                            SelectedIndex++;
+                        }
+                    }),
+                new NavigationScheme.Entry(MenuAction.Green, "Menu.Common.Confirm",
+                    () => CurrentSelection?.PrimaryButtonClick()),
+                new NavigationScheme.Entry(MenuAction.Red, "Menu.Common.Back", Back),
+                new NavigationScheme.Entry(MenuAction.Yellow, "Play Me Show, Mateys!",
+                    OnPlayShowHit),
+                new NavigationScheme.Entry(MenuAction.Blue, "Menu.MusicLibrary.Search",
+                    () => _searchField.Focus()),
+                new NavigationScheme.Entry(MenuAction.Orange, "Menu.MusicLibrary.MoreOptions",
+                    OnButtonHit, OnButtonRelease),
+            }, false));
+        }
+
+        private void ExitPlaylistView()
+        {
+            SelectedPlaylist = null;
+            MenuState = MenuState.PlaylistSelect;
+            Refresh();
+
+            // Select playlist button
+            // TODO: Fix this to select the playlist we entered from, not favorites
+            SetIndexTo(i => i is ButtonViewType { ID: PLAYLIST_ID });
+        }
+
+        private void ExitShowView()
+        {
+            SelectedPlaylist = null;
+            MenuState = MenuState.Library;
+            Refresh();
+
+            // An arbitrary choice
+            SetIndexTo(i => i is ButtonViewType { ID: RANDOM_SONG_ID });
+        }
+
+        private void ExitPlaylistSelect()
+        {
+            MenuState = MenuState.Library;
+            Refresh();
+
+            SetIndexTo(i => i is ButtonViewType { ID: PLAYLIST_ID });
+        }
+
+        private void OnAddButtonHit(NavigationContext ctx)
+        {
+            _heldInputs.Add(new Navigator.HoldContext(ctx));
+        }
+
+        private void OnAddButtonRelease(NavigationContext ctx)
+        {
+            var holdContext = _heldInputs.FirstOrDefault(i => i.Context.IsSameAs(ctx));
+
+            if (ctx.Action == MenuAction.Yellow && (holdContext?.Timer > 0 || ctx.Player is null))
+            {
+                _heldInputs.RemoveAll(i => i.Context.IsSameAs(ctx));
+                AddToPlaylist();
+            }
+            else
+            {
+                _heldInputs.RemoveAll(i => i.Context.IsSameAs(ctx));
+                if (ShowPlaylist.Count > 0)
+                {
+                    StartSetlist();
+                }
+                else
+                {
+                    EnterShowMode();
+                }
+            }
+        }
+
+        private void EnterShowMode()
+        {
+            // Update the navigation scheme
+            SetShowNavigationScheme();
+
+            // Display the show screen
+			SelectedPlaylist = ShowPlaylist;
+            MenuState = MenuState.Show;
+            Refresh();
+
+            DialogManager.Instance.ShowSongPickerDialog("Pick Your Poison", this);
+        }
+
+        private void LeaveShowMode()
+        {
+            // Pop the navigation scheme
+            Navigator.Instance.PopScheme();
+
+            SelectedPlaylist = null;
+
+            // Back to library
+            MenuState = MenuState.Library;
+            Refresh();
+
+            // An arbitrary choice
+            SetIndexTo(i => i is ButtonViewType { ID: RANDOM_SONG_ID });
+        }
+
+        public void CreateShowCategories()
+        {
+
+        }
+
+        private void StartSetlist()
+        {
+            if (ShowPlaylist.Count > 0)
+            {
+                GlobalVariables.State.PlayingAShow = true;
+                GlobalVariables.State.ShowSongs = ShowPlaylist.ToList();
+                GlobalVariables.State.CurrentSong = GlobalVariables.State.ShowSongs.First();
+                GlobalVariables.State.ShowIndex = 0;
+                MenuManager.Instance.PushMenu(MenuManager.Menu.DifficultySelect);
+            }
+        }
+
+        private void AddToPlaylist()
+        {
+            if (CurrentSelection is PlaylistViewType playlist)
+            {
+                if (playlist.Playlist.SongHashes.Count == 0)
+                {
+                    ToastManager.ToastError(Localize.Key("Menu.MusicLibrary.EmptyPlaylist"));
+                    return;
+                }
+
+                if (playlist.Playlist.Ephemeral)
+                {
+                    // No, we won't add the setlist to itself, thanks
+                    ToastManager.ToastError(Localize.Key("Menu.MusicLibrary.CannotAddToSelf"));
+                    return;
+                }
+
+                var i = 0;
+
+                foreach (var song in playlist.Playlist.ToList())
+                {
+                    ShowPlaylist.AddSong(song);
+                    i++;
+                }
+
+                if (i > 0)
+                {
+                    ToastManager.ToastSuccess(Localize.KeyFormat("Menu.MusicLibrary.PlaylistAddedToSet", i));
+                }
+                else
+                {
+                    ToastManager.ToastWarning(Localize.Key("Menu.MusicLibrary.NoSongsInPlaylist"));
+                    ;
+                }
+
+                if (i > 0 && ShowPlaylist.Count == i)
+                {
+                    // We need to rebuild the navigation scheme the first time we add song(s)
+                    SetNavigationScheme(true);
+                }
+
+                // If we are in the playlist view, we need to refresh the view
+                if (MenuState == MenuState.PlaylistSelect)
+                {
+                    RefreshAndReselect();
+                }
+
+                return;
+            }
+
+            if (CurrentSelection is SongViewType selection)
+            {
+                ShowPlaylist.AddSong(selection.SongEntry);
+                if (ShowPlaylist.Count == 1)
+                {
+                    // We need to rebuild the navigation scheme after adding the first song
+                    SetNavigationScheme(true);
+                }
+
+                ToastManager.ToastSuccess(Localize.Key("Menu.MusicLibrary.AddedToSet"));
+            }
+        }
+
+        private void OnPlayShowHit()
+        {
+            if (ShowPlaylist.Count > 0)
+            {
+                GlobalVariables.State.PlayingAShow = true;
+                GlobalVariables.State.ShowSongs = ShowPlaylist.ToList();
+                GlobalVariables.State.CurrentSong = GlobalVariables.State.ShowSongs.First();
+                GlobalVariables.State.ShowIndex = 0;
+                MenuManager.Instance.PushMenu(MenuManager.Menu.DifficultySelect);
+            }
+        }
+    }
+}

--- a/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.Playlist.cs
+++ b/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.Playlist.cs
@@ -166,10 +166,8 @@ namespace YARG.Menu.MusicLibrary
                 new NavigationScheme.Entry(MenuAction.Green, "Menu.Common.Confirm",
                     () => CurrentSelection?.PrimaryButtonClick()),
                 new NavigationScheme.Entry(MenuAction.Red, "Menu.Common.Back", LeaveShowMode),
-                new NavigationScheme.Entry(MenuAction.Yellow, "Menu.MusicLibrary.StartShow",
+                new NavigationScheme.Entry(MenuAction.Blue, "Menu.MusicLibrary.StartShow",
                     OnPlayShowHit),
-                new NavigationScheme.Entry(MenuAction.Blue, "Menu.MusicLibrary.Search",
-                    () => _searchField.Focus()),
                 new NavigationScheme.Entry(MenuAction.Orange, "Menu.MusicLibrary.MoreOptions",
                     OnButtonHit, OnButtonRelease),
             }, false));
@@ -238,6 +236,7 @@ namespace YARG.Menu.MusicLibrary
         private void LeaveShowMode()
         {
             SelectedPlaylist = null;
+            ShowPlaylist.Clear();
 
             // Pop the navigation scheme
             Navigator.Instance.PopScheme();
@@ -245,18 +244,12 @@ namespace YARG.Menu.MusicLibrary
             // in the case that we are leaving show mode with a playlist that has entries
             SetNavigationScheme(true);
 
-
             // Back to library
             MenuState = MenuState.Library;
             Refresh();
 
             // An arbitrary choice
             SetIndexTo(i => i is ButtonViewType { ID: RANDOM_SONG_ID });
-        }
-
-        public void CreateShowCategories()
-        {
-
         }
 
         private void StartSetlist()
@@ -341,6 +334,10 @@ namespace YARG.Menu.MusicLibrary
                 GlobalVariables.State.ShowSongs = ShowPlaylist.ToList();
                 GlobalVariables.State.CurrentSong = GlobalVariables.State.ShowSongs.First();
                 GlobalVariables.State.ShowIndex = 0;
+
+                // Make sure we don't come back to play a show after show has been played
+                LeaveShowMode();
+
                 MenuManager.Instance.PushMenu(MenuManager.Menu.DifficultySelect);
             }
         }

--- a/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.Playlist.cs.meta
+++ b/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.Playlist.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 8eb656f1cc4f4e4ebd52c996bfe383dc
+timeCreated: 1748627527

--- a/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
+++ b/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
@@ -266,7 +266,7 @@ namespace YARG.Menu.MusicLibrary
                     new NavigationScheme.Entry(MenuAction.Yellow, "Menu.MusicLibrary.AddToSet",
                         AddToSetlist),
                     new NavigationScheme.Entry(MenuAction.Blue, "Menu.MusicLibrary.Search",
-                        () => _searchField.Focus()),
+                        EnterShowMode),
                     new NavigationScheme.Entry(MenuAction.Orange, "Menu.MusicLibrary.MoreOptions",
                         OnButtonHit, OnButtonRelease),
                 }, false));

--- a/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
+++ b/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
@@ -265,7 +265,7 @@ namespace YARG.Menu.MusicLibrary
                     new NavigationScheme.Entry(MenuAction.Red, "Menu.Common.Back", Back),
                     new NavigationScheme.Entry(MenuAction.Yellow, "Menu.MusicLibrary.AddToSet",
                         AddToSetlist),
-                    new NavigationScheme.Entry(MenuAction.Blue, "Menu.MusicLibrary.Search",
+                    new NavigationScheme.Entry(MenuAction.Blue, "Menu.MusicLibrary.PlayShow",
                         EnterShowMode),
                     new NavigationScheme.Entry(MenuAction.Orange, "Menu.MusicLibrary.MoreOptions",
                         OnButtonHit, OnButtonRelease),

--- a/Assets/Script/Menu/MusicLibrary/ShowCategories.cs
+++ b/Assets/Script/Menu/MusicLibrary/ShowCategories.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using YARG.Core;
 using YARG.Core.Song;
+using YARG.Localization;
 using YARG.Player;
 using YARG.Playlists;
 using YARG.Song;
@@ -270,7 +271,7 @@ namespace YARG.Menu.MusicLibrary
             var song = SongContainer.Sources[source].ElementAt(Rng.Next(0, SongContainer.Sources[source].Count));
             var sourceDisplay = SongSources.SourceToGameName(source);
 
-            return new ShowCategory($"A Song From {sourceDisplay}", song);
+            return new ShowCategory(Localize.KeyFormat("Menu.MusicLibrary.PlayAShow.SongFromSource", sourceDisplay), song);
         }
 
         private static ShowCategory RandomArtist()
@@ -283,7 +284,7 @@ namespace YARG.Menu.MusicLibrary
 
             var song = SongContainer.Artists[artist].ElementAt(Rng.Next(0, SongContainer.Artists[artist].Count));
 
-            return new ShowCategory($"A Song By {artist}", song);
+            return new ShowCategory(Localize.KeyFormat("Menu.MusicLibrary.PlayAShow.SongFromArtist", artist), song);
         }
 
         private static ShowCategory RandomGenre()
@@ -302,11 +303,11 @@ namespace YARG.Menu.MusicLibrary
             List<string> vowels = new List<string> {"a", "e", "i", "o", "u"};
             if (vowels.Contains(genreString.ToLower()[..1]))
             {
-                outString = $"An {genre} Song";
+                outString = Localize.KeyFormat("Menu.MusicLibrary.PlayAShow.SongFromAnGenre", genre);
             }
             else
             {
-                outString = $"A {genre} Song";
+                outString = Localize.KeyFormat("Menu.MusicLibrary.PlayAShow.SongFromGenre", genre);
             }
 
             return new ShowCategory(outString, song);
@@ -335,7 +336,7 @@ namespace YARG.Menu.MusicLibrary
 
             var outsong = SongContainer.Years[decade].ElementAt(Rng.Next(0, SongContainer.Years[decade].Count));
 
-            return new ShowCategory($"A Song From The {decade}", outsong);
+            return new ShowCategory(Localize.KeyFormat("Menu.MusicLibrary.PlayAShow.SongFromDecade", decade), outsong);
         }
 
         private static ShowCategory ShortSong()
@@ -343,7 +344,7 @@ namespace YARG.Menu.MusicLibrary
             // Get all the songs less than 2 minutes long (because that's what SongCache already knows)
             var songs = SongContainer.SongLengths["00:00 - 02:00"];
             var outsong = songs.ElementAt(Rng.Next(0, songs.Count));
-            return new ShowCategory("A Short Song", outsong);
+            return new ShowCategory(Localize.Key("Menu.MusicLibrary.PlayAShow.ShortSong"), outsong);
         }
 
         private static ShowCategory LongSong()
@@ -368,7 +369,7 @@ namespace YARG.Menu.MusicLibrary
             }
 
             var outsong = songs.ElementAt(Rng.Next(0, songs.Count));
-            return new ShowCategory("A Long Song", outsong);
+            return new ShowCategory(Localize.Key("Menu.MusicLibrary.PlayAShow.LongSong"), outsong);
         }
 
         private static ShowCategory SongStartsWith()
@@ -382,15 +383,15 @@ namespace YARG.Menu.MusicLibrary
 
             if (key == "0-9")
             {
-                return new ShowCategory("A Song Starting With A Number", song);
+                return new ShowCategory(Localize.Key("Menu.MusicLibrary.PlayAShow.StartsWithNumber"), song);
             }
 
             if (key == "*")
             {
-                return new ShowCategory("A Song Starting With Something Non-Alphanumeric", song);
+                return new ShowCategory(Localize.Key("Menu.MusicLibrary.PlayAShow.StartsWithOther"), song);
             }
 
-            return new ShowCategory($"A Song Starting With \"{key}\"", song);
+            return new ShowCategory(Localize.KeyFormat("Menu.MusicLibrary.PlayAShow.StartsWithLetter", key), song);
         }
 
         private static ShowCategory SongFromPlaylist()
@@ -425,7 +426,8 @@ namespace YARG.Menu.MusicLibrary
                 return RandomSong();
             }
 
-            return new ShowCategory($"A Song From Your Playlist {playlist.Name}", SongContainer.SongsByHash[hash][0]);
+            return new ShowCategory(Localize.KeyFormat("Menu.MusicLibrary.PlayAShow.SongFromPlaylist", playlist.Name),
+                SongContainer.SongsByHash[hash][0]);
         }
 
         private static ShowCategory SongFromFavorites()
@@ -446,14 +448,14 @@ namespace YARG.Menu.MusicLibrary
                 return RandomSong();
             }
 
-            return new ShowCategory("One Of Your Favorite Songs", SongContainer.SongsByHash[hash][0]);
+            return new ShowCategory(Localize.Key("Menu.MusicLibrary.PlayAShow.SongFromFavorites"), SongContainer.SongsByHash[hash][0]);
         }
 
         private static ShowCategory RandomSong()
         {
             // Get a random song
             var outsong = SongContainer.GetRandomSong();
-            return new ShowCategory("A Random Song", outsong);
+            return new ShowCategory(Localize.Key("Menu.MusicLibrary.PlayAShow.RandomSong"), outsong);
         }
     }
 }

--- a/Assets/Script/Menu/MusicLibrary/ShowCategories.cs
+++ b/Assets/Script/Menu/MusicLibrary/ShowCategories.cs
@@ -1,0 +1,403 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using YARG.Core;
+using YARG.Core.Song;
+using YARG.Player;
+using YARG.Playlists;
+using YARG.Song;
+
+namespace YARG.Menu.MusicLibrary
+{
+    public class ShowCategories
+    {
+        public struct ShowCategory
+        {
+            public string    CategoryText;
+            public SongEntry Song;
+
+            public ShowCategory(string categoryText, SongEntry song)
+            {
+                CategoryText = categoryText;
+                Song = song;
+            }
+        }
+
+        private struct ShowCategoryType : IEquatable<ShowCategoryType>
+        {
+            public int Chance;
+            public Func<ShowCategory> CategoryAction;
+
+            public bool Equals(ShowCategoryType other) => CategoryAction.Equals(other.CategoryAction);
+
+            public override bool Equals(object obj) => obj is ShowCategoryType other && Equals(other);
+
+            public override int GetHashCode() => CategoryAction.GetHashCode();
+        }
+
+        private static readonly ShowCategory[]         Categories = new ShowCategory[5];
+        private static readonly List<ShowCategoryType> UsedCategoryTypes = new List<ShowCategoryType>();
+        private static readonly Random                 Rng        = new();
+        private                 List<ShowCategoryType> _possibleCategories;
+
+        private readonly Dictionary<YargPlayer, List<Instrument>> _instruments = new();
+        private          List<YargPlayer>                         _players     = new();
+        private readonly MusicLibraryMenu                         _library;
+
+        public ShowCategories(MusicLibraryMenu library)
+        {
+            _library = library;
+            GetProfileInstruments();
+            CreateCategoryTypes();
+            BuildCategoryList();
+        }
+
+        public void Refresh()
+        {
+            BuildCategoryList();
+        }
+
+        public ShowCategory[] GetCategories()
+        {
+            return Categories;
+        }
+
+        private void CreateCategoryTypes()
+        {
+            _possibleCategories = new List<ShowCategoryType>
+            {
+                new ShowCategoryType {Chance = 13, CategoryAction = RandomSource},
+                new ShowCategoryType {Chance = 12, CategoryAction = RandomArtist},
+                new ShowCategoryType {Chance = 15, CategoryAction = RandomGenre},
+                new ShowCategoryType {Chance = 10, CategoryAction = RandomDecade},
+                // Random will get called if SongFromPlaylist or SongFromFavorites fail, so its chance is higher than it appears
+                new ShowCategoryType {Chance = 1, CategoryAction = RandomSong},
+                new ShowCategoryType {Chance = 15, CategoryAction = ShortSong},
+                new ShowCategoryType {Chance = 10, CategoryAction = LongSong},
+                new ShowCategoryType {Chance = 10, CategoryAction = SongStartsWith},
+                new ShowCategoryType {Chance = 10, CategoryAction = SongFromPlaylist},
+                new ShowCategoryType {Chance = 4, CategoryAction = SongFromFavorites},
+            };
+        }
+
+        private void BuildCategoryList()
+        {
+            UsedCategoryTypes.Clear();
+            for (int i = 0; i < Categories.Length; i++)
+            {
+                if (!PickSingleCategory(i))
+                {
+                    // We failed to pick a unique category, so try again. There are more types than slots, so
+                    // this will eventually complete.
+                    i--;
+                }
+            }
+        }
+
+        private bool PickSingleCategory(int i)
+        {
+            // Pick a random category based on Chance
+            var p = Rng.Next(0, 100);
+            foreach (var category in _possibleCategories)
+            {
+                if (p < category.Chance)
+                {
+                    // Get a playable song from the category
+                    int tries = 0;
+                    do
+                    {
+                        Categories[i] = category.CategoryAction();
+                        tries++;
+                    } while (!IsSongPlayable(Categories[i].Song) && tries < 5);
+
+                    if (tries == 5)
+                    {
+                        // We exhausted tries for this category, so move on to the next category
+                        continue;
+                    }
+
+                    // Check if we already used this category
+                    bool reused = false;
+
+                    for (int j = 0; j < i; j++)
+                    {
+                        if (UsedCategoryTypes.Contains(category))
+                        {
+                            reused = true;
+                            break;
+                        }
+                    }
+
+                    if (reused)
+                    {
+                        continue;
+                    }
+
+                    // Success, so category is now used and we need not loop again
+
+                    UsedCategoryTypes.Add(category);
+                    break;
+                }
+
+                // We'll get there eventually since the chances add up to 100.
+                p -= category.Chance;
+            }
+
+            // Just in case we failed to pick a category...
+            if (Categories[i].CategoryText == null)
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        // Song is playable only if all players can play and there is playable instrument commonality with the
+        // rest of the show playlist.
+        private bool IsSongPlayable(SongEntry song)
+        {
+            List<Instrument> candidateInstruments = new();
+            foreach (var player in _players)
+            {
+                bool playable = false;
+                foreach(var instrument in _instruments[player])
+                {
+                    if (song.HasInstrument(instrument))
+                    {
+                        playable = true;
+                        break;
+                    }
+                }
+
+                if (!playable)
+                {
+                    return false;
+                }
+
+                // We also need to check if this song shares at least one instrument with the other songs already in ShowPlaylist
+                var playlist = _library.ShowPlaylist;
+
+                // No need to check if this is the first in the list
+                if (playlist.Count == 0)
+                {
+                    continue;
+                }
+
+                candidateInstruments.Clear();
+                foreach (var instrument in _instruments[player])
+                {
+                    if (song.HasInstrument(instrument))
+                    {
+                        candidateInstruments.Add(instrument);
+                    }
+                }
+
+                foreach (var songHash in playlist.SongHashes)
+                {
+                    // We know this hash exists, because we are only working on the show playlist,
+                    // and we added it to the list ourselves
+                    bool hasCommonInstrument = false;
+                    foreach (var instrument in candidateInstruments)
+                    {
+                        if (SongContainer.SongsByHash[songHash][0].HasInstrument(instrument))
+                        {
+                            hasCommonInstrument = true;
+                            break;
+                        }
+                    }
+
+                    if (!hasCommonInstrument)
+                    {
+                        return false;
+                    }
+                }
+            }
+
+            return true;
+        }
+
+        private void GetProfileInstruments()
+        {
+            _instruments.Clear();
+            _players = PlayerContainer.Players.Where(e => !e.Profile.IsBot).ToList();
+            foreach (var player in _players)
+            {
+                _instruments[player] = new List<Instrument>();
+                // Add the player's possible instruments to the list
+                foreach (var instrument in player.Profile.GameMode.PossibleInstruments())
+                {
+                    _instruments[player].Add(instrument);
+                }
+            }
+        }
+
+        private static ShowCategory RandomSource()
+        {
+            // Pick a random source from the available sources
+            var source = SongContainer.Sources.Keys.ElementAt(Rng.Next(0, SongContainer.Sources.Count));
+            var song = SongContainer.Sources[source].ElementAt(Rng.Next(0, SongContainer.Sources[source].Count));
+            var sourceDisplay = SongSources.SourceToGameName(source);
+
+            return new ShowCategory($"A Song From {sourceDisplay}", song);
+        }
+
+        private static ShowCategory RandomArtist()
+        {
+            // Pick a random artist from the available artists
+            var artist = SongContainer.Artists.Keys.ElementAt(Rng.Next(0, SongContainer.Artists.Count));
+            var song = SongContainer.Artists[artist].ElementAt(Rng.Next(0, SongContainer.Artists[artist].Count));
+
+            return new ShowCategory($"A Song By {artist}", song);
+        }
+
+        private static ShowCategory RandomGenre()
+        {
+            // Pick a random genre from the available genres
+            var genre = SongContainer.Genres.Keys.ElementAt(Rng.Next(0, SongContainer.Genres.Count));
+
+            // Pick a random song from the genre
+            var song = SongContainer.Genres[genre].ElementAt(Rng.Next(0, SongContainer.Genres[genre].Count));
+
+            var genreString = $"{genre}";
+            string outString;
+            List<string> vowels = new List<string> {"a", "e", "i", "o", "u"};
+            if (vowels.Contains(genreString.ToLower()[..1]))
+            {
+                outString = $"An {genre} Song";
+            }
+            else
+            {
+                outString = $"A {genre} Song";
+            }
+
+            return new ShowCategory(outString, song);
+        }
+
+        private static ShowCategory RandomDecade()
+        {
+            // Turns out SongContainer.Years should really be named SongContainer.Decades
+
+            // Pick a random decade (that is actually a number) from the list
+            string decade;
+            do
+            {
+                decade = SongContainer.Years.Keys.ElementAt(Rng.Next(0, SongContainer.Years.Count));
+            } while (decade.Contains("####"));
+
+            var outsong = SongContainer.Years[decade].ElementAt(Rng.Next(0, SongContainer.Years[decade].Count));
+
+            return new ShowCategory($"A Song From The {decade}", outsong);
+        }
+
+        private static ShowCategory ShortSong()
+        {
+            // Get all the songs less than 2 minutes long (because that's what SongCache already knows)
+            var songs = SongContainer.SongLengths["00:00 - 02:00"];
+            var outsong = songs.ElementAt(Rng.Next(0, songs.Count));
+            return new ShowCategory("A Short Song", outsong);
+        }
+
+        private static ShowCategory LongSong()
+        {
+            // Get all the songs greater than 5 minutes long
+            List<SongEntry> songs = new();
+
+            // Define all the time ranges we want to include
+            string[] longSongKeys = {
+                "05:00 - 10:00",
+                "10:00 - 15:00",
+                "15:00 - 20:00",
+                "20:00+"
+            };
+
+            foreach (var range in longSongKeys)
+            {
+                if (SongContainer.SongLengths.ContainsKey(range))
+                {
+                    songs.AddRange(SongContainer.SongLengths[range]);
+                }
+            }
+
+            var outsong = songs.ElementAt(Rng.Next(0, songs.Count));
+            return new ShowCategory("A Long Song", outsong);
+        }
+
+        private static ShowCategory SongStartsWith()
+        {
+            // Pick a random letter, check if we have any songs starting with it
+            var key = SongContainer.Titles.Keys.ElementAt(Rng.Next(0, SongContainer.Titles.Count));
+            var songs = SongContainer.Titles[key];
+            var song = songs.ElementAt(Rng.Next(0, songs.Count));
+
+            if (key == "0-9")
+            {
+                return new ShowCategory("A Song Starting With A Number", song);
+            }
+
+            return new ShowCategory($"A Song Starting With \"{key}\"", song);
+        }
+
+        private static ShowCategory SongFromPlaylist()
+        {
+            var playlists = PlaylistContainer.Playlists.Where(e => e.Count > 4).ToList();
+
+            for (int i = 0; i < playlists.Count; i++)
+            {
+                if (playlists[i].Count < 5 || playlists[i] == PlaylistContainer.FavoritesPlaylist)
+                {
+                    playlists.RemoveAt(i);
+                    // Not sure if actually needed, but just in case..worst case we process some items we're keeping
+                    // more than once
+                    i--;
+                }
+            }
+
+            if (playlists.Count == 0)
+            {
+                return RandomSong();
+            }
+
+            // Get random playlist from the ones that remain
+            var playlist = playlists.ElementAt(Rng.Next(0, playlists.Count));
+
+            // Get random song from said playlist
+            var hash = playlist.SongHashes.ElementAt(Rng.Next(0, playlist.SongHashes.Count));
+
+            // Sometimes a playlist contains a song hash we no longer have
+            if (!SongContainer.SongsByHash.ContainsKey(hash))
+            {
+                return RandomSong();
+            }
+
+            return new ShowCategory($"A Song From Your Playlist {playlist.Name}", SongContainer.SongsByHash[hash][0]);
+        }
+
+        private static ShowCategory SongFromFavorites()
+        {
+            var playlist = PlaylistContainer.FavoritesPlaylist;
+
+            if (playlist == null || playlist.SongHashes.Count < 4)
+            {
+                return RandomSong();
+            }
+
+            // Get random song from favorites playlist
+            var hash = playlist.SongHashes.ElementAt(Rng.Next(0, playlist.SongHashes.Count));
+
+            // Sometimes a playlist contains a song hash we no longer have
+            if (!SongContainer.SongsByHash.ContainsKey(hash))
+            {
+                return RandomSong();
+            }
+
+            return new ShowCategory("One Of Your Favorite Songs", SongContainer.SongsByHash[hash][0]);
+        }
+
+        private static ShowCategory RandomSong()
+        {
+            // Get a random song
+            var outsong = SongContainer.GetRandomSong();
+            return new ShowCategory("A Random Song", outsong);
+        }
+    }
+}

--- a/Assets/Script/Menu/MusicLibrary/ShowCategories.cs
+++ b/Assets/Script/Menu/MusicLibrary/ShowCategories.cs
@@ -6,6 +6,7 @@ using YARG.Core.Song;
 using YARG.Localization;
 using YARG.Player;
 using YARG.Playlists;
+using YARG.Settings;
 using YARG.Song;
 
 namespace YARG.Menu.MusicLibrary
@@ -157,15 +158,18 @@ namespace YARG.Menu.MusicLibrary
 
         // Song is playable only if all players can play and there is playable instrument commonality with the
         // rest of the show playlist.
+        // When RequireAllDifficulties is set, also checks that full difficulty is available for at least one
+        // of each player's possible instruments
         private bool IsSongPlayable(SongEntry song)
         {
             List<Instrument> candidateInstruments = new();
+            bool fdOnly = SettingsManager.Settings.RequireAllDifficulties.Value;
             foreach (var player in _players)
             {
                 bool playable = false;
                 foreach(var instrument in _instruments[player])
                 {
-                    if (song.HasInstrument(instrument))
+                    if (song.HasInstrument(instrument) && (!fdOnly || song.HasEmhxDifficultiesForInstrument(instrument)))
                     {
                         playable = true;
                         break;

--- a/Assets/Script/Menu/MusicLibrary/ShowCategories.cs.meta
+++ b/Assets/Script/Menu/MusicLibrary/ShowCategories.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 4a83b4956bc041b08b500ed847b92e1a
+timeCreated: 1748694359

--- a/Assets/Script/Menu/MusicLibrary/ShowCategoryType.cs
+++ b/Assets/Script/Menu/MusicLibrary/ShowCategoryType.cs
@@ -1,0 +1,12 @@
+﻿
+using System;
+
+namespace YARG.Menu.MusicLibrary
+{
+    public class ShowCategoryType
+    {
+        public string CategoryText;
+        public float  Chance;
+        public Action CategorySelectAction;
+    }
+}

--- a/Assets/Script/Menu/MusicLibrary/ShowCategoryType.cs.meta
+++ b/Assets/Script/Menu/MusicLibrary/ShowCategoryType.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 9d6f8d6063c6403cb23d925f15a03e82
+timeCreated: 1748693916

--- a/Assets/Script/Menu/MusicLibrary/ShowCategoryView.cs
+++ b/Assets/Script/Menu/MusicLibrary/ShowCategoryView.cs
@@ -1,0 +1,21 @@
+﻿using System.Collections.Generic;
+using TMPro;
+using UnityEngine;
+using UnityEngine.Serialization;
+using YARG.Menu.Persistent;
+
+namespace YARG.Menu.MusicLibrary
+{
+    /// <summary>
+    /// Play A Show category view
+    /// </summary>
+    public class ShowCategoryView : MonoBehaviour
+    {
+        [SerializeField]
+        public TextMeshProUGUI CategoryText;
+        [SerializeField]
+        private ShowPickerButton _pickerButton;
+
+
+    }
+}

--- a/Assets/Script/Menu/MusicLibrary/ShowCategoryView.cs
+++ b/Assets/Script/Menu/MusicLibrary/ShowCategoryView.cs
@@ -1,7 +1,9 @@
 ﻿using System.Collections.Generic;
+using DG.Tweening;
 using TMPro;
 using UnityEngine;
 using UnityEngine.Serialization;
+using UnityEngine.UI;
 using YARG.Menu.Persistent;
 
 namespace YARG.Menu.MusicLibrary
@@ -15,7 +17,35 @@ namespace YARG.Menu.MusicLibrary
         public TextMeshProUGUI CategoryText;
         [SerializeField]
         private ShowPickerButton _pickerButton;
+        [Space]
+        [SerializeField]
+        private GameObject _unselectedVisual;
+        [SerializeField]
+        private GameObject _selectedVisual;
 
+        public void SetSelected(bool selected)
+        {
+            var image = _selectedVisual.GetComponent<Image>();
 
+            // Ease in the color on selection
+            if (selected)
+            {
+                _unselectedVisual.SetActive(false);
+                var color = image.color;
+                color.a = 0.01f;
+                image.color = color;
+                _selectedVisual.SetActive(true);
+                // image.CrossFadeAlpha(1.0f, 0.1f, false);
+                image.DOFade(1.0f, 0.2f).SetEase(Ease.OutCubic);
+            }
+            else
+            {
+                _unselectedVisual.SetActive(true);
+                var color = image.color;
+                color.a = 1.0f;
+                image.color = color;
+                _selectedVisual.SetActive(false);
+            }
+        }
     }
 }

--- a/Assets/Script/Menu/MusicLibrary/ShowCategoryView.cs.meta
+++ b/Assets/Script/Menu/MusicLibrary/ShowCategoryView.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 981e6dcb8ea0456b86bd1874ac3a01fb
+timeCreated: 1748638452

--- a/Assets/Script/Menu/MusicLibrary/ViewTypes/PlaylistViewType.cs
+++ b/Assets/Script/Menu/MusicLibrary/ViewTypes/PlaylistViewType.cs
@@ -10,7 +10,6 @@ namespace YARG.Menu.MusicLibrary
 {
     public class PlaylistViewType : CategoryViewType
     {
-        public override         BackgroundType          Background => BackgroundType.Normal;
         private static readonly Dictionary<int, Sprite> Sprites     = new();
         private const           string                  ICON_PATH   = "MusicLibraryIcons[Playlists]";
         private const           int                     PLAYLIST_ID = 1;
@@ -19,20 +18,35 @@ namespace YARG.Menu.MusicLibrary
         private readonly        Sprite                  _sprite;
 
         public PlaylistViewType(string primary, int songCount, SongEntry[] songsUnderCategory, Playlist playlist,
-            Action clickAction = null, int id = -1) : base(primary, songCount, songsUnderCategory, clickAction)
+            Action clickAction = null) : base(primary, songCount, songsUnderCategory, clickAction)
         {
             Playlist = playlist;
-            ID = id;
+
+            if (!Sprites.TryGetValue(PLAYLIST_ID, out _sprite))
+            {
+                Sprites.Add(PLAYLIST_ID, _sprite = Addressables.LoadAssetAsync<Sprite>(ICON_PATH).WaitForCompletion());
+            }
         }
 
         // I do not like that GetSongsFromPlaylist has to do the work twice, but songs can't be cached since
         // it has to be static and I'm not sufficiently familiar with C# to figure out how to make CategoryViewType
         // use an initializer we can override.
-        public PlaylistViewType(string primary, Playlist playlist, Action clickAction = null, int id = -1) :
+        public PlaylistViewType(string primary, Playlist playlist, Action clickAction = null) :
             base(primary, GetSongsFromPlaylist(playlist).Length, GetSongsFromPlaylist(playlist), clickAction)
         {
             Playlist = playlist;
-            ID = id;
+
+            if (!Sprites.TryGetValue(PLAYLIST_ID, out _sprite))
+            {
+                Sprites.Add(PLAYLIST_ID, _sprite = Addressables.LoadAssetAsync<Sprite>(ICON_PATH).WaitForCompletion());
+            }
+        }
+
+#nullable enable
+        public override Sprite? GetIcon()
+#nullable disable
+        {
+            return _sprite;
         }
 
         public static SongEntry[] GetSongsFromPlaylist(Playlist playlist)

--- a/Assets/Script/Menu/MusicLibrary/ViewTypes/PlaylistViewType.cs
+++ b/Assets/Script/Menu/MusicLibrary/ViewTypes/PlaylistViewType.cs
@@ -10,6 +10,7 @@ namespace YARG.Menu.MusicLibrary
 {
     public class PlaylistViewType : CategoryViewType
     {
+        public override         BackgroundType          Background => BackgroundType.Normal;
         private static readonly Dictionary<int, Sprite> Sprites     = new();
         private const           string                  ICON_PATH   = "MusicLibraryIcons[Playlists]";
         private const           int                     PLAYLIST_ID = 1;
@@ -21,11 +22,6 @@ namespace YARG.Menu.MusicLibrary
             Action clickAction = null) : base(primary, songCount, songsUnderCategory, clickAction)
         {
             Playlist = playlist;
-
-            if (!Sprites.TryGetValue(PLAYLIST_ID, out _sprite))
-            {
-                Sprites.Add(PLAYLIST_ID, _sprite = Addressables.LoadAssetAsync<Sprite>(ICON_PATH).WaitForCompletion());
-            }
         }
 
         // I do not like that GetSongsFromPlaylist has to do the work twice, but songs can't be cached since
@@ -35,18 +31,6 @@ namespace YARG.Menu.MusicLibrary
             base(primary, GetSongsFromPlaylist(playlist).Length, GetSongsFromPlaylist(playlist), clickAction)
         {
             Playlist = playlist;
-
-            if (!Sprites.TryGetValue(PLAYLIST_ID, out _sprite))
-            {
-                Sprites.Add(PLAYLIST_ID, _sprite = Addressables.LoadAssetAsync<Sprite>(ICON_PATH).WaitForCompletion());
-            }
-        }
-
-#nullable enable
-        public override Sprite? GetIcon()
-#nullable disable
-        {
-            return _sprite;
         }
 
         public static SongEntry[] GetSongsFromPlaylist(Playlist playlist)

--- a/Assets/Script/Menu/MusicLibrary/ViewTypes/PlaylistViewType.cs
+++ b/Assets/Script/Menu/MusicLibrary/ViewTypes/PlaylistViewType.cs
@@ -19,18 +19,20 @@ namespace YARG.Menu.MusicLibrary
         private readonly        Sprite                  _sprite;
 
         public PlaylistViewType(string primary, int songCount, SongEntry[] songsUnderCategory, Playlist playlist,
-            Action clickAction = null) : base(primary, songCount, songsUnderCategory, clickAction)
+            Action clickAction = null, int id = -1) : base(primary, songCount, songsUnderCategory, clickAction)
         {
             Playlist = playlist;
+            ID = id;
         }
 
         // I do not like that GetSongsFromPlaylist has to do the work twice, but songs can't be cached since
         // it has to be static and I'm not sufficiently familiar with C# to figure out how to make CategoryViewType
         // use an initializer we can override.
-        public PlaylistViewType(string primary, Playlist playlist, Action clickAction = null) :
+        public PlaylistViewType(string primary, Playlist playlist, Action clickAction = null, int id = -1) :
             base(primary, GetSongsFromPlaylist(playlist).Length, GetSongsFromPlaylist(playlist), clickAction)
         {
             Playlist = playlist;
+            ID = id;
         }
 
         public static SongEntry[] GetSongsFromPlaylist(Playlist playlist)

--- a/Assets/Script/Menu/MusicLibrary/ViewTypes/SongViewType.cs
+++ b/Assets/Script/Menu/MusicLibrary/ViewTypes/SongViewType.cs
@@ -152,11 +152,22 @@ namespace YARG.Menu.MusicLibrary
                 return;
             }
 
-            GlobalVariables.State.CurrentSong = SongEntry;
-            // This just makes stuff in DifficultySelectMenu easier
-            GlobalVariables.State.ShowSongs.Clear();
-            GlobalVariables.State.ShowSongs.Add(SongEntry);
-            GlobalVariables.State.PlayingAShow = false;
+            if (_musicLibrary.ShowSongs.Count > 0)
+            {
+                GlobalVariables.State.PlayingAShow = true;
+                // _musicLibrary.ShowSongs.Add(SongEntry);
+                GlobalVariables.State.ShowSongs = _musicLibrary.ShowSongs;
+                GlobalVariables.State.CurrentSong = GlobalVariables.State.ShowSongs.First();
+                GlobalVariables.State.ShowIndex = 0;
+            }
+            else
+            {
+                GlobalVariables.State.CurrentSong = SongEntry;
+                // This just makes stuff in DifficultySelectMenu easier
+                GlobalVariables.State.ShowSongs.Clear();
+                GlobalVariables.State.ShowSongs.Add(SongEntry);
+                GlobalVariables.State.PlayingAShow = false;
+            }
 
             MenuManager.Instance.PushMenu(MenuManager.Menu.DifficultySelect);
         }

--- a/Assets/Script/Menu/MusicLibrary/ViewTypes/SongViewType.cs
+++ b/Assets/Script/Menu/MusicLibrary/ViewTypes/SongViewType.cs
@@ -152,22 +152,11 @@ namespace YARG.Menu.MusicLibrary
                 return;
             }
 
-            if (_musicLibrary.ShowSongs.Count > 0)
-            {
-                GlobalVariables.State.PlayingAShow = true;
-                // _musicLibrary.ShowSongs.Add(SongEntry);
-                GlobalVariables.State.ShowSongs = _musicLibrary.ShowSongs;
-                GlobalVariables.State.CurrentSong = GlobalVariables.State.ShowSongs.First();
-                GlobalVariables.State.ShowIndex = 0;
-            }
-            else
-            {
-                GlobalVariables.State.CurrentSong = SongEntry;
-                // This just makes stuff in DifficultySelectMenu easier
-                GlobalVariables.State.ShowSongs.Clear();
-                GlobalVariables.State.ShowSongs.Add(SongEntry);
-                GlobalVariables.State.PlayingAShow = false;
-            }
+            GlobalVariables.State.CurrentSong = SongEntry;
+            // This just makes stuff in DifficultySelectMenu easier
+            GlobalVariables.State.ShowSongs.Clear();
+            GlobalVariables.State.ShowSongs.Add(SongEntry);
+            GlobalVariables.State.PlayingAShow = false;
 
             MenuManager.Instance.PushMenu(MenuManager.Menu.DifficultySelect);
         }

--- a/Assets/Script/Menu/Navigation/NavigationScheme.cs
+++ b/Assets/Script/Menu/Navigation/NavigationScheme.cs
@@ -79,12 +79,23 @@ namespace YARG.Menu.Navigation
 
         public Action PopCallback;
 
+        public bool SuppressHelpBar;
+
         public NavigationScheme(List<Entry> entries, bool? allowsMusicPlayer, Action popCallback = null)
         {
             _entries = entries;
 
             AllowsMusicPlayer = allowsMusicPlayer;
             PopCallback = popCallback;
+        }
+
+        public NavigationScheme(List<Entry> entries, bool? allowsMusicPlayer, bool suppressHelpBar)
+        {
+            _entries = entries;
+
+            AllowsMusicPlayer = allowsMusicPlayer;
+            PopCallback = null;
+            SuppressHelpBar = suppressHelpBar;
         }
 
         public void InvokeFuncs(NavigationContext context)

--- a/Assets/Script/Menu/Persistent/DialogManager.cs
+++ b/Assets/Script/Menu/Persistent/DialogManager.cs
@@ -1,9 +1,11 @@
 using System;
 using Cysharp.Threading.Tasks;
+using Cysharp.Threading.Tasks.Triggers;
 using UnityEngine;
 using YARG.Localization;
 using YARG.Menu.Data;
 using YARG.Menu.Dialogs;
+using YARG.Menu.MusicLibrary;
 
 namespace YARG.Menu.Persistent
 {
@@ -27,6 +29,8 @@ namespace YARG.Menu.Persistent
         private ConfirmDeleteDialog _confirmDeleteDialog;
         [SerializeField]
         private ColorPickerDialog _colorPickerDialog;
+        [SerializeField]
+        private SongPickerListDialog _playAShowDialog;
 
         private Dialog _currentDialog;
 
@@ -157,6 +161,14 @@ namespace YARG.Menu.Persistent
             dialog.ClearButtons();
             dialog.AddDialogButton("Menu.Common.Cancel", MenuData.Colors.CancelButton, ClearDialog);
             dialog.AddDialogButton("Menu.Common.Apply", MenuData.Colors.ConfirmButton, () => _currentDialog.Submit());
+
+            return dialog;
+        }
+
+        public SongPickerListDialog ShowSongPickerDialog(string title, MusicLibraryMenu menu)
+        {
+            var dialog = ShowDialog(_playAShowDialog);
+            dialog.Initialize(menu);
 
             return dialog;
         }

--- a/Assets/Script/Menu/Persistent/HelpBar.cs
+++ b/Assets/Script/Menu/Persistent/HelpBar.cs
@@ -72,6 +72,13 @@ namespace YARG.Menu.Persistent
                 MusicPlayer.gameObject.SetActive(false);
             }
 
+            if (scheme.SuppressHelpBar)
+            {
+                // We want the black bar, but no buttons
+                gameObject.SetActive(true);
+                return;
+            }
+
             // Update buttons
             int buttonIndex = 0;
             foreach (var entry in scheme.Entries)

--- a/Assets/Script/Menu/Persistent/ShowPickerButton.cs
+++ b/Assets/Script/Menu/Persistent/ShowPickerButton.cs
@@ -1,0 +1,83 @@
+﻿using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+using UnityEngine.EventSystems;
+using YARG.Core.Input;
+using YARG.Menu.Data;
+using YARG.Menu.Dialogs;
+using YARG.Menu.Navigation;
+
+namespace YARG.Menu.Persistent
+{
+    public class ShowPickerButton : MonoBehaviour, IPointerEnterHandler, IPointerExitHandler, IPointerDownHandler, IPointerUpHandler
+    {
+        [SerializeField]
+        private Image _buttonImage;
+        [SerializeField]
+        private Image _buttonBackground;
+        [SerializeField]
+        public TextMeshProUGUI ButtonText;
+
+        [SerializeField]
+        private Button _button;
+
+        [Space]
+        [SerializeField]
+        private SongPickerListDialog _dialog;
+
+        private Image _backgroundImage;
+
+        private NavigationScheme.Entry? _entry;
+
+        private Color _buttonBackgroundColor;
+
+        private void OnEnable()
+        {
+            _buttonBackgroundColor = _buttonImage.color;
+            _buttonBackground.color = Color.clear;
+        }
+
+        public void SetInfoFromSchemeEntry(NavigationScheme.Entry entry)
+        {
+            _entry = entry;
+            var icons = MenuData.NavigationIcons;
+            _buttonBackgroundColor = icons.GetColor(entry.Action);
+
+            // Show/hide text and transitions
+            var special = entry.Action is MenuAction.Select or MenuAction.Start;
+            _button.transition = special
+                ? Selectable.Transition.None
+                : Selectable.Transition.SpriteSwap;
+
+            // Set colors
+            _buttonImage.sprite = icons.GetIcon(entry.Action);
+            _buttonImage.color = _buttonBackgroundColor;
+            _buttonBackground.color = Color.clear;
+        }
+
+        public void OnPointerEnter(PointerEventData eventData)
+        {
+            _buttonBackground.color = _buttonBackgroundColor;
+            _buttonImage.color = _buttonBackgroundColor;
+        }
+
+        public void OnPointerExit(PointerEventData eventData)
+        {
+            _buttonBackground.color = Color.clear;
+            _buttonImage.color = _buttonBackgroundColor;
+        }
+
+        public void OnPointerDown(PointerEventData eventData)
+        {
+            _buttonBackground.color = Color.grey;
+            _buttonImage.color = Color.grey;
+
+            _entry?.Invoke();
+        }
+
+        public void OnPointerUp(PointerEventData eventData)
+        {
+            _entry?.InvokeHoldOffHandler();
+        }
+    }
+}

--- a/Assets/Script/Menu/Persistent/ShowPickerButton.cs.meta
+++ b/Assets/Script/Menu/Persistent/ShowPickerButton.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 04f17c63d7ee4fe5be74e8374cf824bb
+timeCreated: 1748633360

--- a/Assets/Script/Playlists/Playlist.cs
+++ b/Assets/Script/Playlists/Playlist.cs
@@ -52,7 +52,6 @@ namespace YARG.Playlists
                     PlaylistContainer.SavePlaylist(this);
                 }
             }
-
         }
 
         public void RemoveSong(SongEntry song)

--- a/Assets/Script/Settings/SettingsManager.Settings.cs
+++ b/Assets/Script/Settings/SettingsManager.Settings.cs
@@ -107,6 +107,7 @@ namespace YARG.Settings
             public ToggleSetting ShowFavoriteButton { get; } = new(true);
 
             public SliderSetting PlayAShowTimeout { get; } = new (10.0f, 1.0f, 30.0f);
+            public ToggleSetting RequireAllDifficulties { get; } = new(true);
 
             public DropdownSetting<DifficultyRingMode> DifficultyRings { get; }
                 = new(DifficultyRingMode.Classic)

--- a/Assets/Script/Settings/SettingsManager.Settings.cs
+++ b/Assets/Script/Settings/SettingsManager.Settings.cs
@@ -12,6 +12,7 @@ using YARG.Integration;
 using YARG.Integration.RB3E;
 using YARG.Integration.Sacn;
 using YARG.Integration.StageKit;
+using YARG.Menu;
 using YARG.Menu.MusicLibrary;
 using YARG.Menu.Persistent;
 using YARG.Menu.Settings;
@@ -104,6 +105,8 @@ namespace YARG.Settings
             public ToggleSetting UseFullDirectoryForPlaylists { get; } = new(false);
 
             public ToggleSetting ShowFavoriteButton { get; } = new(true);
+
+            public SliderSetting PlayAShowTimeout { get; } = new (10.0f, 1.0f, 30.0f);
 
             public DropdownSetting<DifficultyRingMode> DifficultyRings { get; }
                 = new(DifficultyRingMode.Classic)

--- a/Assets/Script/Settings/SettingsManager.cs
+++ b/Assets/Script/Settings/SettingsManager.cs
@@ -76,6 +76,7 @@ namespace YARG.Settings
                 nameof(Settings.HighScoreInfo),
                 nameof(Settings.HighScoreHistory),
                 nameof(Settings.PlayAShowTimeout),
+                nameof(Settings.RequireAllDifficulties),
             },
             new MetadataTab("Sound", icon: "Sound")
             {

--- a/Assets/Script/Settings/SettingsManager.cs
+++ b/Assets/Script/Settings/SettingsManager.cs
@@ -75,6 +75,7 @@ namespace YARG.Settings
                 nameof(Settings.DifficultyRings),
                 nameof(Settings.HighScoreInfo),
                 nameof(Settings.HighScoreHistory),
+                nameof(Settings.PlayAShowTimeout),
             },
             new MetadataTab("Sound", icon: "Sound")
             {

--- a/Assets/Script/Settings/SettingsManager.cs
+++ b/Assets/Script/Settings/SettingsManager.cs
@@ -75,6 +75,7 @@ namespace YARG.Settings
                 nameof(Settings.DifficultyRings),
                 nameof(Settings.HighScoreInfo),
                 nameof(Settings.HighScoreHistory),
+                new HeaderMetadata("PlayAShow"),
                 nameof(Settings.PlayAShowTimeout),
                 nameof(Settings.RequireAllDifficulties),
             },

--- a/Assets/StreamingAssets/lang/en-US.json
+++ b/Assets/StreamingAssets/lang/en-US.json
@@ -290,7 +290,7 @@
             "AddedToSet": "Added To Setlist",
             "PlaylistAddedToSet": "Added {0:N0} Songs From Playlist To Setlist",
             "StartSet": "Start The Set",
-            "StartShow": "Play Me Show, Mateys!",
+            "PlayShow": "Play A Show",
             "NoSongsInPlaylist": "No Songs In Playlist",
             "CannotAddToSelf": "No, I will not create an ouroboros for you. Nice try, Jaden.",
             "AddToShow": "Add To Show",

--- a/Assets/StreamingAssets/lang/en-US.json
+++ b/Assets/StreamingAssets/lang/en-US.json
@@ -673,6 +673,7 @@
             "Export": "Export",
             "PathsAndFolders": "Paths and Folders",
             "MusicLibrary": "Music Library",
+            "PlayAShow": "Play A Show",
             "ScanningOptions": "Scanning Options",
             "RB3E": "RB3E Settings",
             "Customization": "Buffer Customization",

--- a/Assets/StreamingAssets/lang/en-US.json
+++ b/Assets/StreamingAssets/lang/en-US.json
@@ -960,6 +960,10 @@
                 "Name": "Show Selection Timeout",
                 "Description": "The amount of time to wait for votes before picking a song or refreshing the categories."
             },
+            "RequireAllDifficulties": {
+                "Name": "Require All Difficulties",
+                "Description": "Require show songs to have at least Easy, Medium, Hard, and Expert difficulties"
+            },
             "PracticeRestartDelay": {
                 "Name": "Practice Restart Delay",
                 "Description": "The amount of time (in seconds) to delay the beginning of a section in Practice Mode."

--- a/Assets/StreamingAssets/lang/en-US.json
+++ b/Assets/StreamingAssets/lang/en-US.json
@@ -956,6 +956,10 @@
                     "Sparse": "50, 100, 250, 500, ..."
                 }
             },
+            "PlayAShowTimeout": {
+                "Name": "Show Selection Timeout",
+                "Description": "The amount of time to wait for votes before picking a song or refreshing the categories."
+            },
             "PracticeRestartDelay": {
                 "Name": "Practice Restart Delay",
                 "Description": "The amount of time (in seconds) to delay the beginning of a section in Practice Mode."

--- a/Assets/StreamingAssets/lang/en-US.json
+++ b/Assets/StreamingAssets/lang/en-US.json
@@ -290,6 +290,7 @@
             "AddedToSet": "Added To Setlist",
             "PlaylistAddedToSet": "Added {0:N0} Songs From Playlist To Setlist",
             "StartSet": "Start The Set",
+            "StartShow": "Play Me Show, Mateys!",
             "NoSongsInPlaylist": "No Songs In Playlist",
             "CannotAddToSelf": "No, I will not create an ouroboros for you. Nice try, Jaden.",
             "AddToShow": "Add To Show",

--- a/Assets/StreamingAssets/lang/en-US.json
+++ b/Assets/StreamingAssets/lang/en-US.json
@@ -288,6 +288,9 @@
             "StartSet": "Start The Set",
             "NoSongsInPlaylist": "No Songs In Playlist",
             "CannotAddToSelf": "No, I will not create an ouroboros for you. Nice try, Jaden.",
+            "AddToShow": "Add To Show",
+            "AddedToShow": "Added To Show",
+            "StartShow": "Start The Show",
             "MoreOptions": "<align=left><size=80%>More Options<br>(Hold) Navigate Sections</size></align>"
         },
         "ProfileInfo": {

--- a/Assets/StreamingAssets/lang/en-US.json
+++ b/Assets/StreamingAssets/lang/en-US.json
@@ -202,6 +202,10 @@
                 "Title": "Experimental Features Notice",
                 "Description": "The options about to be displayed represent a work in progress. These features are subject to change, may contain bugs, and <b>could even cause major problems if enabled</b>.",
                 "Confirm": "I Understand"
+            },
+            "ShowDialog": {
+                "Title": "Choose Your Fate",
+                "Select": "That's Plenty"
             }
         },
         "DifficultySelect": {

--- a/Assets/StreamingAssets/lang/en-US.json
+++ b/Assets/StreamingAssets/lang/en-US.json
@@ -295,7 +295,22 @@
             "AddToShow": "Add To Show",
             "AddedToShow": "Added To Show",
             "StartShow": "Start The Show",
-            "MoreOptions": "<align=left><size=80%>More Options<br>(Hold) Navigate Sections</size></align>"
+            "MoreOptions": "<align=left><size=80%>More Options<br>(Hold) Navigate Sections</size></align>",
+            "PlayAShow": {
+                "LongSong": "A Long Song",
+                "RandomSong": "A Random Song",
+                "ShortSong": "A Short Song",
+                "SongFromArtist": "A Song By {0}",
+                "SongFromDecade": "A Song From The {0}",
+                "SongFromFavorites": "One Of Your Favorite Songs",
+                "SongFromAnGenre": "An {0} Song",
+                "SongFromGenre": "A {0} Song",
+                "SongFromPlaylist": "A Song From Your Playlist {0}",
+                "SongFromSource": "A Song From {0}",
+                "StartsWithLetter": "A Song Starting With The Letter \"{0}\"",
+                "StartsWithNumber": "A Song Starting With A Number",
+                "StartsWithOther": "A Song Starting With Something Non-Alphanumeric"
+            }
         },
         "ProfileInfo": {
             "Name": "Edit Profile",


### PR DESCRIPTION
This PR introduces the Play A Show feature, which chooses songs randomly from a list of categories.

When the feature is activated by triggering the blue action from the library menu, a dialog pops up with a list of five categories randomly chosen from a list of (currently) ten possible categories, defined in ShowCategories.cs. The currently active players then select a category from the list using the colored button actions and a song is randomly chosen from the category with the most votes. If there is a tie, the category is chosen at random from the categories with the most votes. There is a timer (adjustable in settings, but defaults to 10 seconds) after which voting closes even if not all players have voted. If there are no votes, no song is added to the setlist and voting begins again with a new set of categories.

After the first category has been chosen, the cycle repeats indefinitely until the select action is triggered, closing the dialog. After closing the dialog, the user is left in a menu showing the generated playlist so that the user has the opportunity to remove any unwanted songs using the usual playlist controls before starting the setlist using the blue action.

After this point, play proceeds as with any other setlist.

Requires [YARG.Core PR #258](https://github.com/YARC-Official/YARG.Core/pull/258)

Play A Show Dialog:
<img width="1320" height="690" alt="play a show dialog" src="https://github.com/user-attachments/assets/43e3156c-7ec7-4db2-af27-eacc9e70386c" />

Note: There is one blue circle for every connected player, which turns to filled when the corresponding player has voted so that players can know if there are stragglers. They are ordered as the players are in the profiles screen.
