### PR TITLE
Lower track on song fail

### DIFF
--- a/Assets/Script/Gameplay/GameManager.cs
+++ b/Assets/Script/Gameplay/GameManager.cs
@@ -1,6 +1,7 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using Cysharp.Threading.Tasks;
 using UnityEngine;
 using UnityEngine.InputSystem;
 using YARG.Core.Audio;
@@ -660,16 +661,21 @@ namespace YARG.Gameplay
             BandCombo += amount;
         }
 
-        private void OnSongFailed()
+        private async void OnSongFailed()
         {
             if (SettingsManager.Settings.NoFailMode.Value || IsPractice)
             {
                 return;
             }
 
-            PlayerHasFailed = true;
-            GlobalAudioHandler.PlayVoxSample(VoxSample.FailSound);
-            Pause();
+            if (!PlayerHasFailed)
+            {
+                PlayerHasFailed = true;
+                _mixer.FadeOut(SONG_END_DELAY);
+                await UniTask.Delay(TimeSpan.FromSeconds(SONG_END_DELAY));
+                GlobalAudioHandler.PlayVoxSample(VoxSample.FailSound);
+                Pause();
+            }
         }
 
         // If we go from no fail to fail, we need to reinitialize the happiness state so we avoid

--- a/Assets/Script/Gameplay/Player/BasePlayer.cs
+++ b/Assets/Script/Gameplay/Player/BasePlayer.cs
@@ -293,8 +293,8 @@ namespace YARG.Gameplay.Player
 
         protected void OnGameInput(ref GameInput input)
         {
-            // Ignore completely if the song hasn't started yet
-            if (!GameManager.Started)
+            // Ignore completely if the song hasn't started yet or player failed
+            if (!GameManager.Started || GameManager.PlayerHasFailed)
                 return;
 
             // Ignore while paused

--- a/Assets/Script/Gameplay/Player/TrackPlayer.cs
+++ b/Assets/Script/Gameplay/Player/TrackPlayer.cs
@@ -385,7 +385,7 @@ namespace YARG.Gameplay.Player
                 TrackView.ShowStarPowerReady();
             }
 
-            if (stats.IsStarPowerActive && !_wasStarPowerActive)
+            if (stats.IsStarPowerActive && !_wasStarPowerActive && !_didLowerTrack)
             {
                 CameraPositioner.Scoop();
             }

--- a/Assets/Script/Gameplay/Player/TrackPlayer.cs
+++ b/Assets/Script/Gameplay/Player/TrackPlayer.cs
@@ -397,7 +397,11 @@ namespace YARG.Gameplay.Player
                 haptics.SetStarPowerFill((float) currentStarPowerAmount);
             }
 
-            if (visualTime > SongLength)
+            if (GameManager.PlayerHasFailed)
+            {
+                CameraPositioner.Lower(false);
+            }
+            else if (visualTime > SongLength)
             {
                 CameraPositioner.Lower(true);
             }

--- a/Assets/Script/Gameplay/Player/TrackPlayer.cs
+++ b/Assets/Script/Gameplay/Player/TrackPlayer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
@@ -161,6 +161,7 @@ namespace YARG.Gameplay.Player
         private double _previousStarPowerAmount;
 
         private bool _wasStarPowerActive;
+        private bool _didLowerTrack;
 
         private Queue<TrackEffect> _upcomingEffects = new();
         private List<TrackEffectElement> _currentEffects = new();
@@ -397,12 +398,14 @@ namespace YARG.Gameplay.Player
                 haptics.SetStarPowerFill((float) currentStarPowerAmount);
             }
 
-            if (GameManager.PlayerHasFailed)
+            if (GameManager.PlayerHasFailed && !_didLowerTrack)
             {
+                _didLowerTrack = true;
                 CameraPositioner.Lower(false);
             }
-            else if (visualTime > SongLength)
+            else if (visualTime > SongLength && !_didLowerTrack)
             {
+                _didLowerTrack = true;
                 CameraPositioner.Lower(true);
             }
         }

--- a/Assets/Script/Gameplay/Player/TrackPlayer.cs
+++ b/Assets/Script/Gameplay/Player/TrackPlayer.cs
@@ -398,15 +398,12 @@ namespace YARG.Gameplay.Player
                 haptics.SetStarPowerFill((float) currentStarPowerAmount);
             }
 
-            if (GameManager.PlayerHasFailed && !_didLowerTrack)
+            bool isSongEnd = visualTime > SongLength;
+            bool shouldLowerTrack = isSongEnd || GameManager.PlayerHasFailed;
+            if (!_didLowerTrack && shouldLowerTrack)
             {
                 _didLowerTrack = true;
-                CameraPositioner.Lower(false);
-            }
-            else if (visualTime > SongLength && !_didLowerTrack)
-            {
-                _didLowerTrack = true;
-                CameraPositioner.Lower(true);
+                CameraPositioner.Lower(isSongEnd);
             }
         }
 

--- a/Assets/Script/Gameplay/Visuals/CameraPositioner.cs
+++ b/Assets/Script/Gameplay/Visuals/CameraPositioner.cs
@@ -260,13 +260,6 @@ namespace YARG.Gameplay.Visuals
 
         private void ScoopHighway()
         {
-            var didLower = _lower?.IsPlaying() == true || _lower?.IsComplete() == true;
-            if (didLower)
-            {
-                //Don't scoop if highway lowered since it will reset position
-                return;
-            }
-
             // Very quick blast down, up and back to origin for SP activation
             _scoop.Restart();
         }

--- a/Assets/Script/Gameplay/Visuals/CameraPositioner.cs
+++ b/Assets/Script/Gameplay/Visuals/CameraPositioner.cs
@@ -216,6 +216,7 @@ namespace YARG.Gameplay.Visuals
 
         private void RaiseHighway(bool isGameplayStart)
         {
+            _scoop?.Kill();
             transform.localRotation = Quaternion.Euler(new Vector3().WithX(_preset.Rotation + ANIM_INIT_ROTATION));
 
             var basePlayer = GetComponentInParent<BasePlayer>();
@@ -231,6 +232,7 @@ namespace YARG.Gameplay.Visuals
         // NOTE: Requires SONG_END_DELAY; will not animate until https://github.com/YARC-Official/YARG/pull/993 is in.
         private void LowerHighway(bool isGameplayEnd)
         {
+            _scoop?.Kill();
             transform.localRotation = Quaternion.Euler(new Vector3().WithX(_preset.Rotation));
 
             var basePlayer = GetComponentInParent<BasePlayer>();
@@ -258,6 +260,13 @@ namespace YARG.Gameplay.Visuals
 
         private void ScoopHighway()
         {
+            var didLower = _lower?.IsPlaying() == true || _lower?.IsComplete() == true;
+            if (didLower)
+            {
+                //Don't scoop if highway lowered since it will reset position
+                return;
+            }
+
             // Very quick blast down, up and back to origin for SP activation
             _scoop.Restart();
         }


### PR DESCRIPTION
This adds an animation to lower the track and a delay when a song is failed

It also fades out the mixer, and disables input after fail.

Previously the failed screen would pop up instantly which was jarring.

Demonstration:


https://github.com/user-attachments/assets/82720f66-b268-4d4b-a008-88a2835c6fd2

