### PR TITLE
fix score box positioning after hud has been edited

### DIFF
--- a/Assets/Prefabs/Gameplay/HUD/ScoreDisplay.prefab
+++ b/Assets/Prefabs/Gameplay/HUD/ScoreDisplay.prefab
@@ -431,7 +431,6 @@ GameObject:
   m_Component:
   - component: {fileID: 1682100933276730677}
   - component: {fileID: 3580836438431718176}
-  - component: {fileID: 1427118048}
   - component: {fileID: 1221296064204129052}
   m_Layer: 5
   m_Name: ScoreDisplay
@@ -489,26 +488,6 @@ MonoBehaviour:
   _brokenBackgroundSprite: {fileID: -648612281, guid: 9a19cea8578114f42bec348c310a8891,
     type: 3}
   _brokenOverlaySprite: {fileID: 2128003, guid: 9a19cea8578114f42bec348c310a8891,
-    type: 3}
---- !u!114 &1427118048
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1682100933276730678}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 26c69184c4c94e07a1c1a5403823ba9a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _draggableElementName: scoreDisplay
-  _horizontal: 1
-  _vertical: 1
-  _onEditModeChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  _draggingDisplayPrefab: {fileID: 5730308542642054521, guid: 2a82983eb1a960843bd5603736f9b042,
     type: 3}
 --- !u!114 &1221296064204129052
 MonoBehaviour:

--- a/Assets/Scenes/Gameplay.unity
+++ b/Assets/Scenes/Gameplay.unity
@@ -1495,7 +1495,7 @@ PrefabInstance:
     - target: {fileID: 227366190812778480, guid: 039fee0ec42345d4f88c0625255415d4,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: -142.36191
+      value: 157.1503
       objectReference: {fileID: 0}
     - target: {fileID: 1335195020114372814, guid: 039fee0ec42345d4f88c0625255415d4,
         type: 3}
@@ -1700,7 +1700,7 @@ PrefabInstance:
     - target: {fileID: 2517693471320601084, guid: 039fee0ec42345d4f88c0625255415d4,
         type: 3}
       propertyPath: m_AnchoredPosition.x
-      value: 142.36191
+      value: -157.1503
       objectReference: {fileID: 0}
     - target: {fileID: 2640522790579517911, guid: 039fee0ec42345d4f88c0625255415d4,
         type: 3}
@@ -3721,7 +3721,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -50, y: -100}
+  m_AnchoredPosition: {x: -50, y: -150}
   m_SizeDelta: {x: 375, y: 210}
   m_Pivot: {x: 1, y: 1}
 --- !u!114 &484523228


### PR DESCRIPTION
Somehow DraggableHudElement was on both the Score Canvas element and the ScoreDisplay prefab, so it has been removed from the prefab so the scorebox actually follows the canvas again.