### PR TITLE
Add missing metal/miss effects to five lane key note elements

### DIFF
--- a/Assets/Script/Gameplay/Visuals/TrackElements/FiveLaneKeys/FiveLaneKeysNoteElement.cs
+++ b/Assets/Script/Gameplay/Visuals/TrackElements/FiveLaneKeys/FiveLaneKeysNoteElement.cs
@@ -57,7 +57,7 @@ namespace YARG.Gameplay.Visuals
                 NoteGroup = NoteRef.Type switch
                 {
                     GuitarNoteType.Strum or
-                    GuitarNoteType.Hopo  or 
+                    GuitarNoteType.Hopo  or
                     GuitarNoteType.Tap   => noteGroups[(int) NoteType.Normal],
                     _ => throw new ArgumentOutOfRangeException(nameof(NoteRef.Type))
                 };
@@ -114,6 +114,14 @@ namespace YARG.Gameplay.Visuals
             }
         }
 
+
+        public override void MissNote()
+        {
+            base.MissNote();
+
+            UpdateColor();
+        }
+
         protected override void UpdateElement()
         {
             base.UpdateElement();
@@ -150,8 +158,16 @@ namespace YARG.Gameplay.Visuals
                 ? colors.GetNoteStarPowerColor(NoteRef.Fret)
                 : colorNoStarPower;
 
+            if (NoteRef.WasMissed)
+            {
+                color = colors.Miss;
+            }
+
             // Set the note color
             NoteGroup.SetColorWithEmission(color.ToUnityColor(), colorNoStarPower.ToUnityColor());
+
+            // Set the metal color
+            NoteGroup.SetMetalColor(colors.GetMetalColor(NoteRef.IsStarPower).ToUnityColor());
 
             // The rest of this method is for sustain only
             if (!NoteRef.IsSustain) return;


### PR DESCRIPTION
#1086 added metal and miss effects to all note elements including five lane guitar, but they are missing in the mostly-identical five lane keys note elements added in #1089. This PR adds those effects to the five lane keys as well to keep visual consistency.

I don't know if it was kept this way intentionally to be able to differ between guitar and keys, but since it only applies to star power notes (or notes you miss, or of course the absence of hopos/taps) and those aren't guaranteed to be visible at a given point in the song, I figured it was just a missing effect. If it was intentional, I would imagine we would want something better to more obviously distinguish the two in a way that doesn't rely on specific elements, some of which aren't reliable indicators anyway since the color profile can be changed to make them match)