### PR TITLE
use unique names when creating new profile

### DIFF
--- a/Assets/Script/Menu/ProfileList/ProfileListMenu.cs
+++ b/Assets/Script/Menu/ProfileList/ProfileListMenu.cs
@@ -95,7 +95,7 @@ namespace YARG.Menu.ProfileList
             }
         }
         
-        private string GetUniqueProfileName(string profileName)
+        private static string GetUniqueProfileName(string profileName)
         {
             int count = 1;
             var existingNames = PlayerContainer.Profiles.Select(p => p.Name);

--- a/Assets/Script/Menu/ProfileList/ProfileListMenu.cs
+++ b/Assets/Script/Menu/ProfileList/ProfileListMenu.cs
@@ -94,12 +94,27 @@ namespace YARG.Menu.ProfileList
                 _navigationGroup.AddNavigatable(go);
             }
         }
+        
+        private string GetUniqueProfileName(string profileName)
+        {
+            int count = 1;
+            var existingNames = PlayerContainer.Profiles.Select(p => p.Name);
+            
+            string newName;
+            do
+            {
+                newName = $"{profileName} {count}";
+                count++;
+            } while (existingNames.Contains(newName));
+            
+            return newName;
+        }
 
         public void AddProfile()
         {
             PlayerContainer.AddProfile(new YargProfile
             {
-                Name = "New Profile",
+                Name = GetUniqueProfileName("New Profile"),
                 NoteSpeed = 5,
                 HighwayLength = 1,
                 GameMode = GameMode.FiveFretGuitar
@@ -112,7 +127,7 @@ namespace YARG.Menu.ProfileList
         {
             PlayerContainer.AddProfile(new YargProfile
             {
-                Name = "Bot",
+                Name = GetUniqueProfileName("Bot"),
                 NoteSpeed = 5,
                 HighwayLength = 1,
                 GameMode = GameMode.FiveFretGuitar,

--- a/Assets/Script/Menu/ProfileList/ProfileListMenu.cs
+++ b/Assets/Script/Menu/ProfileList/ProfileListMenu.cs
@@ -101,15 +101,15 @@ namespace YARG.Menu.ProfileList
 
             if (!existingNames.Contains(profileName))
             {
-            return profileName;
+                return profileName;
             }
 
             int count = 1;
             string newName;
             do
             {
-            newName = $"{profileName} {count}";
-            count++;
+                newName = $"{profileName} {count}";
+                count++;
             } while (existingNames.Contains(newName));
 
             return newName;

--- a/Assets/Script/Menu/ProfileList/ProfileListMenu.cs
+++ b/Assets/Script/Menu/ProfileList/ProfileListMenu.cs
@@ -94,19 +94,24 @@ namespace YARG.Menu.ProfileList
                 _navigationGroup.AddNavigatable(go);
             }
         }
-        
+
         private static string GetUniqueProfileName(string profileName)
         {
-            int count = 1;
             var existingNames = PlayerContainer.Profiles.Select(p => p.Name);
-            
+
+            if (!existingNames.Contains(profileName))
+            {
+            return profileName;
+            }
+
+            int count = 1;
             string newName;
             do
             {
-                newName = $"{profileName} {count}";
-                count++;
+            newName = $"{profileName} {count}";
+            count++;
             } while (existingNames.Contains(newName));
-            
+
             return newName;
         }
 


### PR DESCRIPTION
When creating multiple profiles, it would be helpful for each account to not be created with the same name by default