### PR TITLE
Added setting to choose how to display Discord rich presence

### DIFF
--- a/Assets/Script/Integration/DiscordController.cs
+++ b/Assets/Script/Integration/DiscordController.cs
@@ -37,6 +37,7 @@ namespace YARG.Integration
         private const string LARGE_ICON_KEY = "icon_stable";
 #endif
 
+        private bool _initialized = false;
         private Discord.Discord _discord;
 
         // Keep track of this in case we want to update the value asynchronously
@@ -53,6 +54,19 @@ namespace YARG.Integration
 
         public void Initialize()
         {
+            _initialized = true;
+
+            CreateInstance();
+        }
+
+        public void CreateInstance()
+        {
+            // Skip if loading screen hasn't finished loading localization (localization is required for rich presence to function normally)
+            if (!_initialized)
+            {
+                return;
+            }
+
             // Don't create instance if Discord rich presence is turned off in settings
             if (SettingsManager.Settings.DiscordRichPresence.Value == DiscordRichPresenceMode.Hide)
             {
@@ -65,11 +79,6 @@ namespace YARG.Integration
                 return;
             }
 
-            CreateInstance();
-        }
-
-        private void CreateInstance()
-        {
             try
             {
                 _discord = new Discord.Discord(APPLICATION_ID, (ulong) CreateFlags.NoRequireDiscord);

--- a/Assets/Script/Integration/DiscordController.cs
+++ b/Assets/Script/Integration/DiscordController.cs
@@ -53,24 +53,23 @@ namespace YARG.Integration
 
         public void Initialize()
         {
-            // Listen to the changing of states
-            GameStateFetcher.GameStateChange += OnGameStateChange;
-
-            // Create the Discord instance if Discord rich presence is turned on
-            if (SettingsManager.Settings.DiscordRichPresence.Value != DiscordRichPresenceMode.Hide)
+            // Don't create instance if Discord rich presence is turned off in settings
+            if (SettingsManager.Settings.DiscordRichPresence.Value == DiscordRichPresenceMode.Hide)
             {
-                CreateInstance();
+                return;
             }
-        }
 
-        private void CreateInstance()
-        {
             // Don't create new instance if instance already exists
             if (_discord is not null)
             {
                 return;
             }
 
+            CreateInstance();
+        }
+
+        private void CreateInstance()
+        {
             try
             {
                 _discord = new Discord.Discord(APPLICATION_ID, (ulong) CreateFlags.NoRequireDiscord);
@@ -82,6 +81,9 @@ namespace YARG.Integration
                 _discord = null;
                 return;
             }
+
+            // Listen to the changing of states
+            GameStateFetcher.GameStateChange += OnGameStateChange;
 
             // Get the start time of the game (Discord requires it in this format)
             _gameStartTime = DateTimeOffset.Now.ToUnixTimeMilliseconds();
@@ -265,6 +267,8 @@ namespace YARG.Integration
 
             try
             {
+                GameStateFetcher.GameStateChange -= OnGameStateChange;
+
                 _discord.GetActivityManager().ClearActivity(_ => { });
                 _discord.Dispose();
                 _discord = null;

--- a/Assets/Script/Settings/SettingsManager.Settings.cs
+++ b/Assets/Script/Settings/SettingsManager.Settings.cs
@@ -98,6 +98,15 @@ namespace YARG.Settings
             public ToggleSetting PauseOnFocusLoss { get; } = new(true);
 
             public ToggleSetting WrapAroundNavigation { get; } = new(true);
+
+            public DropdownSetting<DiscordRichPresenceMode> DiscordRichPresence { get; }
+                = new(DiscordRichPresenceMode.Show, DiscordRichPresenceCallback)
+                {
+                    DiscordRichPresenceMode.Show,
+                    DiscordRichPresenceMode.Limited,
+                    DiscordRichPresenceMode.Hide
+                };
+
             public ToggleSetting AmIAwesome { get; } = new(false);
 
             #endregion
@@ -462,6 +471,19 @@ namespace YARG.Settings
             private static void SetLogLevelCallback(LogLevel level)
             {
                 YargLogger.MinimumLogLevel = level;
+            }
+
+            private static void DiscordRichPresenceCallback(DiscordRichPresenceMode mode)
+            {
+                // Dispose Discord instance if rich presence is turned off, otherwise try initializing it again
+                if (mode == DiscordRichPresenceMode.Hide)
+                {
+                    DiscordController.Instance.TryDispose();
+                }
+                else
+                {
+                    DiscordController.Instance.Initialize();
+                }
             }
 
             private static void ShowBatteryCallback(bool value)

--- a/Assets/Script/Settings/SettingsManager.Settings.cs
+++ b/Assets/Script/Settings/SettingsManager.Settings.cs
@@ -12,6 +12,7 @@ using YARG.Integration;
 using YARG.Integration.RB3E;
 using YARG.Integration.Sacn;
 using YARG.Integration.StageKit;
+using YARG.Localization;
 using YARG.Menu;
 using YARG.Menu.MusicLibrary;
 using YARG.Menu.Persistent;
@@ -482,7 +483,7 @@ namespace YARG.Settings
                 }
                 else
                 {
-                    DiscordController.Instance.Initialize();
+                    DiscordController.Instance.CreateInstance();
                 }
             }
 

--- a/Assets/Script/Settings/SettingsManager.cs
+++ b/Assets/Script/Settings/SettingsManager.cs
@@ -65,6 +65,7 @@ namespace YARG.Settings
                 nameof(Settings.PauseOnDeviceDisconnect),
                 nameof(Settings.PauseOnFocusLoss),
                 nameof(Settings.WrapAroundNavigation),
+                nameof(Settings.DiscordRichPresence),
                 nameof(Settings.AmIAwesome),
             },
             new SongManagerTab("SongManager", icon: "Songs")

--- a/Assets/StreamingAssets/lang/en-US.json
+++ b/Assets/StreamingAssets/lang/en-US.json
@@ -817,6 +817,15 @@
                 "Name": "Disable Text Notifications",
                 "Description": "Disables text notification on the track such as \"100-Note Streak\" and \"Full Combo.\""
             },
+            "DiscordRichPresence": {
+                "Name": "Discord Rich Presence",
+                "Description": "Choose how YARG shows on your activity status on Discord.",
+                "Dropdown": {
+                    "Show": "Show all details",
+                    "Limited": "Show without the currently playing song",
+                    "Hide": "Hide"
+                }
+            },
             "DMXBlueChannels": {
                 "Name": "DMX Blue",
                 "Description": "The eight channels here represent the eight blue LEDs of the StageKit. They will receive on (255) and off (0) commands."
@@ -1073,10 +1082,10 @@
                     "Reduced": "Reduced"
                 }
             },
-			"SongBackgroundOpacity": {
-				"Name": "Song Background Opacity",
-				"Description": "Adjusts the opacity of background during gameplay."
-			},
+            "SongBackgroundOpacity": {
+                "Name": "Song Background Opacity",
+                "Description": "Adjusts the opacity of background during gameplay."
+            },
             "UseChipmunkSpeed": {
                 "Name": "Chipmunk Speed",
                 "Description": "Disables pitch correction when playing songs at a fast or slow speed which may lead to some... interesting results."
@@ -1138,10 +1147,10 @@
                 "PauseName": "Vocals",
                 "Description": "Adjusts the song's vocal track volume. Only does something if the song is multi-track."
             },
-            "VoiceActivatedVocalStarPower" : {
-				"Name": "Voice Activated Star Power (Vocals)",
-				"Description": "If enabled, vocalists can activate their Star Power by making a noise. Keybinds can be used instead, regardless of this setting."
-			},
+            "VoiceActivatedVocalStarPower": {
+                "Name": "Voice Activated Star Power (Vocals)",
+                "Description": "If enabled, vocalists can activate their Star Power by making a noise. Keybinds can be used instead, regardless of this setting."
+            },
             "VSync": {
                 "Name": "Enable VSync",
                 "Description": "Enables VSync. VSync caps the framerate at your monitor's maximum framerate, and prevents tearing."

--- a/Assets/StreamingAssets/lang/es-ES.json
+++ b/Assets/StreamingAssets/lang/es-ES.json
@@ -1,4 +1,4 @@
-{
+﻿{
     "Language": {
         "Name": "English",
         "Region": "United States",
@@ -546,6 +546,15 @@
             "DisableTextNotifications": {
                 "Name": "Disable Text Notifications",
                 "Description": "Disables text notification on the track such as \"100-Note Streak\" and \"Full Combo.\""
+            },
+            "DiscordRichPresence": {
+                "Name": "Discord Rich Presence",
+                "Description": "Choose how YARG shows on your activity status on Discord.",
+                "Dropdown": {
+                    "Show": "Show all details",
+                    "Limited": "Show without the currently playing song",
+                    "Hide": "Hide"
+                }
             },
             "DMXBlueChannels": {
                 "Name": "DMX Blue",

--- a/Assets/StreamingAssets/lang/ja-JP.json
+++ b/Assets/StreamingAssets/lang/ja-JP.json
@@ -1,4 +1,4 @@
-{
+﻿{
     "Language": {
         "Name": "English",
         "Region": "United States",
@@ -546,6 +546,15 @@
             "DisableTextNotifications": {
                 "Name": "Disable Text Notifications",
                 "Description": "Disables text notification on the track such as \"100-Note Streak\" and \"Full Combo.\""
+            },
+            "DiscordRichPresence": {
+                "Name": "Discord Rich Presence",
+                "Description": "Choose how YARG shows on your activity status on Discord.",
+                "Dropdown": {
+                    "Show": "Show all details",
+                    "Limited": "Show without the currently playing song",
+                    "Hide": "Hide"
+                }
             },
             "DMXBlueChannels": {
                 "Name": "DMX Blue",

--- a/Assets/StreamingAssets/lang/pt-BR.json
+++ b/Assets/StreamingAssets/lang/pt-BR.json
@@ -1,4 +1,4 @@
-{
+﻿{
     "Language": {
         "Name": "English",
         "Region": "United States",
@@ -542,6 +542,15 @@
             "DisableTextNotifications": {
                 "Name": "Disable Text Notifications",
                 "Description": "Disables text notification on the track such as \"100-Note Streak\" and \"Full Combo.\""
+            },
+            "DiscordRichPresence": {
+                "Name": "Discord Rich Presence",
+                "Description": "Choose how YARG shows on your activity status on Discord.",
+                "Dropdown": {
+                    "Show": "Show all details",
+                    "Limited": "Show without the currently playing song",
+                    "Hide": "Hide"
+                }
             },
             "DMXBlueChannels": {
                 "Name": "DMX Blue",

--- a/Assets/StreamingAssets/lang/pt-PT.json
+++ b/Assets/StreamingAssets/lang/pt-PT.json
@@ -1,4 +1,4 @@
-{
+﻿{
     "Language": {
         "Name": "English",
         "Region": "United States",
@@ -546,6 +546,15 @@
             "DisableTextNotifications": {
                 "Name": "Disable Text Notifications",
                 "Description": "Disables text notification on the track such as \"100-Note Streak\" and \"Full Combo.\""
+            },
+            "DiscordRichPresence": {
+                "Name": "Discord Rich Presence",
+                "Description": "Choose how YARG shows on your activity status on Discord.",
+                "Dropdown": {
+                    "Show": "Show all details",
+                    "Limited": "Show without the currently playing song",
+                    "Hide": "Hide"
+                }
             },
             "DMXBlueChannels": {
                 "Name": "DMX Blue",


### PR DESCRIPTION
This PR adds a new setting: **Discord Rich Presence**. It adjusts how YARG shows on your current activity on Discord, also known as rich presence.

The setting has 3 options:

- **Show all details** (default)
  - The normal functionality. It remains unchanged to how it was before this PR.
- **Show without the currently playing song**
  - Still shows the activity on discord, but not the song you are currently playing. Instead it'll show the default activity by calling `SetDefaultActivity()` in `DiscordController`.
- **Hide**
  - Completely hides the activity on discord and also disposes the discord instance in YARG by calling `TryDispose()` in `DiscordController`.

<img width="609" height="133" alt="image" src="https://github.com/user-attachments/assets/25412bbb-65d0-44db-a82f-6caf48e94e0b" />

Let me know if anything needs changing. This is my first PR.