### PR TITLE
Add command line argument for verbose replays, etc

### DIFF
--- a/Assets/Script/Audio/Bass/BassStemMixer.cs
+++ b/Assets/Script/Audio/Bass/BassStemMixer.cs
@@ -224,6 +224,17 @@ namespace YARG.Audio.BASS
             return data;
         }
 
+        protected override int GetLevel_Internal(float[] level)
+        {
+            bool status = Bass.ChannelGetLevel(_mixerHandle, level, 0.2f, LevelRetrievalFlags.Mono | LevelRetrievalFlags.RMS);
+            if (!status)
+            {
+                return (int) Bass.LastError;
+            }
+
+            return (int) ManagedBass.Errors.OK;
+        }
+
         protected override void SetSpeed_Internal(float speed, bool shiftPitch)
         {
             speed = (float) Math.Clamp(speed, 0.05, 50);

--- a/Assets/Script/Gameplay/GameManager.Loading.cs
+++ b/Assets/Script/Gameplay/GameManager.Loading.cs
@@ -216,7 +216,8 @@ namespace YARG.Gameplay
 
         private bool LoadReplay()
         {
-            var (result, data) = ReplayIO.TryLoadData(ReplayInfo, GlobalVariables.VerboseReplays);
+            var readOptions = new ReplayReadOptions { KeepFrameTimes = GlobalVariables.VerboseReplays };
+            var (result, data) = ReplayIO.TryLoadData(ReplayInfo, readOptions);
             if (result != ReplayReadResult.Valid)
             {
                 YargLogger.LogFormatError("Failed to load replay! Result: {0}", result);

--- a/Assets/Script/Gameplay/GameManager.Loading.cs
+++ b/Assets/Script/Gameplay/GameManager.Loading.cs
@@ -216,7 +216,7 @@ namespace YARG.Gameplay
 
         private bool LoadReplay()
         {
-            var (result, data) = ReplayIO.TryLoadData(ReplayInfo);
+            var (result, data) = ReplayIO.TryLoadData(ReplayInfo, GlobalVariables.VerboseReplays);
             if (result != ReplayReadResult.Valid)
             {
                 YargLogger.LogFormatError("Failed to load replay! Result: {0}", result);

--- a/Assets/Script/Gameplay/GameManager.cs
+++ b/Assets/Script/Gameplay/GameManager.cs
@@ -248,9 +248,10 @@ namespace YARG.Gameplay
                 totalStars += player.Stars;
             }
 
-            #if UNITY_EDITOR || YARG_TEST_BUILD
-            _frameTimes.Add(_songRunner.InputTime);
-            #endif
+            if (GlobalVariables.VerboseReplays)
+            {
+                _frameTimes.Add(_songRunner.InputTime);
+            }
 
             BandScore = totalScore;
             BandCombo = totalCombo;
@@ -590,7 +591,7 @@ namespace YARG.Gameplay
                 return null;
             }
 
-           ReplayContainer.AddEntry(replayInfo);
+            ReplayContainer.AddEntry(replayInfo);
             _isReplaySaved = true;
             return replayInfo;
         }

--- a/Assets/Script/Menu/History/ViewTypes/ReplayViewType.cs
+++ b/Assets/Script/Menu/History/ViewTypes/ReplayViewType.cs
@@ -127,7 +127,7 @@ namespace YARG.Menu.History
                 return;
             }
 
-            var (result, data) = ReplayIO.TryLoadData(_entry);
+            var (result, data) = ReplayIO.TryLoadData(_entry, GlobalVariables.VerboseReplays);
             if (result != ReplayReadResult.Valid)
             {
                 YargLogger.LogFormatError("Failed to load replay. {0}", result);

--- a/Assets/Script/Menu/History/ViewTypes/ReplayViewType.cs
+++ b/Assets/Script/Menu/History/ViewTypes/ReplayViewType.cs
@@ -127,7 +127,8 @@ namespace YARG.Menu.History
                 return;
             }
 
-            var (result, data) = ReplayIO.TryLoadData(_entry, GlobalVariables.VerboseReplays);
+            var replayOptions = new ReplayReadOptions { KeepFrameTimes = GlobalVariables.VerboseReplays };
+            var (result, data) = ReplayIO.TryLoadData(_entry, replayOptions);
             if (result != ReplayReadResult.Valid)
             {
                 YargLogger.LogFormatError("Failed to load replay. {0}", result);

--- a/Assets/Script/Menu/ScoreScreen/ScoreScreenMenu.cs
+++ b/Assets/Script/Menu/ScoreScreen/ScoreScreenMenu.cs
@@ -204,7 +204,7 @@ namespace YARG.Menu.ScoreScreen
                 return true;
             }
 
-            var (result, data) = ReplayIO.TryLoadData(replayEntry);
+            var (result, data) = ReplayIO.TryLoadData(replayEntry, GlobalVariables.VerboseReplays);
             if (result != ReplayReadResult.Valid)
             {
                 YargLogger.LogFormatError("Replay did not load. {0}", result);

--- a/Assets/Script/Menu/ScoreScreen/ScoreScreenMenu.cs
+++ b/Assets/Script/Menu/ScoreScreen/ScoreScreenMenu.cs
@@ -204,7 +204,8 @@ namespace YARG.Menu.ScoreScreen
                 return true;
             }
 
-            var (result, data) = ReplayIO.TryLoadData(replayEntry, GlobalVariables.VerboseReplays);
+            var replayOptions = new ReplayReadOptions { KeepFrameTimes = GlobalVariables.VerboseReplays };
+            var (result, data) = ReplayIO.TryLoadData(replayEntry, replayOptions);
             if (result != ReplayReadResult.Valid)
             {
                 YargLogger.LogFormatError("Replay did not load. {0}", result);

--- a/Assets/Script/Persistent/CommandLineArgs.cs
+++ b/Assets/Script/Persistent/CommandLineArgs.cs
@@ -12,12 +12,17 @@ namespace YARG
 
         /// <summary>
         /// Whether or not the game should be launched in offline mode. Offline mode disables
-        /// offline features such as fetching the OpenSource icons.
+        /// online features such as fetching the OpenSource icons.
         /// </summary>
         private const string OFFLINE_ARG = "-offline";
 
         /// <summary>
-        /// Used to select the language the game will be launcher in. The argument after should be
+        /// Defines whether we should save frame time data to replays
+        /// </summary>
+        private const string VERBOSE_REPLAYS = "-verbose-replays";
+
+        /// <summary>
+        /// Used to select the language the game will be launched in. The argument after should be
         /// the language code.
         /// </summary>
         private const string LANGUAGE_ARG = "-lang";
@@ -32,9 +37,12 @@ namespace YARG
 
         public static bool Offline { get; private set; }
 
-        public static string Language { get; private set; }
-        public static string DownloadLocation { get; private set; }
+        public static bool VerboseReplays { get; private set; }
+
+        public static string Language           { get; private set; }
+        public static string DownloadLocation   { get; private set; }
         public static string PersistentDataPath { get; private set; }
+
 
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSplashScreen)]
         private static void InitCommandLineArgs()
@@ -48,6 +56,9 @@ namespace YARG
                 {
                     case OFFLINE_ARG:
                         Offline = true;
+                        break;
+                    case VERBOSE_REPLAYS:
+                        VerboseReplays = true;
                         break;
                     case LANGUAGE_ARG:
                         i++;

--- a/Assets/Script/Persistent/GlobalVariables.cs
+++ b/Assets/Script/Persistent/GlobalVariables.cs
@@ -39,7 +39,8 @@ namespace YARG
     {
         public List<YargPlayer> Players { get; private set; }
 
-        public static bool OfflineMode { get; private set; }
+        public static bool OfflineMode    { get; private set; }
+        public static bool VerboseReplays { get; private set; }
 
         public static string PersistentDataPathOverride { get; private set; }
 
@@ -58,13 +59,22 @@ namespace YARG
 
             if (CommandLineArgs.Offline)
             {
+                OfflineMode = true;
                 YargLogger.LogInfo("Playing in offline mode");
+            }
+
+            if (CommandLineArgs.VerboseReplays)
+            {
+                VerboseReplays = true;
+                YargLogger.LogInfo("Verbose replays enabled");
             }
 
             if (!string.IsNullOrEmpty(CommandLineArgs.DownloadLocation))
             {
                 PathHelper.SetSetlistPathFromDownloadLocation(CommandLineArgs.DownloadLocation);
             }
+
+            // TODO: Actually respect the PersistentDataPath arg
 
             // Initialize important classes
 


### PR DESCRIPTION
This PR adds support for a command line argument that controls whether or not we capture and save frame times in replays.

When set, frame times are saved and passed to the replay serializer to be saved. When not set, we don't do that. Additionally, this argument controls whether replay deserialization in core actually loads frame times in replays that have the data.

This also adds GetLevel_Internal to BassStemMixer so the two engine-fixes branches will actually compile again (This will conflict with #993 but it's my PR and I'll fix it once engine-fixes is merged)

Requires YARG.Core [#259](https://github.com/YARC-Official/YARG.Core/pull/259)