### PR TITLE
Use Harmony Instrument Icons on Fail Meter / Active Player List

### DIFF
--- a/Assets/Script/Gameplay/HUD/FailMeter.cs
+++ b/Assets/Script/Gameplay/HUD/FailMeter.cs
@@ -93,9 +93,12 @@ namespace YARG.Gameplay.HUD
                 _playerPositions[i] = _playerSliders[i].handleRect.transform.position;
 
                 var handleImage = _playerSliders[i].handleRect.GetComponentInChildren<Image>();
-                var spriteName = $"InstrumentIcons[{_players[i].Instrument.ToResourceName()}]";
+                var spriteName = _players[i].GetInstrumentSprite();
+
                 var sprite = Addressables.LoadAssetAsync<Sprite>(spriteName).WaitForCompletion();
                 handleImage.sprite = sprite;
+                handleImage.color = _players[i].GetHarmonyColor();
+
                 _playerSliders[i].value = 0.01f;
                 _playerSliders[i].gameObject.SetActive(true);
 

--- a/Assets/Script/Gameplay/HUD/InstrumentIconProvider.cs
+++ b/Assets/Script/Gameplay/HUD/InstrumentIconProvider.cs
@@ -1,0 +1,74 @@
+﻿using UnityEngine;
+using YARG.Core;
+using YARG.Core.Engine;
+using YARG.Core.Logging;
+using YARG.Gameplay.Player;
+using YARG.Helpers.Extensions;
+using YARG.Player;
+
+namespace YARG.Gameplay.HUD
+{
+    public static class InstrumentIconProvider
+    {
+        public static string GetInstrumentSprite(this EngineManager.EngineContainer container)
+        {
+            return GetInstrumentSprite(container.Instrument, container.HarmonyIndex, false);
+        }
+
+        public static string GetInstrumentSprite(this YargPlayer player)
+        {
+            var isMissingDevice = player.IsMissingInputDevice || player.IsMissingMicrophone;
+            return GetInstrumentSprite(player.Profile.CurrentInstrument, player.Profile.HarmonyIndex, isMissingDevice);
+        }
+
+        private static string GetInstrumentSprite(Instrument instrument, int harmonyIndex, bool isMissingDevice)
+        {
+            if (isMissingDevice)
+            {
+                return $"NoInstrumentIcons[{instrument.ToResourceName()}]";
+            }
+
+            if (instrument == Instrument.Harmony)
+            {
+                return $"HarmonyVocalsIcons[{harmonyIndex + 1}]";
+            }
+
+            return $"InstrumentIcons[{instrument.ToResourceName()}]";
+        }
+
+        public static Color GetHarmonyColor(this YargPlayer player)
+        {
+            return GetHarmonyColor(player.Profile.CurrentInstrument, player.Profile.HarmonyIndex, player.IsMissingInputDevice || player.IsMissingMicrophone, player.SittingOut);
+        }
+
+        public static Color GetHarmonyColor(this EngineManager.EngineContainer container)
+        {
+            return GetHarmonyColor(container.Instrument, container.HarmonyIndex, false, false);
+        }
+
+        private static Color GetHarmonyColor(Instrument instrument, int harmonyIndex, bool isMissingDevice, bool isSittingOut)
+        {
+            if (isMissingDevice)
+            {
+                // NoInstrumentIcons are coloured to begin with - don't override that.
+                return Color.white;
+            }
+            if (isSittingOut)
+            {
+                return Color.gray;
+            }
+            if (instrument != Instrument.Harmony)
+            {
+                return Color.white;
+            }
+
+            if (harmonyIndex >= VocalTrack.Colors.Length)
+            {
+                YargLogger.LogWarning("PlayerNameDisplay", $"Harmony index {harmonyIndex} is out of bounds.");
+                return Color.white;
+            }
+
+            return VocalTrack.Colors[harmonyIndex];
+        }
+    }
+}

--- a/Assets/Script/Gameplay/HUD/InstrumentIconProvider.cs.meta
+++ b/Assets/Script/Gameplay/HUD/InstrumentIconProvider.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 13c4bc784294fb34189d7451826b1326
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Script/Gameplay/HUD/PlayerNameDisplay.cs
+++ b/Assets/Script/Gameplay/HUD/PlayerNameDisplay.cs
@@ -44,7 +44,7 @@ namespace YARG.Gameplay.HUD
             var profile = player.Profile;
             _playerName.text = profile.Name;
 
-            var spriteName = GetSpriteName(profile.CurrentInstrument, profile.HarmonyIndex);
+            var spriteName = player.GetInstrumentSprite();
             _instrumentIcon.sprite = Addressables
                 .LoadAssetAsync<Sprite>(spriteName)
                 .WaitForCompletion();
@@ -61,39 +61,13 @@ namespace YARG.Gameplay.HUD
 
             var textureNeedle = $"VocalNeedleTexture/{needleId}";
             _needleIcon.texture = Addressables.LoadAssetAsync<Texture2D>(textureNeedle).WaitForCompletion();
-            _instrumentIcon.color = GetHarmonyColor(player);
+            _instrumentIcon.color = player.GetHarmonyColor();
             ShowPlayer(player);
         }
 
         private bool ShouldShowPlayer()
         {
             return !GameManager.IsPractice && SettingsManager.Settings.ShowPlayerNameWhenStartingSong.Value;
-        }
-
-        private string GetSpriteName(Instrument currentInstrument, byte harmonyIndex)
-        {
-            if (currentInstrument == Instrument.Harmony)
-            {
-                return $"HarmonyVocalsIcons[{harmonyIndex + 1}]";
-            }
-
-            return $"InstrumentIcons[{currentInstrument.ToResourceName()}]";
-        }
-
-        private Color GetHarmonyColor(YargPlayer player)
-        {
-            if (player.Profile.CurrentInstrument != Instrument.Harmony)
-            {
-                return Color.white;
-            }
-
-            if (player.Profile.HarmonyIndex >= VocalTrack.Colors.Length)
-            {
-                YargLogger.LogWarning("PlayerNameDisplay", $"Harmony index {player.Profile.HarmonyIndex} is out of bounds.");
-                return Color.white;
-            }
-
-            return VocalTrack.Colors[player.Profile.HarmonyIndex];
         }
 
         private IEnumerator FadeoutCoroutine()

--- a/Assets/Script/Gameplay/Player/VocalsPlayer.cs
+++ b/Assets/Script/Gameplay/Player/VocalsPlayer.cs
@@ -1,4 +1,4 @@
-using System.Linq;
+﻿using System.Linq;
 using UnityEngine;
 using UnityEngine.AddressableAssets;
 using YARG.Core;
@@ -186,7 +186,7 @@ namespace YARG.Gameplay.Player
             HitWindow = EngineParams.HitWindow;
 
             var engine = new YargVocalsEngine(NoteTrack, SyncTrack, EngineParams, Player.Profile.IsBot);
-            EngineContainer = GameManager.EngineManager.Register(engine, NoteTrack.Instrument, _chart);
+            EngineContainer = GameManager.EngineManager.Register(engine, NoteTrack.Instrument, Player.Profile.HarmonyIndex, _chart);
 
             engine.OnStarPowerPhraseHit += _ => OnStarPowerPhraseHit();
             engine.OnStarPowerStatus += OnStarPowerStatus;

--- a/Assets/Script/Menu/DifficultySelect/DifficultySelectMenu.cs
+++ b/Assets/Script/Menu/DifficultySelect/DifficultySelectMenu.cs
@@ -156,6 +156,7 @@ namespace YARG.Menu.DifficultySelect
             // Reset content
             _navGroup.ClearNavigatables();
             _container.DestroyChildren();
+            StatsManager.Instance.UpdateActivePlayers();
 
             // Create the menu
             switch (_menuState)
@@ -320,9 +321,6 @@ namespace YARG.Menu.DifficultySelect
 
                     _menuState = State.Main;
                     UpdateForPlayer();
-
-                    // Update the instrument icons on the Status Bar (if enabled)
-                    StatsManager.Instance.UpdateActivePlayers();
                 });
             }
         }

--- a/Assets/Script/Menu/Persistent/ActivePlayerListItem.cs
+++ b/Assets/Script/Menu/Persistent/ActivePlayerListItem.cs
@@ -3,6 +3,7 @@ using TMPro;
 using UnityEngine;
 using UnityEngine.AddressableAssets;
 using UnityEngine.UI;
+using YARG.Gameplay.HUD;
 using YARG.Helpers.Extensions;
 using YARG.Player;
 
@@ -36,13 +37,12 @@ namespace YARG.Menu.Persistent
 
            _playerNameText.text = profile.Name;
 
-            var instrumentSprite =player.IsMissingInputDevice || player.IsMissingMicrophone
-                 ? $"NoInstrumentIcons[{profile.CurrentInstrument.ToResourceName()}]"
-                 : $"InstrumentIcons[{profile.CurrentInstrument.ToResourceName()}]";
+            var instrumentSprite = player.GetInstrumentSprite();
 
             _playerInstrumentIcon.sprite = Addressables
                 .LoadAssetAsync<Sprite>(instrumentSprite)
                 .WaitForCompletion();
+            _playerInstrumentIcon.color = player.GetHarmonyColor();
         }
     }
 }


### PR DESCRIPTION
This PR adds support for Harmony Player Icons, both to the Active Players List (at the top of the screen), and the new Fail Meter. This means that the game will display unique instrument icons for each Harmony vocalist based on which harmony part they're playing, instead of the generic harmony instrument icon, making it much easier to tell players apart. These are the same icons that are already displayed at the start of the song, below the vocal highway.

<img width="2009" height="1039" alt="image" src="https://github.com/user-attachments/assets/28cf63d7-6e3a-4949-985f-4489ac9da0a6" />

In addition, players that are sitting out will now be displayed with a grayed out icon on the Active Players List.

Requires YARG.Core PR: https://github.com/YARC-Official/YARG.Core/pull/287