### PR TITLE
Fix mono stems coming out of one channel

### DIFF
--- a/Assets/Script/Audio/Bass/BassStemMixer.cs
+++ b/Assets/Script/Audio/Bass/BassStemMixer.cs
@@ -224,14 +224,17 @@ namespace YARG.Audio.BASS
                     return false;
                 }
 
-                if (!BassMix.MixerAddChannel(_mixerHandle, streamHandles.Stream, BassFlags.MixerChanMatrix) ||
-                    !BassMix.MixerAddChannel(_mixerHandle, reverbHandles.Stream, BassFlags.MixerChanMatrix))
+                var isMultiChannel = indices != null && panning != null;
+                var flags = isMultiChannel ? BassFlags.MixerChanMatrix : BassFlags.Default;
+
+                if (!BassMix.MixerAddChannel(_mixerHandle, streamHandles.Stream, flags) ||
+                    !BassMix.MixerAddChannel(_mixerHandle, reverbHandles.Stream, flags))
                 {
                     YargLogger.LogFormatError("Failed to add channel {0} to mixer: {1}!", stem, Bass.LastError);
                     return false;
                 }
 
-                if (indices != null && panning != null)
+                if (isMultiChannel)
                 {
                     // First array = left pan, second = right pan
                     float[,] volumeMatrix = new float[2, indices.Length];


### PR DESCRIPTION
I broke this here https://github.com/YARC-Official/YARG/pull/1140

Turns out the using `MixerChanMatrix` with no matrix specified does not do the same thing as default behavior.  I was confidently incorrect about that.

Fix is to only use the flag if we have multichannel audio

An alternative way to fix is to always specify a matrix so we explicitly say how to route mono audio between L/R but for now this works, and is consistent with previous behavior.  Default behavior seems to map 1.0,1.0 from mono -> stereo

Some day I will push a pr without breaking something else 