### PR TITLE
Update CountdownDisplay for YARG.Core changes

### DIFF
--- a/Assets/Script/Gameplay/HUD/CountdownDisplay.cs
+++ b/Assets/Script/Gameplay/HUD/CountdownDisplay.cs
@@ -3,7 +3,6 @@ using TMPro;
 using DG.Tweening;
 using UnityEngine;
 using UnityEngine.UI;
-using YARG.Core.Chart;
 using System;
 using Cysharp.Text;
 
@@ -81,9 +80,10 @@ namespace YARG.Gameplay.HUD
                 case CountdownDisplayMode.Measures:
                 {
                     var syncTrack = GameManager.Chart.SyncTrack;
-                    uint measureTick = syncTrack.TimeToMeasureTick(currentTime);
-                    uint endMeasureTick = syncTrack.TimeToMeasureTick(endTime);
-                    uint remainingMeasures = (endMeasureTick - measureTick) / syncTrack.MeasureResolution;
+                    // This is floored to snap the end time to the start of the measure
+                    double endMeasure = Math.Floor(syncTrack.GetMeasurePosition(endTime));
+                    double currentMeasure = syncTrack.GetMeasurePosition(currentTime);
+                    int remainingMeasures = (int) Math.Ceiling(endMeasure - currentMeasure);
                     _countdownText.SetText(remainingMeasures);
                     break;
                 }

--- a/Assets/Script/Gameplay/HUD/CountdownDisplay.cs
+++ b/Assets/Script/Gameplay/HUD/CountdownDisplay.cs
@@ -19,6 +19,7 @@ namespace YARG.Gameplay.HUD
     public class CountdownDisplay : GameplayBehaviour
     {
         private const float FADE_ANIM_LENGTH = 0.5f;
+        private const double HIDE_DELAY = 1;
 
         public static CountdownDisplayMode DisplayStyle;
 
@@ -46,8 +47,11 @@ namespace YARG.Gameplay.HUD
 
             double currentTime = GameManager.SongTime;
             double timeRemaining = endTime - currentTime;
-
-            bool shouldDisplay = timeRemaining > WaitCountdown.END_COUNTDOWN_SECOND + FADE_ANIM_LENGTH;
+            if (timeRemaining < 0)
+            {
+                return;
+            }
+            bool shouldDisplay = timeRemaining > HIDE_DELAY + FADE_ANIM_LENGTH;
 
             if (GameManager.IsPractice)
             {


### PR DESCRIPTION
I moved `END_COUNTDOWN_SECOND` from YARG.Core to here, since it was no longer needed in Core for DeactivateTime.
The return statement was added since sometimes while the countdown was fading out, `endMeasureTick - measureTick` would become negative, and as they are both uints, it would overflow. This does occur on nightly.

This does not technically depend on the core PR, but if the core PR is merged, this must also be merged since `END_COUNTDOWN_SECOND` got removed.