### PR TITLE
Angle highways in multiplayer to prevent fail meter icons from getting too close to the highways

### DIFF
--- a/Assets/Art/Animations/Gameplay/Rectangular/FretCymbalHit.anim
+++ b/Assets/Art/Animations/Gameplay/Rectangular/FretCymbalHit.anim
@@ -95,7 +95,7 @@ AnimationClip:
     m_Level: 0
     m_CycleOffset: 0
     m_HasAdditiveReferencePose: 0
-    m_LoopTime: 1
+    m_LoopTime: 0
     m_LoopBlend: 0
     m_LoopBlendOrientation: 0
     m_LoopBlendPositionY: 0

--- a/Assets/Prefabs/Gameplay/HUD/TrackView.prefab
+++ b/Assets/Prefabs/Gameplay/HUD/TrackView.prefab
@@ -560,8 +560,8 @@ MonoBehaviour:
       m_Calls: []
   m_text: 
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: f941d094fa226f74e9866f5e556ce769, type: 2}
-  m_sharedMaterial: {fileID: 3946058399964092608, guid: f941d094fa226f74e9866f5e556ce769,
+  m_fontAsset: {fileID: 11400000, guid: 19b7115073766a24aa48ceca884dcbf5, type: 2}
+  m_sharedMaterial: {fileID: 4249517445589659644, guid: 19b7115073766a24aa48ceca884dcbf5,
     type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
@@ -882,8 +882,8 @@ MonoBehaviour:
       m_Calls: []
   m_text: 
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: f941d094fa226f74e9866f5e556ce769, type: 2}
-  m_sharedMaterial: {fileID: 3946058399964092608, guid: f941d094fa226f74e9866f5e556ce769,
+  m_fontAsset: {fileID: 11400000, guid: 19b7115073766a24aa48ceca884dcbf5, type: 2}
+  m_sharedMaterial: {fileID: 4249517445589659644, guid: 19b7115073766a24aa48ceca884dcbf5,
     type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
@@ -1019,8 +1019,8 @@ MonoBehaviour:
       m_Calls: []
   m_text: 100%
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: f941d094fa226f74e9866f5e556ce769, type: 2}
-  m_sharedMaterial: {fileID: 3946058399964092608, guid: f941d094fa226f74e9866f5e556ce769,
+  m_fontAsset: {fileID: 11400000, guid: 19b7115073766a24aa48ceca884dcbf5, type: 2}
+  m_sharedMaterial: {fileID: 4249517445589659644, guid: 19b7115073766a24aa48ceca884dcbf5,
     type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
@@ -1046,7 +1046,7 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 42.4
+  m_fontSize: 43.8
   m_fontSizeBase: 20
   m_fontWeight: 400
   m_enableAutoSizing: 1
@@ -1198,7 +1198,7 @@ PrefabInstance:
     - target: {fileID: 8429420445829968483, guid: f1057b18ead5aa441b8d91b2c7d29efc,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -50
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8429420445829968483, guid: f1057b18ead5aa441b8d91b2c7d29efc,
         type: 3}
@@ -1280,7 +1280,7 @@ PrefabInstance:
     - target: {fileID: 3967995507941194808, guid: 249f3206655c65946a0f15b17834fca4,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 0
+      value: 50
       objectReference: {fileID: 0}
     - target: {fileID: 3967995507941194808, guid: 249f3206655c65946a0f15b17834fca4,
         type: 3}

--- a/Assets/Prefabs/Gameplay/HUD/TrackView.prefab
+++ b/Assets/Prefabs/Gameplay/HUD/TrackView.prefab
@@ -54,6 +54,7 @@ MonoBehaviour:
   _aspectRatioFitter: {fileID: 8972788446298205954}
   _UIScaler: {fileID: 8179462097464755339}
   _topElementContainer: {fileID: 2784863481168182611}
+  _centerElementContainer: {fileID: 7858415040353329453}
   _soloBox: {fileID: 2390146520270845346}
   _textNotifications: {fileID: 4946571513074747625}
   _countdownDisplay: {fileID: 202077715988875599}
@@ -246,6 +247,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _initialSize: {x: 1920, y: 1080}
+  _scaleMode: 0
 --- !u!1 &1315879251065754542
 GameObject:
   m_ObjectHideFlags: 0
@@ -395,12 +397,18 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0323261970874b6e8d89d1421ec2322e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  _animLength: 2
+  _animBaseToPeakInterval: 0.167
+  _animPeakToValleyInterval: 0.167
+  _animPeakScale: 1.1
+  _animValleyScale: 1
   _text: {fileID: 8078771021002508975}
   _containerRect: {fileID: 8448967496905679418}
   _notificationBackground: {fileID: 1849009881569265160}
   _defaultColor: {r: 0.09411765, g: 0.09411765, b: 0.09411765, a: 1}
   _starpowerColor: {r: 0.09411765, g: 0.09411765, b: 0.09411765, a: 1}
   _grooveColor: {r: 0.09411765, g: 0.09411765, b: 0.09411765, a: 1}
+  _isVocals: 0
 --- !u!1 &2238794423646391257
 GameObject:
   m_ObjectHideFlags: 0
@@ -1190,7 +1198,7 @@ PrefabInstance:
     - target: {fileID: 8429420445829968483, guid: f1057b18ead5aa441b8d91b2c7d29efc,
         type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -100
+      value: -50
       objectReference: {fileID: 0}
     - target: {fileID: 8429420445829968483, guid: f1057b18ead5aa441b8d91b2c7d29efc,
         type: 3}
@@ -1272,7 +1280,7 @@ PrefabInstance:
     - target: {fileID: 3967995507941194808, guid: 249f3206655c65946a0f15b17834fca4,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -49.99991
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3967995507941194808, guid: 249f3206655c65946a0f15b17834fca4,
         type: 3}

--- a/Assets/Prefabs/Gameplay/HUD/VocalPlayerHUD.prefab
+++ b/Assets/Prefabs/Gameplay/HUD/VocalPlayerHUD.prefab
@@ -1140,8 +1140,8 @@ MonoBehaviour:
       m_Calls: []
   m_text: 99 PHRASE STREAK!
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: f941d094fa226f74e9866f5e556ce769, type: 2}
-  m_sharedMaterial: {fileID: 3946058399964092608, guid: f941d094fa226f74e9866f5e556ce769,
+  m_fontAsset: {fileID: 11400000, guid: d9dd031fb1c2f2f4fabb34137edfa885, type: 2}
+  m_sharedMaterial: {fileID: 1536850694454096710, guid: d9dd031fb1c2f2f4fabb34137edfa885,
     type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
@@ -1311,6 +1311,11 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.x
       value: -105
       objectReference: {fileID: 0}
+    - target: {fileID: 6424116249910258502, guid: c950f4332cd2fde4ca0568dd2b24be0f,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -18
+      objectReference: {fileID: 0}
     - target: {fileID: 6731294974148575212, guid: c950f4332cd2fde4ca0568dd2b24be0f,
         type: 3}
       propertyPath: m_SizeDelta.x
@@ -1320,6 +1325,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 95
+      objectReference: {fileID: 0}
+    - target: {fileID: 6731294974148575212, guid: c950f4332cd2fde4ca0568dd2b24be0f,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -17
       objectReference: {fileID: 0}
     - target: {fileID: 7257162965220430353, guid: c950f4332cd2fde4ca0568dd2b24be0f,
         type: 3}

--- a/Assets/Prefabs/Gameplay/HUD/VocalsPlayerNameDisplay.prefab
+++ b/Assets/Prefabs/Gameplay/HUD/VocalsPlayerNameDisplay.prefab
@@ -56,7 +56,7 @@ MonoBehaviour:
   _playerName: {fileID: 7279130075171954488}
   _instrumentIcon: {fileID: 4052958757949844642}
   _needleIcon: {fileID: 1402306547666697911}
-  DisplayTime: 3
+  DisplayTime: 5
   FadeDuration: 0.5
 --- !u!225 &1169966280076727379
 CanvasGroup:

--- a/Assets/Script/Gameplay/HUD/PlayerNameDisplay.cs
+++ b/Assets/Script/Gameplay/HUD/PlayerNameDisplay.cs
@@ -25,7 +25,7 @@ namespace YARG.Gameplay.HUD
 
         private CanvasGroup _canvasGroup;
 
-        public float DisplayTime = 3.0f;
+        public float DisplayTime = 5f;
         public float FadeDuration = 0.5f;
 
         protected override void GameplayAwake()

--- a/Assets/Script/Gameplay/HUD/TrackView.cs
+++ b/Assets/Script/Gameplay/HUD/TrackView.cs
@@ -17,6 +17,8 @@ namespace YARG.Gameplay.HUD
         private ScaleByParentSize _UIScaler;
         [SerializeField]
         private RectTransform _topElementContainer;
+        [SerializeField]
+        private RectTransform _centerElementContainer;
 
         [Space]
         [SerializeField]
@@ -44,7 +46,8 @@ namespace YARG.Gameplay.HUD
         public void UpdateHUDPosition(int highwayIndex, int highwayCount)
         {
             var rect = GetComponent<RectTransform>();
-            var viewportPos = _trackPlayer.HUDViewportPosition;
+            var topViewportPos = _trackPlayer.HUDTopElementViewportPosition;
+            var centerViewportPos = _trackPlayer.HUDCenterElementViewportPosition;
 
             // Caching this is faster
             var rectRect = rect.rect;
@@ -56,8 +59,12 @@ namespace YARG.Gameplay.HUD
             // Adjust the screen's viewport position to the rect's viewport position
             // -0.5f as our position is relative to center, not the corner
             _topElementContainer.localPosition = _topElementContainer.localPosition
-                .WithX(rectRect.width * (viewportPos.x - 0.5f - hudOffset))
-                .WithY(rectRect.height * (viewportPos.y - 0.5f));
+                .WithX(rectRect.width * (topViewportPos.x - 0.5f - hudOffset))
+                .WithY(rectRect.height * (topViewportPos.y - 0.5f));
+
+            _centerElementContainer.localPosition = _centerElementContainer.localPosition
+                .WithX(rectRect.width * (centerViewportPos.x - 0.5f - hudOffset))
+                .WithY(rectRect.height * (centerViewportPos.y - 0.5f));
         }
 
         public void UpdateCountdown(double countdownLength, double endTime)

--- a/Assets/Script/Gameplay/HUD/TrackView.cs
+++ b/Assets/Script/Gameplay/HUD/TrackView.cs
@@ -2,8 +2,10 @@
 using UnityEngine.UI;
 using YARG.Core.Engine;
 using YARG.Gameplay.Player;
+using YARG.Gameplay.Visuals;
 using YARG.Player;
 using YARG.Helpers.UI;
+using YARG.Settings;
 
 namespace YARG.Gameplay.HUD
 {
@@ -39,7 +41,7 @@ namespace YARG.Gameplay.HUD
             _trackPlayer = trackPlayer;
         }
 
-        public void UpdateHUDPosition()
+        public void UpdateHUDPosition(int highwayIndex, int highwayCount)
         {
             var rect = GetComponent<RectTransform>();
             var viewportPos = _trackPlayer.HUDViewportPosition;
@@ -47,9 +49,15 @@ namespace YARG.Gameplay.HUD
             // Caching this is faster
             var rectRect = rect.rect;
 
+            // Divide tilt by 4; if highway tilt is maxed out, we want the bounds to be (-0.25, 0.25)
+            float hudOffset = HighwayCameraRendering.GetMultiplayerXOffset(highwayIndex, highwayCount,
+                SettingsManager.Settings.HighwayTiltMultiplier.Value / 4);
+
             // Adjust the screen's viewport position to the rect's viewport position
             // -0.5f as our position is relative to center, not the corner
-            _topElementContainer.localPosition = _topElementContainer.localPosition.WithY(rectRect.height * (viewportPos.y - 0.5f));
+            _topElementContainer.localPosition = _topElementContainer.localPosition
+                .WithX(rectRect.width * (viewportPos.x - 0.5f - hudOffset))
+                .WithY(rectRect.height * (viewportPos.y - 0.5f));
         }
 
         public void UpdateCountdown(double countdownLength, double endTime)

--- a/Assets/Script/Gameplay/HUD/TrackViewManager.cs
+++ b/Assets/Script/Gameplay/HUD/TrackViewManager.cs
@@ -73,14 +73,5 @@ namespace YARG.Gameplay.HUD
             _horizontalLayoutGroup.padding.top = (int)(rectRect.height * (1.0f - _highwayCameraRendering.Scale));
             _horizontalLayoutGroup.enabled = true;
         }
-
-        public void SetAllHUDPositions()
-        {
-            // The positions of the track view have probably not updated yet at this point
-            Canvas.ForceUpdateCanvases();
-
-            foreach (var view in _trackViews)
-                view.UpdateHUDPosition();
-        }
     }
 }

--- a/Assets/Script/Gameplay/Player/TrackPlayer.cs
+++ b/Assets/Script/Gameplay/Player/TrackPlayer.cs
@@ -28,8 +28,6 @@ namespace YARG.Gameplay.Player
         public const float TRACK_HEIGHT = 100f;
 
         public const float HUD_TOP_ELEMENT_HEIGHT    = 0.15f;
-        public const float HUD_CENTER_ELEMENT_HEIGHT = 0f;
-        public const float HUD_CENTER_ELEMENT_DEPTH  = -1.5f;
 
         public static int HighwayCount = 1;
 
@@ -79,8 +77,8 @@ namespace YARG.Gameplay.Player
 
         public Vector2 HUDCenterElementViewportPosition =>
             TrackCamera.WorldToViewportPoint(_hudLocation.position
-                .WithY(HUD_CENTER_ELEMENT_HEIGHT + TRACK_HEIGHT)
-                .WithZ(HUD_CENTER_ELEMENT_DEPTH));
+                .WithY(TRACK_HEIGHT)
+                .WithZ(0));
 
         protected List<Beatline> Beatlines;
 

--- a/Assets/Script/Gameplay/Player/TrackPlayer.cs
+++ b/Assets/Script/Gameplay/Player/TrackPlayer.cs
@@ -26,6 +26,11 @@ namespace YARG.Gameplay.Player
 
         public const float TRACK_WIDTH = 2f;
 
+        public const float HIGHWAY_GAP = 100f;
+        public const float HUD_HEIGHT  = 0.15f;
+
+        public static int HighwayCount = 1;
+
         public double SpawnTimeOffset => (ZeroFadePosition + _spawnAheadDelay + -STRIKE_LINE_POS) / NoteSpeed;
 
         protected TrackView TrackView { get; private set; }
@@ -65,7 +70,10 @@ namespace YARG.Gameplay.Player
         public float ZeroFadePosition { get; private set; }
         public float FadeSize         { get; private set; }
 
-        public Vector2 HUDViewportPosition => TrackCamera.WorldToViewportPoint(_hudLocation.position);
+        // Multiply by the reciprocal of 1 / player count to prevent the HUD from being too close to the highway;
+        public Vector2 HUDViewportPosition =>
+            TrackCamera.WorldToViewportPoint(_hudLocation.position.WithY(
+                HUD_HEIGHT * (1 / HighwayCameraRendering.CalculateScale(HighwayCount)) + HIGHWAY_GAP));
 
         protected List<Beatline> Beatlines;
 
@@ -174,6 +182,12 @@ namespace YARG.Gameplay.Player
             if (IsInitialized)
             {
                 return;
+            }
+
+            // Get player count
+            if (index + 1 > HighwayCount)
+            {
+                HighwayCount = index + 1;
             }
 
             // Consolidate tracks into a parent object for animation purposes
@@ -299,7 +313,6 @@ namespace YARG.Gameplay.Player
         protected virtual void FinishInitialization()
         {
             TrackMaterial.Initialize(Player.HighwayPreset);
-            TrackView.UpdateHUDPosition();
             CameraPositioner.Initialize(Player.CameraPreset);
             FinalizeTrackEffects();
         }
@@ -328,6 +341,9 @@ namespace YARG.Gameplay.Player
 
         protected override void UpdateVisuals(double visualTime)
         {
+            // Allow the HUD to track the highway with animations
+            TrackView.UpdateHUDPosition(HighwayIndex, HighwayCount);
+
             UpdateNotes(visualTime);
             UpdateBeatlines(visualTime);
             UpdateTrackEffects(visualTime);

--- a/Assets/Script/Gameplay/Player/TrackPlayer.cs
+++ b/Assets/Script/Gameplay/Player/TrackPlayer.cs
@@ -185,7 +185,12 @@ namespace YARG.Gameplay.Player
             }
 
             // Get player count
-            if (index + 1 > HighwayCount)
+            if (index == 0)
+            {
+                // Reset
+                HighwayCount = 1;
+            }
+            else if (index + 1 > HighwayCount)
             {
                 HighwayCount = index + 1;
             }

--- a/Assets/Script/Gameplay/Player/TrackPlayer.cs
+++ b/Assets/Script/Gameplay/Player/TrackPlayer.cs
@@ -24,10 +24,12 @@ namespace YARG.Gameplay.Player
         public const float DEFAULT_ZERO_FADE_POS = 3f;
         public const float NOTE_SPAWN_OFFSET     = 5f;
 
-        public const float TRACK_WIDTH = 2f;
+        public const float TRACK_WIDTH  = 2f;
+        public const float TRACK_HEIGHT = 100f;
 
-        public const float HIGHWAY_GAP = 100f;
-        public const float HUD_HEIGHT  = 0.15f;
+        public const float HUD_TOP_ELEMENT_HEIGHT    = 0.15f;
+        public const float HUD_CENTER_ELEMENT_HEIGHT = 0f;
+        public const float HUD_CENTER_ELEMENT_DEPTH  = -1.5f;
 
         public static int HighwayCount = 1;
 
@@ -71,9 +73,14 @@ namespace YARG.Gameplay.Player
         public float FadeSize         { get; private set; }
 
         // Multiply by the reciprocal of 1 / player count to prevent the HUD from being too close to the highway;
-        public Vector2 HUDViewportPosition =>
+        public Vector2 HUDTopElementViewportPosition =>
             TrackCamera.WorldToViewportPoint(_hudLocation.position.WithY(
-                HUD_HEIGHT * (1 / HighwayCameraRendering.CalculateScale(HighwayCount)) + HIGHWAY_GAP));
+                HUD_TOP_ELEMENT_HEIGHT * (1 / HighwayCameraRendering.CalculateScale(HighwayCount)) + TRACK_HEIGHT));
+
+        public Vector2 HUDCenterElementViewportPosition =>
+            TrackCamera.WorldToViewportPoint(_hudLocation.position
+                .WithY(HUD_CENTER_ELEMENT_HEIGHT + TRACK_HEIGHT)
+                .WithZ(HUD_CENTER_ELEMENT_DEPTH));
 
         protected List<Beatline> Beatlines;
 

--- a/Assets/Script/Gameplay/Player/TrackPlayer.cs
+++ b/Assets/Script/Gameplay/Player/TrackPlayer.cs
@@ -27,7 +27,8 @@ namespace YARG.Gameplay.Player
         public const float TRACK_WIDTH  = 2f;
         public const float TRACK_HEIGHT = 100f;
 
-        public const float HUD_TOP_ELEMENT_HEIGHT    = 0.15f;
+        public const float HUD_TOP_ELEMENT_HEIGHT = 0.15f;
+        public const float HUD_CENTER_ELEMENT_DEPTH = -1f;
 
         public static int HighwayCount = 1;
 
@@ -78,7 +79,7 @@ namespace YARG.Gameplay.Player
         public Vector2 HUDCenterElementViewportPosition =>
             TrackCamera.WorldToViewportPoint(_hudLocation.position
                 .WithY(TRACK_HEIGHT)
-                .WithZ(0));
+                .WithZ(HUD_CENTER_ELEMENT_DEPTH));
 
         protected List<Beatline> Beatlines;
 

--- a/Assets/Script/Gameplay/Visuals/HighwayCameraRendering.cs
+++ b/Assets/Script/Gameplay/Visuals/HighwayCameraRendering.cs
@@ -6,6 +6,7 @@ using UnityEngine.Rendering.RendererUtils;
 using UnityEngine.Rendering.Universal;
 using UnityEngine.UI;
 using YARG.Gameplay.Player;
+using YARG.Settings;
 
 namespace YARG.Gameplay.Visuals
 {
@@ -258,7 +259,8 @@ namespace YARG.Gameplay.Visuals
             {
                 var camera = _cameras[i];
 
-                float multiplayerXOffset = GetMultiplayerXOffset(i, _cameras.Count, -0.5f);
+                float multiplayerXOffset = GetMultiplayerXOffset(i, _cameras.Count,
+                    -1f * SettingsManager.Settings.HighwayTiltMultiplier.Value);
                 OffsetLocalPosition(camera.transform, multiplayerXOffset);
 
                 _camViewMatrices[i] = camera.worldToCameraMatrix;
@@ -300,7 +302,8 @@ namespace YARG.Gameplay.Visuals
             // Divide screen into N equal regions: [-1, 1] => 2.0 width
             float laneWidth = 2.0f / highwayCount; // NDC horizontal span is [-1, 1] → 2.0
             float centerX = -1.0f + laneWidth * (index + 0.5f);
-            float offsetX = centerX + GetMultiplayerXOffset(index, highwayCount, -0.5f / highwayCount);
+            float offsetX = centerX + GetMultiplayerXOffset(index, highwayCount,
+                -1f * SettingsManager.Settings.HighwayTiltMultiplier.Value / highwayCount);
             float offsetY = -1.0f + highwayScale; // Offset down if scaled vertically
 
             // This matrix modifies the output of clip space before perspective divide

--- a/Assets/Script/Gameplay/Visuals/HighwayCameraRendering.cs
+++ b/Assets/Script/Gameplay/Visuals/HighwayCameraRendering.cs
@@ -121,7 +121,7 @@ namespace YARG.Gameplay.Visuals
             _renderCamera.orthographicSize = Math.Max(25, (maxWorld - minWorld) / 2);
         }
 
-        private static float CalculateScale(int count)
+        public static float CalculateScale(int count)
         {
             // This equation calculates a good scale for all of the tracks.
             // It was made with experimentation; there's probably a "real" formula for this.

--- a/Assets/Script/Gameplay/Visuals/HighwayCameraRendering.cs
+++ b/Assets/Script/Gameplay/Visuals/HighwayCameraRendering.cs
@@ -257,6 +257,10 @@ namespace YARG.Gameplay.Visuals
             for (int i = 0; i < _cameras.Count; ++i)
             {
                 var camera = _cameras[i];
+
+                float multiplayerXOffset = GetMultiplayerXOffset(i, _cameras.Count, -0.5f);
+                OffsetLocalPosition(camera.transform, multiplayerXOffset);
+
                 _camViewMatrices[i] = camera.worldToCameraMatrix;
                 _camInvViewMatrices[i] = camera.cameraToWorldMatrix;
             }
@@ -296,7 +300,7 @@ namespace YARG.Gameplay.Visuals
             // Divide screen into N equal regions: [-1, 1] => 2.0 width
             float laneWidth = 2.0f / highwayCount; // NDC horizontal span is [-1, 1] → 2.0
             float centerX = -1.0f + laneWidth * (index + 0.5f);
-            float offsetX = centerX;
+            float offsetX = centerX + GetMultiplayerXOffset(index, highwayCount, -0.5f / highwayCount);
             float offsetY = -1.0f + highwayScale; // Offset down if scaled vertically
 
             // This matrix modifies the output of clip space before perspective divide
@@ -360,6 +364,27 @@ namespace YARG.Gameplay.Visuals
 
                 CommandBufferPool.Release(cmd);
             }
+        }
+
+        // Offset is defined from -1f to 1f
+        public static float GetMultiplayerXOffset(int playerIndex, int totalPlayers, float magnitude)
+        {
+            // No need to offset if only one or fewer players
+            if (totalPlayers < 2)
+            {
+                return 0f;
+            }
+
+            // Take segments = (n - 1); e.g., if 3 players, have 3 highways with 2 separations
+            float segmentSize = 2f / (totalPlayers - 1);
+
+            // Offset so that the second player out three players is centered
+            return magnitude * (-1f + playerIndex * segmentSize);
+        }
+
+        public static void OffsetLocalPosition(Transform transform, float xOffset)
+        {
+            transform.localPosition = new Vector3(xOffset, transform.localPosition.y, transform.localPosition.z);
         }
     }
 }

--- a/Assets/Script/Persistent/GlobalVariables.cs
+++ b/Assets/Script/Persistent/GlobalVariables.cs
@@ -48,7 +48,7 @@ namespace YARG
 
         public SceneIndex CurrentScene { get; private set; } = SceneIndex.Persistent;
 
-        public string CurrentVersion { get; private set; } = "v0.13.0";
+        public string CurrentVersion { get; private set; } = "v0.13.1";
 
         protected override void SingletonAwake()
         {

--- a/Assets/Script/Settings/SettingsManager.Settings.cs
+++ b/Assets/Script/Settings/SettingsManager.Settings.cs
@@ -288,6 +288,7 @@ namespace YARG.Settings
             public ToggleSetting EnableTrackEffects { get; } = new(true);
             public ToggleSetting EnableHighwayRaise { get; } = new(true);
             public SliderSetting KickBounceMultiplier { get; } = new(1f, 0f, 2f);
+            public SliderSetting HighwayTiltMultiplier { get; } = new(0.5f, 0f, 1f);
 
             public ToggleSetting ShowHitWindow { get; } = new(false, ShowHitWindowCallback);
             public ToggleSetting DisableTextNotifications { get; } = new(false);

--- a/Assets/Script/Settings/SettingsManager.Settings.cs
+++ b/Assets/Script/Settings/SettingsManager.Settings.cs
@@ -173,7 +173,7 @@ namespace YARG.Settings
                 new(1f, v => GlobalAudioHandler.SetVolumeSetting(SongStem.Song, v));
 
             public VolumeSetting CrowdVolume { get; } =
-                new(0.5f, v => GlobalAudioHandler.SetVolumeSetting(SongStem.Crowd, v));
+                new(1f, v => GlobalAudioHandler.SetVolumeSetting(SongStem.Crowd, v));
 
             public VolumeSetting SfxVolume { get; } =
                 new(0.8f, v => GlobalAudioHandler.SetVolumeSetting(SongStem.Sfx, v));

--- a/Assets/Script/Settings/SettingsManager.Settings.cs
+++ b/Assets/Script/Settings/SettingsManager.Settings.cs
@@ -329,7 +329,7 @@ namespace YARG.Settings
                 };
 
             public DropdownSetting<SongProgressMode> SongTimeOnScoreBox { get; }
-                = new(SongProgressMode.CountUpOnly)
+                = new(SongProgressMode.CountUpAndTotal)
                 {
                     SongProgressMode.None,
                     SongProgressMode.CountUpAndTotal,

--- a/Assets/Script/Settings/SettingsManager.cs
+++ b/Assets/Script/Settings/SettingsManager.cs
@@ -147,6 +147,7 @@ namespace YARG.Settings
                 nameof(Settings.EnableTrackEffects),
                 nameof(Settings.EnableHighwayRaise),
                 nameof(Settings.KickBounceMultiplier),
+                nameof(Settings.HighwayTiltMultiplier),
 
                 new HeaderMetadata("HUD"),
                 nameof(Settings.ShowHitWindow),

--- a/Assets/StreamingAssets/lang/en-US.json
+++ b/Assets/StreamingAssets/lang/en-US.json
@@ -916,6 +916,10 @@
                     "HighestDifficulty": "Highest-played difficulty only"
                 }
             },
+            "HighwayTiltMultiplier": {
+                "Name": "Highway Tilt Multiplier",
+                "Description": "Controls the amount that the tracks should tilt inward during multiplayer gameplay only."
+            },
             "InputDeviceLogging": {
                 "Name": "Input Device Logging",
                 "Description": "Prints information about connected input devices to the game's log. Do not enable this unless you are having issues with specific devices, as it can print a very large amount of text for some devices!"

--- a/Assets/StreamingAssets/lang/en-US.json
+++ b/Assets/StreamingAssets/lang/en-US.json
@@ -1003,7 +1003,7 @@
                 "Dropdown": {
                     "Disabled": "Disabled",
                     "Frequent": "50, 100, 200, 300, ...",
-                    "Sparse": "50, 100, 250, 500, ..."
+                    "Sparse": "50, 100, 250, 500, 750, ..."
                 }
             },
             "PlayAShowTimeout": {

--- a/Assets/StreamingAssets/lang/es-ES.json
+++ b/Assets/StreamingAssets/lang/es-ES.json
@@ -716,7 +716,7 @@
                 "Dropdown": {
                     "Disabled": "Disabled",
                     "Frequent": "50, 100, 200, 300, ...",
-                    "Sparse": "50, 100, 250, 500, ..."
+                    "Sparse": "50, 100, 250, 500, 750, ..."
                 }
             },
             "PreviewVolume": {

--- a/Assets/StreamingAssets/lang/ja-JP.json
+++ b/Assets/StreamingAssets/lang/ja-JP.json
@@ -716,7 +716,7 @@
                 "Dropdown": {
                     "Disabled": "Disabled",
                     "Frequent": "50, 100, 200, 300, ...",
-                    "Sparse": "50, 100, 250, 500, ..."
+                    "Sparse": "50, 100, 250, 500, 750, ..."
                 }
             },
             "PreviewVolume": {

--- a/Assets/StreamingAssets/lang/pt-BR.json
+++ b/Assets/StreamingAssets/lang/pt-BR.json
@@ -712,7 +712,7 @@
                 "Dropdown": {
                     "Disabled": "Disabled",
                     "Frequent": "50, 100, 200, 300, ...",
-                    "Sparse": "50, 100, 250, 500, ..."
+                    "Sparse": "50, 100, 250, 500, 750, ..."
                 }
             },
             "PreviewVolume": {

--- a/Assets/StreamingAssets/lang/pt-PT.json
+++ b/Assets/StreamingAssets/lang/pt-PT.json
@@ -716,7 +716,7 @@
                 "Dropdown": {
                     "Disabled": "Disabled",
                     "Frequent": "50, 100, 200, 300, ...",
-                    "Sparse": "50, 100, 250, 500, ..."
+                    "Sparse": "50, 100, 250, 500, 750, ..."
                 }
             },
             "PreviewVolume": {


### PR DESCRIPTION
## Changes

Angles the highways like in Rock Band to make the spacing between the edges of the screen and each highway roughly equal; also prevents player icons on the crowd meter from getting too close to the leftmost highway (very rare, but can happen for four players if the players are doing particularly poorly).

This is done by first shifting the camera, then shifting the viewport.

## Issues

- The HUD does not currently reposition to align with the back of the highway; must follow up on this.
- A setting to disable this needs to eventually be added as GH players may want to disable this feature.

## Testing

![](https://media.discordapp.net/attachments/839947923223609415/1427823706998046800/Screenshot_2025-10-14_at_6.00.06_PM.png?ex=68f043f3&is=68eef273&hm=1e32f51b464f22db7948ed034558704ffa2e2f56e219544f2f28ea6a129e4c81&=&format=webp&quality=lossless&width=2720&height=1636)

![](https://media.discordapp.net/attachments/839947923223609415/1427823708323577897/Screenshot_2025-10-14_at_6.00.28_PM.png?ex=68f043f3&is=68eef273&hm=cad589f7762a59f63a801957e892c51e0fb582fbfbf5b14c545ae516464883ac&=&format=webp&quality=lossless&width=2720&height=1636)

![](https://media.discordapp.net/attachments/839947923223609415/1427823709347119304/Screenshot_2025-10-14_at_6.00.49_PM.png?ex=68f043f3&is=68eef273&hm=405bb19b9e40d2edc67cb3c82834ef3b47bcc43a2563a58635a3b593fa19e32e&=&format=webp&quality=lossless&width=2720&height=1636)