### PR TITLE
Fix whammy desync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,6 @@ reload_lock~.meta
 # Submodule commit hash
 *.githash
 *.githash.meta
+
+# Unity crash dumps
+mono_crash.mem.*.blob

--- a/Assets/Script/Audio/Bass/BassAudioManager.cs
+++ b/Assets/Script/Audio/Bass/BassAudioManager.cs
@@ -530,12 +530,16 @@ namespace YARG.Audio.BASS
 
         internal static bool SetupPitchBend(in PitchShiftParametersStruct pitchParams, StreamHandle handles)
         {
-            handles.CompressorFX = BassHelpers.FXAddParameters(handles.Stream, EffectType.PitchShift, pitchParams);
-            if (handles.CompressorFX == 0)
+            handles.PitchFX = BassHelpers.FXAddParameters(handles.Stream, EffectType.PitchShift, pitchParams);
+            if (handles.PitchFX == 0)
             {
                 YargLogger.LogError("Failed to set up pitch bend for main stream!");
                 return false;
             }
+
+            // Adjust the position to account for inherent pitch fx delay
+            Bass.ChannelSetPosition(handles.Stream, GlobalAudioHandler.WHAMMY_FFT_DEFAULT * 2);
+
             return true;
         }
 

--- a/Assets/Script/Audio/Bass/BassStemChannel.cs
+++ b/Assets/Script/Audio/Bass/BassStemChannel.cs
@@ -1,4 +1,4 @@
-﻿using ManagedBass;
+using ManagedBass;
 using ManagedBass.Mix;
 using UnityEngine;
 using YARG.Core.Audio;
@@ -35,16 +35,6 @@ namespace YARG.Audio.BASS
 
         protected override void SetWhammyPitch_Internal(float percent)
         {
-            // If pitch effect hasn't been added yet, add it.
-            if (_streamHandles.PitchFX == 0)
-            {
-                _streamHandles.PitchFX = BassHelpers.AddPitchShiftToChannel(_streamHandles.Stream, _pitchParams);
-            }
-            if (_reverbHandles.PitchFX == 0)
-            {
-                _reverbHandles.PitchFX = BassHelpers.AddPitchShiftToChannel(_reverbHandles.Stream, _pitchParams);
-            }
-
             // Calculate shift
             float shift = Mathf.Pow(2, -(GlobalAudioHandler.WhammyPitchShiftAmount * percent) / 12);
             _pitchParams.fPitchShift = shift;
@@ -64,28 +54,15 @@ namespace YARG.Audio.BASS
                     YargLogger.LogFormatError("Failed to set pitch on reverb: {0}", Bass.LastError);
                 }
             }
-            /*
-            else
-            {
-                // If pitch is effect running we could remove it.
-                // This would help with delay but there's a skip when adding or removing.
-                // Probably better to do this after at zero whammy rest for a period of time.
+        }
 
-                if (_streamHandles.PitchFX != 0)
-                {
-                    if (!Bass.ChannelRemoveFX(_streamHandles.Stream, _streamHandles.PitchFX))
-                    {
-                        YargLogger.LogFormatError("Failed to remove pitch effect: {0}!", Bass.LastError);
-                    }
-                    if (!Bass.ChannelRemoveFX(_reverbHandles.Stream, _streamHandles.PitchFX))
-                    {
-                        YargLogger.LogFormatError("Failed to remove pitch effect: {0}!", Bass.LastError);
-                    }
-                    _streamHandles.PitchFX = 0;
-                    _reverbHandles.PitchFX = 0;
-                }
+        protected override float GetWhammyPitch_Internal()
+        {
+            if (_streamHandles.PitchFX == 0)
+            {
+                return 0f;
             }
-            */
+            return _pitchParams.fPitchShift;
         }
 
         protected override void SetPosition_Internal(double position)
@@ -102,11 +79,47 @@ namespace YARG.Audio.BASS
                 return;
             }
 
+            if (_streamHandles.PitchFX != 0)
+            {
+                //Account for inherent pitch shift delay
+                bytes += GlobalAudioHandler.WHAMMY_FFT_DEFAULT * 2;
+            }
+
             bool success = BassMix.ChannelSetPosition(_streamHandles.Stream, bytes, PositionFlags.Bytes | PositionFlags.MixerReset);
             if (!success)
             {
                 YargLogger.LogFormatError("Failed to seek to position {0}!", position);
             }
+        }
+
+        protected override double GetPosition_Internal()
+        {
+            if (_streamHandles.Stream == 0)
+            {
+                return 0.0;
+            }
+
+            long bytes = BassMix.ChannelGetPosition(_streamHandles.Stream, PositionFlags.Bytes);
+            if (bytes < 0)
+            {
+                YargLogger.LogFormatError("Failed to get byte position: {0}!", Bass.LastError);
+                return 0.0;
+            }
+
+            if (_streamHandles.PitchFX != 0)
+            {
+                //Account for inherent pitch shift delay
+                bytes -= GlobalAudioHandler.WHAMMY_FFT_DEFAULT * 2;
+            }
+
+            double position = Bass.ChannelBytes2Seconds(_streamHandles.Stream, bytes);
+            if (position < 0)
+            {
+                YargLogger.LogFormatError("Failed to convert bytes to seconds: {0}!", Bass.LastError);
+                return 0.0;
+            }
+
+            return position;
         }
 
         protected override void SetSpeed_Internal(float speed, bool shiftPitch)
@@ -126,7 +139,7 @@ namespace YARG.Audio.BASS
             }
 
             float reverbVolume = _isReverbing ? (float) volume * BassHelpers.REVERB_VOLUME_MULTIPLIER : 0;
-            
+
             if (!Bass.ChannelSlideAttribute(_reverbHandles.Stream, ChannelAttribute.Volume, reverbVolume, 0))
             {
                 YargLogger.LogFormatError("Failed to set reverb volume: {0}!", Bass.LastError);

--- a/Assets/Script/Audio/Bass/BassStemChannel.cs
+++ b/Assets/Script/Audio/Bass/BassStemChannel.cs
@@ -99,8 +99,8 @@ namespace YARG.Audio.BASS
                 return 0.0;
             }
 
-            long bytes = BassMix.ChannelGetPosition(_streamHandles.Stream, PositionFlags.Bytes);
-            if (bytes < 0)
+            long position = BassMix.ChannelGetPosition(_streamHandles.Stream);
+            if (position < 0)
             {
                 YargLogger.LogFormatError("Failed to get byte position: {0}!", Bass.LastError);
                 return 0.0;
@@ -109,17 +109,17 @@ namespace YARG.Audio.BASS
             if (_streamHandles.PitchFX != 0)
             {
                 //Account for inherent pitch shift delay
-                bytes -= GlobalAudioHandler.WHAMMY_FFT_DEFAULT * 2;
+                position -= GlobalAudioHandler.WHAMMY_FFT_DEFAULT * 2;
             }
 
-            double position = Bass.ChannelBytes2Seconds(_streamHandles.Stream, bytes);
-            if (position < 0)
+            double seconds = Bass.ChannelBytes2Seconds(_streamHandles.Stream, position);
+            if (seconds < 0)
             {
                 YargLogger.LogFormatError("Failed to convert bytes to seconds: {0}!", Bass.LastError);
                 return 0.0;
             }
 
-            return position;
+            return seconds;
         }
 
         protected override void SetSpeed_Internal(float speed, bool shiftPitch)

--- a/Assets/Script/Audio/Bass/BassStemMixer.cs
+++ b/Assets/Script/Audio/Bass/BassStemMixer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Threading.Tasks;
 using ManagedBass;
@@ -14,6 +14,7 @@ namespace YARG.Audio.BASS
         private readonly int _mixerHandle;
         private readonly int _sourceStream;
 
+        private StemChannel _mainChannel;
         private StreamHandle _mainHandle;
         private int _songEndHandle;
         private float _speed;
@@ -93,20 +94,9 @@ namespace YARG.Audio.BASS
 
         protected override double GetPosition_Internal()
         {
-            long position = Bass.ChannelGetPosition(_mainHandle.Stream);
-            if (position < 0)
-            {
-                YargLogger.LogFormatError("Failed to get channel position in bytes: {0}", Bass.LastError);
-                return -1;
-            }
+            double seconds = _mainChannel.GetPosition();
 
-            double seconds = Bass.ChannelBytes2Seconds(_mainHandle.Stream, position);
-            if (seconds < 0)
-            {
-                YargLogger.LogFormatError("Failed to get channel position in seconds: {0}", Bass.LastError);
-                return -1;
-            }
-
+            //Adjust for playback buffer
             if (Settings.SettingsManager.Settings.EnablePlaybackBuffer.Value)
             {
                 seconds -= (Bass.PlaybackBufferLength / 1000.0f) * _speed;
@@ -136,30 +126,14 @@ namespace YARG.Audio.BASS
                 // Pause when seeking to avoid desyncing individual stems
                 Pause_Internal();
             }
-
-            if (_channels.Count == 0)
+            if (_sourceStream != 0)
             {
-                long bytes = Bass.ChannelSeconds2Bytes(_mainHandle.Stream, position);
-                if (bytes < 0)
-                {
-                    YargLogger.LogFormatError("Failed to get channel position in bytes: {0}!", Bass.LastError);
-                }
-                else if (!BassMix.ChannelSetPosition(_mainHandle.Stream, bytes, PositionFlags.Bytes | PositionFlags.MixerReset))
-                {
-                    YargLogger.LogFormatError("Failed to set channel position: {0}!", Bass.LastError);
-                }
+                BassMix.SplitStreamReset(_sourceStream);
             }
-            else
-            {
-                if (_sourceStream != 0)
-                {
-                    BassMix.SplitStreamReset(_sourceStream);
-                }
 
-                foreach (var channel in _channels)
-                {
-                    channel.SetPosition(position);
-                }
+            foreach (var channel in _channels)
+            {
+                channel.SetPosition(position);
             }
 
             if (playing)
@@ -252,18 +226,20 @@ namespace YARG.Audio.BASS
 
         protected override bool AddChannel_Internal(SongStem stem)
         {
-            _mainHandle = StreamHandle.Create(_sourceStream, null);
-            if (_mainHandle == null)
+            if (!BassAudioManager.CreateSplitStreams(_sourceStream, null, out var streamHandles, out var reverbHandles))
             {
-                YargLogger.LogFormatError("Failed to load stem split stream {stem}: {0}!", Bass.LastError);
-            }
-
-            if (!BassMix.MixerAddChannel(_mixerHandle, _mainHandle.Stream, BassFlags.Default))
-            {
-                YargLogger.LogFormatError("Failed to add channel {stem} to mixer: {0}!", Bass.LastError);
+                YargLogger.LogFormatError("Failed to load stem split streams {0}: {1}!", stem, Bass.LastError);
                 return false;
             }
-            _length = BassAudioManager.GetLengthInSeconds(_sourceStream);
+
+            if (!BassMix.MixerAddChannel(_mixerHandle, streamHandles.Stream, BassFlags.Default) ||
+                !BassMix.MixerAddChannel(_mixerHandle, reverbHandles.Stream, BassFlags.Default))
+            {
+                YargLogger.LogFormatError("Failed to add channel {0} to mixer: {1}!", stem, Bass.LastError);
+                return false;
+            }
+
+            CreateChannel(stem, _sourceStream, streamHandles, reverbHandles);
             return true;
         }
 
@@ -410,6 +386,7 @@ namespace YARG.Audio.BASS
             double length = BassAudioManager.GetLengthInSeconds(streamHandles.Stream);
             if (_mainHandle == null || length > _length)
             {
+                _mainChannel = stemchannel;
                 _mainHandle = streamHandles;
                 _length = length;
             }

--- a/Assets/Script/Gameplay/GameManager.cs
+++ b/Assets/Script/Gameplay/GameManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Cysharp.Threading.Tasks;

--- a/Assets/Script/Playback/SongRunner.cs
+++ b/Assets/Script/Playback/SongRunner.cs
@@ -401,6 +401,15 @@ namespace YARG.Playback
                         continue;
                     }
 
+                    foreach (var channel in _mixer.Channels)
+                    {
+                        if (channel.GetWhammyPitch() == 0.0f)
+                        {
+                            //Correct drift caused by pitch shift effect
+                            channel.SetWhammyPitch(0.0f);
+                        }
+                    }
+
                     // Account for song speed
                     double initialThreshold = INITIAL_SYNC_THRESH * SongSpeed;
                     double adjustThreshold = ADJUST_SYNC_THRESH * SongSpeed;


### PR DESCRIPTION
Corresponding YARG.Core PR: https://github.com/YARC-Official/YARG.Core/pull/284

This PR fixes issues with whammy so we can use it without stems going out of sync.

---

#### The Problems

1.  **Inherent Delay**: Applying the PitchEffect introduces a delay caused by the FFT. When `Bass.GetChannelPosition` is called on a pitch-shifted stream, the reported position is **2048 samples** behind the actual position.
2.  **Sync Drift**: The delay is not constant and fluctuates over time, especially with pitch shift values above and below zero. This causes the audio to drift out of sync.

---

#### The Fixes

1.  **Correcting the Delay**:
    * To correct the initial delay, when seeking or starting playback, the position must be set to `position + 2048` samples. Since BASS uses bytes for position, this translates to `2048 * 2 bytes` for 16-bit PCM output.
    * To get the correct position, we must override the reported position from `Bass.GetChannelPosition` to be `position - 2048` samples.

2.  **Correcting Sync Drift**:
    * Setting the pitch shift to `0.0` resets the drift, returning the effective delay to `2048 samples`.
    * In the **SongRunner**, check if the pitch shift is `0.0` on each iteration and set it to `0.0` again.
    * This approach re-syncs the pitch after whammy is used on sustains, though some drift may still occur while pitch shifting
    
#### Notes

There is one small tradeoff with this fix, which is that the first 2048 samples of a pitch shifted channel are lost in playback.  That is, when starting playback, we are effectively replacing the first 2048 samples or `46.44 ms` of audio with silence.  In my opinion this is not noticeable.

#### Video

Example with music:

https://github.com/user-attachments/assets/3408c280-9741-4a4f-ba72-42e1b49fcbcb




Example with click track (ignore the visual / audio sync here, just demonstrating that the stems line up):


https://github.com/user-attachments/assets/e71fc9cd-f406-470b-90aa-1e323fa07786


