### PR TITLE
Fix UI elements being squashed when not starting at a 16:9 aspect

### DIFF
--- a/Assets/Script/Helpers/UI/ScaleByParentSize.cs
+++ b/Assets/Script/Helpers/UI/ScaleByParentSize.cs
@@ -25,6 +25,8 @@ namespace YARG.Helpers.UI
 
         [SerializeField]
         private Vector2 _initialSize = Vector2.one;
+        [SerializeField]
+        private ScaleMode _scaleMode = ScaleMode.ScaleByHeight;
 
         private void Update()
         {
@@ -34,10 +36,17 @@ namespace YARG.Helpers.UI
         private void UpdateScale()
         {
             var size = ParentRectTransform.rect.size;
-            float xRatio = size.x / _initialSize.x;
-            float yRatio = size.y / _initialSize.y;
+            float scale = _scaleMode == ScaleMode.ScaleByWidth ?
+                size.x / _initialSize.x :
+                size.y / _initialSize.y;
 
-            transform.localScale = new Vector3(xRatio, yRatio, 1f);
+            transform.localScale = new Vector3(scale, scale, 1f);
+        }
+
+        public enum ScaleMode
+        {
+            ScaleByHeight,
+            ScaleByWidth
         }
     }
 }

--- a/Assets/Script/Helpers/UI/ScaleByParentSize.cs
+++ b/Assets/Script/Helpers/UI/ScaleByParentSize.cs
@@ -36,9 +36,15 @@ namespace YARG.Helpers.UI
         private void UpdateScale()
         {
             var size = ParentRectTransform.rect.size;
-            float scale = _scaleMode == ScaleMode.ScaleByWidth ?
-                size.x / _initialSize.x :
-                size.y / _initialSize.y;
+            float scale;
+            if (_scaleMode == ScaleMode.ScaleByWidth)
+            {
+                scale = size.x / _initialSize.x;
+            }
+            else
+            {
+                scale = size.y / _initialSize.y;
+            }
 
             transform.localScale = new Vector3(scale, scale, 1f);
         }


### PR DESCRIPTION
ScaleByParentSize can set a unique scaling factor for both x and y causing squashing. I constrained it to only scale from one axis, and added a field to let you choose which one. As far as I can tell there are only 2 prefabs that use this component: TrackView and VocalPlayerHUD. I played around resizing the game a whole bunch, and both appear to be the correct size with no squash.

<img width="2048" height="685" alt="image" src="https://github.com/user-attachments/assets/1da21b42-3992-492c-ae96-331d49b61e0b" />
<img width="2048" height="691" alt="image" src="https://github.com/user-attachments/assets/6f94ec06-09cf-4a01-9990-f0f5a0abb9cf" />
