### PR TITLE
Fix issues where stem files were getting locked by os

### DIFF
--- a/Assets/Script/Audio/Bass/BassAudioManager.cs
+++ b/Assets/Script/Audio/Bass/BassAudioManager.cs
@@ -174,26 +174,7 @@ namespace YARG.Audio.BASS
             {
                 return null;
             }
-            return new BassStemMixer(name, this, speed, mixerVolume, handle, 0, clampStemVolume);
-        }
-
-        protected override StemMixer? CreateMixer(string name, Stream stream, float speed, double mixerVolume, bool clampStemVolume)
-        {
-            if (GlobalAudioHandler.LogMixerStatus)
-            {
-                YargLogger.LogDebug("Loading song");
-            }
-
-            if (!CreateMixerHandle(out int handle))
-            {
-                return null;
-            }
-
-            if (!CreateSourceStream(stream, out int sourceStream))
-            {
-                return null;
-            }
-            return new BassStemMixer(name, this, speed, mixerVolume, handle, sourceStream, clampStemVolume);
+            return new BassStemMixer(name, this, speed, mixerVolume, handle, clampStemVolume);
         }
 
         protected override MicDevice? GetInputDevice(string name)

--- a/Assets/Script/Audio/Bass/BassStemMixer.cs
+++ b/Assets/Script/Audio/Bass/BassStemMixer.cs
@@ -12,7 +12,6 @@ namespace YARG.Audio.BASS
     public sealed class BassStemMixer : StemMixer
     {
         private readonly int _mixerHandle;
-        private readonly int _sourceStream;
 
         private StemChannel _mainChannel;
         private StreamHandle _mainHandle;
@@ -45,11 +44,10 @@ namespace YARG.Audio.BASS
             }
         }
 
-        internal BassStemMixer(string name, BassAudioManager manager, float speed, double volume, int handle, int sourceStream, bool clampStemVolume)
+        internal BassStemMixer(string name, BassAudioManager manager, float speed, double volume, int handle, bool clampStemVolume)
             : base(name, manager, clampStemVolume)
         {
             _mixerHandle = handle;
-            _sourceStream = sourceStream;
             _speed = speed;
             SetVolume_Internal(volume);
             _BufferSetter(Settings.SettingsManager.Settings.EnablePlaybackBuffer.Value, Bass.PlaybackBufferLength);
@@ -114,10 +112,6 @@ namespace YARG.Audio.BASS
             {
                 // Pause when seeking to avoid desyncing individual stems
                 Pause_Internal();
-            }
-            if (_sourceStream != 0)
-            {
-                BassMix.SplitStreamReset(_sourceStream);
             }
 
             foreach (var channel in _channels)
@@ -213,26 +207,7 @@ namespace YARG.Audio.BASS
             }
         }
 
-        protected override bool AddChannel_Internal(SongStem stem)
-        {
-            if (!BassAudioManager.CreateSplitStreams(_sourceStream, null, out var streamHandles, out var reverbHandles))
-            {
-                YargLogger.LogFormatError("Failed to load stem split streams {0}: {1}!", stem, Bass.LastError);
-                return false;
-            }
-
-            if (!BassMix.MixerAddChannel(_mixerHandle, streamHandles.Stream, BassFlags.Default) ||
-                !BassMix.MixerAddChannel(_mixerHandle, reverbHandles.Stream, BassFlags.Default))
-            {
-                YargLogger.LogFormatError("Failed to add channel {0} to mixer: {1}!", stem, Bass.LastError);
-                return false;
-            }
-
-            CreateChannel(stem, streamHandles, reverbHandles);
-            return true;
-        }
-
-        protected override bool AddChannel_Internal(SongStem stem, Stream stream)
+        protected override bool AddChannel_Internal(SongStem stem, Stream stream, int[] indices = null, float[] panning = null)
         {
             if (!BassAudioManager.CreateSourceStream(stream, out int sourceStream))
             {
@@ -240,26 +215,7 @@ namespace YARG.Audio.BASS
                 return false;
             }
 
-            if (!BassAudioManager.CreateSplitStreams(sourceStream, null, out var streamHandles, out var reverbHandles))
-            {
-                YargLogger.LogFormatError("Failed to load stem split streams {stem}: {0}!", Bass.LastError);
-                return false;
-            }
-
-            if (!BassMix.MixerAddChannel(_mixerHandle, streamHandles.Stream, BassFlags.Default) ||
-                !BassMix.MixerAddChannel(_mixerHandle, reverbHandles.Stream, BassFlags.Default))
-            {
-                YargLogger.LogFormatError("Failed to add channel {stem} to mixer: {0}!", Bass.LastError);
-                return false;
-            }
-
-            CreateChannel(stem, streamHandles, reverbHandles);
-            return true;
-        }
-
-        protected override bool AddChannel_Internal(SongStem stem, int[] indices, float[] panning)
-        {
-            if (!BassAudioManager.CreateSplitStreams(_sourceStream, indices, out var streamHandles, out var reverbHandles))
+            if (!BassAudioManager.CreateSplitStreams(sourceStream, indices, out var streamHandles, out var reverbHandles))
             {
                 YargLogger.LogFormatError("Failed to load stem {0}: {1}!", stem, Bass.LastError);
                 return false;
@@ -272,29 +228,32 @@ namespace YARG.Audio.BASS
                 return false;
             }
 
-            // First array = left pan, second = right pan
-            float[,] volumeMatrix = new float[2, indices.Length];
-
-            const int LEFT_PAN = 0;
-            const int RIGHT_PAN = 1;
-            for (int i = 0; i < indices.Length; ++i)
+            if (indices != null && panning != null)
             {
-                volumeMatrix[LEFT_PAN, i] = panning[2 * i];
+                // First array = left pan, second = right pan
+                float[,] volumeMatrix = new float[2, indices.Length];
+
+                const int LEFT_PAN = 0;
+                const int RIGHT_PAN = 1;
+                for (int i = 0; i < indices.Length; ++i)
+                {
+                    volumeMatrix[LEFT_PAN, i] = panning[2 * i];
+                }
+
+                for (int i = 0; i < indices.Length; ++i)
+                {
+                    volumeMatrix[RIGHT_PAN, i] = panning[2 * i + 1];
+                }
+
+                if (!BassMix.ChannelSetMatrix(streamHandles.Stream, volumeMatrix) ||
+                    !BassMix.ChannelSetMatrix(reverbHandles.Stream, volumeMatrix))
+                {
+                    YargLogger.LogFormatError("Failed to set {stem} matrices: {0}!", Bass.LastError);
+                    return false;
+                }
             }
 
-            for (int i = 0; i < indices.Length; ++i)
-            {
-                volumeMatrix[RIGHT_PAN, i] = panning[2 * i + 1];
-            }
-
-            if (!BassMix.ChannelSetMatrix(streamHandles.Stream, volumeMatrix) ||
-                !BassMix.ChannelSetMatrix(reverbHandles.Stream, volumeMatrix))
-            {
-                YargLogger.LogFormatError("Failed to set {stem} matrices: {0}!", Bass.LastError);
-                return false;
-            }
-
-            CreateChannel(stem, streamHandles, reverbHandles);
+            CreateChannel(stem, sourceStream, streamHandles, reverbHandles);
             return true;
         }
 
@@ -357,20 +316,12 @@ namespace YARG.Audio.BASS
                     YargLogger.LogFormatError("Failed to free mixer stream (THIS WILL LEAK MEMORY!): {0}!", Bass.LastError);
                 }
             }
-
-            if (_sourceStream != 0)
-            {
-                if (!Bass.StreamFree(_sourceStream))
-                {
-                    YargLogger.LogFormatError("Failed to free mixer source stream (THIS WILL LEAK MEMORY!): {0}!", Bass.LastError);
-                }
-            }
         }
 
-        private void CreateChannel(SongStem stem, StreamHandle streamHandles, StreamHandle reverbHandles)
+        private void CreateChannel(SongStem stem, int sourceHandle, StreamHandle streamHandles, StreamHandle reverbHandles)
         {
             var pitchparams = BassAudioManager.SetPitchParams(stem, _speed, streamHandles, reverbHandles);
-            var stemchannel = new BassStemChannel(_manager, stem, _clampStemVolume, pitchparams, streamHandles, reverbHandles);
+            var stemchannel = new BassStemChannel(_manager, stem, _clampStemVolume, pitchparams, sourceHandle, streamHandles, reverbHandles);
 
             double length = BassAudioManager.GetLengthInSeconds(streamHandles.Stream);
             if (_mainHandle == null || length > _length)


### PR DESCRIPTION
**Corresponding YARG.Core PR:** https://github.com/YARC-Official/YARG.Core/pull/293

The issue is we were freeing everything except the **source handle**s of the stems. This broke previously in this pr https://github.com/YARC-Official/YARG/pull/1126

This broke because I mistakenly thought there was a single **source handle** that the mixer was freeing.

## The Original Bug

1. Launch, select quickplay
2. Highlight a song A, then highlight a different song B
3. Try to rename one of the source audio files for Song A

**Expected:** Rename works  
**Actual:** File was locked by OS

## Background Notes

- The **source handle** is created from the C# io `Stream` class, which accesses the file on disk.
- If the source handle is not freed, it will probably keep some portion of the file in memory, and the OS will lock the file. So when scrolling previews, we were leaking memory.
- Previously, a Mixer had an optional source handle, and the channels of the mixer also had a reference to a source handle.  This was causing the double free issue.  With these changes only the channels of the mixer have a source handle.

## Solution

We need to free the source handle when the mixer is disposed.  This is going to be the responsibility of channels added to the mixer.  The mixer will only free its own handle when disposed.

Since source stream -> channel is one-to-many, the channel might have already freed its source stream in `onDispose()`.  It will try to free it again, and if it was already freed it will return a `Handle` error.  We ignore that error, and log any other error.

This does some refactoring to simplify the mixer logic and source handle management:

The main changes are:
* 3 `StemMixer.addChannel` methods -> `addChannel` and `addChannels` methods
  * `addChannel` is a convenience method for `addChannels` 
    * One-to-one `Stream` to stem
  * `addChannels` takes in a stream and list of ChannelInfo structs, which contain stem and optional indices information
    * One-to-many mapping of `Stream` to stems, and prevents creating multiple source streams from the same `Stream`
    * Used for MOGG sources
