### PR TITLE
Export readability improvement

### DIFF
--- a/Assets/Script/Song/SongExport.cs
+++ b/Assets/Script/Song/SongExport.cs
@@ -48,6 +48,7 @@ namespace YARG.Song
                     string name = RichTextUtils.StripRichTextTags(song.Name);
                     output.WriteLine($"{artist} - {name}");
                 }
+                output.WriteLine("");
             }
             output.Flush();
         }


### PR DESCRIPTION
Adds a break so it goes from:

Artist1
--------------------
Artist1 - Song1
Artist2
--------------------
Artist2 - Song1

To this:

Artist1
--------------------
Artist1 - Song1

Artist2
--------------------
Artist2 - Song1

I guess it does add an extra break at the end of the file. Worry about that later 'cuz who cares. No one is even reading this...