### PR TITLE
add vocal character animation states

### DIFF
--- a/Assets/Script/Venue/Characters/VenueCharacter.AnimationLookups.cs
+++ b/Assets/Script/Venue/Characters/VenueCharacter.AnimationLookups.cs
@@ -589,7 +589,10 @@ namespace YARG.Venue.Characters
             Pick,
             Finger,
             IdleIntense,
-            PlayingSolo
+            PlayingSolo,
+            // Vocal Animations
+            MouthOpen,
+            MouthClose
         }
 
         private AnimationStateType? GetAnimationStateForHandMap(HandMap.HandMapType handMap)

--- a/Assets/Script/Venue/Characters/VenueCharacter.cs
+++ b/Assets/Script/Venue/Characters/VenueCharacter.cs
@@ -214,7 +214,27 @@ namespace YARG.Venue.Characters
                 return;
             }
 
-            // TODO: Add check for vocals/keys when we actually support those
+            string[] requiredVocals =
+            {
+                "MouthOpen",
+                "MouthClose"
+            };
+
+            if (Type == CharacterType.Vocals)
+            {
+                foreach (var name in requiredVocals)
+                {
+                    if (!_animationEvents.TryGet(name, out var info))
+                    {
+                        allFound = false;
+                        break;
+                    }
+                }
+                _hasAdvancedAnimations = allFound;
+                return;
+            }
+
+            // TODO: Add check for keys when we actually support those
 
             _hasAdvancedAnimations = false;
         }
@@ -499,9 +519,10 @@ namespace YARG.Venue.Characters
                 }
             }
 
-            if (note is Note<VocalNote>)
+            if (note is VocalNote vNote)
             {
-
+                SetTrigger(AnimationStateType.MouthOpen);
+                SetDelayedTrigger(AnimationStateType.MouthClose, (float) vNote.TotalTimeLength);
             }
 
             if (note is Note<ProKeysNote>)


### PR DESCRIPTION
adds MouthOpen and MouthClose animation events to the venue character script

this may very well be incomplete as I'm not sure what everything in the character code is actually for.
i didn't put in Start/Stop Animation in process vocals because i didn't see what the actual use of those is considering the tempo gets updated anyways in the character manager update method and i didn't see _isAnimating used for anything else