### PR TITLE
Added ability to collapse sort headers in the music library menu.

### DIFF
--- a/Assets/Art/Menu/MusicLibrary/MusicLibraryIcons.png
+++ b/Assets/Art/Menu/MusicLibrary/MusicLibraryIcons.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d689a1103ed1c772050aa7b54f6533b274acba81fa15f365d14c158fe75ffd92
-size 2600
+oid sha256:82675a8033e7f21ff695859ccab3e056564e75b806c5b1ce6ef9d6fd2550570f
+size 4002

--- a/Assets/Art/Menu/MusicLibrary/MusicLibraryIcons.png.meta
+++ b/Assets/Art/Menu/MusicLibrary/MusicLibraryIcons.png.meta
@@ -3,7 +3,7 @@ guid: 6947e69a25ccfa049a22215a785e9f8a
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}
-  serializedVersion: 12
+  serializedVersion: 13
   mipmaps:
     mipMapMode: 0
     enableMipMap: 0
@@ -20,11 +20,12 @@ TextureImporter:
     externalNormalMap: 0
     heightScale: 0.25
     normalMapFilter: 0
+    flipGreenChannel: 0
   isReadable: 0
   streamingMipmaps: 0
   streamingMipmapsPriority: 0
   vTOnly: 0
-  ignoreMasterTextureLimit: 0
+  ignoreMipmapLimit: 0
   grayScaleToAlpha: 0
   generateCubemap: 6
   cubemapConvolution: 0
@@ -63,6 +64,7 @@ TextureImporter:
   textureFormatSet: 0
   ignorePngGamma: 0
   applyGammaDecoding: 0
+  swizzle: 50462976
   cookieLightType: 0
   platformSettings:
   - serializedVersion: 3
@@ -75,6 +77,7 @@ TextureImporter:
     crunchedCompression: 0
     allowsAlphaSplitting: 0
     overridden: 0
+    ignorePlatformSupport: 0
     androidETC2FallbackOverride: 0
     forceMaximumCompressionQuality_BC6H_BC7: 0
   - serializedVersion: 3
@@ -87,6 +90,7 @@ TextureImporter:
     crunchedCompression: 0
     allowsAlphaSplitting: 0
     overridden: 0
+    ignorePlatformSupport: 0
     androidETC2FallbackOverride: 0
     forceMaximumCompressionQuality_BC6H_BC7: 0
   - serializedVersion: 3
@@ -99,6 +103,7 @@ TextureImporter:
     crunchedCompression: 0
     allowsAlphaSplitting: 0
     overridden: 0
+    ignorePlatformSupport: 0
     androidETC2FallbackOverride: 0
     forceMaximumCompressionQuality_BC6H_BC7: 0
   spriteSheet:
@@ -109,11 +114,11 @@ TextureImporter:
       rect:
         serializedVersion: 2
         x: 0
-        y: 64
+        y: 192
         width: 64
         height: 64
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []
@@ -130,11 +135,11 @@ TextureImporter:
       rect:
         serializedVersion: 2
         x: 64
-        y: 64
+        y: 192
         width: 64
         height: 64
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []
@@ -151,11 +156,11 @@ TextureImporter:
       rect:
         serializedVersion: 2
         x: 0
-        y: 0
+        y: 128
         width: 64
         height: 64
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []
@@ -172,7 +177,28 @@ TextureImporter:
       rect:
         serializedVersion: 2
         x: 64
-        y: 0
+        y: 128
+        width: 64
+        height: 64
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: a52d2e6606e11d44184449da481ba538
+      internalID: -812612277
+      vertices: []
+      indices: 
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Right
+      rect:
+        serializedVersion: 2
+        x: 0
+        y: 64
         width: 64
         height: 64
       alignment: 0
@@ -182,8 +208,8 @@ TextureImporter:
       physicsShape: []
       tessellationDetail: 0
       bones: []
-      spriteID: a52d2e6606e11d44184449da481ba538
-      internalID: -812612277
+      spriteID: 2b625daf2e6c418409a6c59873d16b2f
+      internalID: 1389926479
       vertices: []
       indices: 
       edges: []
@@ -203,9 +229,9 @@ TextureImporter:
       Down: 1494863122
       Playlists: 1787899732
       Random: -258697563
-  spritePackingTag: 
+      Right: 1389926479
+  mipmapLimitGroupName: 
   pSDRemoveMatte: 0
-  pSDShowRemoveMatteOption: 0
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
+++ b/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
@@ -394,7 +394,7 @@ namespace YARG.Menu.MusicLibrary
 
             if (!_sortedSongs.Any(section => section.Songs.Length > 0))
             {
-                list.Add(new SortHeaderViewType(Localize.Key("Menu.MusicLibrary.NoSongsMatchCriteria"), 0, null));
+                list.Add(new SortHeaderViewType(Localize.Key("Menu.MusicLibrary.NoSongsMatchCriteria"), 0, null, this));
                 return list;
             }
 
@@ -493,14 +493,17 @@ namespace YARG.Menu.MusicLibrary
 
                 if (_sortedSongs.Length > 1)
                 {
-                    list.Add(new SortHeaderViewType(displayName, section.Songs.Length, section.CategoryGroup));
+                    list.Add(new SortHeaderViewType(displayName, section.Songs.Length, section.CategoryGroup, this));
                 }
 
-                foreach (var song in section.Songs)
+                if (!SongContainer.IsHeaderCollapsed(displayName))
                 {
-                    if (allowdupes || !song.IsDuplicate)
+                    foreach (var song in section.Songs)
                     {
-                        list.Add(new SongViewType(this, song));
+                        if (allowdupes || !song.IsDuplicate)
+                        {
+                            list.Add(new SongViewType(this, song));
+                        }
                     }
                 }
             }
@@ -530,7 +533,7 @@ namespace YARG.Menu.MusicLibrary
                 list.Add(new SortHeaderViewType(
                     section.Category.ToUpperInvariant(),
                     section.Songs.Length,
-                    section.CategoryGroup));
+                    section.CategoryGroup, this));
 
                 foreach (var song in section.Songs)
                 {
@@ -997,6 +1000,144 @@ namespace YARG.Menu.MusicLibrary
         public void SetSearchInput(SortAttribute songAttribute, string input)
         {
             _searchField.SetSearchInput(songAttribute, input);
+        }
+
+        public void ToggleCollapseOfSortHeader(SortHeaderViewType sortHeader)
+        {
+            var headerIndex = ((List<ViewType>) ViewList).IndexOf(sortHeader);
+            if(headerIndex < 0)
+                return;
+
+            SongContainer.ToggleCategoryCollapse(sortHeader.HeaderText);
+            var isCollapsing = SongContainer.IsHeaderCollapsed(sortHeader.HeaderText);
+
+            var index = SelectedIndex;
+            // Check if header is above selected entry
+            // If so, we have to calculate a new selected index
+            if (index > headerIndex)
+            {
+                if (isCollapsing)
+                {
+                    if (IsSelectedEntryInSectionBeingCollapsed())
+                    {
+                        index = headerIndex;
+                    }
+                    else
+                    {
+                        index -= GetEntryCountUnderSortHeader();
+                    }
+                    UpdateSearch(true);
+                    SelectedIndex = index;
+                }
+                else // Is Expanding
+                {
+                    UpdateSearch(true);
+                    SelectedIndex = index + GetEntryCountUnderSortHeader();
+                }
+            }
+            else // Sort header below selected index
+            {
+                UpdateSearch(true);
+                SelectedIndex = index;
+            }
+
+            // Local Functions
+            bool IsSelectedEntryInSectionBeingCollapsed()
+            {
+                if (ViewList[index] is SortHeaderViewType) return false;
+                for (int i = headerIndex + 1; i < index; i++)
+                {
+                    if (ViewList[i] is SortHeaderViewType) return false;
+                }
+                return true;
+            }
+
+            int GetEntryCountUnderSortHeader()
+            {
+                for (int i = headerIndex + 1; i < ViewList.Count; i++)
+                {
+                    if (ViewList[i] is SortHeaderViewType) return i - headerIndex - 1;
+                }
+                return headerIndex - ViewList.Count - 1;
+            }
+        }
+
+        public void CollapseAll()
+        {
+            foreach (var header in ViewList.OfType<SortHeaderViewType>())
+            {
+                SongContainer.CollapseHeader(header.HeaderText);
+            }
+            int firstSortHeaderIndex = -1;
+            int headerCount = 0;
+            var count = Math.Min(ViewList.Count, SelectedIndex + 1);
+            for (int i = 0; i < count; i++)
+            {
+                if (ViewList[i] is SortHeaderViewType sortHeader)
+                {
+                    if (firstSortHeaderIndex == -1)
+                    {
+                        firstSortHeaderIndex = i;
+                    }
+                    headerCount++;
+                }
+            }
+
+            var prevIndex = SelectedIndex;
+            UpdateSearch(true);
+            if (firstSortHeaderIndex != -1)
+            {
+                SelectedIndex = firstSortHeaderIndex + headerCount - 1;
+            }
+            else
+            {
+                SelectedIndex = prevIndex;
+            }
+        }
+
+        public void ExpandAll()
+        {
+            int offsetFromHeader = SelectedIndex;
+            string headerText = string.Empty;
+            int index = SelectedIndex;
+
+            if (CurrentSelection is SortHeaderViewType sortHeader)
+            {
+                offsetFromHeader = 0;
+                headerText = sortHeader.HeaderText;
+            }
+            else
+            {
+                for (int i = index - 1; i >= 0; i--)
+                {
+                    if (ViewList[i] is SortHeaderViewType sortHeaderAbove)
+                    {
+                        offsetFromHeader = index - i;
+                        headerText = sortHeaderAbove.HeaderText;
+                        break;
+                    }
+                }
+            }
+
+            foreach (var header in ViewList.OfType<SortHeaderViewType>())
+            {
+                SongContainer.ExpandHeader(header.HeaderText);
+            }
+
+            UpdateSearch(true);
+            SelectedIndex = GetSelectedIndex();
+
+            int GetSelectedIndex()
+            {
+                for (int i = 0; i < ViewList.Count; i++)
+                {
+                    if (ViewList[i] is SortHeaderViewType header && header.HeaderText == headerText)
+                    {
+                        return i + offsetFromHeader;
+                    }
+                }
+                return index;
+            }
         }
     }
 }

--- a/Assets/Script/Menu/MusicLibrary/PopupMenu.cs
+++ b/Assets/Script/Menu/MusicLibrary/PopupMenu.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
 using TMPro;
 using UnityEngine;
 using UnityEngine.Events;
@@ -130,6 +131,26 @@ namespace YARG.Menu.MusicLibrary
                     _menuState = State.GoToSection;
                     UpdateForState();
                 });
+
+                if (SongContainer.AreAnyHeadersCollapsed())
+                {
+                    CreateItem("ExpandAll", () =>
+                    {
+                        _musicLibrary.ExpandAll();
+                        gameObject.SetActive(false);
+                    });
+                }
+
+                IEnumerable<string> headerTexts = _musicLibrary.ViewList.OfType<SortHeaderViewType>()
+                    .Select(header => header.HeaderText);
+                if (!SongContainer.AreAllHeaderCollapsed(headerTexts))
+                {
+                    CreateItem("CollapseAll", () =>
+                    {
+                        _musicLibrary.CollapseAll();
+                        gameObject.SetActive(false);
+                    });
+                }
             }
 
             var viewType = _musicLibrary.CurrentSelection;
@@ -272,6 +293,7 @@ namespace YARG.Menu.MusicLibrary
 
                 CreateItemUnlocalized(sort.ToLocalizedName(), () =>
                 {
+                    SongContainer.ClearCollapsedHeaders();
                     _musicLibrary.ChangeSort(sort);
                     gameObject.SetActive(false);
                 });

--- a/Assets/Script/Menu/MusicLibrary/ViewTypes/SortHeaderViewType.cs
+++ b/Assets/Script/Menu/MusicLibrary/ViewTypes/SortHeaderViewType.cs
@@ -1,6 +1,6 @@
-﻿using Cysharp.Threading.Tasks;
-using UnityEngine;
+﻿using UnityEngine;
 using UnityEngine.AddressableAssets;
+using YARG.Song;
 
 namespace YARG.Menu.MusicLibrary
 {
@@ -10,15 +10,19 @@ namespace YARG.Menu.MusicLibrary
 
         public override bool UseWiderPrimaryText => true;
 
+        private readonly MusicLibraryMenu _musicLibrary;
+
         public readonly string HeaderText;
         public readonly string ShortcutName;
         private readonly int _songCount;
 
-        public SortHeaderViewType(string headerText, int songCount, string shortcutName)
+        public SortHeaderViewType(string headerText, int songCount, string shortcutName, MusicLibraryMenu musicLibrary)
         {
+            _musicLibrary = musicLibrary;
+
             HeaderText = headerText;
             _songCount = songCount;
-            
+
             ShortcutName = shortcutName;
         }
 
@@ -32,11 +36,18 @@ namespace YARG.Menu.MusicLibrary
             return CreateSongCountString(_songCount);
         }
 
+        public override void PrimaryButtonClick()
+        {
+            _musicLibrary.ToggleCollapseOfSortHeader(this);
+        }
+
 #nullable enable
         public override Sprite? GetIcon()
 #nullable disable
         {
-            return Addressables.LoadAssetAsync<Sprite>("MusicLibraryIcons[Down]").WaitForCompletion();
+            bool collapsed = SongContainer.IsHeaderCollapsed(HeaderText);
+            var key = collapsed ? "MusicLibraryIcons[Right]" : "MusicLibraryIcons[Down]";
+            return Addressables.LoadAssetAsync<Sprite>(key).WaitForCompletion();
         }
     }
 }

--- a/Assets/Script/Song/SongContainer.cs
+++ b/Assets/Script/Song/SongContainer.cs
@@ -95,6 +95,7 @@ namespace YARG.Song
         private static SongCategory[] _sortSongLengths = Array.Empty<SongCategory>();
         private static SongCategory[] _sortDatesAdded = Array.Empty<SongCategory>();
         private static Dictionary<Instrument, SongCategory[]> _sortInstruments = new();
+        private static HashSet<string> _collapsedHeaders = new();
 
         private static SongCategory[] _playables = null;
 
@@ -210,6 +211,45 @@ namespace YARG.Song
         {
             return _sortInstruments.ContainsKey(instrument);
         }
+
+        public static bool IsHeaderCollapsed(string headerText)
+        {
+            return _collapsedHeaders.Contains(headerText);
+        }
+
+        public static void ToggleCategoryCollapse(string headerText)
+        {
+            if (!_collapsedHeaders.Add(headerText))
+            {
+                _collapsedHeaders.Remove(headerText);
+            }
+        }
+
+        public static void CollapseHeader(string headerText)
+        {
+            _collapsedHeaders.Add(headerText);
+        }
+
+        public static void ExpandHeader(string headerText)
+        {
+            _collapsedHeaders.Remove(headerText);
+        }
+
+        public static void ClearCollapsedHeaders()
+        {
+            _collapsedHeaders.Clear();
+        }
+
+        public static bool AreAnyHeadersCollapsed()
+        {
+            return _collapsedHeaders.Count > 0;
+        }
+
+        public static bool AreAllHeaderCollapsed(IEnumerable<string> headers)
+        {
+            return headers.All(h => _collapsedHeaders.Contains(h));
+        }
+
 
         private static HashSet<Instrument> _instruments = null;
         private static SongCategory[] GetPlayableSongs()

--- a/Assets/StreamingAssets/lang/en-US.json
+++ b/Assets/StreamingAssets/lang/en-US.json
@@ -273,7 +273,9 @@
                     "CreateNewPlaylist": "Create New...",
                     "RemovePlaylist": "Remove Playlist",
                     "ViewSongFolder": "View Song Folder",
-                    "CopySongChecksum": "Copy Song Checksum"
+                    "CopySongChecksum": "Copy Song Checksum",
+                    "CollapseAll": "Collapse All",
+                    "ExpandAll": "Expand All"
                 }
             },
             "Back": "BACK",

--- a/Assets/StreamingAssets/lang/es-ES.json
+++ b/Assets/StreamingAssets/lang/es-ES.json
@@ -253,7 +253,9 @@
                     "AddToFavorites": "Add To Favorites",
                     "RemoveFromFavorites": "Remove From Favorites",
                     "ViewSongFolder": "View Song Folder",
-                    "CopySongChecksum": "Copy Song Checksum"
+                    "CopySongChecksum": "Copy Song Checksum",
+                    "CollapseAll": "Collapse All",
+                    "ExpandAll": "Expand All"
                 }
             },
             "Back": "BACK",

--- a/Assets/StreamingAssets/lang/ja-JP.json
+++ b/Assets/StreamingAssets/lang/ja-JP.json
@@ -253,7 +253,9 @@
                     "AddToFavorites": "Add To Favorites",
                     "RemoveFromFavorites": "Remove From Favorites",
                     "ViewSongFolder": "View Song Folder",
-                    "CopySongChecksum": "Copy Song Checksum"
+                    "CopySongChecksum": "Copy Song Checksum",
+                    "CollapseAll": "Collapse All",
+                    "ExpandAll": "Expand All"
                 }
             },
             "Back": "BACK",

--- a/Assets/StreamingAssets/lang/pt-BR.json
+++ b/Assets/StreamingAssets/lang/pt-BR.json
@@ -253,7 +253,9 @@
                     "AddToFavorites": "Add To Favorites",
                     "RemoveFromFavorites": "Remove From Favorites",
                     "ViewSongFolder": "View Song Folder",
-                    "CopySongChecksum": "Copy Song Checksum"
+                    "CopySongChecksum": "Copy Song Checksum",
+                    "CollapseAll": "Collapse All",
+                    "ExpandAll": "Expand All"
                 }
             },
             "Back": "BACK",

--- a/Assets/StreamingAssets/lang/pt-PT.json
+++ b/Assets/StreamingAssets/lang/pt-PT.json
@@ -253,7 +253,9 @@
                     "AddToFavorites": "Add To Favorites",
                     "RemoveFromFavorites": "Remove From Favorites",
                     "ViewSongFolder": "View Song Folder",
-                    "CopySongChecksum": "Copy Song Checksum"
+                    "CopySongChecksum": "Copy Song Checksum",
+                    "CollapseAll": "Collapse All",
+                    "ExpandAll": "Expand All"
                 }
             },
             "Back": "BACK",


### PR DESCRIPTION
Tried my best to follow existing code styles and put things in the correct spot. The header collapse state is stored in `SongContainer`, this could be wrong. `SortHeaderViewType` does not point back to the category it represents, so I'm using the `HeaderText` as the key for storing and looking up collapsed states. There is a fair bit of logic restoring the SelectedIndex to the entry you were on before a collapse/expand happens. Lemme know if anything needs changing. 

https://github.com/user-attachments/assets/ba5a19e3-8718-4150-9bf7-6fb7609248ef

