### PR TITLE
More graceful handling of malformed HARM phrases in static vocals

### DIFF
--- a/Assets/Script/Gameplay/Visuals/VocalElements/VocalStaticLyricPhraseElement.cs
+++ b/Assets/Script/Gameplay/Visuals/VocalElements/VocalStaticLyricPhraseElement.cs
@@ -73,7 +73,13 @@ namespace YARG.Gameplay.Visuals
 
                     var mergedLyric = mergedPhrase.Lyrics[mergedLyricIdx++];
                     var probableMergedLyricEnd = GetProbableNoteEndOfLyric(mergedPhrase, mergedLyric);
-                    MakeStaticLyricSyllable(mergedLyric.Text, mergedLyric.Time, probableMergedLyricEnd, mergedLyric.Flags, isLastLyricOfMergedPhrase);
+
+                    if (probableMergedLyricEnd is null)
+                    {
+                        continue;
+                    }
+
+                    MakeStaticLyricSyllable(mergedLyric.Text, mergedLyric.Time, probableMergedLyricEnd.Value, mergedLyric.Flags, isLastLyricOfMergedPhrase);
                 }
             }
 
@@ -82,6 +88,11 @@ namespace YARG.Gameplay.Visuals
                 {
                     var mainLyric = mainPhrase.Lyrics[mainLyricIdx];
                     var probableMainLyricEnd = GetProbableNoteEndOfLyric(mainPhrase, mainLyric);
+                    if (probableMainLyricEnd is null)
+                    {
+                        continue;
+                    }
+
                     var isLastLyricOfMainPhrase = mainLyricIdx == mainPhrase.Lyrics.Count - 1;
 
                     if (mergedPhrase is not null)
@@ -96,9 +107,13 @@ namespace YARG.Gameplay.Visuals
 
                             var mergedLyric = mergedPhrase.Lyrics[mergedLyricIdx++];
                             var probableMergedLyricEnd = GetProbableNoteEndOfLyric(mergedPhrase, mergedLyric);
+                            if (probableMergedLyricEnd is null)
+                            {
+                                continue;
+                            }
 
                             // isLastLyricOfPhrase is definitely false, because we still have at least one main phrase lyric to add
-                            MakeStaticLyricSyllable(mergedLyric.Text, mergedLyric.Time, probableMergedLyricEnd, mergedLyric.Flags, false);
+                            MakeStaticLyricSyllable(mergedLyric.Text, mergedLyric.Time, probableMergedLyricEnd.Value, mergedLyric.Flags, false);
                         }
                     }
 
@@ -113,7 +128,7 @@ namespace YARG.Gameplay.Visuals
                         mainLyricIsLastLyricOfEntirePhrase = false;
                     }
 
-                    MakeStaticLyricSyllable(mainLyric.Text, mainLyric.Time, probableMainLyricEnd, mainLyric.Flags, mainLyricIsLastLyricOfEntirePhrase);
+                    MakeStaticLyricSyllable(mainLyric.Text, mainLyric.Time, probableMainLyricEnd.Value, mainLyric.Flags, mainLyricIsLastLyricOfEntirePhrase);
 
                     // If there's a simultaneous syllable in the merged part...
                     if (mergedPhrase is not null && mergedLyricIdx < mergedPhrase.Lyrics.Count && mergedPhrase.Lyrics[mergedLyricIdx].Time == mainLyric.Time)
@@ -124,16 +139,20 @@ namespace YARG.Gameplay.Visuals
                         if (simultaneousMergedLyric.Text != mainLyric.Text)
                         {
                             var probableSimultaneousMergedLyricEnd = GetProbableNoteEndOfLyric(mergedPhrase, simultaneousMergedLyric);
-                            var isLastLyricOfMergedPhrase = mergedLyricIdx == mergedPhrase.Lyrics.Count - 1;
 
-                            // ...add it after the main syllable
-                            MakeStaticLyricSyllable(
-                                simultaneousMergedLyric.Text,
-                                simultaneousMergedLyric.Time,
-                                probableSimultaneousMergedLyricEnd,
-                                simultaneousMergedLyric.Flags,
-                                mainLyricIsLastLyricOfEntirePhrase && mergedLyricIdx == mergedPhrase.Lyrics.Count - 1
-                            );
+                            if (probableSimultaneousMergedLyricEnd is not null)
+                            {
+                                var isLastLyricOfMergedPhrase = mergedLyricIdx == mergedPhrase.Lyrics.Count - 1;
+
+                                // ...add it after the main syllable
+                                MakeStaticLyricSyllable(
+                                    simultaneousMergedLyric.Text,
+                                    simultaneousMergedLyric.Time,
+                                    probableSimultaneousMergedLyricEnd.Value,
+                                    simultaneousMergedLyric.Flags,
+                                    mainLyricIsLastLyricOfEntirePhrase && mergedLyricIdx == mergedPhrase.Lyrics.Count - 1
+                                );
+                            }
                         }
                     }
                 }
@@ -145,8 +164,13 @@ namespace YARG.Gameplay.Visuals
                     {
                         var mergedLyric = mergedPhrase.Lyrics[mergedLyricIdx++];
                         var probableMergedLyricEnd = GetProbableNoteEndOfLyric(mergedPhrase, mergedLyric);
+                        if (probableMergedLyricEnd is null)
+                        {
+                            continue;
+                        }
+
                         var isLastLyricOfMergedPhrase = mergedLyricIdx == mergedPhrase.Lyrics.Count - 1;
-                        MakeStaticLyricSyllable(mergedLyric.Text, mergedLyric.Time, probableMergedLyricEnd, mergedLyric.Flags, mergedLyricIdx == mergedPhrase.Lyrics.Count - 1);
+                        MakeStaticLyricSyllable(mergedLyric.Text, mergedLyric.Time, probableMergedLyricEnd.Value, mergedLyric.Flags, mergedLyricIdx == mergedPhrase.Lyrics.Count - 1);
                     }
                 }
             }
@@ -218,10 +242,10 @@ namespace YARG.Gameplay.Visuals
             _builder.Append(CLOSE_COLOR_TAG);
         }
 
-        private static double GetProbableNoteEndOfLyric(VocalsPhrase phrase, LyricEvent lyric)
+        private static double? GetProbableNoteEndOfLyric(VocalsPhrase phrase, LyricEvent lyric)
         {
             return phrase.PhraseParentNote.ChildNotes
-                .FirstOrDefault(note => note.Tick == lyric.Tick).TotalTimeEnd;
+                .FirstOrDefault(note => note.Tick == lyric.Tick)?.TotalTimeEnd;
         }
 
         private void MakeStaticLyricSyllable(string text, double time, double timeEnd, LyricSymbolFlags flags, bool isLastLyricOfPhrase)


### PR DESCRIPTION
All HARM3 notes must be contained within a HARM2 phrase to function correctly in static vocals. Not doing so is a hard error. However, YARG currently hits a null reference exception in this scenario and breaks the offending lyric lane entirely (see [here](https://discord.com/channels/1086048856678084609/1417578282529853470/1417578282529853470)). This change makes YARG handle the situation more gracefully, where it will simply refuse to render lyrics for notes that are not correctly contained within a phrase. Lyrics that _are_ in phrases will render normally.

The current version of the YARN chart "Code 75" can be used to reproduce this behavior. If I patch the chart before this PR is merged, I'll update this PR with a dedicated repro chart.