### PR TITLE
Implement normalization

### DIFF
--- a/Assets/Script/Audio/Bass/BassAudioManager.cs
+++ b/Assets/Script/Audio/Bass/BassAudioManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using ManagedBass;
@@ -171,7 +171,7 @@ namespace YARG.Audio.BASS
         }
 
 #nullable enable
-        protected override StemMixer? CreateMixer(string name, float speed, double mixerVolume, bool clampStemVolume)
+        protected override StemMixer? CreateMixer(string name, float speed, double mixerVolume, bool clampStemVolume, bool normalize)
         {
             if (GlobalAudioHandler.LogMixerStatus)
             {
@@ -182,7 +182,7 @@ namespace YARG.Audio.BASS
             {
                 return null;
             }
-            return new BassStemMixer(name, this, speed, mixerVolume, handle, clampStemVolume);
+            return new BassStemMixer(name, this, speed, mixerVolume, handle, clampStemVolume, normalize);
         }
 
         protected override MicDevice? GetInputDevice(string name)

--- a/Assets/Script/Audio/Bass/BassNormalizer.cs
+++ b/Assets/Script/Audio/Bass/BassNormalizer.cs
@@ -1,0 +1,219 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using ManagedBass;
+using ManagedBass.Fx;
+using ManagedBass.Mix;
+using YARG.Core.Audio;
+using YARG.Core.Logging;
+
+namespace YARG.Audio.BASS
+{
+    public class BassNormalizer : IDisposable
+    {
+        private const int   BUFFER_SIZE        = 512 * 1024;
+        private const float TARGET_RMS         = 0.175f;
+        private const float MAX_GAIN           = 1.5f;
+        private const int   MAX_THREADS_ATTRIB = 86017;
+        private const int   START_SECONDS      = 5;
+
+        private          int                     _mixer;
+        private readonly List<Stream>            _streams = new();
+        private readonly List<int>               _handles = new();
+        private          CancellationTokenSource _gainCalcCts = new();
+
+        public float               Gain { get; private set; } = 1.0f;
+        public event Action<float> OnGainAdjusted;
+
+        public bool AddStream(Stream stream, params StemMixer.StemInfo[] stemInfos)
+        {
+            if (_mixer == 0)
+            {
+                if (!CreateMixer(out _mixer))
+                {
+                    return false;
+                }
+            }
+
+            if (!CloneStreamToMemory(stream, out var clonedStream))
+            {
+                YargLogger.LogError("Failed to clone stream!");
+                return false;
+            }
+
+            if (!BassAudioManager.CreateSourceStream(clonedStream, out int sourceStream))
+            {
+                YargLogger.LogFormatError("Failed to load stem source stream: {0}!", Bass.LastError);
+                return false;
+            }
+            _handles.Add(sourceStream);
+
+            foreach (var stemInfo in stemInfos)
+            {
+                var volumeMatrix = stemInfo.VolumeMatrix;
+                if (volumeMatrix != null)
+                {
+                    int[] channelMap = stemInfo.Indices.Append(-1).ToArray();
+                    int streamSplit = BassMix.CreateSplitStream(sourceStream, BassFlags.Decode, channelMap);
+                    if (streamSplit == 0)
+                    {
+                        YargLogger.LogFormatError("Failed to create split stream: {0}!", Bass.LastError);
+                        return false;
+                    }
+                    _handles.Add(streamSplit);
+
+                    if (!BassMix.MixerAddChannel(_mixer, streamSplit, BassFlags.MixerChanMatrix))
+                    {
+                        Bass.StreamFree(streamSplit);
+                        YargLogger.LogFormatError("Failed to add channel {0} to mixer: {1}!", stemInfo.Stem,
+                            Bass.LastError);
+                        return false;
+                    }
+
+                    if (!BassMix.ChannelSetMatrix(streamSplit, volumeMatrix))
+                    {
+                        YargLogger.LogFormatError("Failed to set {stem} matrices: {0}!", stemInfo.Stem, Bass.LastError);
+                        return false;
+                    }
+                }
+                else
+                {
+                    if (!BassMix.MixerAddChannel(_mixer, sourceStream, BassFlags.Default))
+                    {
+                        YargLogger.LogFormatError("Failed to add channel {0} to mixer: {1}!", stemInfo.Stem,
+                            Bass.LastError);
+                        return false;
+                    }
+                }
+            }
+
+            StartGainCalculation();
+            return true;
+        }
+
+        private bool CreateMixer(out int mixerHandle)
+        {
+            mixerHandle = BassMix.CreateMixerStream(44100, 2, BassFlags.Decode);
+            if (mixerHandle == 0)
+            {
+                YargLogger.LogFormatError("Failed to create mixer: {0}!", Bass.LastError);
+                return false;
+            }
+
+            if (!Bass.ChannelSetAttribute(mixerHandle, (ChannelAttribute) MAX_THREADS_ATTRIB, GlobalAudioHandler.MAX_THREADS))
+            {
+                YargLogger.LogFormatError("Failed to set mixer processing threads: {0}!", Bass.LastError);
+            }
+
+            _handles.Add(mixerHandle);
+            return true;
+        }
+
+        private bool CloneStreamToMemory(Stream original, out MemoryStream clonedStream)
+        {
+            clonedStream = null;
+            if (!original.CanRead || !original.CanSeek)
+                return false;
+
+            var originalPosition = original.Position;
+            try
+            {
+                original.Position = 0;
+                clonedStream = new MemoryStream();
+                original.CopyTo(clonedStream);
+                clonedStream.Position = originalPosition;
+                _streams.Add(clonedStream);
+                return true;
+            }
+            catch
+            {
+                clonedStream?.Dispose();
+                clonedStream = null;
+                return false;
+            }
+            finally
+            {
+                original.Position = originalPosition;
+            }
+        }
+
+        private void StartGainCalculation()
+        {
+            _gainCalcCts.Cancel();
+            _gainCalcCts.Dispose();
+            _gainCalcCts = new CancellationTokenSource();
+
+            var progress = new Progress<double>(gain =>
+            {
+                OnGainAdjusted?.Invoke((float) gain);
+            });
+
+            Task.Run(() => CalculateRms(progress, _gainCalcCts.Token), _gainCalcCts.Token);
+        }
+
+        private void CalculateRms(IProgress<double> progress, CancellationToken token)
+        {
+            double cumulativeSumSquares = 0.0;
+            long totalSamples = 0;
+            Bass.ChannelSetPosition(_mixer, START_SECONDS);
+            byte[] buffer = new byte[BUFFER_SIZE * sizeof(short)];
+
+            while (true)
+            {
+                if (token.IsCancellationRequested)
+                {
+                    return;
+                }
+
+                int bytesRead = Bass.ChannelGetData(_mixer, buffer, buffer.Length);
+                if (bytesRead <= 0)
+                    break;
+
+                var bufferSeconds = Bass.ChannelBytes2Seconds(_mixer, bytesRead);
+                float[] level = new float[1];
+                bool didGetLevel = Bass.ChannelGetLevel(_mixer, level, (float) bufferSeconds,
+                    LevelRetrievalFlags.Mono | LevelRetrievalFlags.RMS);
+
+                var chunkedRms = level[0];
+                if (didGetLevel && chunkedRms > 0)
+                {
+                    long numSamples = bytesRead / sizeof(short);
+                    double sumSquares = chunkedRms * chunkedRms * numSamples;
+                    cumulativeSumSquares += sumSquares;
+                    totalSamples += numSamples;
+
+                    double rms = Math.Sqrt(cumulativeSumSquares / totalSamples);
+                    double gain = Math.Min(MAX_GAIN, TARGET_RMS / rms);
+                    Gain = (float) gain;
+                    progress?.Report(gain);
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+            foreach (var stream in _streams)
+            {
+                stream.Dispose();
+            }
+            foreach (var handle in _handles)
+            {
+                if (!Bass.StreamFree(handle))
+                {
+                    if (Bass.LastError != Errors.Handle)
+                    {
+                        YargLogger.LogFormatError("Failed to free stream (THIS WILL LEAK MEMORY!): {0}!",
+                            Bass.LastError);
+                    }
+                }
+            }
+            _mixer = 0;
+            _streams.Clear();
+            _handles.Clear();
+        }
+    }
+}

--- a/Assets/Script/Audio/Bass/BassNormalizer.cs
+++ b/Assets/Script/Audio/Bass/BassNormalizer.cs
@@ -27,7 +27,6 @@ namespace YARG.Audio.BASS
         private const float MAX_GAIN_INCREASE  = 0.1f;
         private const float MAX_GAIN_DECREASE  = 0.1f;
         private const int   MAX_THREADS_ATTRIB = 86017;
-        private const int   START_SECONDS      = 5;
 
         private          int                     _mixer;
         private readonly List<Stream>            _streams = new();
@@ -168,7 +167,6 @@ namespace YARG.Audio.BASS
         {
             double cumulativeSumSquares = 0.0;
             long totalSamples = 0;
-            Bass.ChannelSetPosition(_mixer, START_SECONDS);
             byte[] buffer = new byte[BUFFER_SIZE * sizeof(short)];
 
             while (true)
@@ -206,6 +204,9 @@ namespace YARG.Audio.BASS
 
         public void Dispose()
         {
+            _gainCalcCts.Cancel();
+            _gainCalcCts.Dispose();
+
             foreach (var stream in _streams)
             {
                 stream.Dispose();

--- a/Assets/Script/Audio/Bass/BassNormalizer.cs.meta
+++ b/Assets/Script/Audio/Bass/BassNormalizer.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 2e51b490f344414d9aafa5c0a609dd9c
+timeCreated: 1758727483

--- a/Assets/Script/Audio/Bass/BassStemMixer.cs
+++ b/Assets/Script/Audio/Bass/BassStemMixer.cs
@@ -470,7 +470,7 @@ namespace YARG.Audio.BASS
             }
             if (_gainDspHandle != 0)
             {
-                Bass.StreamFree(_gainDspHandle);
+                Bass.ChannelRemoveDSP(_mixerHandle, _gainDspHandle);
             }
 
 

--- a/Assets/Script/Settings/SettingsManager.Settings.cs
+++ b/Assets/Script/Settings/SettingsManager.Settings.cs
@@ -482,6 +482,8 @@ namespace YARG.Settings
                 BandComboType.Strict
             };
 
+            public ToggleSetting EnableNormalization { get; } = new(false);
+
             #endregion
 
             #region Callbacks

--- a/Assets/Script/Settings/SettingsManager.cs
+++ b/Assets/Script/Settings/SettingsManager.cs
@@ -227,6 +227,7 @@ namespace YARG.Settings
                 new HeaderMetadata("Other"),
                 nameof(Settings.BandComboTypeSetting),
                 nameof(Settings.DataStreamEnable),
+                nameof(Settings.EnableNormalization),
             }
         };
 

--- a/Assets/StreamingAssets/lang/en-US.json
+++ b/Assets/StreamingAssets/lang/en-US.json
@@ -1361,6 +1361,10 @@
             "EnableVoxSamples": {
                 "Name": "Enable Vox Samples",
                 "Description": "If enabled, the game might make some noises at you on the score screen."
+            },
+            "EnableNormalization": {
+                "Name": "Normalize Audio",
+                "Description": "If enabled, normalizes audio so that all songs are approximately the same volume.  Increases memory and performance requirements."
             }
         },
         "PresetType": {


### PR DESCRIPTION
**Corresponding YARG.Core PR:** https://github.com/YARC-Official/YARG.Core/pull/295

## Overview

This PR implements normalization across songs as an optional setting.

## Problem

Songs tend to have different volumes, which is an annoyance to users.

## Solution

We add a new `BassNormalizer` class that handles asynchronous normalization.

### BassNormalizer Class

The `BassNormalizer` class has public:
- `AddStream` method 
- `Gain` value
- `OnGainAdjusted` action

### Summary

- Any time we add a channel to `BassStemMixer`, we also call `AddStream` on the `BassNormalizer`
- Once stems are added, the normalizer will begin async processing the input streams to calculate a gain factor
- The gain factor is then applied to the playback mixer to normalize the audio

## How It Works


The processing is done in chunks. Each time we add a stream to the normalizer:
* The input stream is first copied to memory
  * We need to do this because otherwise we would have a parallel disk read in the file, which makes both operations slower (at least on HDD)
  * On my machine (a relatively beefy PC) with songs on HDD, the memory copy takes anywhere from 1-100ms.  Most of the time caching the stream happened in 1ms, even on HDD.  I believe this is because of OS level cache warmup.  It would be worth testing to see how this performs on a USB thumb drive or similarly slow device for example.
* The normalizer adds the stream to an internal mixer and starts RMS calculation
  * Each time a new channel is added the RMS calc restarts
* The mixer output is processed in chunks
  * For each chunk, we calculate RMS value by using `Bass.ChannelGetLevel()` which is faster than doing it manually
    * A bit about the math: Since we are processing in chunks, we need to take the RMS value of the chunk, square it, then multiply by the number of samples in the chunk.  This gives us just the sum of squares.   To get the actual RMS value of all audio up to this point we accumulate the total sum of squares and divide by the total samples processed, then square root.  Even with the extra multiplications and sqrt call, using the built in `Bass.ChannelGetLevel()` is still much faster than manually calculating.
    * This means we don't have to wait for the entire song to be processed before we can start normalizing, as processing the entire song can typically take 1000 ms or more.  We can obtain "good enough" RMS values usually within the first 10% of the file being processed.  On my machine this happens in like 50-100 ms.
* We implement a max gain factor to prevent very high gain values when we first start processing the stream.  If a song has a long introduction that is very quiet, then the first chunks will report high gain factors.  So we cap it.
* The target gain factor is intended to normalize songs to about -14 LUFS, based on my testing, which is industry standard normalization levels for streaming services apparently.
* We use relative updates to avoid rapid changes in gain

### Memory usage

Actual memory usage might increase anywhere from 50-200 MB typically.  This is based on the size of the files being loaded into memory.  Some CON files can be quite large.

If normalization is turned off, we will no longer be doing the memory copy. So it is important to note the memory and compute requirements of this feature.

## Demonstration

Testing was done with [MiniMeters](https://minimeters.app/)

### Normalization Off
https://github.com/user-attachments/assets/20bf42b2-8c2e-4f04-b7df-9efc140689e1

### Normalization On
https://github.com/user-attachments/assets/48b85e27-cf21-42a8-abf2-eb77f28d96d6



### Settings Screenshot
<img width="1382" height="966" alt="image" src="https://github.com/user-attachments/assets/cab5f0d3-1160-4208-b53a-19b4f2989d98" />

