### PR TITLE
Add Expand / Collapse functionality to headers in Music Library

### DIFF
--- a/Assets/Art/Menu/MusicLibrary/MusicLibraryIcons.png
+++ b/Assets/Art/Menu/MusicLibrary/MusicLibraryIcons.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d689a1103ed1c772050aa7b54f6533b274acba81fa15f365d14c158fe75ffd92
-size 2600
+oid sha256:82675a8033e7f21ff695859ccab3e056564e75b806c5b1ce6ef9d6fd2550570f
+size 4002

--- a/Assets/Art/Menu/MusicLibrary/MusicLibraryIcons.png.meta
+++ b/Assets/Art/Menu/MusicLibrary/MusicLibraryIcons.png.meta
@@ -3,7 +3,7 @@ guid: 6947e69a25ccfa049a22215a785e9f8a
 TextureImporter:
   internalIDToNameTable: []
   externalObjects: {}
-  serializedVersion: 12
+  serializedVersion: 13
   mipmaps:
     mipMapMode: 0
     enableMipMap: 0
@@ -20,11 +20,12 @@ TextureImporter:
     externalNormalMap: 0
     heightScale: 0.25
     normalMapFilter: 0
+    flipGreenChannel: 0
   isReadable: 0
   streamingMipmaps: 0
   streamingMipmapsPriority: 0
   vTOnly: 0
-  ignoreMasterTextureLimit: 0
+  ignoreMipmapLimit: 0
   grayScaleToAlpha: 0
   generateCubemap: 6
   cubemapConvolution: 0
@@ -63,6 +64,7 @@ TextureImporter:
   textureFormatSet: 0
   ignorePngGamma: 0
   applyGammaDecoding: 0
+  swizzle: 50462976
   cookieLightType: 0
   platformSettings:
   - serializedVersion: 3
@@ -75,6 +77,7 @@ TextureImporter:
     crunchedCompression: 0
     allowsAlphaSplitting: 0
     overridden: 0
+    ignorePlatformSupport: 0
     androidETC2FallbackOverride: 0
     forceMaximumCompressionQuality_BC6H_BC7: 0
   - serializedVersion: 3
@@ -87,6 +90,7 @@ TextureImporter:
     crunchedCompression: 0
     allowsAlphaSplitting: 0
     overridden: 0
+    ignorePlatformSupport: 0
     androidETC2FallbackOverride: 0
     forceMaximumCompressionQuality_BC6H_BC7: 0
   - serializedVersion: 3
@@ -99,6 +103,7 @@ TextureImporter:
     crunchedCompression: 0
     allowsAlphaSplitting: 0
     overridden: 0
+    ignorePlatformSupport: 0
     androidETC2FallbackOverride: 0
     forceMaximumCompressionQuality_BC6H_BC7: 0
   spriteSheet:
@@ -109,11 +114,11 @@ TextureImporter:
       rect:
         serializedVersion: 2
         x: 0
-        y: 64
+        y: 192
         width: 64
         height: 64
       alignment: 0
-      pivot: {x: 0, y: 0}
+      pivot: {x: 0.5, y: 0.5}
       border: {x: 0, y: 0, z: 0, w: 0}
       outline: []
       physicsShape: []
@@ -122,7 +127,7 @@ TextureImporter:
       spriteID: 728f821f6fa34c6448eb3160c6daba5c
       internalID: -258697563
       vertices: []
-      indices: 
+      indices:
       edges: []
       weights: []
     - serializedVersion: 2
@@ -130,6 +135,69 @@ TextureImporter:
       rect:
         serializedVersion: 2
         x: 64
+        y: 192
+        width: 64
+        height: 64
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: 3768118b24cf6b641a29cdef42f10613
+      internalID: 1787899732
+      vertices: []
+      indices:
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Down
+      rect:
+        serializedVersion: 2
+        x: 0
+        y: 128
+        width: 64
+        height: 64
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: a2fba8611b44b9942ad876cc3c402a36
+      internalID: 1494863122
+      vertices: []
+      indices:
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Back
+      rect:
+        serializedVersion: 2
+        x: 64
+        y: 128
+        width: 64
+        height: 64
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: a52d2e6606e11d44184449da481ba538
+      internalID: -812612277
+      vertices: []
+      indices:
+      edges: []
+      weights: []
+    - serializedVersion: 2
+      name: Right
+      rect:
+        serializedVersion: 2
+        x: 0
         y: 64
         width: 64
         height: 64
@@ -140,52 +208,10 @@ TextureImporter:
       physicsShape: []
       tessellationDetail: 0
       bones: []
-      spriteID: 3768118b24cf6b641a29cdef42f10613
-      internalID: 1787899732
+      spriteID: 2b625daf2e6c418409a6c59873d16b2f
+      internalID: 1389926479
       vertices: []
-      indices: 
-      edges: []
-      weights: []
-    - serializedVersion: 2
-      name: Down
-      rect:
-        serializedVersion: 2
-        x: 0
-        y: 0
-        width: 64
-        height: 64
-      alignment: 0
-      pivot: {x: 0, y: 0}
-      border: {x: 0, y: 0, z: 0, w: 0}
-      outline: []
-      physicsShape: []
-      tessellationDetail: 0
-      bones: []
-      spriteID: a2fba8611b44b9942ad876cc3c402a36
-      internalID: 1494863122
-      vertices: []
-      indices: 
-      edges: []
-      weights: []
-    - serializedVersion: 2
-      name: Back
-      rect:
-        serializedVersion: 2
-        x: 64
-        y: 0
-        width: 64
-        height: 64
-      alignment: 0
-      pivot: {x: 0, y: 0}
-      border: {x: 0, y: 0, z: 0, w: 0}
-      outline: []
-      physicsShape: []
-      tessellationDetail: 0
-      bones: []
-      spriteID: a52d2e6606e11d44184449da481ba538
-      internalID: -812612277
-      vertices: []
-      indices: 
+      indices:
       edges: []
       weights: []
     outline: []
@@ -194,7 +220,7 @@ TextureImporter:
     spriteID: 5e97eb03825dee720800000000000000
     internalID: 0
     vertices: []
-    indices: 
+    indices:
     edges: []
     weights: []
     secondaryTextures: []
@@ -203,9 +229,9 @@ TextureImporter:
       Down: 1494863122
       Playlists: 1787899732
       Random: -258697563
-  spritePackingTag: 
+      Right: 1389926479
+  mipmapLimitGroupName:
   pSDRemoveMatte: 0
-  pSDShowRemoveMatteOption: 0
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
+++ b/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
@@ -491,7 +491,7 @@ namespace YARG.Menu.MusicLibrary
             bool showSortHeaders = _sortedSongs.Length > 1 ||
                 YARG.Menu.Filters.FiltersMenu.ActiveFilterPredicate != null;
 
-            foreach (var section in _sortedSongs)
+            foreach (var (section, index) in _sortedSongs.Select((s, i) => (s, i)))
             {
                 var displayName = section.Category;
                 if (SettingsManager.Settings.LibrarySort == SortAttribute.Source)
@@ -513,20 +513,50 @@ namespace YARG.Menu.MusicLibrary
                 SortHeaderViewType sortHeader = null;
                 if (showSortHeaders)
                 {
-                    sortHeader = new SortHeaderViewType(displayName, section.Songs.Length, section.CategoryGroup, section.Songs);
+                    Action onHeaderClicked = null;
+                    if (_sortedSongs.Length > 1)
+                    {
+                        onHeaderClicked = () =>
+                        {
+                            var category = _sortedSongs[index];
+                            _sortedSongs[index] = new SongCategory(
+                                category.Category,
+                                category.Songs,
+                                category.CategoryGroup,
+                                !category.Collapsed
+                            );
+
+                            RequestViewListUpdate();
+                        };
+                    }
+
+                    sortHeader = new SortHeaderViewType(
+                        displayName,
+                        section.Songs.Length,
+                        section.CategoryGroup,
+                        section.Songs,
+                        onHeaderClicked);
                     list.Add(sortHeader);
                 }
 
                 int sectionTotalStars = 0;
-                foreach (var song in section.Songs)
+                if (_sortedSongs.Length <= 1 || !section.Collapsed)
                 {
-                    if (allowdupes || !song.IsDuplicate)
+                    foreach (var song in section.Songs)
                     {
+                        if (!allowdupes && song.IsDuplicate)
+                        {
+                            continue;
+                        }
+
                         var songView = new SongViewType(this, song);
                         list.Add(songView);
 
-                        var starAmount = songView?.GetStarAmount();
-                        sectionTotalStars += starAmount is null ? 0 : StarAmountHelper.GetStarCount(starAmount.Value);
+                        var starAmount = songView.GetStarAmount();
+                        if (starAmount is not null)
+                        {
+                            sectionTotalStars += StarAmountHelper.GetStarCount(starAmount.Value);
+                        }
                     }
                 }
                 _totalStarCount += sectionTotalStars;

--- a/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
+++ b/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
@@ -519,19 +519,19 @@ namespace YARG.Menu.MusicLibrary
                         onHeaderClicked = () =>
                         {
                             var category = _sortedSongs[index];
-                            var isNowCollapsed = !category.Collapsed;
                             _sortedSongs[index] = new SongCategory(
                                 category.Category,
                                 category.Songs,
                                 category.CategoryGroup,
-                                isNowCollapsed
+                                !category.Collapsed
                             );
 
                             var (headerIndex, offset) = GetClosestHeaderIndexAndOffset();
                             RequestViewListUpdate();
-                            if (isNowCollapsed && ViewList[_sectionHeaderIndices[headerIndex]] is SortHeaderViewType)
+                            var closestHeader = ViewList[_sectionHeaderIndices[headerIndex]];
+                            if (closestHeader is SortHeaderViewType closestSortHeader && closestSortHeader.Collapsed)
                             {
-                                // If we are in the section that is collapsing, return to the section header.
+                                // If the current section is collapsed, return to its header.
                                 offset = 0;
                             }
                             SelectedIndex = _sectionHeaderIndices[headerIndex] + offset;
@@ -971,6 +971,41 @@ namespace YARG.Menu.MusicLibrary
             } while (CurrentSelection is not SongViewType);
         }
 
+        public void ExpandAll()
+        {
+            var (headerIndex, offset) = GetClosestHeaderIndexAndOffset();
+            _sortedSongs = _sortedSongs
+                .Select(cat => new SongCategory(cat.Category, cat.Songs, cat.CategoryGroup, false))
+                .ToArray();
+            RequestViewListUpdate();
+            SelectedIndex = _sectionHeaderIndices[headerIndex] + offset;
+        }
+
+        public void CollapseAll()
+        {
+            var (headerIndex, offset) = GetClosestHeaderIndexAndOffset();
+            _sortedSongs = _sortedSongs
+                .Select(cat => new SongCategory(cat.Category, cat.Songs, cat.CategoryGroup, true))
+                .ToArray();
+            RequestViewListUpdate();
+            var closestHeader = ViewList[_sectionHeaderIndices[headerIndex]];
+            if (closestHeader is SortHeaderViewType sortHeader && sortHeader.Collapsed)
+            {
+                offset = 0;
+            }
+            SelectedIndex = _sectionHeaderIndices[headerIndex] + offset;
+        }
+
+        private (int headerIndex, int offset) GetClosestHeaderIndexAndOffset()
+        {
+            var closestHeader = _sectionHeaderIndices
+                .Where(x => x <= SelectedIndex)
+                .OrderByDescending(x => x)
+                .First();
+            var headerIndex = _sectionHeaderIndices.IndexOf(closestHeader);
+            var offset = SelectedIndex - _sectionHeaderIndices[headerIndex];
+            return (headerIndex, offset);
+        }
         public void RefreshAndReselect()
         {
             int index = SelectedIndex;

--- a/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
+++ b/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
@@ -526,7 +526,9 @@ namespace YARG.Menu.MusicLibrary
                                 !category.Collapsed
                             );
 
+                            var (headerIndex, offset) = GetClosestHeaderIndexAndOffset();
                             RequestViewListUpdate();
+                            SelectedIndex = _sectionHeaderIndices[headerIndex] + offset;
                         };
                     }
 

--- a/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
+++ b/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
@@ -519,15 +519,21 @@ namespace YARG.Menu.MusicLibrary
                         onHeaderClicked = () =>
                         {
                             var category = _sortedSongs[index];
+                            var isNowCollapsed = !category.Collapsed;
                             _sortedSongs[index] = new SongCategory(
                                 category.Category,
                                 category.Songs,
                                 category.CategoryGroup,
-                                !category.Collapsed
+                                isNowCollapsed
                             );
 
                             var (headerIndex, offset) = GetClosestHeaderIndexAndOffset();
                             RequestViewListUpdate();
+                            if (isNowCollapsed && ViewList[_sectionHeaderIndices[headerIndex]] is SortHeaderViewType)
+                            {
+                                // If we are in the section that is collapsing, return to the section header.
+                                offset = 0;
+                            }
                             SelectedIndex = _sectionHeaderIndices[headerIndex] + offset;
                         };
                     }
@@ -594,7 +600,7 @@ namespace YARG.Menu.MusicLibrary
             for (int i = 0; i < list.Count; i++)
             {
                 var entry = list[i];
-                if (entry is CategoryViewType)
+                if (entry is CategoryViewType or ButtonViewType)
                 {
                     _sectionHeaderIndices.Add(i);
                 }

--- a/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
+++ b/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
@@ -535,6 +535,7 @@ namespace YARG.Menu.MusicLibrary
                         section.Songs.Length,
                         section.CategoryGroup,
                         section.Songs,
+                        section.Collapsed,
                         onHeaderClicked);
                     list.Add(sortHeader);
                 }

--- a/Assets/Script/Menu/MusicLibrary/PopupMenu.cs
+++ b/Assets/Script/Menu/MusicLibrary/PopupMenu.cs
@@ -138,6 +138,19 @@ namespace YARG.Menu.MusicLibrary
                 });
             }
 
+            // Expand/Collapse All options
+            CreateItem("ExpandAll", () =>
+            {
+                _musicLibrary.ExpandAll();
+                gameObject.SetActive(false);
+            });
+
+            CreateItem("CollapseAll", () =>
+            {
+                _musicLibrary.CollapseAll();
+                gameObject.SetActive(false);
+            });
+
             var viewType = _musicLibrary.CurrentSelection;
 
             // Add/remove to favorites

--- a/Assets/Script/Menu/MusicLibrary/PopupMenu.cs
+++ b/Assets/Script/Menu/MusicLibrary/PopupMenu.cs
@@ -138,7 +138,6 @@ namespace YARG.Menu.MusicLibrary
                 });
             }
 
-            // Expand/Collapse All options
             CreateItem("ExpandAll", () =>
             {
                 _musicLibrary.ExpandAll();

--- a/Assets/Script/Menu/MusicLibrary/ViewTypes/SortHeaderViewType.cs
+++ b/Assets/Script/Menu/MusicLibrary/ViewTypes/SortHeaderViewType.cs
@@ -22,7 +22,7 @@ namespace YARG.Menu.MusicLibrary
         public readonly  string GenreCountText;
         private readonly int    _songCount;
         public           int    TotalStarsCount { get; set; }
-        private readonly bool   _collapsed;
+        public readonly  bool   Collapsed;
         private readonly Action _onClicked;
 
         private static readonly HashSet<string> SourceCounter  = new();
@@ -35,7 +35,7 @@ namespace YARG.Menu.MusicLibrary
             HeaderText = headerText;
             _songCount = songCount;
             ShortcutName = shortcutName;
-            _collapsed = collapsed;
+            Collapsed = collapsed;
             _onClicked = onClicked;
 
             foreach (var song in songsUnderCategory)
@@ -90,7 +90,7 @@ namespace YARG.Menu.MusicLibrary
         public override Sprite? GetIcon()
 #nullable disable
         {
-            string assetKey = _collapsed ? "MusicLibraryIcons[Right]" : "MusicLibraryIcons[Down]";
+            string assetKey = Collapsed ? "MusicLibraryIcons[Right]" : "MusicLibraryIcons[Down]";
             return Addressables.LoadAssetAsync<Sprite>(assetKey).WaitForCompletion();
         }
 

--- a/Assets/Script/Menu/MusicLibrary/ViewTypes/SortHeaderViewType.cs
+++ b/Assets/Script/Menu/MusicLibrary/ViewTypes/SortHeaderViewType.cs
@@ -22,6 +22,7 @@ namespace YARG.Menu.MusicLibrary
         public readonly  string GenreCountText;
         private readonly int    _songCount;
         public           int    TotalStarsCount { get; set; }
+        private readonly bool   _collapsed;
         private readonly Action _onClicked;
 
         private static readonly HashSet<string> SourceCounter  = new();
@@ -29,11 +30,12 @@ namespace YARG.Menu.MusicLibrary
         private static readonly HashSet<string> GenreCounter   = new();
 
         public SortHeaderViewType(string headerText, int songCount, string shortcutName, SongEntry[] songsUnderCategory,
-            Action onClicked = null)
+            bool collapsed = false, Action onClicked = null)
         {
             HeaderText = headerText;
             _songCount = songCount;
             ShortcutName = shortcutName;
+            _collapsed = collapsed;
             _onClicked = onClicked;
 
             foreach (var song in songsUnderCategory)
@@ -88,7 +90,8 @@ namespace YARG.Menu.MusicLibrary
         public override Sprite? GetIcon()
 #nullable disable
         {
-            return Addressables.LoadAssetAsync<Sprite>("MusicLibraryUpIcon").WaitForCompletion();
+            string assetKey = _collapsed ? "MusicLibraryIcons[Right]" : "MusicLibraryIcons[Down]";
+            return Addressables.LoadAssetAsync<Sprite>(assetKey).WaitForCompletion();
         }
 
         public override void PrimaryButtonClick()

--- a/Assets/Script/Menu/MusicLibrary/ViewTypes/SortHeaderViewType.cs
+++ b/Assets/Script/Menu/MusicLibrary/ViewTypes/SortHeaderViewType.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Cysharp.Text;
 using UnityEngine;
 using UnityEngine.AddressableAssets;
@@ -21,17 +22,19 @@ namespace YARG.Menu.MusicLibrary
         public readonly  string GenreCountText;
         private readonly int    _songCount;
         public           int    TotalStarsCount { get; set; }
+        private readonly Action _onClicked;
 
         private static readonly HashSet<string> SourceCounter  = new();
         private static readonly HashSet<string> CharterCounter = new();
         private static readonly HashSet<string> GenreCounter   = new();
 
-        public SortHeaderViewType(string headerText, int songCount, string shortcutName, SongEntry[] songsUnderCategory)
+        public SortHeaderViewType(string headerText, int songCount, string shortcutName, SongEntry[] songsUnderCategory,
+            Action onClicked = null)
         {
             HeaderText = headerText;
             _songCount = songCount;
-
             ShortcutName = shortcutName;
+            _onClicked = onClicked;
 
             foreach (var song in songsUnderCategory)
             {
@@ -86,6 +89,11 @@ namespace YARG.Menu.MusicLibrary
 #nullable disable
         {
             return Addressables.LoadAssetAsync<Sprite>("MusicLibraryUpIcon").WaitForCompletion();
+        }
+
+        public override void PrimaryButtonClick()
+        {
+            _onClicked?.Invoke();
         }
     }
 }

--- a/Assets/Script/Song/SongContainer.cs
+++ b/Assets/Script/Song/SongContainer.cs
@@ -65,12 +65,14 @@ namespace YARG.Song
         public string      Category      { get; }
         public string      CategoryGroup { get; }
         public SongEntry[] Songs         { get; }
+        public bool Collapsed { get; }
 
-        public SongCategory(string category, SongEntry[] songs, string categoryGroupName)
+        public SongCategory(string category, SongEntry[] songs, string categoryGroupName, bool collapsed = false)
         {
             Category = category;
             Songs = songs;
             CategoryGroup = categoryGroupName;
+            Collapsed = collapsed;
         }
 
         public void Deconstruct(out string category, out SongEntry[] songs)

--- a/Assets/StreamingAssets/lang/en-US.json
+++ b/Assets/StreamingAssets/lang/en-US.json
@@ -323,7 +323,9 @@
                     "CreateNewPlaylist": "Create New...",
                     "RemovePlaylist": "Remove Playlist",
                     "ViewSongFolder": "View Song Folder",
-                    "CopySongChecksum": "Copy Song Checksum"
+                    "CopySongChecksum": "Copy Song Checksum",
+                    "CollapseAll": "Collapse All",
+                    "ExpandAll": "Expand All"
                 }
             },
             "Back": "BACK",

--- a/Assets/StreamingAssets/lang/es-ES.json
+++ b/Assets/StreamingAssets/lang/es-ES.json
@@ -308,7 +308,9 @@
                     "CreateNewPlaylist": "Crear Nueva...",
                     "RemovePlaylist": "Eliminar Lista",
                     "ViewSongFolder": "Ver Carpeta de Canciones",
-                    "CopySongChecksum": "Copiar Checksum de Canciones"
+                    "CopySongChecksum": "Copiar Checksum de Canciones",
+                    "CollapseAll": "Colapsar todo",
+                    "ExpandAll": "Expandir todo"
                 }
             },
             "Back": "VOLVER",

--- a/Assets/StreamingAssets/lang/ja-JP.json
+++ b/Assets/StreamingAssets/lang/ja-JP.json
@@ -308,7 +308,9 @@
                     "CreateNewPlaylist": "新しい作成",
                     "RemovePlaylist": "プレイリストを削除",
                     "ViewSongFolder": "曲歌フォルダを見る",
-                    "CopySongChecksum": "曲のチェックサムをコピー"
+                    "CopySongChecksum": "曲のチェックサムをコピー",
+                    "CollapseAll": "すべて折りたたむ",
+                    "ExpandAll": "すべて展開"
                 }
             },
             "Back": "戻る",

--- a/Assets/StreamingAssets/lang/pt-BR.json
+++ b/Assets/StreamingAssets/lang/pt-BR.json
@@ -308,7 +308,9 @@
                     "CreateNewPlaylist": "Criar nova...",
                     "RemovePlaylist": "Remover playlist",
                     "ViewSongFolder": "Ver pasta da música",
-                    "CopySongChecksum": "Copiar código da música"
+                    "CopySongChecksum": "Copiar código da música",
+                    "CollapseAll": "Recolher tudo",
+                    "ExpandAll": "Expandir tudo"
                 }
             },
             "Back": "VOLTAR",

--- a/Assets/StreamingAssets/lang/pt-PT.json
+++ b/Assets/StreamingAssets/lang/pt-PT.json
@@ -308,7 +308,9 @@
                     "CreateNewPlaylist": "Create New...",
                     "RemovePlaylist": "Remove Playlist",
                     "ViewSongFolder": "View Song Folder",
-                    "CopySongChecksum": "Copy Song Checksum"
+                    "CopySongChecksum": "Copy Song Checksum",
+                    "CollapseAll": "Collapse All",
+                    "ExpandAll": "Expand All"
                 }
             },
             "Back": "BACK",


### PR DESCRIPTION
This adds expand and collapse functionality to headers.  

This builds off of previous work by @prgmatic here https://github.com/YARC-Official/YARG/pull/1062

Demonstration:

https://github.com/user-attachments/assets/5008b876-fa68-4d08-a0dd-0407a6ac7f0f

