### PR TITLE
Fix fading to use per-pixel distance to camera

### DIFF
--- a/Assets/Art/Shaders/HighwaysAlphaMask.shader
+++ b/Assets/Art/Shaders/HighwaysAlphaMask.shader
@@ -1,0 +1,71 @@
+Shader "HighwaysAlphaMask"
+{
+    SubShader
+    {
+        Tags { "RenderType"="Opaque" "UniversalMaterialType"="Unlit" }
+
+        Pass
+        {
+            Tags { "LightMode"="UniversalForward" }
+
+            ZWrite Off
+            Cull Off
+            Blend One Zero   // no blending, overwrite red channel
+
+            HLSLPROGRAM
+            #pragma vertex vert
+            #pragma fragment frag
+            #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
+            #include "Assets/Art/Shaders/highways.hlsl"
+
+            struct Attributes
+            {
+                float4 positionOS : POSITION;
+            };
+
+            struct Varyings
+            {
+                float4 positionCS : SV_POSITION;
+                float3 positionWS : TEXCOORD0;
+            };
+
+            Varyings vert(Attributes IN)
+            {
+                Varyings OUT;
+                OUT.positionWS = TransformObjectToWorld(IN.positionOS.xyz);
+                OUT.positionCS = YargTransformWorldToHClip(OUT.positionWS);
+                return OUT;
+            }
+
+            half4 frag(Varyings IN) : SV_Target
+            {
+                int index = WorldPosToIndex(IN.positionWS);
+                float fadeStartPos = _YargFadeParams[index * 2];
+                float fadeEndPos   = _YargFadeParams[index * 2 + 1];
+                // Euclidean distance from camera to this fragment
+                float3 camPos = YargWorldSpaceCameraPos(IN.positionWS);
+                float dist = distance(camPos, IN.positionWS);
+                float alpha = 0.0;
+
+                if (dist < fadeStartPos)
+                {
+                    alpha = 1.0;
+                }
+                else if (dist > fadeEndPos)
+                {
+                    alpha = 0.0;
+                }
+                else
+                {
+                    float rate = 1.0 / (fadeEndPos - fadeStartPos);
+                    float fadeValue = (dist - fadeStartPos) * rate;
+                    alpha = 1.0 - smoothstep(0.0, 1.0, fadeValue);
+                }
+
+                // Only write into R channel, others zero
+                return half4(alpha, 0, 0, 0);
+            }
+            ENDHLSL
+        }
+    }
+}

--- a/Assets/Art/Shaders/HighwaysAlphaMask.shader.meta
+++ b/Assets/Art/Shaders/HighwaysAlphaMask.shader.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: f417439f3ea550445b35f90faa690633
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  preprocessorOverride: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Art/Shaders/UberPP.shader
+++ b/Assets/Art/Shaders/UberPP.shader
@@ -255,6 +255,17 @@ Shader "Artificial Artists/Universal Render Pipeline/AA_UberPost"
                     real depth = lerp(UNITY_NEAR_CLIP_VALUE, 1, SampleSceneDepth(uvDistorted));
                 #endif
                 
+                // Account for highway Z-clash avoidance offset in clip space
+                // The highways.hlsl modifies NDC Z: ndcZ += 0.005 * (index % 2)
+                // We need to reverse this before converting to linear depth
+                float offset = 0.005 * (index % 2);
+                // This highway had its NDC Z modified, reverse it
+                #ifdef UNITY_REVERSED_Z
+                    depth -= offset; // Remove the NDC offset
+                #else
+                    depth += offset; // Remove the NDC offset
+                #endif
+
                 // Use Unity's built-in LinearEyeDepth with main camera params as approximation
                 float linearDepth = LinearEyeDepth(depth, _ZBufferParams);
                 

--- a/Assets/Art/Shaders/highways.hlsl
+++ b/Assets/Art/Shaders/highways.hlsl
@@ -154,24 +154,24 @@ inline float4 YargTransformWorldToHClip(float3 positionWS)
     float4 viewPOS = mul(_YargCamViewMatrices[index], float4(positionWS, 1.0));
     float4 clipPOS = mul(_YargCamProjMatrices[index], viewPOS);
 
-// #ifdef _RAISE_Z
-//     // We use this to raise certain elements to be rendered on top of the others without actually
-//     // raising them in the world space
-//     #ifdef UNITY_REVERSED_Z
-//         clipPOS.z += 0.002;
-//     #else
-//         clipPOS.z -= 0.002;
-//     #endif
-// #endif
+#ifdef _RAISE_Z
+    // We use this to raise certain elements to be rendered on top of the others without actually
+    // raising them in the world space
+    #ifdef UNITY_REVERSED_Z
+        clipPOS.z += 0.002;
+    #else
+        clipPOS.z -= 0.002;
+    #endif
+#endif
 
-//     // separate highways to avoid clashes when there are a lot of them on at the same time
-//     float ndcZ = clipPOS.z / clipPOS.w;
-// #ifdef UNITY_REVERSED_Z
-//     ndcZ += 0.005 * (index % (uint) 2);
-// #else
-//     ndcZ -= 0.005 * (index % (uint) 2);
-// #endif
-//     clipPOS.z = ndcZ * clipPOS.w;
+    // separate highways to avoid clashes when there are a lot of them on at the same time
+    float ndcZ = clipPOS.z / clipPOS.w;
+#ifdef UNITY_REVERSED_Z
+    ndcZ += 0.005 * (index % (uint) 2);
+#else
+    ndcZ -= 0.005 * (index % (uint) 2);
+#endif
+    clipPOS.z = ndcZ * clipPOS.w;
 
     return clipPOS;
 }
@@ -182,201 +182,3 @@ inline float4 YargObjectToClipPos( in float3 pos )
     return YargTransformWorldToHClip(mul(unity_ObjectToWorld, float4(pos, 1.0)).xyz);
 }
 
-// TODO: Should we construct this in C# side and pass another array instead?
-// could be a bit expensive to do this for every pixel in PP
-
-// Function to construct Unity's _ZBufferParams from projection matrix
-// Unity's _ZBufferParams format: (1-far/near, far/near, x/far, y/far)
-// where x and y are platform-specific linearization parameters
-
-// Matrix inverse function for 4x4 matrices
-float4x4 InverseMatrix(float4x4 m)
-{
-    float4x4 inv;
-    
-    inv[0][0] = m[1][1] * m[2][2] * m[3][3] - 
-                m[1][1] * m[2][3] * m[3][2] - 
-                m[2][1] * m[1][2] * m[3][3] + 
-                m[2][1] * m[1][3] * m[3][2] +
-                m[3][1] * m[1][2] * m[2][3] - 
-                m[3][1] * m[1][3] * m[2][2];
-
-    inv[1][0] = -m[1][0] * m[2][2] * m[3][3] + 
-                 m[1][0] * m[2][3] * m[3][2] + 
-                 m[2][0] * m[1][2] * m[3][3] - 
-                 m[2][0] * m[1][3] * m[3][2] - 
-                 m[3][0] * m[1][2] * m[2][3] + 
-                 m[3][0] * m[1][3] * m[2][2];
-
-    inv[2][0] = m[1][0] * m[2][1] * m[3][3] - 
-                m[1][0] * m[2][3] * m[3][1] - 
-                m[2][0] * m[1][1] * m[3][3] + 
-                m[2][0] * m[1][3] * m[3][1] + 
-                m[3][0] * m[1][1] * m[2][3] - 
-                m[3][0] * m[1][3] * m[2][1];
-
-    inv[3][0] = -m[1][0] * m[2][1] * m[3][2] + 
-                 m[1][0] * m[2][2] * m[3][1] +
-                 m[2][0] * m[1][1] * m[3][2] - 
-                 m[2][0] * m[1][2] * m[3][1] - 
-                 m[3][0] * m[1][1] * m[2][2] + 
-                 m[3][0] * m[1][2] * m[2][1];
-
-    inv[0][1] = -m[0][1] * m[2][2] * m[3][3] + 
-                 m[0][1] * m[2][3] * m[3][2] + 
-                 m[2][1] * m[0][2] * m[3][3] - 
-                 m[2][1] * m[0][3] * m[3][2] - 
-                 m[3][1] * m[0][2] * m[2][3] + 
-                 m[3][1] * m[0][3] * m[2][2];
-
-    inv[1][1] = m[0][0] * m[2][2] * m[3][3] - 
-                m[0][0] * m[2][3] * m[3][2] - 
-                m[2][0] * m[0][2] * m[3][3] + 
-                m[2][0] * m[0][3] * m[3][2] + 
-                m[3][0] * m[0][2] * m[2][3] - 
-                m[3][0] * m[0][3] * m[2][2];
-
-    inv[2][1] = -m[0][0] * m[2][1] * m[3][3] + 
-                 m[0][0] * m[2][3] * m[3][1] + 
-                 m[2][0] * m[0][1] * m[3][3] - 
-                 m[2][0] * m[0][3] * m[3][1] - 
-                 m[3][0] * m[0][1] * m[2][3] + 
-                 m[3][0] * m[0][3] * m[2][1];
-
-    inv[3][1] = m[0][0] * m[2][1] * m[3][2] - 
-                m[0][0] * m[2][2] * m[3][1] - 
-                m[2][0] * m[0][1] * m[3][2] + 
-                m[2][0] * m[0][2] * m[3][1] + 
-                m[3][0] * m[0][1] * m[2][2] - 
-                m[3][0] * m[0][2] * m[2][1];
-
-    inv[0][2] = m[0][1] * m[1][2] * m[3][3] - 
-                m[0][1] * m[1][3] * m[3][2] - 
-                m[1][1] * m[0][2] * m[3][3] + 
-                m[1][1] * m[0][3] * m[3][2] + 
-                m[3][1] * m[0][2] * m[1][3] - 
-                m[3][1] * m[0][3] * m[1][2];
-
-    inv[1][2] = -m[0][0] * m[1][2] * m[3][3] + 
-                 m[0][0] * m[1][3] * m[3][2] + 
-                 m[1][0] * m[0][2] * m[3][3] - 
-                 m[1][0] * m[0][3] * m[3][2] - 
-                 m[3][0] * m[0][2] * m[1][3] + 
-                 m[3][0] * m[0][3] * m[1][2];
-
-    inv[2][2] = m[0][0] * m[1][1] * m[3][3] - 
-                m[0][0] * m[1][3] * m[3][1] - 
-                m[1][0] * m[0][1] * m[3][3] + 
-                m[1][0] * m[0][3] * m[3][1] + 
-                m[3][0] * m[0][1] * m[1][3] - 
-                m[3][0] * m[0][3] * m[1][1];
-
-    inv[3][2] = -m[0][0] * m[1][1] * m[3][2] + 
-                 m[0][0] * m[1][2] * m[3][1] + 
-                 m[1][0] * m[0][1] * m[3][2] - 
-                 m[1][0] * m[0][2] * m[3][1] - 
-                 m[3][0] * m[0][1] * m[1][2] + 
-                 m[3][0] * m[0][2] * m[1][1];
-
-    inv[0][3] = -m[0][1] * m[1][2] * m[2][3] + 
-                 m[0][1] * m[1][3] * m[2][2] + 
-                 m[1][1] * m[0][2] * m[2][3] - 
-                 m[1][1] * m[0][3] * m[2][2] - 
-                 m[2][1] * m[0][2] * m[1][3] + 
-                 m[2][1] * m[0][3] * m[1][2];
-
-    inv[1][3] = m[0][0] * m[1][2] * m[2][3] - 
-                m[0][0] * m[1][3] * m[2][2] - 
-                m[1][0] * m[0][2] * m[2][3] + 
-                m[1][0] * m[0][3] * m[2][2] + 
-                m[2][0] * m[0][2] * m[1][3] - 
-                m[2][0] * m[0][3] * m[1][2];
-
-    inv[2][3] = -m[0][0] * m[1][1] * m[2][3] + 
-                 m[0][0] * m[1][3] * m[2][1] + 
-                 m[1][0] * m[0][1] * m[2][3] - 
-                 m[1][0] * m[0][3] * m[2][1] - 
-                 m[2][0] * m[0][1] * m[1][3] + 
-                 m[2][0] * m[0][3] * m[1][1];
-
-    inv[3][3] = m[0][0] * m[1][1] * m[2][2] - 
-                m[0][0] * m[1][2] * m[2][1] - 
-                m[1][0] * m[0][1] * m[2][2] + 
-                m[1][0] * m[0][2] * m[2][1] + 
-                m[2][0] * m[0][1] * m[1][2] - 
-                m[2][0] * m[0][2] * m[1][1];
-
-    float det = m[0][0] * inv[0][0] + m[0][1] * inv[1][0] + m[0][2] * inv[2][0] + m[0][3] * inv[3][0];
-
-    if (abs(det) < 1e-6)
-        return float4x4(1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,1); // Return identity if singular
-
-    det = 1.0 / det;
-
-    for (int i = 0; i < 4; i++)
-        for (int j = 0; j < 4; j++)
-            inv[i][j] = inv[i][j] * det;
-
-    return inv;
-}
-
-float4 ConstructZBufferParams(float4x4 projectionMatrix, float nearPlane, float farPlane)
-{
-    float4 zBufferParams;
-    
-    // Unity's _ZBufferParams components:
-    // x = 1 - far/near
-    // y = far/near  
-    // z = x/far = (1 - far/near)/far
-    // w = y/far = (far/near)/far = 1/near
-    
-    float farOverNear = farPlane / nearPlane;
-    
-    zBufferParams.x = 1.0 - farOverNear;        // 1 - far/near
-    zBufferParams.y = farOverNear;              // far/near
-    zBufferParams.z = zBufferParams.x / farPlane; // (1 - far/near)/far
-    zBufferParams.w = 1.0 / nearPlane;          // 1/near
-    
-    return zBufferParams;
-}
-
-// Alternative version that extracts near/far from projection matrix
-float4 ConstructZBufferParamsFromMatrix(float4x4 projectionMatrix)
-{
-    // Extract near and far planes from projection matrix
-    // Unity uses reverse-Z, so the formulas are different
-    
-    float nearPlane, farPlane;
-    
-    // Check if it's a perspective projection (P[3][2] != 0)
-    if (abs(projectionMatrix[3][2]) > 0.0001)
-    {
-        // Perspective projection
-        float A = projectionMatrix[2][2];
-        float B = projectionMatrix[2][3];
-        
-        // For Unity's reverse-Z: A = f/(n-f), B = fn/(n-f)
-        // Solve for n and f:
-        farPlane = B / A;
-        nearPlane = B / (A + 1.0);
-        
-        // Ensure positive values
-        nearPlane = abs(nearPlane);
-        farPlane = abs(farPlane);
-    }
-    else
-    {
-        // Orthographic projection - less common, keeping original logic
-        float A = projectionMatrix[2][2];
-        float B = projectionMatrix[2][3];
-        
-        float range = -2.0 / A;
-        nearPlane = (-B - 1.0) * range * 0.5;
-        farPlane = nearPlane + range;
-        
-        nearPlane = abs(nearPlane);
-        farPlane = abs(farPlane);
-    }
-    
-    return ConstructZBufferParams(projectionMatrix, nearPlane, farPlane);
-}

--- a/Assets/Script/Gameplay/Visuals/HighwayCameraRendering.cs
+++ b/Assets/Script/Gameplay/Visuals/HighwayCameraRendering.cs
@@ -54,6 +54,21 @@ namespace YARG.Gameplay.Visuals
             return _highwaysOutputTexture;
         }
 
+        private Vector2 WorldToViewport(Vector3 positionWS, int index)
+        {
+            Vector4 clipSpacePos = (_camProjMatrices[index] * _camViewMatrices[index]) * new Vector4(positionWS.x, positionWS.y, positionWS.z, 1.0f);
+            // Perspective divide to get NDC
+            float ndcX = clipSpacePos.x / clipSpacePos.w;
+            float ndcY = clipSpacePos.y / clipSpacePos.w;
+
+            // NDC [-1, 1] → Viewport [0, 1]
+            float viewportX = (ndcX + 1.0f) * 0.5f;
+            float viewportY = (ndcY + 1.0f) * 0.5f;
+
+            Vector2 viewportPos = new Vector2(viewportX, viewportY);
+            return viewportPos;
+        }
+
         private Vector2 CalculateFadeParams(int index, Vector3 trackPosition, float ZeroFadePosition, float FadeSize)
         {
             var worldZeroFadePosition = new Vector3(trackPosition.x, trackPosition.y, ZeroFadePosition - FadeSize);


### PR DESCRIPTION
(instead of approximation that it is rn)
Use actual distance from camera for fading
(which makes fade follow the curve instead of weird horizontal cut). Also use actual corresponding cameras to calculate linear depth for fading shader code.

PR:
<img width="1438" height="481" alt="image" src="https://github.com/user-attachments/assets/b63397b1-0ab4-4dec-84ce-726667d1a32a" />
DEV:
<img width="1428" height="589" alt="image" src="https://github.com/user-attachments/assets/cd0823a9-c0aa-4179-b78a-992d0553ab7d" />


especially note the curviest (3rd) highway's preset and the difference this makes for it