### PR TITLE
Added Spotlights and Singalongs to the UDP datastream

### DIFF
--- a/Assets/Script/Integration/Data Stream/DataStreamController.cs
+++ b/Assets/Script/Integration/Data Stream/DataStreamController.cs
@@ -43,6 +43,8 @@ namespace YARG.Integration
             public LightingType       Keyframe;
             public bool               BonusEffect;
             public bool               AutoGenVenueTrack;
+            public Performer          Spotlight;
+            public Performer          Singalong;
         }
 
         public enum PlatformByte
@@ -113,6 +115,8 @@ namespace YARG.Integration
         public static LightingType       MLCCurrentLightingCue;
         public static PostProcessingType MLCPostProcessing;
         public static bool               MLCAutoGenVenueTrack;
+        public static Performer          MLCSpotlight;
+        public static Performer          MLCSingalong;
 
         public static ushort MLCudpPort = 36107; //hardcoded for now.
         public static string MLCudpIP = "255.255.255.255"; // "this" network's broadcast address
@@ -177,12 +181,13 @@ namespace YARG.Integration
             message.PostProcessing = MLCPostProcessing;         // setter triggered by the GameplayMonitor.
             message.FogState = MLCFogState;                     // gets set by the GameplayMonitor.
             message.StrobeState = MLCStrobeState;               // gets set by the GameplayMonitor.
-            message.Performer = 0x00;                           // Performer isn't parsed yet
             message.Beat = MLCCurrentBeat;                      // gets set by the GameplayMonitor.
             message.Keyframe = MLCKeyframe;                     // gets set on lighting cue change.
             message.BonusEffect = MLCBonusFX;                   // gets set by the GameplayMonitor.
 
             message.AutoGenVenueTrack = MLCAutoGenVenueTrack;   // gets set on chart load by the GameplayMonitor.
+            message.Spotlight = MLCSpotlight;                     // gets set by the GameplayMonitor.
+            message.Singalong = MLCSingalong;             // gets set by the GameplayMonitor.
 
             SerializeAndSend(message);
 
@@ -246,6 +251,9 @@ namespace YARG.Integration
             MLCCurrentBeat = 0;
             MLCKeyframe = 0;
             MLCBonusFX = false;
+            //MLCAutoGenVenueTrack set on chart load by the GameplayMonitor.
+            MLCSpotlight = Performer.None;
+            MLCSingalong = Performer.None;
 
 
             switch ((SceneIndex) scene.buildIndex)
@@ -333,11 +341,12 @@ namespace YARG.Integration
                 _writer.Write((byte) message.PostProcessing);
                 _writer.Write(message.FogState); //bool
                 _writer.Write((byte) message.StrobeState);
-                _writer.Write(message.Performer); //byte
                 _writer.Write(message.Beat); //byte
                 _writer.Write((byte) message.Keyframe);
                 _writer.Write(message.BonusEffect); //bool
                 _writer.Write(message.AutoGenVenueTrack); //bool
+                _writer.Write((byte) message.Spotlight);
+                _writer.Write((byte) message.Singalong);
 
                 _sendClient.Send(_ms.GetBuffer(), (int) _ms.Position);
             }

--- a/Assets/Script/Integration/Data Stream/DataStreamGameplayMonitor.cs
+++ b/Assets/Script/Integration/Data Stream/DataStreamGameplayMonitor.cs
@@ -57,7 +57,8 @@ namespace YARG.Integration
         private int _guitarIndex;
         private int _bassIndex;
         private int _stageIndex;
-        private int _performerIndex;
+        private int _performerStartIndex;
+        private int _performerEndIndex;
         private int _postProcessingIndex;
 
         private List<VocalNoteEvent> _vocalsNotes;
@@ -98,7 +99,8 @@ namespace YARG.Integration
             _guitarIndex = 0;
             _bassIndex = 0;
             _drumIndex = 0;
-            _performerIndex = 0;
+            _performerStartIndex = 0;
+            _performerEndIndex = 0;
             _postProcessingIndex = 0;
             _keysIndex = 0;
 
@@ -197,21 +199,22 @@ namespace YARG.Integration
 
         private void PerformerEventChecker(PerformerEventType type, ref Performer MLCvar)
         {
-            while (_performerIndex < Venue.Performer.Count &&
-                Venue.Performer[_performerIndex].Time <= GameManager.SongTime &&
-                Venue.Performer[_performerIndex].Type == type &&
-                MLCvar == Performer.None)
+            // Add all starting performers at or before SongTime
+            while (_performerStartIndex < Venue.Performer.Count &&
+                Venue.Performer[_performerStartIndex].Time <= GameManager.SongTime &&
+                Venue.Performer[_performerStartIndex].Type == type)
             {
-                MLCvar = Venue.Performer[_performerIndex].Performers;
+                MLCvar |= Venue.Performer[_performerStartIndex].Performers; // use bitwise OR to combine
+                _performerStartIndex++;
             }
 
-            while (_performerIndex < Venue.Performer.Count &&
-                Venue.Performer[_performerIndex].TimeEnd <= GameManager.SongTime &&
-                Venue.Performer[_performerIndex].Type == type &&
-                MLCvar != Performer.None)
+            // Remove all ending performers at or before SongTime
+            while (_performerEndIndex < Venue.Performer.Count &&
+                Venue.Performer[_performerEndIndex].TimeEnd <= GameManager.SongTime &&
+                Venue.Performer[_performerEndIndex].Type == type)
             {
-                MLCvar = Performer.None;
-                _performerIndex++;
+                MLCvar &= ~Venue.Performer[_performerEndIndex].Performers; // bitwise remove
+                _performerEndIndex++;
             }
         }
 
@@ -226,7 +229,7 @@ namespace YARG.Integration
             // Let's get the current state of the game
 
             // Pause state
-            //this is uglier than a simple != because the pausestatetype has 3 states. AtMenu, pause, unpaused.
+            //this is uglier than a simple != because the pause state type has 3 states. AtMenu, pause, unpaused.
             switch (DataStreamController.MLCPaused, GameManager.Paused)
             {
                 case (DataStreamController.PauseStateType.Unpaused, true):
@@ -295,7 +298,7 @@ namespace YARG.Integration
                 _postProcessingIndex++;
             }
 
-            // Beatline events
+            // Beat line events
             while (_syncIndex < _sync.Beatlines.Count && _sync.Beatlines[_syncIndex].Time <= GameManager.SongTime)
             {
                 DataStreamController.MLCCurrentBeat = (byte)_sync.Beatlines[_syncIndex].Type;
@@ -337,8 +340,8 @@ namespace YARG.Integration
                     default:
                         // Okay so this a bit odd. The stage kit never has the strobe on with a lighting cue.
                         // But the Strobe_Off event is almost never used, relying instead on the cue change to turn it off.
-                        // So this technically should be in the stage kit lighting controller code but I don't want the
-                        // stage kit reaching into this main lighting controller.So we'll just turn it off here.
+                        // So this technically should be in the stage kit lighting controller code, but I don't want the
+                        // stage kit reaching into this main lighting controller. So we'll just turn it off here.
                         DataStreamController.MLCStrobeState = LightingType.StrobeOff;
                         DataStreamController.CurrentLightingCue = Venue.Lighting[LightingIndex];
                         break;

--- a/Assets/Script/Integration/Data Stream/DataStreamGameplayMonitor.cs
+++ b/Assets/Script/Integration/Data Stream/DataStreamGameplayMonitor.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using PlasticBand.Haptics;
 using UnityEngine;
+using UnityEngine.Experimental.GlobalIllumination;
 using UnityEngine.SceneManagement;
 using YARG.Core;
 using YARG.Core.Chart;
@@ -56,8 +57,7 @@ namespace YARG.Integration
         private int _guitarIndex;
         private int _bassIndex;
         private int _stageIndex;
-        //NYI
-        //private int _performerIndex;
+        private int _performerIndex;
         private int _postProcessingIndex;
 
         private List<VocalNoteEvent> _vocalsNotes;
@@ -98,8 +98,7 @@ namespace YARG.Integration
             _guitarIndex = 0;
             _bassIndex = 0;
             _drumIndex = 0;
-            //NYI
-            //_performerIndex = 0;
+            _performerIndex = 0;
             _postProcessingIndex = 0;
             _keysIndex = 0;
 
@@ -196,6 +195,26 @@ namespace YARG.Integration
             return -2; // don't change the current note
         }
 
+        private void PerformerEventChecker(PerformerEventType type, ref Performer MLCvar)
+        {
+            while (_performerIndex < Venue.Performer.Count &&
+                Venue.Performer[_performerIndex].Time <= GameManager.SongTime &&
+                Venue.Performer[_performerIndex].Type == type &&
+                MLCvar == Performer.None)
+            {
+                MLCvar = Venue.Performer[_performerIndex].Performers;
+            }
+
+            while (_performerIndex < Venue.Performer.Count &&
+                Venue.Performer[_performerIndex].TimeEnd <= GameManager.SongTime &&
+                Venue.Performer[_performerIndex].Type == type &&
+                MLCvar != Performer.None)
+            {
+                MLCvar = Performer.None;
+                _performerIndex++;
+            }
+        }
+
         private void Update()
         {
             // Don't do any of this if the option is off
@@ -262,11 +281,11 @@ namespace YARG.Integration
                 DataStreamController.MLCCurrentHarmony2Note = harmony2Note;
             }
 
-            //Camera Cut events
-            // NYI - waiting for parser rewrite
 
-            // Performer events
-            // NYI - waiting for parser rewrite
+            //Performer events broken down into two types. Spotlight and Singalong
+            PerformerEventChecker(PerformerEventType.Singalong, ref DataStreamController.MLCSingalong);
+            PerformerEventChecker(PerformerEventType.Spotlight, ref DataStreamController.MLCSpotlight);
+
 
             // Post-processing events
             while (_postProcessingIndex < Venue.PostProcessing.Count &&


### PR DESCRIPTION
While both are in the Performer venue track, I split them into their own bytes in the datastream.