### PR TITLE
Added Sync Songs button to Quickplay and Main Menu Pages

### DIFF
--- a/Assets/Script/Menu/Main/MainMenu.cs
+++ b/Assets/Script/Menu/Main/MainMenu.cs
@@ -8,6 +8,7 @@ using YARG.Menu.Settings;
 using YARG.Menu.Navigation;
 using YARG.Menu.Persistent;
 using YARG.Settings;
+using YARG.Song;
 
 namespace YARG.Menu.Main
 {
@@ -47,6 +48,7 @@ namespace YARG.Menu.Main
                 NavigationScheme.Entry.NavigateUp,
                 NavigationScheme.Entry.NavigateDown,
                 new NavigationScheme.Entry(MenuAction.Select, "Menu.Main.GoToCurrentlyPlaying", CurrentlyPlaying),
+                new NavigationScheme.Entry(MenuAction.Orange, "Menu.Main.ScanSongs", RefreshSongs),
             }, true));
         }
 
@@ -124,6 +126,12 @@ namespace YARG.Menu.Main
         public void OpenGithub()
         {
             Application.OpenURL("https://github.com/YARC-Official/YARG");
+        }
+
+        public async void RefreshSongs()
+        {
+            using var context = new LoadingContext();
+            await SongContainer.RunRefresh(false, context);
         }
     }
 }

--- a/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
+++ b/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
@@ -19,6 +19,7 @@ using YARG.Player;
 using YARG.Playlists;
 using YARG.Settings;
 using YARG.Song;
+using YARG.Helpers;
 using static YARG.Menu.Navigation.Navigator;
 using Random = UnityEngine.Random;
 
@@ -807,6 +808,13 @@ namespace YARG.Menu.MusicLibrary
         public void SetSearchInput(SortAttribute songAttribute, string input)
         {
             _searchField.SetSearchInput(songAttribute, input);
+        }
+
+        public async void RefreshSongs()
+        {
+            using var context = new LoadingContext();
+            await SongContainer.RunRefresh(false, context);
+            RefreshAndReselect();
         }
 
         private void OnPlayerAdded(YargPlayer player)

--- a/Assets/Script/Menu/MusicLibrary/PopupMenu.cs
+++ b/Assets/Script/Menu/MusicLibrary/PopupMenu.cs
@@ -117,6 +117,12 @@ namespace YARG.Menu.MusicLibrary
                 gameObject.SetActive(false);
             });
 
+            CreateItem("ScanSongs", () =>
+            {
+                _musicLibrary.RefreshSongs();
+                gameObject.SetActive(false);
+            });
+
             CreateItem("SortBy", SettingsManager.Settings.LibrarySort.ToLocalizedName(), () =>
             {
                 _menuState = State.SortSelect;


### PR DESCRIPTION
  Quick Play Page (MusicLibraryMenu):

  - Method: Added RefreshSongs() method in MusicLibraryMenu.cs:813-818
  - UI Access: Added "Scan Songs" option to the popup menu (accessed with Orange button/right-click) in PopupMenu.cs:120-124

  Main Menu Page (MainMenu):

  - Method: Added RefreshSongs() method in MainMenu.cs:130-134
  - UI Access: Added keyboard shortcut (Orange button) in navigation scheme in MainMenu.cs:51

   Proper Development Branch:

  - All changes made on dev branch as required by contributing rules
