### PR TITLE
[perf] Use highways as stencil when rendering venue

### DIFF
--- a/Assets/Art/Shaders/HighwayStencil.shader
+++ b/Assets/Art/Shaders/HighwayStencil.shader
@@ -1,0 +1,81 @@
+Shader "HighwayStencil"
+{
+    SubShader
+    {
+        Tags { "RenderType"="Transparent" "RenderQueue" = "Transparent"}
+
+        ColorMask 0      // Don't write to any color buffer
+        ZTest Always
+        ZWrite Off
+        Cull Off
+        Blend Off
+
+        Pass
+        {
+            Name "HighwayStencil"
+
+            Stencil
+            {
+                Ref 8
+                Comp always
+                Pass replace
+            }
+
+            HLSLPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+            #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
+
+            struct Attributes
+            {
+                float4 positionHCS   : POSITION;
+                float2 uv           : TEXCOORD0;
+                UNITY_VERTEX_INPUT_INSTANCE_ID
+            };
+
+            struct Varyings
+            {
+                float4  positionCS  : SV_POSITION;
+                float2  uv          : TEXCOORD0;
+                UNITY_VERTEX_OUTPUT_STEREO
+            };
+
+            Varyings vert(Attributes input)
+            {
+                Varyings output;
+                UNITY_SETUP_INSTANCE_ID(input);
+                UNITY_INITIALIZE_VERTEX_OUTPUT_STEREO(output);
+
+                // Note: The pass is setup with a mesh already in clip
+                // space, that's why, it's enough to just output vertex
+                // positions
+                output.positionCS = float4(input.positionHCS.xyz, 1.0);
+
+                #if UNITY_UV_STARTS_AT_TOP
+                output.positionCS.y *= -1;
+                #endif
+
+                output.uv = input.uv;
+                return output;
+            }
+
+            TEXTURE2D_X(_MainTex);
+            SAMPLER(sampler_MainTex);
+   
+ 
+            float4 frag (Varyings IN) : SV_Target
+            {
+                float4 color = SAMPLE_TEXTURE2D_X(_MainTex, sampler_MainTex, IN.uv);
+
+                if (color.a < 0.9)
+                {
+                    discard;
+                }
+
+                return color;
+
+            }
+            ENDHLSL
+        }
+    }
+}

--- a/Assets/Art/Shaders/HighwayStencil.shader.meta
+++ b/Assets/Art/Shaders/HighwayStencil.shader.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: d401e57306d63ad8c95aebbec69297e9
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  preprocessorOverride: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Settings/High_Renderer.asset
+++ b/Assets/Settings/High_Renderer.asset
@@ -67,10 +67,10 @@ MonoBehaviour:
     serializedVersion: 2
     m_Bits: 4294967295
   m_DefaultStencilState:
-    overrideStencilState: 0
-    stencilReference: 0
-    stencilCompareFunction: 8
-    passOperation: 2
+    overrideStencilState: 1
+    stencilReference: 8
+    stencilCompareFunction: 6
+    passOperation: 0
     failOperation: 0
     zFailOperation: 0
   m_ShadowTransparentReceive: 1

--- a/Assets/Settings/Low_Renderer.asset
+++ b/Assets/Settings/Low_Renderer.asset
@@ -43,10 +43,10 @@ MonoBehaviour:
     serializedVersion: 2
     m_Bits: 4294967295
   m_DefaultStencilState:
-    overrideStencilState: 0
-    stencilReference: 0
-    stencilCompareFunction: 8
-    passOperation: 2
+    overrideStencilState: 1
+    stencilReference: 8
+    stencilCompareFunction: 6
+    passOperation: 0
     failOperation: 0
     zFailOperation: 0
   m_ShadowTransparentReceive: 1

--- a/ProjectSettings/GraphicsSettings.asset
+++ b/ProjectSettings/GraphicsSettings.asset
@@ -37,7 +37,7 @@ GraphicsSettings:
   - {fileID: 10753, guid: 0000000000000000f000000000000000, type: 0}
   - {fileID: 10770, guid: 0000000000000000f000000000000000, type: 0}
   - {fileID: 10783, guid: 0000000000000000f000000000000000, type: 0}
-  - {fileID: 4800000, guid: 358932d403fb17de0b26c0a868118cb0, type: 3}
+  - {fileID: 4800000, guid: d401e57306d63ad8c95aebbec69297e9, type: 3}
   m_PreloadedShaders: []
   m_PreloadShadersBatchTimeLimit: -1
   m_SpritesDefaultMaterial: {fileID: 10754, guid: 0000000000000000f000000000000000,


### PR DESCRIPTION
This makes it so that venue does not render parts that are obscured by highways.
This bumps my fps at 2560x1440 when using Fractal77 with 2  highways from 88 to 117 fps
It doesn't have such a pronounced effect with less demanding venues though obviously