### PR TITLE
Fix pro keys when vocals player is present

### DIFF
--- a/Assets/Script/Gameplay/GameManager.Loading.cs
+++ b/Assets/Script/Gameplay/GameManager.Loading.cs
@@ -402,7 +402,7 @@ namespace YARG.Gameplay
                         // Setup player
                         var trackPlayer = playerObject.GetComponent<TrackPlayer>();
                         var trackView = _trackViewManager.CreateTrackView(trackPlayer, player);
-                        trackPlayer.Initialize(index, player, Chart, trackView, _mixer, lastHighScore);
+                        trackPlayer.Initialize(highwayIndex, player, Chart, trackView, _mixer, lastHighScore);
 
                         _players.Add(trackPlayer);
                         _trackViewManager._highwayCameraRendering.AddTrackPlayer(trackPlayer);

--- a/Assets/Script/Gameplay/Player/BasePlayer.cs
+++ b/Assets/Script/Gameplay/Player/BasePlayer.cs
@@ -18,7 +18,7 @@ namespace YARG.Gameplay.Player
 {
     public abstract class BasePlayer : GameplayBehaviour
     {
-        public int PlayerIndex { get; private set; }
+        public int HighwayIndex { get; private set; }
 
         public YargPlayer Player { get; private set; }
 
@@ -131,7 +131,7 @@ namespace YARG.Gameplay.Player
                 return;
             }
 
-            PlayerIndex = index;
+            HighwayIndex = index;
             Player = player;
 
             SyncTrack = chart.SyncTrack;

--- a/Assets/Script/Gameplay/Visuals/Fret/KeysArray.cs
+++ b/Assets/Script/Gameplay/Visuals/Fret/KeysArray.cs
@@ -64,7 +64,7 @@ namespace YARG.Gameplay.Visuals
                     fretComp.Initialize(color, color, color, color);
 
                     var material = fret.GetComponentInChildren<MeshRenderer>().material;
-                    material.SetFloat(IndexId, player.PlayerIndex);
+                    material.SetFloat(IndexId, player.HighwayIndex);
 
                     _keys.Add(fretComp);
 
@@ -89,7 +89,7 @@ namespace YARG.Gameplay.Visuals
                     fretComp.Initialize(color, color, color, color);
 
                     var material = fret.GetComponentInChildren<MeshRenderer>().material;
-                    material.SetFloat(IndexId, player.PlayerIndex);
+                    material.SetFloat(IndexId, player.HighwayIndex);
 
                     _keys.Add(fretComp);
 

--- a/Assets/Script/Gameplay/Visuals/TrackElements/ProKeys/ProKeysTrackOverlay.cs
+++ b/Assets/Script/Gameplay/Visuals/TrackElements/ProKeys/ProKeysTrackOverlay.cs
@@ -97,7 +97,7 @@ namespace YARG.Gameplay.Visuals
             var material = meshRenderer.material;
             material.color = color.WithAlpha(0.3f);
             material.SetTexture(BaseMap, _heldGradientTexture);
-            material.SetFloat(Index, player.PlayerIndex);
+            material.SetFloat(Index, player.HighwayIndex);
             material.SetKeyword(new LocalKeyword(material.shader, "_ISHIGHLIGHT"), true);
 
             highlight.SetActive(false);
@@ -113,7 +113,7 @@ namespace YARG.Gameplay.Visuals
 
             var material = overlay.GetComponentInChildren<MeshRenderer>().material;
             material.color = color.WithAlpha(0.05f);
-            material.SetFloat(Index, player.PlayerIndex);
+            material.SetFloat(Index, player.HighwayIndex);
 
             // Set up the correct texture
 


### PR DESCRIPTION
Pro keys materials expect highway to be positioned at `100*PlayerIndex`, but as part of rendering overhaul highways are positioned at `100*highwayIndex` where vocal players are not counted in highwayIndex. Seeing as the only usage of playerIndex was for pro keys materials - rename it into HighwayIndex and repurpose.