### PR TITLE
Fix issues with audio buffer and AV sync

### DIFF
--- a/Assets/Script/Audio/Bass/BassAudioManager.cs
+++ b/Assets/Script/Audio/Bass/BassAudioManager.cs
@@ -538,8 +538,7 @@ namespace YARG.Audio.BASS
             }
 
             // Adjust the position to account for inherent pitch fx delay
-            var position = GlobalAudioHandler.WHAMMY_FFT_DEFAULT * 2;
-            Bass.ChannelSetPosition(handles.Stream, position);
+            Bass.ChannelSetPosition(handles.Stream, GlobalAudioHandler.WHAMMY_FFT_DEFAULT * 2);
 
             return true;
         }

--- a/Assets/Script/Audio/Bass/BassAudioManager.cs
+++ b/Assets/Script/Audio/Bass/BassAudioManager.cs
@@ -538,7 +538,8 @@ namespace YARG.Audio.BASS
             }
 
             // Adjust the position to account for inherent pitch fx delay
-            Bass.ChannelSetPosition(handles.Stream, GlobalAudioHandler.WHAMMY_FFT_DEFAULT * 2);
+            var position = GlobalAudioHandler.WHAMMY_FFT_DEFAULT * 2;
+            Bass.ChannelSetPosition(handles.Stream, position);
 
             return true;
         }

--- a/Assets/Script/Audio/Bass/BassStemMixer.cs
+++ b/Assets/Script/Audio/Bass/BassStemMixer.cs
@@ -95,17 +95,6 @@ namespace YARG.Audio.BASS
         protected override double GetPosition_Internal()
         {
             double seconds = _mainChannel.GetPosition();
-
-            //Adjust for playback buffer
-            if (Settings.SettingsManager.Settings.EnablePlaybackBuffer.Value)
-            {
-                seconds -= (Bass.PlaybackBufferLength / 1000.0f) * _speed;
-                // Gotta do this because ChannelBytes2Seconds() may not be less than the buffer at position 0
-                if (seconds < 0)
-                {
-                    seconds = 0;
-                }
-            }
             return seconds;
         }
 


### PR DESCRIPTION
AV sync gets screwed up sometimes when using an audio buffer.  Logging reveals that the SongRunner is constantly trying to adjust the speed to correct it.  

We had a manual adjustment to account for the playback buffer, which I think is unnecessary because setting the buffer size in BASS does not introduce any delay.  So it is already reporting the correct position without adjustments.  It also messed up calibration when enabled, because of a small refactor which changed mixer position to always match main channel position, which applied this adjustment.

Also this was messing up the song runner, because it would report zero position to the song runner for the first [buffer_size] ms, resulting in a huge delta that the song runner tries to correct (and fails).

If anyone knows the history of the code I am removing, I'd love to have more input as I don't want to unintentionally break something else.  But I can't see any reason to do this and in my testing everything works fine without it.