### PR TITLE
Adjust rectangle theme note size, position, and rotation

### DIFF
--- a/Assets/Art/Materials/Gameplay/Notes/Rectangular/CymbalMetal.mat
+++ b/Assets/Art/Materials/Gameplay/Notes/Rectangular/CymbalMetal.mat
@@ -107,7 +107,7 @@ Material:
     - _ReceiveShadows: 1
     - _SHINE: 0
     - _ShineAmount: 0
-    - _Smoothness: 0.5
+    - _Smoothness: 0
     - _SmoothnessTextureChannel: 0
     - _SpecularHighlights: 1
     - _SrcBlend: 1

--- a/Assets/Art/Materials/Gameplay/Notes/Rectangular/CymbalMiddle.mat
+++ b/Assets/Art/Materials/Gameplay/Notes/Rectangular/CymbalMiddle.mat
@@ -105,7 +105,7 @@ Material:
     - _GlossMapScale: 0
     - _Glossiness: 0
     - _GlossyReflections: 0
-    - _Metallic: 0.2
+    - _Metallic: 0
     - _MinDarkness: 0.4
     - _NoiseScale: -1.02
     - _NoiseSpeed: 0.25
@@ -119,7 +119,7 @@ Material:
     - _SHINE: 1
     - _ShineAmount: 0.15
     - _Shine_Amount: 0.1
-    - _Smoothness: 0.5
+    - _Smoothness: 0
     - _SmoothnessTextureChannel: 0
     - _SpecularHighlights: 1
     - _SrcBlend: 1

--- a/Assets/Art/Materials/Gameplay/Notes/Rectangular/CymbalMiddle.mat
+++ b/Assets/Art/Materials/Gameplay/Notes/Rectangular/CymbalMiddle.mat
@@ -8,16 +8,14 @@ Material:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: CymbalMiddle
-  m_Shader: {fileID: -6465566751694194690, guid: 0c474304b74472f4a8b212da29713486,
+  m_Shader: {fileID: -6465566751694194690, guid: f234a0dbfe313d94697e5acc4c227a98,
     type: 3}
-  m_ValidKeywords:
-  - _EMISSION_DISABLED
-  - _SHINE
+  m_ValidKeywords: []
   m_InvalidKeywords: []
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0
   m_DoubleSidedGI: 0
-  m_CustomRenderQueue: 3000
+  m_CustomRenderQueue: -1
   stringTagMap: {}
   disabledShaderPasses: []
   m_SavedProperties:

--- a/Assets/Prefabs/Gameplay/Visual/Themes/RectangularTheme.prefab
+++ b/Assets/Prefabs/Gameplay/Visual/Themes/RectangularTheme.prefab
@@ -10018,6 +10018,38 @@ MonoBehaviour:
     EmissionMultiplier: 2.5
     EmissionAddition: 0
   _coloredMaterialsNoStarPower: []
+--- !u!1 &864788763194525350
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5459707410730856336}
+  m_Layer: 0
+  m_Name: ScaleContainer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5459707410730856336
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 864788763194525350}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.1, z: 0.05}
+  m_LocalScale: {x: 11, y: 17, z: 4}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1035037677447328001}
+  m_Father: {fileID: 1255107110921496919}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &915166862513918969
 GameObject:
   m_ObjectHideFlags: 0
@@ -10043,11 +10075,11 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 915166862513918969}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0.489, y: 0, z: -0.531}
+  m_LocalPosition: {x: 0.5, y: 0, z: -0.5}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 573661293016020163}
+  - {fileID: 2220679005884815455}
   m_Father: {fileID: 6787859722296056190}
   m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -10367,6 +10399,70 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: faddd484b7894e0788b12f145d49f469, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &1659694984188197966
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7290527880227086549}
+  m_Layer: 0
+  m_Name: ScaleContainer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7290527880227086549
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1659694984188197966}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.1, z: 0.0333}
+  m_LocalScale: {x: 9, y: 11.5, z: 2.666}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4864352661746187452}
+  m_Father: {fileID: 4385094516663375282}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1865154006296656815
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5427686495276499991}
+  m_Layer: 0
+  m_Name: ScaleContainer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5427686495276499991
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1865154006296656815}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.1, z: 0.05}
+  m_LocalScale: {x: 11, y: 17, z: 4}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7970818849864002351}
+  m_Father: {fileID: 7041194549241324351}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1885553132478600074
 GameObject:
   m_ObjectHideFlags: 0
@@ -10411,6 +10507,38 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: faddd484b7894e0788b12f145d49f469, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1 &1971882269369441077
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2220679005884815455}
+  m_Layer: 0
+  m_Name: ScaleContainer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2220679005884815455
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1971882269369441077}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.1, z: 0.0333}
+  m_LocalScale: {x: 7.333, y: 11.333, z: 2.333}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 573661293016020163}
+  m_Father: {fileID: 2569389835667191552}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2238827561735956608
 GameObject:
   m_ObjectHideFlags: 0
@@ -15601,6 +15729,38 @@ MonoBehaviour:
     EmissionMultiplier: 8
     EmissionAddition: 0
   _coloredMaterialsNoStarPower: []
+--- !u!1 &2573877056044305055
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2283758889320465535}
+  m_Layer: 0
+  m_Name: ScaleContainer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2283758889320465535
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2573877056044305055}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.1, z: 0.05}
+  m_LocalScale: {x: 13.5, y: 17, z: 4}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 762020061369257404}
+  m_Father: {fileID: 5133703135408220971}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2852395855816787385
 GameObject:
   m_ObjectHideFlags: 0
@@ -20517,7 +20677,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 1077079606126651289}
+  - {fileID: 5735184220902717393}
   m_Father: {fileID: 1308121178878633657}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -25457,7 +25617,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 1035037677447328001}
+  - {fileID: 5459707410730856336}
   m_Father: {fileID: 6787859722296056190}
   m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -30494,7 +30654,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 762020061369257404}
+  - {fileID: 2283758889320465535}
   m_Father: {fileID: 1308121178878633657}
   m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -30810,6 +30970,38 @@ Transform:
   - {fileID: 8202880826653267939}
   m_Father: {fileID: 4500990497932702555}
   m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &5162723492363337439
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5735184220902717393}
+  m_Layer: 0
+  m_Name: ScaleContainer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5735184220902717393
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5162723492363337439}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.1, z: 0.05}
+  m_LocalScale: {x: 13.5, y: 17, z: 4}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1077079606126651289}
+  m_Father: {fileID: 7840990161661725984}
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &5220489739260093962
 GameObject:
@@ -40889,7 +41081,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 4864352661746187452}
+  - {fileID: 7290527880227086549}
   m_Father: {fileID: 1308121178878633657}
   m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -41130,7 +41322,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 7970818849864002351}
+  - {fileID: 5427686495276499991}
   m_Father: {fileID: 6787859722296056190}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -60879,7 +61071,7 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    m_TransformParent: {fileID: 2569389835667191552}
+    m_TransformParent: {fileID: 2220679005884815455}
     m_Modifications:
     - target: {fileID: -8679921383154817045, guid: 3d87184571563894b90138a046c56d8a,
         type: 3}
@@ -60889,17 +61081,17 @@ PrefabInstance:
     - target: {fileID: -8679921383154817045, guid: 3d87184571563894b90138a046c56d8a,
         type: 3}
       propertyPath: m_LocalScale.x
-      value: 10.95383
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 3d87184571563894b90138a046c56d8a,
         type: 3}
       propertyPath: m_LocalScale.y
-      value: 7.260089
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 3d87184571563894b90138a046c56d8a,
         type: 3}
       propertyPath: m_LocalScale.z
-      value: 10.95383
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 3d87184571563894b90138a046c56d8a,
         type: 3}
@@ -60909,12 +61101,12 @@ PrefabInstance:
     - target: {fileID: -8679921383154817045, guid: 3d87184571563894b90138a046c56d8a,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.04603345
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 3d87184571563894b90138a046c56d8a,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.10910642
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 3d87184571563894b90138a046c56d8a,
         type: 3}
@@ -60924,32 +61116,32 @@ PrefabInstance:
     - target: {fileID: -8679921383154817045, guid: 3d87184571563894b90138a046c56d8a,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 3d87184571563894b90138a046c56d8a,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0.6765453
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 3d87184571563894b90138a046c56d8a,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0.73640096
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 3d87184571563894b90138a046c56d8a,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -85.148
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 3d87184571563894b90138a046c56d8a,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 3d87184571563894b90138a046c56d8a,
         type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
+      propertyPath: m_LocalRotation.y
+      value: 0.7372774
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 3d87184571563894b90138a046c56d8a,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.67559016
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 3d87184571563894b90138a046c56d8a,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -85
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 3d87184571563894b90138a046c56d8a,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
       value: 180
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 3d87184571563894b90138a046c56d8a,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -7511558181221131132, guid: 3d87184571563894b90138a046c56d8a,
         type: 3}
@@ -61005,32 +61197,32 @@ PrefabInstance:
     - target: {fileID: -8679921383154817045, guid: 8ccc7600fd1624a458f5db0357b192a4,
         type: 3}
       propertyPath: m_LocalScale.x
-      value: 4.561636
+      value: 4.5
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 8ccc7600fd1624a458f5db0357b192a4,
         type: 3}
       propertyPath: m_LocalScale.y
-      value: 4.6472716
+      value: 3.25
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 8ccc7600fd1624a458f5db0357b192a4,
         type: 3}
       propertyPath: m_LocalScale.z
-      value: 4.647245
+      value: 6.5
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 8ccc7600fd1624a458f5db0357b192a4,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0.0005
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 8ccc7600fd1624a458f5db0357b192a4,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.0515
+      value: 0.073
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 8ccc7600fd1624a458f5db0357b192a4,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.063
+      value: 0.0475
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 8ccc7600fd1624a458f5db0357b192a4,
         type: 3}
@@ -61045,17 +61237,17 @@ PrefabInstance:
     - target: {fileID: -8679921383154817045, guid: 8ccc7600fd1624a458f5db0357b192a4,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.7069834
+      value: 0.7071068
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 8ccc7600fd1624a458f5db0357b192a4,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0.7072302
+      value: 0.7071068
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 8ccc7600fd1624a458f5db0357b192a4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: -89.98
+      value: -90
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 8ccc7600fd1624a458f5db0357b192a4,
         type: 3}
@@ -61111,7 +61303,7 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    m_TransformParent: {fileID: 7840990161661725984}
+    m_TransformParent: {fileID: 5735184220902717393}
     m_Modifications:
     - target: {fileID: -8679921383154817045, guid: 29198bc9964214b43aa85e6658f976c9,
         type: 3}
@@ -61121,32 +61313,32 @@ PrefabInstance:
     - target: {fileID: -8679921383154817045, guid: 29198bc9964214b43aa85e6658f976c9,
         type: 3}
       propertyPath: m_LocalScale.x
-      value: 14.585325
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 29198bc9964214b43aa85e6658f976c9,
         type: 3}
       propertyPath: m_LocalScale.y
-      value: 9.125298
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 29198bc9964214b43aa85e6658f976c9,
         type: 3}
       propertyPath: m_LocalScale.z
-      value: 14.348699
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 29198bc9964214b43aa85e6658f976c9,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0.0003899932
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 29198bc9964214b43aa85e6658f976c9,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.0672
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 29198bc9964214b43aa85e6658f976c9,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.1148
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 29198bc9964214b43aa85e6658f976c9,
         type: 3}
@@ -61161,17 +61353,17 @@ PrefabInstance:
     - target: {fileID: -8679921383154817045, guid: 29198bc9964214b43aa85e6658f976c9,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.68810767
+      value: 0.7372774
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 29198bc9964214b43aa85e6658f976c9,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0.7256086
+      value: 0.67559016
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 29198bc9964214b43aa85e6658f976c9,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: -93.039
+      value: -85
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 29198bc9964214b43aa85e6658f976c9,
         type: 3}
@@ -61181,6 +61373,31 @@ PrefabInstance:
     - target: {fileID: -8679921383154817045, guid: 29198bc9964214b43aa85e6658f976c9,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -7511558181221131132, guid: 29198bc9964214b43aa85e6658f976c9,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -7511558181221131132, guid: 29198bc9964214b43aa85e6658f976c9,
+        type: 3}
+      propertyPath: m_CastShadows
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -7511558181221131132, guid: 29198bc9964214b43aa85e6658f976c9,
+        type: 3}
+      propertyPath: m_DynamicOccludee
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -7511558181221131132, guid: 29198bc9964214b43aa85e6658f976c9,
+        type: 3}
+      propertyPath: m_LightProbeUsage
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -7511558181221131132, guid: 29198bc9964214b43aa85e6658f976c9,
+        type: 3}
+      propertyPath: m_StaticShadowCaster
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -7511558181221131132, guid: 29198bc9964214b43aa85e6658f976c9,
@@ -61222,7 +61439,7 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    m_TransformParent: {fileID: 1255107110921496919}
+    m_TransformParent: {fileID: 5459707410730856336}
     m_Modifications:
     - target: {fileID: -8679921383154817045, guid: 1a56b8eb590cca340a7a795af1147ac6,
         type: 3}
@@ -61232,12 +61449,17 @@ PrefabInstance:
     - target: {fileID: -8679921383154817045, guid: 1a56b8eb590cca340a7a795af1147ac6,
         type: 3}
       propertyPath: m_LocalScale.x
-      value: 12.235269
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 1a56b8eb590cca340a7a795af1147ac6,
         type: 3}
       propertyPath: m_LocalScale.y
-      value: 10.5075035
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 1a56b8eb590cca340a7a795af1147ac6,
+        type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 1a56b8eb590cca340a7a795af1147ac6,
         type: 3}
@@ -61247,12 +61469,12 @@ PrefabInstance:
     - target: {fileID: -8679921383154817045, guid: 1a56b8eb590cca340a7a795af1147ac6,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.071
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 1a56b8eb590cca340a7a795af1147ac6,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.105
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 1a56b8eb590cca340a7a795af1147ac6,
         type: 3}
@@ -61267,27 +61489,27 @@ PrefabInstance:
     - target: {fileID: -8679921383154817045, guid: 1a56b8eb590cca340a7a795af1147ac6,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.6922062
+      value: 0.7372774
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 1a56b8eb590cca340a7a795af1147ac6,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0.7216998
+      value: 0.67559016
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 1a56b8eb590cca340a7a795af1147ac6,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: -87.61
+      value: -85
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 1a56b8eb590cca340a7a795af1147ac6,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
+      value: 180
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 1a56b8eb590cca340a7a795af1147ac6,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
-      value: 180
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -7511558181221131132, guid: 1a56b8eb590cca340a7a795af1147ac6,
         type: 3}
@@ -61333,7 +61555,7 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    m_TransformParent: {fileID: 5133703135408220971}
+    m_TransformParent: {fileID: 2283758889320465535}
     m_Modifications:
     - target: {fileID: -8679921383154817045, guid: 1a56b8eb590cca340a7a795af1147ac6,
         type: 3}
@@ -61343,32 +61565,32 @@ PrefabInstance:
     - target: {fileID: -8679921383154817045, guid: 1a56b8eb590cca340a7a795af1147ac6,
         type: 3}
       propertyPath: m_LocalScale.x
-      value: 16.689787
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 1a56b8eb590cca340a7a795af1147ac6,
         type: 3}
       propertyPath: m_LocalScale.y
-      value: 11.572653
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 1a56b8eb590cca340a7a795af1147ac6,
         type: 3}
       propertyPath: m_LocalScale.z
-      value: 15.583922
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 1a56b8eb590cca340a7a795af1147ac6,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0.011
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 1a56b8eb590cca340a7a795af1147ac6,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.072
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 1a56b8eb590cca340a7a795af1147ac6,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.124
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 1a56b8eb590cca340a7a795af1147ac6,
         type: 3}
@@ -61383,27 +61605,27 @@ PrefabInstance:
     - target: {fileID: -8679921383154817045, guid: 1a56b8eb590cca340a7a795af1147ac6,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.6922062
+      value: 0.7372774
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 1a56b8eb590cca340a7a795af1147ac6,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0.7216998
+      value: 0.67559016
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 1a56b8eb590cca340a7a795af1147ac6,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: -87.61
+      value: -85
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 1a56b8eb590cca340a7a795af1147ac6,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
+      value: 180
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 1a56b8eb590cca340a7a795af1147ac6,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
-      value: 180
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -7511558181221131132, guid: 1a56b8eb590cca340a7a795af1147ac6,
         type: 3}
@@ -61464,32 +61686,32 @@ PrefabInstance:
     - target: {fileID: -8679921383154817045, guid: cbc2f0647e367e14291313e9420b5695,
         type: 3}
       propertyPath: m_LocalScale.x
-      value: 6.944194
+      value: 6.7
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: cbc2f0647e367e14291313e9420b5695,
         type: 3}
       propertyPath: m_LocalScale.y
-      value: 5.064006
+      value: 3.5
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: cbc2f0647e367e14291313e9420b5695,
         type: 3}
       propertyPath: m_LocalScale.z
-      value: 5.7896996
+      value: 7
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: cbc2f0647e367e14291313e9420b5695,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0.000006938
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: cbc2f0647e367e14291313e9420b5695,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.067
+      value: 0.0785
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: cbc2f0647e367e14291313e9420b5695,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.074
+      value: 0.05
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: cbc2f0647e367e14291313e9420b5695,
         type: 3}
@@ -61696,17 +61918,17 @@ PrefabInstance:
     - target: {fileID: -8679921383154817045, guid: 8675816fd84351b4b8c697e4ebf1ff30,
         type: 3}
       propertyPath: m_LocalScale.x
-      value: 32.3649
+      value: 32.3
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 8675816fd84351b4b8c697e4ebf1ff30,
         type: 3}
       propertyPath: m_LocalScale.y
-      value: 2.5219367
+      value: 2.5
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 8675816fd84351b4b8c697e4ebf1ff30,
         type: 3}
       propertyPath: m_LocalScale.z
-      value: 3.641734
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 8675816fd84351b4b8c697e4ebf1ff30,
         type: 3}
@@ -61716,17 +61938,17 @@ PrefabInstance:
     - target: {fileID: -8679921383154817045, guid: 8675816fd84351b4b8c697e4ebf1ff30,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.039
+      value: 0.03
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 8675816fd84351b4b8c697e4ebf1ff30,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.047
+      value: 0.04
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 8675816fd84351b4b8c697e4ebf1ff30,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.7071067
+      value: 0.7071068
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 8675816fd84351b4b8c697e4ebf1ff30,
         type: 3}
@@ -61736,17 +61958,17 @@ PrefabInstance:
     - target: {fileID: -8679921383154817045, guid: 8675816fd84351b4b8c697e4ebf1ff30,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 8675816fd84351b4b8c697e4ebf1ff30,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 8675816fd84351b4b8c697e4ebf1ff30,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
+      value: -90
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 8675816fd84351b4b8c697e4ebf1ff30,
         type: 3}
@@ -61802,17 +62024,17 @@ PrefabInstance:
     - target: {fileID: -8679921383154817045, guid: 9750834e38886314d86b70120408ac15,
         type: 3}
       propertyPath: m_LocalScale.x
-      value: 3.0272114
+      value: 2.8
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 9750834e38886314d86b70120408ac15,
         type: 3}
       propertyPath: m_LocalScale.y
-      value: 3.5654547
+      value: 3.75
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 9750834e38886314d86b70120408ac15,
         type: 3}
       propertyPath: m_LocalScale.z
-      value: 3.5654547
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 9750834e38886314d86b70120408ac15,
         type: 3}
@@ -61822,17 +62044,17 @@ PrefabInstance:
     - target: {fileID: -8679921383154817045, guid: 9750834e38886314d86b70120408ac15,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.0388
+      value: 0.0666
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 9750834e38886314d86b70120408ac15,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.06
+      value: 0.055
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 9750834e38886314d86b70120408ac15,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.7071067
+      value: 0.7071068
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 9750834e38886314d86b70120408ac15,
         type: 3}
@@ -61847,12 +62069,12 @@ PrefabInstance:
     - target: {fileID: -8679921383154817045, guid: 9750834e38886314d86b70120408ac15,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 9750834e38886314d86b70120408ac15,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
+      value: -90
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 9750834e38886314d86b70120408ac15,
         type: 3}
@@ -61918,32 +62140,32 @@ PrefabInstance:
     - target: {fileID: -8679921383154817045, guid: f907a43e655c21b46b01b01f6a2ee801,
         type: 3}
       propertyPath: m_LocalScale.x
-      value: 4.982476
+      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: f907a43e655c21b46b01b01f6a2ee801,
         type: 3}
       propertyPath: m_LocalScale.y
-      value: 5.0760136
+      value: 3.75
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: f907a43e655c21b46b01b01f6a2ee801,
         type: 3}
       propertyPath: m_LocalScale.z
-      value: 4.8222127
+      value: 7
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: f907a43e655c21b46b01b01f6a2ee801,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0.0021
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: f907a43e655c21b46b01b01f6a2ee801,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.053
+      value: 0.0775
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: f907a43e655c21b46b01b01f6a2ee801,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.0697
+      value: 0.055
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: f907a43e655c21b46b01b01f6a2ee801,
         type: 3}
@@ -61958,17 +62180,17 @@ PrefabInstance:
     - target: {fileID: -8679921383154817045, guid: f907a43e655c21b46b01b01f6a2ee801,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.7069834
+      value: 0.7071068
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: f907a43e655c21b46b01b01f6a2ee801,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0.7072302
+      value: 0.7071068
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: f907a43e655c21b46b01b01f6a2ee801,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: -89.98
+      value: -90
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: f907a43e655c21b46b01b01f6a2ee801,
         type: 3}
@@ -62029,37 +62251,37 @@ PrefabInstance:
     - target: {fileID: -8679921383154817045, guid: 8ca0be366f488d34d8967cbc81ff8b2d,
         type: 3}
       propertyPath: m_LocalScale.x
-      value: 4.096773
+      value: 3.75
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 8ca0be366f488d34d8967cbc81ff8b2d,
         type: 3}
       propertyPath: m_LocalScale.y
-      value: 4.173682
+      value: 3.75
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 8ca0be366f488d34d8967cbc81ff8b2d,
         type: 3}
       propertyPath: m_LocalScale.z
-      value: 4.173682
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 8ca0be366f488d34d8967cbc81ff8b2d,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0.0009
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 8ca0be366f488d34d8967cbc81ff8b2d,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.046
+      value: 0.0666
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 8ca0be366f488d34d8967cbc81ff8b2d,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.063
+      value: 0.055
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 8ca0be366f488d34d8967cbc81ff8b2d,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.7071067
+      value: 0.7071068
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 8ca0be366f488d34d8967cbc81ff8b2d,
         type: 3}
@@ -62069,17 +62291,17 @@ PrefabInstance:
     - target: {fileID: -8679921383154817045, guid: 8ca0be366f488d34d8967cbc81ff8b2d,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 8ca0be366f488d34d8967cbc81ff8b2d,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 8ca0be366f488d34d8967cbc81ff8b2d,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
+      value: -90
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 8ca0be366f488d34d8967cbc81ff8b2d,
         type: 3}
@@ -62246,7 +62468,7 @@ PrefabInstance:
     - target: {fileID: 7137662299531785058, guid: 646e582c8d8303248aa9d4bd931b2081,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0
+      value: 0.03
       objectReference: {fileID: 0}
     - target: {fileID: 7137662299531785058, guid: 646e582c8d8303248aa9d4bd931b2081,
         type: 3}
@@ -62312,17 +62534,17 @@ PrefabInstance:
     - target: {fileID: -8679921383154817045, guid: 8675816fd84351b4b8c697e4ebf1ff30,
         type: 3}
       propertyPath: m_LocalScale.x
-      value: 32.3649
+      value: 32.3
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 8675816fd84351b4b8c697e4ebf1ff30,
         type: 3}
       propertyPath: m_LocalScale.y
-      value: 2.5219367
+      value: 2.3
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 8675816fd84351b4b8c697e4ebf1ff30,
         type: 3}
       propertyPath: m_LocalScale.z
-      value: 3.641734
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 8675816fd84351b4b8c697e4ebf1ff30,
         type: 3}
@@ -62332,17 +62554,17 @@ PrefabInstance:
     - target: {fileID: -8679921383154817045, guid: 8675816fd84351b4b8c697e4ebf1ff30,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.039
+      value: 0.03
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 8675816fd84351b4b8c697e4ebf1ff30,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.047
+      value: 0.04
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 8675816fd84351b4b8c697e4ebf1ff30,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.7071067
+      value: 0.7071068
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 8675816fd84351b4b8c697e4ebf1ff30,
         type: 3}
@@ -62352,17 +62574,17 @@ PrefabInstance:
     - target: {fileID: -8679921383154817045, guid: 8675816fd84351b4b8c697e4ebf1ff30,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 8675816fd84351b4b8c697e4ebf1ff30,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 8675816fd84351b4b8c697e4ebf1ff30,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
+      value: -90
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 8675816fd84351b4b8c697e4ebf1ff30,
         type: 3}
@@ -62612,7 +62834,7 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    m_TransformParent: {fileID: 4385094516663375282}
+    m_TransformParent: {fileID: 7290527880227086549}
     m_Modifications:
     - target: {fileID: -8679921383154817045, guid: 3d87184571563894b90138a046c56d8a,
         type: 3}
@@ -62622,17 +62844,17 @@ PrefabInstance:
     - target: {fileID: -8679921383154817045, guid: 3d87184571563894b90138a046c56d8a,
         type: 3}
       propertyPath: m_LocalScale.x
-      value: 10.186889
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 3d87184571563894b90138a046c56d8a,
         type: 3}
       propertyPath: m_LocalScale.y
-      value: 6.751768
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 3d87184571563894b90138a046c56d8a,
         type: 3}
       propertyPath: m_LocalScale.z
-      value: 10.186889
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 3d87184571563894b90138a046c56d8a,
         type: 3}
@@ -62642,12 +62864,12 @@ PrefabInstance:
     - target: {fileID: -8679921383154817045, guid: 3d87184571563894b90138a046c56d8a,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.046933398
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 3d87184571563894b90138a046c56d8a,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.10940623
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 3d87184571563894b90138a046c56d8a,
         type: 3}
@@ -62657,32 +62879,32 @@ PrefabInstance:
     - target: {fileID: -8679921383154817045, guid: 3d87184571563894b90138a046c56d8a,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 3d87184571563894b90138a046c56d8a,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0.68804514
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 3d87184571563894b90138a046c56d8a,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0.72566795
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 3d87184571563894b90138a046c56d8a,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -86.951
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 3d87184571563894b90138a046c56d8a,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 3d87184571563894b90138a046c56d8a,
         type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
+      propertyPath: m_LocalRotation.y
+      value: 0.7372774
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 3d87184571563894b90138a046c56d8a,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.67559016
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 3d87184571563894b90138a046c56d8a,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -85
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 3d87184571563894b90138a046c56d8a,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
       value: 180
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 3d87184571563894b90138a046c56d8a,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -7511558181221131132, guid: 3d87184571563894b90138a046c56d8a,
         type: 3}
@@ -62758,7 +62980,7 @@ PrefabInstance:
     - target: {fileID: 7137662299531785058, guid: 9d72c5330e79c7440b60de8f2fc35fc1,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0
+      value: 0.03
       objectReference: {fileID: 0}
     - target: {fileID: 7137662299531785058, guid: 9d72c5330e79c7440b60de8f2fc35fc1,
         type: 3}
@@ -62824,32 +63046,32 @@ PrefabInstance:
     - target: {fileID: -8679921383154817045, guid: f907a43e655c21b46b01b01f6a2ee801,
         type: 3}
       propertyPath: m_LocalScale.x
-      value: 4.982476
+      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: f907a43e655c21b46b01b01f6a2ee801,
         type: 3}
       propertyPath: m_LocalScale.y
-      value: 5.0760136
+      value: 3.75
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: f907a43e655c21b46b01b01f6a2ee801,
         type: 3}
       propertyPath: m_LocalScale.z
-      value: 4.8222127
+      value: 7
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: f907a43e655c21b46b01b01f6a2ee801,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0.0020999908
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: f907a43e655c21b46b01b01f6a2ee801,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.053
+      value: 0.0775
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: f907a43e655c21b46b01b01f6a2ee801,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.085
+      value: 0.055
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: f907a43e655c21b46b01b01f6a2ee801,
         type: 3}
@@ -62859,22 +63081,22 @@ PrefabInstance:
     - target: {fileID: -8679921383154817045, guid: f907a43e655c21b46b01b01f6a2ee801,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: f907a43e655c21b46b01b01f6a2ee801,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.7069834
+      value: 0.7071068
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: f907a43e655c21b46b01b01f6a2ee801,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0.7072302
+      value: 0.7071068
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: f907a43e655c21b46b01b01f6a2ee801,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: -89.98
+      value: -90
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: f907a43e655c21b46b01b01f6a2ee801,
         type: 3}
@@ -62935,32 +63157,32 @@ PrefabInstance:
     - target: {fileID: -8679921383154817045, guid: f907a43e655c21b46b01b01f6a2ee801,
         type: 3}
       propertyPath: m_LocalScale.x
-      value: 4.982476
+      value: 5
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: f907a43e655c21b46b01b01f6a2ee801,
         type: 3}
       propertyPath: m_LocalScale.y
-      value: 5.0760136
+      value: 3.75
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: f907a43e655c21b46b01b01f6a2ee801,
         type: 3}
       propertyPath: m_LocalScale.z
-      value: 4.8222127
+      value: 7
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: f907a43e655c21b46b01b01f6a2ee801,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0.0020999908
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: f907a43e655c21b46b01b01f6a2ee801,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.053
+      value: 0.0775
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: f907a43e655c21b46b01b01f6a2ee801,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.0697
+      value: 0.055
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: f907a43e655c21b46b01b01f6a2ee801,
         type: 3}
@@ -62970,22 +63192,22 @@ PrefabInstance:
     - target: {fileID: -8679921383154817045, guid: f907a43e655c21b46b01b01f6a2ee801,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: f907a43e655c21b46b01b01f6a2ee801,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.7069834
+      value: 0.7071068
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: f907a43e655c21b46b01b01f6a2ee801,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0.7072302
+      value: 0.7071068
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: f907a43e655c21b46b01b01f6a2ee801,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: -89.98
+      value: -90
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: f907a43e655c21b46b01b01f6a2ee801,
         type: 3}
@@ -63046,32 +63268,32 @@ PrefabInstance:
     - target: {fileID: -8679921383154817045, guid: c58cec31fa674ce43a64f4fff3bb71b4,
         type: 3}
       propertyPath: m_LocalScale.x
-      value: 4.561636
+      value: 4.5
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: c58cec31fa674ce43a64f4fff3bb71b4,
         type: 3}
       propertyPath: m_LocalScale.y
-      value: 4.6472716
+      value: 3.25
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: c58cec31fa674ce43a64f4fff3bb71b4,
         type: 3}
       propertyPath: m_LocalScale.z
-      value: 4.647245
+      value: 6.5
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: c58cec31fa674ce43a64f4fff3bb71b4,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0.0005
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: c58cec31fa674ce43a64f4fff3bb71b4,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.0515
+      value: 0.073
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: c58cec31fa674ce43a64f4fff3bb71b4,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.063
+      value: 0.0475
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: c58cec31fa674ce43a64f4fff3bb71b4,
         type: 3}
@@ -63086,17 +63308,17 @@ PrefabInstance:
     - target: {fileID: -8679921383154817045, guid: c58cec31fa674ce43a64f4fff3bb71b4,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.7069834
+      value: 0.7071068
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: c58cec31fa674ce43a64f4fff3bb71b4,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0.7072302
+      value: 0.7071068
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: c58cec31fa674ce43a64f4fff3bb71b4,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: -89.98
+      value: -90
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: c58cec31fa674ce43a64f4fff3bb71b4,
         type: 3}
@@ -63152,7 +63374,7 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    m_TransformParent: {fileID: 7041194549241324351}
+    m_TransformParent: {fileID: 5427686495276499991}
     m_Modifications:
     - target: {fileID: -8679921383154817045, guid: 29198bc9964214b43aa85e6658f976c9,
         type: 3}
@@ -63162,32 +63384,32 @@ PrefabInstance:
     - target: {fileID: -8679921383154817045, guid: 29198bc9964214b43aa85e6658f976c9,
         type: 3}
       propertyPath: m_LocalScale.x
-      value: 12.000514
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 29198bc9964214b43aa85e6658f976c9,
         type: 3}
       propertyPath: m_LocalScale.y
-      value: 10.32345
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 29198bc9964214b43aa85e6658f976c9,
         type: 3}
       propertyPath: m_LocalScale.z
-      value: 11.996373
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 29198bc9964214b43aa85e6658f976c9,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0.0003900528
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 29198bc9964214b43aa85e6658f976c9,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.06
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 29198bc9964214b43aa85e6658f976c9,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.107
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 29198bc9964214b43aa85e6658f976c9,
         type: 3}
@@ -63197,22 +63419,22 @@ PrefabInstance:
     - target: {fileID: -8679921383154817045, guid: 29198bc9964214b43aa85e6658f976c9,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 29198bc9964214b43aa85e6658f976c9,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0.6621505
+      value: 0.7372774
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 29198bc9964214b43aa85e6658f976c9,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0.74937093
+      value: 0.67559016
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 29198bc9964214b43aa85e6658f976c9,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: -97.072
+      value: -85
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 29198bc9964214b43aa85e6658f976c9,
         type: 3}
@@ -63273,37 +63495,37 @@ PrefabInstance:
     - target: {fileID: -8679921383154817045, guid: 840fe3e9962feda4897b3cf0ad4a0413,
         type: 3}
       propertyPath: m_LocalScale.x
-      value: 3.3491778
+      value: 3.75
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 840fe3e9962feda4897b3cf0ad4a0413,
         type: 3}
       propertyPath: m_LocalScale.y
-      value: 3.9446669
+      value: 3.75
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 840fe3e9962feda4897b3cf0ad4a0413,
         type: 3}
       propertyPath: m_LocalScale.z
-      value: 3.9446669
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 840fe3e9962feda4897b3cf0ad4a0413,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0.00000077486
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 840fe3e9962feda4897b3cf0ad4a0413,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.0439
+      value: 0.0666
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 840fe3e9962feda4897b3cf0ad4a0413,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.06
+      value: 0.055
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 840fe3e9962feda4897b3cf0ad4a0413,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.7071067
+      value: 0.7071068
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 840fe3e9962feda4897b3cf0ad4a0413,
         type: 3}
@@ -63313,17 +63535,17 @@ PrefabInstance:
     - target: {fileID: -8679921383154817045, guid: 840fe3e9962feda4897b3cf0ad4a0413,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 840fe3e9962feda4897b3cf0ad4a0413,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 840fe3e9962feda4897b3cf0ad4a0413,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
+      value: -90
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: 840fe3e9962feda4897b3cf0ad4a0413,
         type: 3}
@@ -63384,17 +63606,17 @@ PrefabInstance:
     - target: {fileID: -8679921383154817045, guid: d70acdcb0dd69fe4e8f1510f47b73f99,
         type: 3}
       propertyPath: m_LocalScale.x
-      value: 4.381881
+      value: 3.65
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: d70acdcb0dd69fe4e8f1510f47b73f99,
         type: 3}
       propertyPath: m_LocalScale.y
-      value: 4.464115
+      value: 3.25
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: d70acdcb0dd69fe4e8f1510f47b73f99,
         type: 3}
       propertyPath: m_LocalScale.z
-      value: 4.464115
+      value: 5.72
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: d70acdcb0dd69fe4e8f1510f47b73f99,
         type: 3}
@@ -63404,12 +63626,12 @@ PrefabInstance:
     - target: {fileID: -8679921383154817045, guid: d70acdcb0dd69fe4e8f1510f47b73f99,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.053
+      value: 0.064
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: d70acdcb0dd69fe4e8f1510f47b73f99,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.066
+      value: 0.05
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: d70acdcb0dd69fe4e8f1510f47b73f99,
         type: 3}
@@ -63500,17 +63722,17 @@ PrefabInstance:
     - target: {fileID: -8679921383154817045, guid: d70acdcb0dd69fe4e8f1510f47b73f99,
         type: 3}
       propertyPath: m_LocalScale.x
-      value: 4.046229
+      value: 3.65
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: d70acdcb0dd69fe4e8f1510f47b73f99,
         type: 3}
       propertyPath: m_LocalScale.y
-      value: 4.122164
+      value: 3.25
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: d70acdcb0dd69fe4e8f1510f47b73f99,
         type: 3}
       propertyPath: m_LocalScale.z
-      value: 4.122164
+      value: 5.72
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: d70acdcb0dd69fe4e8f1510f47b73f99,
         type: 3}
@@ -63520,12 +63742,12 @@ PrefabInstance:
     - target: {fileID: -8679921383154817045, guid: d70acdcb0dd69fe4e8f1510f47b73f99,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.052408
+      value: 0.064
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: d70acdcb0dd69fe4e8f1510f47b73f99,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.066
+      value: 0.05
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: d70acdcb0dd69fe4e8f1510f47b73f99,
         type: 3}
@@ -63839,32 +64061,32 @@ PrefabInstance:
     - target: {fileID: -8679921383154817045, guid: cbc2f0647e367e14291313e9420b5695,
         type: 3}
       propertyPath: m_LocalScale.x
-      value: 5.4025083
+      value: 5.36
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: cbc2f0647e367e14291313e9420b5695,
         type: 3}
       propertyPath: m_LocalScale.y
-      value: 5.064006
+      value: 2.8
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: cbc2f0647e367e14291313e9420b5695,
         type: 3}
       propertyPath: m_LocalScale.z
-      value: 5.7896996
+      value: 6.2
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: cbc2f0647e367e14291313e9420b5695,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0.00000071526
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: cbc2f0647e367e14291313e9420b5695,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0.053
+      value: 0.07
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: cbc2f0647e367e14291313e9420b5695,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.074
+      value: 0.041
       objectReference: {fileID: 0}
     - target: {fileID: -8679921383154817045, guid: cbc2f0647e367e14291313e9420b5695,
         type: 3}


### PR DESCRIPTION
Resized all rectangle theme notes slightly. See the following changes:

- Cymbal notes now maintain their triangular shape while moving towards the strikeline.
- Most note types are now vertically to cover more of the fret when at the strikeline.
- The front edges of kick notes and tom notes now align for unified judgement.
- Tom notes now sit on top of the kick note rather than being skewered by them.
- 5L cymbal ghost note is no longer randomly misaligned to the left.
- Small notes are standardized as 4/5 of the normal note height for better readability.
- Cymbal notes no longer have metallic shine (fixes graying and discoloration).
- Kick note is now slightly thinner to allow note to visibly sit on top.

https://github.com/user-attachments/assets/1813336b-d627-4958-91ed-22a0e3b57243


https://github.com/user-attachments/assets/ccdd102b-d1eb-494c-8cf0-55c14a3f4797


