### PR TITLE
Add modifier to disallow star power overlap

### DIFF
--- a/Assets/Script/Gameplay/Player/DrumsPlayer.cs
+++ b/Assets/Script/Gameplay/Player/DrumsPlayer.cs
@@ -69,8 +69,10 @@ namespace YARG.Gameplay.Player
 
             if (!Player.IsReplay)
             {
+                bool noStarPowerOverlap = (Player.Profile.CurrentModifiers & Core.Game.Modifier.NoStarPowerOverlap) != 0;
+
                 // Create the engine params from the engine preset
-                EngineParams = Player.EnginePreset.Drums.Create(StarMultiplierThresholds, mode);
+                EngineParams = Player.EnginePreset.Drums.Create(StarMultiplierThresholds, noStarPowerOverlap, mode);
             }
             else
             {

--- a/Assets/Script/Gameplay/Player/FiveFretPlayer.cs
+++ b/Assets/Script/Gameplay/Player/FiveFretPlayer.cs
@@ -107,8 +107,10 @@ namespace YARG.Gameplay.Player
 
             if (!Player.IsReplay)
             {
+                bool noStarPowerOverlap = (Player.Profile.CurrentModifiers & Core.Game.Modifier.NoStarPowerOverlap) != 0;
+
                 // Create the engine params from the engine preset
-                EngineParams = Player.EnginePreset.FiveFretGuitar.Create(StarMultiplierThresholds, isBass);
+                EngineParams = Player.EnginePreset.FiveFretGuitar.Create(StarMultiplierThresholds, isBass, noStarPowerOverlap);
                 //EngineParams = EnginePreset.Precision.FiveFretGuitar.Create(StarMultiplierThresholds, isBass);
             }
             else

--- a/Assets/Script/Gameplay/Player/ProKeysPlayer.cs
+++ b/Assets/Script/Gameplay/Player/ProKeysPlayer.cs
@@ -96,8 +96,10 @@ namespace YARG.Gameplay.Player
         {
             if (!Player.IsReplay)
             {
+                bool noStarPowerOverlap = (Player.Profile.CurrentModifiers & Core.Game.Modifier.NoStarPowerOverlap) != 0;
+
                 // Create the engine params from the engine preset
-                EngineParams = Player.EnginePreset.ProKeys.Create(StarMultiplierThresholds);
+                EngineParams = Player.EnginePreset.ProKeys.Create(StarMultiplierThresholds, noStarPowerOverlap);
             }
             else
             {

--- a/Assets/Script/Gameplay/Visuals/TrackElements/Drums/FiveLaneDrumsNoteElement.cs
+++ b/Assets/Script/Gameplay/Visuals/TrackElements/Drums/FiveLaneDrumsNoteElement.cs
@@ -90,7 +90,7 @@ namespace YARG.Gameplay.Visuals
             {
                 color = colors.ActivationNote;
             }
-            else if (NoteRef.IsStarPower)
+            else if (NoteRef.IsStarPower && !(Player.Engine.BaseParameters.NoStarPowerOverlap && Player.Engine.EngineStats.IsStarPowerActive))
             {
                 color = colors.GetNoteStarPowerColor(pad);
             }

--- a/Assets/Script/Gameplay/Visuals/TrackElements/Drums/FourLaneDrumsNoteElement.cs
+++ b/Assets/Script/Gameplay/Visuals/TrackElements/Drums/FourLaneDrumsNoteElement.cs
@@ -98,7 +98,7 @@ namespace YARG.Gameplay.Visuals
             {
                 color = colors.ActivationNote;
             }
-            else if (NoteRef.IsStarPower)
+            else if (NoteRef.IsStarPower && !(Player.Engine.BaseParameters.NoStarPowerOverlap && Player.Engine.EngineStats.IsStarPowerActive))
             {
                 color = colors.GetNoteStarPowerColor(pad);
             }

--- a/Assets/Script/Gameplay/Visuals/TrackElements/Guitar/FiveFretNoteElement.cs
+++ b/Assets/Script/Gameplay/Visuals/TrackElements/Guitar/FiveFretNoteElement.cs
@@ -151,7 +151,8 @@ namespace YARG.Gameplay.Visuals
 
             // Get which note color to use
             var colorNoStarPower = colors.GetNoteColor(NoteRef.Fret);
-            var color = NoteRef.IsStarPower
+            var shouldDisplayStarPower = NoteRef.IsStarPower && !(Player.Engine.BaseParameters.NoStarPowerOverlap && Player.Engine.EngineStats.IsStarPowerActive);
+            var color = shouldDisplayStarPower
                 ? colors.GetNoteStarPowerColor(NoteRef.Fret)
                 : colorNoStarPower;
 

--- a/Assets/Script/Gameplay/Visuals/TrackElements/Guitar/FiveFretNoteElement.cs
+++ b/Assets/Script/Gameplay/Visuals/TrackElements/Guitar/FiveFretNoteElement.cs
@@ -151,8 +151,7 @@ namespace YARG.Gameplay.Visuals
 
             // Get which note color to use
             var colorNoStarPower = colors.GetNoteColor(NoteRef.Fret);
-            var shouldDisplayStarPower = NoteRef.IsStarPower && !(Player.Engine.BaseParameters.NoStarPowerOverlap && Player.Engine.EngineStats.IsStarPowerActive);
-            var color = shouldDisplayStarPower
+            var color = NoteRef.IsStarPower && !(Player.Engine.BaseParameters.NoStarPowerOverlap && Player.Engine.EngineStats.IsStarPowerActive)
                 ? colors.GetNoteStarPowerColor(NoteRef.Fret)
                 : colorNoStarPower;
 

--- a/Assets/Script/Gameplay/Visuals/TrackElements/NoteElement.cs
+++ b/Assets/Script/Gameplay/Visuals/TrackElements/NoteElement.cs
@@ -39,6 +39,7 @@ namespace YARG.Gameplay.Visuals
         public override double ElementTime => NoteRef.Time;
 
         private bool _lastStarPowerState;
+        private bool _lastStarPowerActiveState;
 
         public abstract void SetThemeModels(ThemeDict models, ThemeDict starPowerModels);
 
@@ -46,16 +47,18 @@ namespace YARG.Gameplay.Visuals
         {
             SustainState = SustainState.Waiting;
             _lastStarPowerState = NoteRef.IsStarPower;
+            _lastStarPowerActiveState = Player.BaseEngine.BaseStats.IsStarPowerActive;
         }
 
         protected override void UpdateElement()
         {
             // Call OnStarPowerUpdated if the star power state of the note changes
-            if (_lastStarPowerState != NoteRef.IsStarPower)
+            if (_lastStarPowerState != NoteRef.IsStarPower || _lastStarPowerActiveState != Player.BaseEngine.BaseStats.IsStarPowerActive)
             {
                 OnStarPowerUpdated();
-                _lastStarPowerState = NoteRef.IsStarPower;
             }
+            _lastStarPowerState = NoteRef.IsStarPower;
+            _lastStarPowerActiveState = Player.BaseEngine.BaseStats.IsStarPowerActive;
         }
 
         /// <summary>

--- a/Assets/Script/Gameplay/Visuals/TrackElements/ProKeys/ProKeysNoteElement.cs
+++ b/Assets/Script/Gameplay/Visuals/TrackElements/ProKeys/ProKeysNoteElement.cs
@@ -143,7 +143,7 @@ namespace YARG.Gameplay.Visuals
                 ? colors.BlackNoteStarPower.ToUnityColor()
                 : colors.WhiteNoteStarPower.ToUnityColor();
 
-            var color = NoteRef.IsStarPower
+            var color = NoteRef.IsStarPower && !(Player.Engine.BaseParameters.NoStarPowerOverlap && Player.Engine.EngineStats.IsStarPowerActive)
                 ? colorStarPower
                 : colorNoStarPower;
 

--- a/Assets/StreamingAssets/lang/en-US.json
+++ b/Assets/StreamingAssets/lang/en-US.json
@@ -61,7 +61,8 @@
             "UnpitchedOnly": "Unpitched Only",
             "NoDynamics": "No Dynamics",
             "NoVocalPercussion" : "No Percussion",
-            "RangeCompress": "No Range Shifts"
+            "RangeCompress": "No Range Shifts",
+            "NoStarPowerOverlap": "No Star Power Overlap"
         },
         "SortAttribute": {
             "Album": "Album",


### PR DESCRIPTION
YARG.Core PR: https://github.com/YARC-Official/YARG.Core/pull/274

> Hey! I'm not sure if this is a feature that anybody wants, but since YARG is very flexible and supports features from a variety of GH+RB games, I thought it'd be nice to add to that.
>
> This PR adds a modifier to prevent earning a star power phrase while star power is already active, just like it works in the early Guitar Hero games. Hitting a SP note while SP is active will kill that phrase, but if SP ends before the first note of the phrase is hit (even if it's already on the fretboard) then SP works like normal.

Some things that need to be considered:

* All the stuff in my YARG.Core PR
* The list of modifiers on Guitar is now too long to see all at once. Strumming through it should make it automatically scroll the scrollbar
* The modifier will need an icon, right now it's just showing up on the endscreen as a pure white square :P 

Video demonstrating functionality: Left is normal and right has the modifier

https://github.com/user-attachments/assets/e3ccf02c-00ff-4c3c-9ef6-9418aa304f59

> Regardless of if this is something we want in the game, this was a nice warmup for me to get used to using Unity and navigating the codebase. Thank you all for your hard work developing YARG, I've been loving it so far :)
