### PR TITLE
Fix issue where preview source streams were getting disposed twice

### DIFF
--- a/Assets/Script/Audio/Bass/BassStemChannel.cs
+++ b/Assets/Script/Audio/Bass/BassStemChannel.cs
@@ -8,8 +8,6 @@ namespace YARG.Audio.BASS
 {
     public sealed class BassStemChannel : StemChannel
     {
-        private readonly int _sourceHandle;
-
         private StreamHandle _streamHandles;
         private StreamHandle _reverbHandles;
         private PitchShiftParametersStruct _pitchParams;
@@ -17,10 +15,9 @@ namespace YARG.Audio.BASS
         private double _volume;
         private bool _isReverbing;
 
-        internal BassStemChannel(AudioManager manager, SongStem stem, bool clampStemVolume, int sourceStream, in PitchShiftParametersStruct pitchParams, in StreamHandle streamHandles, in StreamHandle reverbHandles)
+        internal BassStemChannel(AudioManager manager, SongStem stem, bool clampStemVolume, in PitchShiftParametersStruct pitchParams, in StreamHandle streamHandles, in StreamHandle reverbHandles)
             : base(manager, stem, clampStemVolume)
         {
-            _sourceHandle = sourceStream;
             _streamHandles = streamHandles;
             _reverbHandles = reverbHandles;
             _pitchParams = pitchParams;
@@ -67,11 +64,6 @@ namespace YARG.Audio.BASS
 
         protected override void SetPosition_Internal(double position)
         {
-            if (_sourceHandle != 0)
-            {
-                BassMix.SplitStreamReset(_sourceHandle);
-            }
-
             long bytes = Bass.ChannelSeconds2Bytes(_streamHandles.Stream, position);
             if (bytes < 0)
             {
@@ -206,12 +198,6 @@ namespace YARG.Audio.BASS
         {
             _streamHandles.Dispose();
             _reverbHandles.Dispose();
-
-            if (_sourceHandle != 0)
-            {
-                if (!Bass.StreamFree(_sourceHandle) && Bass.LastError != Errors.Handle)
-                    YargLogger.LogFormatError("Failed to free file stream (THIS WILL LEAK MEMORY): {0}!", Bass.LastError);
-            }
         }
     }
 }

--- a/Assets/Script/Audio/Bass/BassStemMixer.cs
+++ b/Assets/Script/Audio/Bass/BassStemMixer.cs
@@ -239,7 +239,7 @@ namespace YARG.Audio.BASS
                 return false;
             }
 
-            CreateChannel(stem, _sourceStream, streamHandles, reverbHandles);
+            CreateChannel(stem, streamHandles, reverbHandles);
             return true;
         }
 
@@ -264,7 +264,7 @@ namespace YARG.Audio.BASS
                 return false;
             }
 
-            CreateChannel(stem, sourceStream, streamHandles, reverbHandles);
+            CreateChannel(stem, streamHandles, reverbHandles);
             return true;
         }
 
@@ -305,7 +305,7 @@ namespace YARG.Audio.BASS
                 return false;
             }
 
-            CreateChannel(stem, 0, streamHandles, reverbHandles);
+            CreateChannel(stem, streamHandles, reverbHandles);
             return true;
         }
 
@@ -378,10 +378,10 @@ namespace YARG.Audio.BASS
             }
         }
 
-        private void CreateChannel(SongStem stem, int sourceStream, StreamHandle streamHandles, StreamHandle reverbHandles)
+        private void CreateChannel(SongStem stem, StreamHandle streamHandles, StreamHandle reverbHandles)
         {
             var pitchparams = BassAudioManager.SetPitchParams(stem, _speed, streamHandles, reverbHandles);
-            var stemchannel = new BassStemChannel(_manager, stem, _clampStemVolume, sourceStream, pitchparams, streamHandles, reverbHandles);
+            var stemchannel = new BassStemChannel(_manager, stem, _clampStemVolume, pitchparams, streamHandles, reverbHandles);
 
             double length = BassAudioManager.GetLengthInSeconds(streamHandles.Stream);
             if (_mainHandle == null || length > _length)


### PR DESCRIPTION
We were disposing the source stream in both the stem and the mixer

I see no reason for the stem to care about the source stream, just causes extra calls to `SplitStreamReset` which probably does nothing. You can see we are already doing it in the mixer when setting position.