### PR TITLE
update to score screen favorite button

### DIFF
--- a/Assets/Script/Menu/ScoreScreen/ScoreScreenMenu.cs
+++ b/Assets/Script/Menu/ScoreScreen/ScoreScreenMenu.cs
@@ -91,6 +91,7 @@ namespace YARG.Menu.ScoreScreen
                     {
                         PlaylistContainer.FavoritesPlaylist.AddSong(song);
                         isFavorited = true;
+                        Navigator.Instance.PopScheme();
                         Navigator.Instance.PushScheme(new NavigationScheme(new()
                         {
                             continueButtonEntry,
@@ -106,6 +107,7 @@ namespace YARG.Menu.ScoreScreen
                     {
                         PlaylistContainer.FavoritesPlaylist.RemoveSong(song);
                         isFavorited = false;
+                        Navigator.Instance.PopScheme();
                         Navigator.Instance.PushScheme(new NavigationScheme(new()
                         {
                             continueButtonEntry,


### PR DESCRIPTION
i forgot to clear the previous scheme, because i didn't realize it was a stack of schemes.
the issue this creates is that after changing the favorite status of the current song, and thus the button when you hit continue it will show the original button (from the lowest scheme on the stack) for a few frames until the next scene is properly loaded thus giving the user unclear visual feedback on if the song is still added to favorites.