### PR TITLE
Fix issues with volume quick settings not persisting

### DIFF
--- a/Assets/Script/Gameplay/GameManager.Audio.cs
+++ b/Assets/Script/Gameplay/GameManager.Audio.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+using System;
+using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 using YARG.Core.Audio;
@@ -11,15 +12,16 @@ namespace YARG.Gameplay
         private const double DEFAULT_VOLUME = 1.0;
         public class StemState
         {
-            public readonly double Volume;
+            private SongStem _stem;
+            public double Volume => GetVolumeSetting();
             public int Total;
             public int Audible;
             public int ReverbCount;
             public float WhammyPitch;
 
-            public StemState(double volume)
+            public StemState(SongStem stem)
             {
-                Volume = volume;
+                _stem = stem;
             }
 
             public double SetMute(bool muted)
@@ -57,9 +59,30 @@ namespace YARG.Gameplay
                 return WhammyPitch;
             }
 
-            public double CalculateVolumeSetting()
+            private double GetVolumeSetting()
             {
-                return Volume * Audible / Total;
+                return _stem switch
+                {
+                    SongStem.Guitar => SettingsManager.Settings.GuitarVolume.Value,
+                    SongStem.Rhythm => SettingsManager.Settings.RhythmVolume.Value,
+                    SongStem.Bass   => SettingsManager.Settings.BassVolume.Value,
+                    SongStem.Keys   => SettingsManager.Settings.KeysVolume.Value,
+                    SongStem.Drums
+                        or SongStem.Drums1
+                        or SongStem.Drums2
+                        or SongStem.Drums3
+                        or SongStem.Drums4
+                        => SettingsManager.Settings.DrumsVolume.Value,
+                    SongStem.Vocals
+                        or SongStem.Vocals1
+                        or SongStem.Vocals2
+                        => SettingsManager.Settings.VocalsVolume.Value,
+                    SongStem.Song    => SettingsManager.Settings.SongVolume.Value,
+                    SongStem.Crowd   => SettingsManager.Settings.CrowdVolume.Value,
+                    SongStem.Sfx     => SettingsManager.Settings.SfxVolume.Value,
+                    SongStem.DrumSfx => SettingsManager.Settings.DrumSfxVolume.Value,
+                    _                => DEFAULT_VOLUME
+                };
             }
         }
 
@@ -81,8 +104,7 @@ namespace YARG.Gameplay
             _backgroundStem = SongStem.Song;
             foreach (var channel in _mixer.Channels)
             {
-                double volume = GlobalAudioHandler.GetVolumeSetting(channel.Stem);
-                var stemState = new StemState(volume);
+                var stemState = new StemState(channel.Stem);
                 switch (channel.Stem)
                 {
                     case SongStem.Drums:

--- a/Assets/Script/Gameplay/GameManager.cs
+++ b/Assets/Script/Gameplay/GameManager.cs
@@ -175,9 +175,10 @@ namespace YARG.Gameplay
                 Navigator.Instance.NavigationEvent -= OnNavigationEvent;
             }
 
-            foreach (var state in _stemStates)
+            //Restore stem volumes to their original state
+            foreach (var (stem, state) in _stemStates)
             {
-                GlobalAudioHandler.SetVolumeSetting(state.Key, state.Value.Volume);
+                GlobalAudioHandler.SetVolumeSetting(stem, state.Volume);
             }
 
             DisposeDebug();


### PR DESCRIPTION
Original issue:
1. Play song
2. Change volume in quick settings
3. Leave song
4. Play song again

Expected: Volume settings persist
Actual: Volume settings are reset to main sound settings, even though sliders appear correct

The cause of this bug is that the GameManager restores the original `StemState` volume settings, which have since changed after being adjusted in the volume quick settings.  

To fix this, we should instead tie the `StemState` volume to the current volume settings for that stem at all times.  This represents the base volume of the track, whereas the `GlobalAudioHandler` volume settings represent the actual volume heard by the user.  This changes depending on mute state, etc.

When the song is exited, we have to restore the base volume again.  The fix is to use the most up to date volume settings always for this.