### PR TITLE
Gracefully handle short stems when seeking

### DIFF
--- a/Assets/Script/Audio/Bass/BassStemChannel.cs
+++ b/Assets/Script/Audio/Bass/BassStemChannel.cs
@@ -1,4 +1,4 @@
-using ManagedBass;
+﻿using ManagedBass;
 using ManagedBass.Mix;
 using UnityEngine;
 using YARG.Core.Audio;
@@ -66,7 +66,7 @@ namespace YARG.Audio.BASS
             return _pitchParams.fPitchShift;
         }
 
-        protected override void SetPosition_Internal(double position)
+        protected override bool SetPosition_Internal(double position)
         {
             BassMix.SplitStreamReset(_sourceHandle);
 
@@ -74,7 +74,7 @@ namespace YARG.Audio.BASS
             if (bytes < 0)
             {
                 YargLogger.LogFormatError("Failed to get byte position at {0}!", position);
-                return;
+                return false;
             }
 
             if (_streamHandles.PitchFX != 0)
@@ -83,11 +83,7 @@ namespace YARG.Audio.BASS
                 bytes += GlobalAudioHandler.WHAMMY_FFT_DEFAULT * 2;
             }
 
-            bool success = BassMix.ChannelSetPosition(_streamHandles.Stream, bytes, PositionFlags.Bytes | PositionFlags.MixerReset);
-            if (!success)
-            {
-                YargLogger.LogFormatError("Failed to seek to position {0}!", position);
-            }
+            return BassMix.ChannelSetPosition(_streamHandles.Stream, bytes, PositionFlags.Bytes | PositionFlags.MixerReset);
         }
 
         protected override double GetPosition_Internal()

--- a/Assets/Script/Audio/Bass/BassStemMixer.cs
+++ b/Assets/Script/Audio/Bass/BassStemMixer.cs
@@ -118,11 +118,19 @@ namespace YARG.Audio.BASS
             {
                 if (channel.SetPosition(position))
                 {
+                    // Restore the volume, in case we previously failed to seek and muted the stem
                     double volume = GlobalAudioHandler.GetTrueVolume(channel.Stem);
                     channel.SetVolume(volume);
                 } else
                 {
-                    // Failed to seek, so mute
+                    if (Bass.LastError is not Errors.Position)
+                    {
+                        // We only expect seeking to fail due to the position being invalid (if the stem is short).
+                        // If we failed for some other reason, log it
+                        YargLogger.LogFormatError("Failed to seek to position: {0}", Bass.LastError);
+                    }
+
+                    // Regardless of why we failed to seek, we definitely don't want to play the stem, so mtue it
                     channel.SetVolume(0);
                 }
             }

--- a/Assets/Script/Audio/Bass/BassStemMixer.cs
+++ b/Assets/Script/Audio/Bass/BassStemMixer.cs
@@ -130,7 +130,7 @@ namespace YARG.Audio.BASS
                         YargLogger.LogFormatError("Failed to seek to position: {0}", Bass.LastError);
                     }
 
-                    // Regardless of why we failed to seek, we definitely don't want to play the stem, so mtue it
+                    // Regardless of why we failed to seek, we definitely don't want to play the stem, so mute it
                     channel.SetVolume(0);
                 }
             }

--- a/Assets/Script/Audio/Bass/BassStemMixer.cs
+++ b/Assets/Script/Audio/Bass/BassStemMixer.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.IO;
 using System.Threading.Tasks;
 using ManagedBass;
@@ -116,7 +116,15 @@ namespace YARG.Audio.BASS
 
             foreach (var channel in _channels)
             {
-                channel.SetPosition(position);
+                if (channel.SetPosition(position))
+                {
+                    double volume = GlobalAudioHandler.GetTrueVolume(channel.Stem);
+                    channel.SetVolume(volume);
+                } else
+                {
+                    // Failed to seek, so mute
+                    channel.SetVolume(0);
+                }
             }
 
             if (playing)


### PR DESCRIPTION
[Corresponding YARG.Core PR](https://github.com/YARC-Official/YARG.Core/pull/298)

Currently, if a song contains a stem that is shorter than the full length of the song, then seeking to a position later than the end of the stem (such as when loading a preview) plays the short stem from the beginning and logs an error.

This changes the behavior to mute the stem instead. If we somehow fail to seek for some other reason, we log an error, but still mute the stem. When seeking succeeds, we unmute the stem in case it was previously muted