### PR TITLE
Fix = and perc bugs in static vocals

### DIFF
--- a/Assets/Script/Gameplay/HUD/LyricBar.cs
+++ b/Assets/Script/Gameplay/HUD/LyricBar.cs
@@ -169,7 +169,7 @@ namespace YARG.Gameplay.HUD
             {
                 var lyric = lyrics[i++];
                 _builder.Append(lyric.Text);
-                if (!lyric.JoinWithNext && i < lyrics.Count)
+                if (!lyric.JoinOrHyphenateWithNext && i < lyrics.Count)
                 {
                     _builder.Append(' ');
                 }
@@ -181,7 +181,7 @@ namespace YARG.Gameplay.HUD
             {
                 var lyric = lyrics[i++];
                 _builder.Append(lyric.Text);
-                if (!lyric.JoinWithNext && i < lyrics.Count)
+                if (!lyric.JoinOrHyphenateWithNext && i < lyrics.Count)
                 {
                     _builder.Append(' ');
                 }
@@ -217,7 +217,7 @@ namespace YARG.Gameplay.HUD
             {
                 var lyric = lyrics[i++];
                 _builder.Append(lyric.Text);
-                if (!lyric.JoinWithNext && i < lyrics.Count)
+                if (!lyric.JoinOrHyphenateWithNext && i < lyrics.Count)
                 {
                     _builder.Append(' ');
                 }

--- a/Assets/Script/Gameplay/Player/Vocals/VocalTrack.Tracking.cs
+++ b/Assets/Script/Gameplay/Player/Vocals/VocalTrack.Tracking.cs
@@ -24,7 +24,7 @@ namespace YARG.Gameplay.Player
         {
             private const double IMMINENCE_THRESHOLD = .3d;
 
-            public List<VocalPhrasePair> PhrasePairs { get; } = new();
+            public List<VocalPhrasePair> PhrasePairs { get; }
 
             // Index of the the phrase that should be leftmost in the static lyrics display. This updates as soon as the last note
             // of a phrase ends, not when the phrase itself ends
@@ -56,16 +56,12 @@ namespace YARG.Gameplay.Player
                 // We've passed the last note of the leftmost phrase, so it's time to shift
                 else if (time >= currentLeftmostPhrasePair.GetLastNoteTotalEndTime())
                 {
-                    // Skip percussion phrases
-                    do
+                    if (_leftmostPhraseIndex + 1 >= PhrasePairs.Count)
                     {
-                        if (_leftmostPhraseIndex + 1 >= PhrasePairs.Count)
-                        {
-                            return StaticLyricShiftType.FinalPhraseComplete;
-                        }
+                        return StaticLyricShiftType.FinalPhraseComplete;
+                    }
 
-                        _leftmostPhraseIndex++;
-                    } while (PhrasePairs[_leftmostPhraseIndex].IsPercussion);
+                    _leftmostPhraseIndex++;
 
                     var newLeftmostPhrase = PhrasePairs[_leftmostPhraseIndex];
 
@@ -89,7 +85,14 @@ namespace YARG.Gameplay.Player
 
             public StaticPhraseTracker(List<VocalPhrasePair> phrasePairs)
             {
-                PhrasePairs = phrasePairs;
+                PhrasePairs = new();
+                foreach (var phrasePair in phrasePairs)
+                {
+                    if (!phrasePair.IsPercussion)
+                    {
+                        PhrasePairs.Add(phrasePair);
+                    }
+                }
             }
 
             public void Reset()

--- a/Assets/Script/Gameplay/Visuals/VocalElements/VocalStaticLyricPhraseElement.cs
+++ b/Assets/Script/Gameplay/Visuals/VocalElements/VocalStaticLyricPhraseElement.cs
@@ -278,10 +278,6 @@ namespace YARG.Gameplay.Visuals
                 if ((flags & LyricSymbolFlags.JoinWithNext) != 0)
                 {
                     builder.Append(text[0..^1]);
-                    if (text.EndsWith("="))
-                    {
-                        builder.Append("-");
-                    }
                 } else
                 {
                     builder.Append(text);
@@ -292,7 +288,7 @@ namespace YARG.Gameplay.Visuals
                     builder.Append("</i>");
                 }
 
-                if (!isLastLyricOfPhrase && ((flags & LyricSymbolFlags.JoinWithNext) == 0))
+                if (!isLastLyricOfPhrase && (flags & LyricSymbolFlags.JoinWithNext) == 0 && (flags & LyricSymbolFlags.HyphenateWithNext) == 0)
                 {
                     builder.Append(" ");
                 }


### PR DESCRIPTION
[Corresponding YARG.Core PR](https://github.com/YARC-Official/YARG.Core/pull/288) - Note that this only applies to Bug 1; Bug 2 is fully YARG-side and is fixed by this PR alone

Fixes two bugs in the Static Vocals implementation

# Bug 1 - `=` Symbol
The current implementation does not correctly render the `=` symbol as a hyphen in Static Vocals because we convert it to a hyphen earlier than I realized. I fixed this by creating a new `LyricSymbolFlag` value, `HyphenateWithNext`. Logic for scrolling vocals and the nonplayable lyric bar doesn't care about the distinction, so I also created `JoinOrHyphenateWithNext` as a derived field of `LyricEvent` for them to use, returning `JoinWithNext || HyphenateWithNext`.

# Bug 2 - Percussion sections
The current implementation incorrectly does not fully ignore percussion phrases, resulting in phrases shifting left when they shouldn't. I fixed this by making the `StaticPhraseTracker` constructor filter out all percussion phrases up front, which guarantees they're fully ignored and simplifies a little logic inside `UpdateCurrentPhrase`.