### PR TITLE
Fix double press red/green on score screen

### DIFF
--- a/Assets/Script/Menu/ScoreScreen/ScoreScreenMenu.cs
+++ b/Assets/Script/Menu/ScoreScreen/ScoreScreenMenu.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Collections.Generic;
 using Cysharp.Threading.Tasks;

--- a/Assets/Script/Persistent/GlobalVariables.cs
+++ b/Assets/Script/Persistent/GlobalVariables.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using JetBrains.Annotations;
 using UnityEngine;
 using UnityEngine.SceneManagement;
+using UnityEngine.UI;
 using YARG.Audio.BASS;
 using YARG.Core;
 using YARG.Core.Logging;
@@ -14,6 +15,7 @@ using YARG.Helpers;
 using YARG.Input;
 using YARG.Integration;
 using YARG.Localization;
+using YARG.Menu.Navigation;
 using YARG.Menu.ScoreScreen;
 using YARG.Player;
 using YARG.Playlists;
@@ -155,11 +157,13 @@ namespace YARG
             {
                 // When complete, set the newly loaded scene to the active one
                 SceneManager.SetActiveScene(SceneManager.GetSceneByBuildIndex((int) scene));
+                Navigator.Instance.DisableMenuInputs = false;
             };
         }
 
         public void LoadScene(SceneIndex scene)
         {
+            Navigator.Instance.DisableMenuInputs = true;
             // Unload the current scene and load in the new one, or just load in the new one
             if (CurrentScene != SceneIndex.Persistent)
             {


### PR DESCRIPTION
To repro the bug:

1. Start a set with > 1 song
2. After the first song completes, press red and green button at the same time

**Expected**: First button press takes precedence

**Actual**:

Whatever this is
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/f7311036-56a6-43c8-9991-63f1befffd67" />

Fix is to check if we are loading a scene, if a scene is loading, ignore the next button presses because we are essentially done with the score screen at that point
