### PR TITLE
Use event system for player audio

### DIFF
--- a/Assets/Script/Audio/PlayerAudioManager.cs
+++ b/Assets/Script/Audio/PlayerAudioManager.cs
@@ -83,6 +83,9 @@ namespace YARG.Audio
                     case SustainEnded:
                         OnSustainEnded();
                         break;
+                    case StarPowerPhraseHit:
+                        OnStarPowerPhraseHit();
+                        break;
                     case WhammyDuringSustain(var whammyFactor):
                         OnWhammyDuringSustain(whammyFactor);
                         break;
@@ -92,6 +95,16 @@ namespace YARG.Audio
             private void OnReplayTimeChanged()
             {
                 SetMuteState(false);
+            }
+
+            private void OnStarPowerPhraseHit()
+            {
+                if (_gameManager.Paused || _gameManager.IsSeekingReplay)
+                {
+                    return;
+                }
+
+                GlobalAudioHandler.PlaySoundEffect(SfxSample.StarPowerAward);
             }
 
             private void OnStarPowerChanged(bool active)
@@ -177,9 +190,6 @@ namespace YARG.Audio
                 {
                     return;
                 }
-
-
-                YargLogger.LogDebug($"SETTING MUTE STATE {muted}");
                 _gameManager.ChangeStemMuteState(_stem, muted);
                 _isMuted = muted;
             }

--- a/Assets/Script/Audio/PlayerAudioManager.cs
+++ b/Assets/Script/Audio/PlayerAudioManager.cs
@@ -4,15 +4,18 @@ using YARG.Core.Audio;
 using YARG.Core.Logging;
 using YARG.Gameplay;
 using YARG.Gameplay.Player;
+using YARG.Settings;
 using static YARG.Core.Audio.SongStem;
 using static YARG.Gameplay.Player.PlayerEvent;
+using Random = UnityEngine.Random;
 
 namespace YARG.Audio
 {
     public class PlayerAudioManager : IDisposable
     {
-        private readonly List<AudioHandler> _handlers;
-        private readonly GameManager        _gameManager;
+        private readonly        List<AudioHandler> _handlers;
+        private readonly        GameManager        _gameManager;
+        private static bool AllowOverhitSfx => SettingsManager.Settings.OverstrumAndOverhitSoundEffects.Value;
 
         public PlayerAudioManager(GameManager gameManager)
         {
@@ -69,6 +72,9 @@ namespace YARG.Audio
                     case NoteMissed:
                         OnNoteMissed();
                         break;
+                    case Overhit:
+                        OnOverhit();
+                        break;
                     case SustainBroken:
                         OnSustainBroken();
                         break;
@@ -122,6 +128,24 @@ namespace YARG.Audio
                 {
                     SetMuteState(true);
                 }
+            }
+
+            private void OnOverhit()
+            {
+                if (_gameManager.IsSeekingReplay)
+                {
+                    return;
+                }
+
+                if (!AllowOverhitSfx)
+                {
+                    return;
+                }
+
+                const int MIN = (int) SfxSample.Overstrum1;
+                const int MAX = (int) SfxSample.Overstrum4;
+                var randomOverstrum = (SfxSample) Random.Range(MIN, MAX + 1);
+                GlobalAudioHandler.PlaySoundEffect(randomOverstrum);
             }
 
             private void OnNoteHit()

--- a/Assets/Script/Audio/PlayerAudioManager.cs
+++ b/Assets/Script/Audio/PlayerAudioManager.cs
@@ -45,6 +45,7 @@ namespace YARG.Audio
             private readonly GameManager _gameManager;
             private          bool        _isMuted;
             private Instrument CurrentInstrument => _player.Player.Profile.CurrentInstrument;
+            private bool IsSeekingReplay => _gameManager.IsSeekingReplay;
 
             public AudioHandler(SongStem stem, BasePlayer player, GameManager gameManager)
             {
@@ -99,7 +100,7 @@ namespace YARG.Audio
 
             private void OnStarPowerPhraseHit()
             {
-                if (_gameManager.Paused || _gameManager.IsSeekingReplay)
+                if (_gameManager.Paused || IsSeekingReplay)
                 {
                     return;
                 }
@@ -139,7 +140,7 @@ namespace YARG.Audio
 
             private void OnNoteMissed(int lastCombo)
             {
-                if (_gameManager.IsSeekingReplay)
+                if (IsSeekingReplay)
                 {
                     return;
                 }
@@ -155,7 +156,7 @@ namespace YARG.Audio
 
             private void OnOverhit()
             {
-                if (_gameManager.IsSeekingReplay)
+                if (IsSeekingReplay)
                 {
                     return;
                 }
@@ -178,10 +179,11 @@ namespace YARG.Audio
 
             private void OnNoteHit()
             {
-                if (!_gameManager.IsSeekingReplay)
+                if (IsSeekingReplay)
                 {
-                    SetMuteState(false);
+                    return;
                 }
+                SetMuteState(false);
             }
 
             private void SetMuteState(bool muted)

--- a/Assets/Script/Audio/PlayerAudioManager.cs
+++ b/Assets/Script/Audio/PlayerAudioManager.cs
@@ -1,0 +1,154 @@
+﻿using System;
+using System.Collections.Generic;
+using YARG.Core.Audio;
+using YARG.Core.Logging;
+using YARG.Gameplay;
+using YARG.Gameplay.Player;
+using static YARG.Core.Audio.SongStem;
+using static YARG.Gameplay.Player.PlayerEvent;
+
+namespace YARG.Audio
+{
+    public class PlayerAudioManager : IDisposable
+    {
+        private readonly List<AudioHandler> _handlers;
+        private readonly GameManager        _gameManager;
+
+        public PlayerAudioManager(GameManager gameManager)
+        {
+            _gameManager = gameManager;
+            _handlers = new List<AudioHandler>();
+        }
+
+        public void AddPlayer(SongStem stem, BasePlayer player)
+        {
+            _handlers.Add(new AudioHandler(stem, player, _gameManager));
+        }
+
+        public void Dispose()
+        {
+            foreach (var handler in _handlers)
+            {
+                handler.Dispose();
+            }
+            _handlers.Clear();
+        }
+
+        private class AudioHandler : IDisposable
+        {
+            private readonly SongStem    _stem;
+            private readonly BasePlayer  _player;
+            private readonly GameManager _gameManager;
+            private          bool        _isMuted;
+
+            public AudioHandler(SongStem stem, BasePlayer player, GameManager gameManager)
+            {
+                _stem = stem;
+                _gameManager = gameManager;
+                _player = player;
+                _player.Events += HandlePlayerEvent;
+            }
+
+            private void HandlePlayerEvent(PlayerEvent playerEvent)
+            {
+                YargLogger.LogDebug($"Received event: {playerEvent} for stem {_stem}");
+                switch (playerEvent)
+                {
+                    case StarPowerChanged(var active):
+                        OnStarPowerChanged(active);
+                        break;
+                    case ReplayTimeChanged:
+                        OnReplayTimeChanged();
+                        break;
+                    case VisualsReset:
+                        OnVisualsReset();
+                        break;
+                    case NoteHit:
+                        OnNoteHit();
+                        break;
+                    case NoteMissed:
+                        OnNoteMissed();
+                        break;
+                    case SustainBroken:
+                        OnSustainBroken();
+                        break;
+                    case SustainEnded:
+                        OnSustainEnded();
+                        break;
+                    case WhammyDuringSustain(var whammyFactor):
+                        OnWhammyDuringSustain(whammyFactor);
+                        break;
+                }
+            }
+
+            private void OnReplayTimeChanged()
+            {
+                SetMuteState(false);
+            }
+
+            private void OnStarPowerChanged(bool active)
+            {
+                var reverbStem = SongStem.Song;
+                if (_stem is Drums or Bass or Rhythm or Guitar)
+                {
+                    reverbStem = _stem;
+                }
+                _gameManager.ChangeStemReverbState(reverbStem, active);
+            }
+
+            private void OnWhammyDuringSustain(float whammyFactor)
+            {
+                _gameManager.ChangeStemWhammyPitch(_stem, whammyFactor);
+            }
+
+            private void OnSustainEnded()
+            {
+                _gameManager.ChangeStemWhammyPitch(_stem, 0);
+            }
+
+            private void OnSustainBroken()
+            {
+                SetMuteState(true);
+            }
+
+            private void OnVisualsReset()
+            {
+                SetMuteState(false);
+            }
+
+            private void OnNoteMissed()
+            {
+                if (!_gameManager.IsSeekingReplay)
+                {
+                    SetMuteState(true);
+                }
+            }
+
+            private void OnNoteHit()
+            {
+                if (!_gameManager.IsSeekingReplay)
+                {
+                    SetMuteState(false);
+                }
+            }
+
+            private void SetMuteState(bool muted)
+            {
+                if (_stem == Vocals || _isMuted == muted)
+                {
+                    return;
+                }
+
+
+                YargLogger.LogDebug($"SETTING MUTE STATE {muted}");
+                _gameManager.ChangeStemMuteState(_stem, muted);
+                _isMuted = muted;
+            }
+
+            public void Dispose()
+            {
+                _player.Events -= HandlePlayerEvent;
+            }
+        }
+    }
+}

--- a/Assets/Script/Audio/PlayerAudioManager.cs
+++ b/Assets/Script/Audio/PlayerAudioManager.cs
@@ -72,8 +72,8 @@ namespace YARG.Audio
                     case NoteHit:
                         OnNoteHit();
                         break;
-                    case NoteMissed(var lastCombo):
-                        OnNoteMissed(lastCombo);
+                    case NoteMissed(var isComboBreak):
+                        OnNoteMissed(isComboBreak);
                         break;
                     case Overhit:
                         OnOverhit();
@@ -138,7 +138,7 @@ namespace YARG.Audio
                 SetMuteState(false);
             }
 
-            private void OnNoteMissed(int lastCombo)
+            private void OnNoteMissed(bool isComboBreak)
             {
                 if (IsSeekingReplay)
                 {
@@ -147,8 +147,7 @@ namespace YARG.Audio
 
                 SetMuteState(true);
 
-                int comboBreakThreshold = _stem == Vocals ? 2 : BasePlayer.COMBO_BREAK_THRESHOLD;
-                if (lastCombo >= comboBreakThreshold)
+                if (isComboBreak)
                 {
                     GlobalAudioHandler.PlaySoundEffect(SfxSample.NoteMiss);
                 }
@@ -156,25 +155,11 @@ namespace YARG.Audio
 
             private void OnOverhit()
             {
-                if (IsSeekingReplay)
+                var shouldPlaySfx = !IsSeekingReplay && CurrentInstrument.IsFiveFret() && AllowOverhitSfx;
+                if (shouldPlaySfx)
                 {
-                    return;
+                    PlayOverstrumSfx();
                 }
-
-                if (!CurrentInstrument.IsFiveFret())
-                {
-                    return;
-                }
-
-                if (!AllowOverhitSfx)
-                {
-                    return;
-                }
-
-                const int min = (int) SfxSample.Overstrum1;
-                const int max = (int) SfxSample.Overstrum4;
-                var randomOverstrum = (SfxSample) Random.Range(min, max + 1);
-                GlobalAudioHandler.PlaySoundEffect(randomOverstrum);
             }
 
             private void OnNoteHit()
@@ -194,6 +179,14 @@ namespace YARG.Audio
                 }
                 _gameManager.ChangeStemMuteState(_stem, muted);
                 _isMuted = muted;
+            }
+
+            private void PlayOverstrumSfx()
+            {
+                const int min = (int) SfxSample.Overstrum1;
+                const int max = (int) SfxSample.Overstrum4;
+                var randomOverstrum = (SfxSample) Random.Range(min, max + 1);
+                GlobalAudioHandler.PlaySoundEffect(randomOverstrum);
             }
 
             public void Dispose()

--- a/Assets/Script/Audio/PlayerAudioManager.cs.meta
+++ b/Assets/Script/Audio/PlayerAudioManager.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 969fa17999934933a0110553bd905332
+timeCreated: 1760676209

--- a/Assets/Script/Gameplay/GameManager.Loading.cs
+++ b/Assets/Script/Gameplay/GameManager.Loading.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using Cysharp.Threading.Tasks;
 using UnityEngine;
+using YARG.Audio;
 using YARG.Core;
 using YARG.Core.Audio;
 using YARG.Core.Chart;
@@ -195,6 +196,7 @@ namespace YARG.Gameplay
 
             // Spawn players
             CreatePlayers();
+            SetupPlayerAudio();
 
             // Set up the crowd stem so it can be restored after muting (if it exists)
             if (_stemStates.TryGetValue(SongStem.Crowd, out var state))
@@ -258,6 +260,20 @@ namespace YARG.Gameplay
             enabled = true;
             IsSongStarted = true;
             _songStarted?.Invoke();
+        }
+
+        private void SetupPlayerAudio()
+        {
+            _playerAudioManager = new PlayerAudioManager(this);
+            foreach (var player in _players)
+            {
+                var songStem = player.Player.Profile.CurrentInstrument.ToSongStem();
+                if (songStem == SongStem.Bass && _mixer[SongStem.Bass] == null)
+                {
+                    songStem = SongStem.Rhythm;
+                }
+                _playerAudioManager.AddPlayer(songStem, player);
+            }
         }
 
         private bool LoadReplay()

--- a/Assets/Script/Gameplay/GameManager.cs
+++ b/Assets/Script/Gameplay/GameManager.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using Cysharp.Threading.Tasks;
 using UnityEngine;
 using UnityEngine.InputSystem;
+using YARG.Audio;
 using YARG.Core.Audio;
 using YARG.Core.Chart;
 using YARG.Core.Engine;
@@ -72,6 +73,8 @@ namespace YARG.Gameplay
         private List<BasePlayer> _players;
 
         public int TotalPlayers => _players.Count;
+
+        private PlayerAudioManager _playerAudioManager;
 
         public bool IsSongStarted { get; private set; } = false;
 
@@ -240,6 +243,7 @@ namespace YARG.Gameplay
             _pauseMenu.PopAllMenus();
             _mixer?.Dispose();
             _songRunner?.Dispose();
+            _playerAudioManager?.Dispose();
             BackgroundManager.Dispose();
             CrowdEventHandler.Dispose();
 

--- a/Assets/Script/Gameplay/Player/BasePlayer.cs
+++ b/Assets/Script/Gameplay/Player/BasePlayer.cs
@@ -22,6 +22,8 @@ namespace YARG.Gameplay.Player
 {
     public abstract class BasePlayer : GameplayBehaviour
     {
+        public const int COMBO_BREAK_THRESHOLD = 10;
+
         public event Action<PlayerEvent> Events;
         protected void OnEvent(PlayerEvent playerEvent)
         {

--- a/Assets/Script/Gameplay/Player/BasePlayer.cs
+++ b/Assets/Script/Gameplay/Player/BasePlayer.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using PlasticBand.Haptics;
 using UnityEngine;
 using UnityEngine.InputSystem;
@@ -15,11 +16,18 @@ using YARG.Input;
 using YARG.Playback;
 using YARG.Player;
 using YARG.Settings;
+using static YARG.Gameplay.Player.PlayerEvent;
 
 namespace YARG.Gameplay.Player
 {
     public abstract class BasePlayer : GameplayBehaviour
     {
+        public event Action<PlayerEvent> Events;
+        protected void OnEvent(PlayerEvent playerEvent)
+        {
+            Events?.Invoke(playerEvent);
+        }
+
         public int HighwayIndex { get; private set; }
 
         public YargPlayer Player { get; private set; }
@@ -200,12 +208,9 @@ namespace YARG.Gameplay.Player
 
         public abstract void SetPracticeSection(uint start, uint end);
 
-        // TODO Make this more generic
-        public abstract void SetStemMuteState(bool muted);
-
         public virtual void SetStarPowerFX(bool active)
         {
-            GameManager.ChangeStemReverbState(SongStem.Song, active);
+            OnEvent(new StarPowerChanged(active));
         }
 
         public virtual void SetReplayTime(double time)
@@ -214,7 +219,7 @@ namespace YARG.Gameplay.Player
 
             _replayInputIndex = BaseEngine.ProcessUpToTime(time, ReplayInputs);
 
-            SetStemMuteState(false);
+            OnEvent(new ReplayTimeChanged(time));
 
             ResetVisuals();
             UpdateVisuals(time);

--- a/Assets/Script/Gameplay/Player/BasePlayer.cs
+++ b/Assets/Script/Gameplay/Player/BasePlayer.cs
@@ -363,10 +363,7 @@ namespace YARG.Gameplay.Player
 
         protected virtual void OnStarPowerPhraseHit()
         {
-            if (!GameManager.Paused && !GameManager.IsSeekingReplay)
-            {
-                GlobalAudioHandler.PlaySoundEffect(SfxSample.StarPowerAward);
-            }
+            OnEvent(new StarPowerPhraseHit());
         }
 
         protected virtual void OnStarPowerPhraseMissed()

--- a/Assets/Script/Gameplay/Player/DrumsPlayer.cs
+++ b/Assets/Script/Gameplay/Player/DrumsPlayer.cs
@@ -306,20 +306,6 @@ namespace YARG.Gameplay.Player
             }
         }
 
-        public override void SetStemMuteState(bool muted)
-        {
-            if (IsStemMuted != muted)
-            {
-                GameManager.ChangeStemMuteState(SongStem.Drums, muted);
-                IsStemMuted = muted;
-            }
-        }
-
-        public override void SetStarPowerFX(bool active)
-        {
-            GameManager.ChangeStemReverbState(SongStem.Drums, active);
-        }
-
         protected override void ResetVisuals()
         {
             base.ResetVisuals();

--- a/Assets/Script/Gameplay/Player/FiveFretGuitarPlayer.cs
+++ b/Assets/Script/Gameplay/Player/FiveFretGuitarPlayer.cs
@@ -425,15 +425,6 @@ namespace YARG.Gameplay.Player
                 return;
             }
 
-            if (SettingsManager.Settings.OverstrumAndOverhitSoundEffects.Value)
-            {
-                const int MIN = (int) SfxSample.Overstrum1;
-                const int MAX = (int) SfxSample.Overstrum4;
-
-                var randomOverstrum = (SfxSample) Random.Range(MIN, MAX + 1);
-                GlobalAudioHandler.PlaySoundEffect(randomOverstrum);
-            }
-
             // To check if held frets are valid
             GuitarNote currentNote = null;
             if (Engine.NoteIndex < Notes.Count)

--- a/Assets/Script/Gameplay/Player/FiveFretGuitarPlayer.cs
+++ b/Assets/Script/Gameplay/Player/FiveFretGuitarPlayer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
@@ -10,15 +10,14 @@ using YARG.Core.Engine.Guitar.Engines;
 using YARG.Core.Input;
 using YARG.Core.Logging;
 using YARG.Core.Replays;
-using YARG.Gameplay.HUD;
 using YARG.Gameplay.Visuals;
 using YARG.Helpers;
 using YARG.Helpers.Extensions;
 using YARG.Playback;
-using YARG.Player;
 using YARG.Settings;
 using YARG.Themes;
 using static YARG.Core.Game.ColorProfile;
+using static YARG.Gameplay.Player.PlayerEvent;
 using Random = UnityEngine.Random;
 
 namespace YARG.Gameplay.Player
@@ -122,19 +121,7 @@ namespace YARG.Gameplay.Player
         public float WhammyFactor { get; private set; }
 
         private int _sustainCount;
-
-        private SongStem _stem;
         private double _practiceSectionStartTime;
-
-        public override void Initialize(int index, YargPlayer player, SongChart chart, TrackView trackView, StemMixer mixer, int? currentHighScore)
-        {
-            _stem = player.Profile.CurrentInstrument.ToSongStem();
-            if (_stem == SongStem.Bass && mixer[SongStem.Bass] == null)
-            {
-                _stem = SongStem.Rhythm;
-            }
-            base.Initialize(index, player, chart, trackView, mixer, currentHighScore);
-        }
 
         protected override InstrumentDifficulty<GuitarNote> GetNotes(SongChart chart)
         {
@@ -363,20 +350,6 @@ namespace YARG.Gameplay.Player
             _shiftIndicators.Dequeue();
         }
 
-        public override void SetStemMuteState(bool muted)
-        {
-            if (IsStemMuted != muted)
-            {
-                GameManager.ChangeStemMuteState(_stem, muted);
-                IsStemMuted = muted;
-            }
-        }
-
-        public override void SetStarPowerFX(bool active)
-        {
-            GameManager.ChangeStemReverbState(_stem, active);
-        }
-
         protected override void ResetVisuals()
         {
             base.ResetVisuals();
@@ -545,14 +518,14 @@ namespace YARG.Gameplay.Player
             {
                 if (!parent.IsDisjoint || _sustainCount == 0)
                 {
-                    SetStemMuteState(true);
+                    OnEvent(new SustainBroken());
                 }
             }
 
             if (_sustainCount == 0)
             {
+                OnEvent(new SustainEnded());
                 WhammyFactor = 0;
-                GameManager.ChangeStemWhammyPitch(_stem, 0);
             }
         }
 
@@ -581,7 +554,7 @@ namespace YARG.Gameplay.Player
             if (_sustainCount > 0 && input.GetAction<GuitarAction>() == GuitarAction.Whammy)
             {
                 WhammyFactor = Mathf.Clamp01(input.Axis);
-                GameManager.ChangeStemWhammyPitch(_stem, WhammyFactor);
+                OnEvent(new WhammyDuringSustain(WhammyFactor));
             }
         }
 

--- a/Assets/Script/Gameplay/Player/FiveLaneKeysPlayer.cs
+++ b/Assets/Script/Gameplay/Player/FiveLaneKeysPlayer.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 using YARG.Core;
-using YARG.Core.Audio;
 using YARG.Core.Chart;
 using YARG.Core.Engine.Keys;
 using YARG.Core.Engine.Keys.Engines;
@@ -11,20 +10,20 @@ using YARG.Core.Input;
 using YARG.Core.Logging;
 using YARG.Core.Replays;
 using YARG.Gameplay;
-using YARG.Gameplay.HUD;
 using YARG.Gameplay.Player;
 using YARG.Gameplay.Visuals;
 using YARG.Helpers;
 using YARG.Helpers.Extensions;
 using YARG.Playback;
-using YARG.Player;
 using YARG.Themes;
+using static YARG.Gameplay.Player.PlayerEvent;
 using static YARG.Core.Engine.Keys.FiveLaneKeysEngine;
 
 namespace YARG.Assets.Script.Gameplay.Player
 {
     public sealed class FiveLaneKeysPlayer : TrackPlayer<FiveLaneKeysEngine, GuitarNote>
     {
+
         private const double SUSTAIN_END_MUTE_THRESHOLD = 0.1;
 
         private const int SHIFT_INDICATOR_MEASURES_BEFORE = 5;
@@ -115,19 +114,7 @@ public override bool ShouldUpdateInputsOnResume => true;
         public float WhammyFactor { get; private set; }
 
         private int _sustainCount;
-
-        private SongStem _stem;
         private double _practiceSectionStartTime;
-
-        public override void Initialize(int index, YargPlayer player, SongChart chart, TrackView trackView, StemMixer mixer, int? currentHighScore)
-        {
-            _stem = player.Profile.CurrentInstrument.ToSongStem();
-            if (_stem == SongStem.Bass && mixer[SongStem.Bass] == null)
-            {
-                _stem = SongStem.Rhythm;
-            }
-            base.Initialize(index, player, chart, trackView, mixer, currentHighScore);
-        }
 
         protected override InstrumentDifficulty<GuitarNote> GetNotes(SongChart chart)
         {
@@ -384,7 +371,7 @@ public override bool ShouldUpdateInputsOnResume => true;
             if (_sustainCount > 0 && input.GetAction<ProKeysAction>() == ProKeysAction.TouchEffects)
             {
                 WhammyFactor = Mathf.Clamp01(input.Axis);
-                GameManager.ChangeStemWhammyPitch(_stem, WhammyFactor);
+                OnEvent(new WhammyDuringSustain(WhammyFactor));
             }
         }
 
@@ -474,7 +461,7 @@ public override bool ShouldUpdateInputsOnResume => true;
             if (!finished)
             {
                 // Do we want to check if its part of a chord, and if so, if all sustains were dropped to mute?
-                SetStemMuteState(true);
+                OnEvent(new SustainBroken());
             }
 
             if (note.FiveLaneKeysAction is not FiveLaneKeysAction.OpenNote || UsingOpenLane)
@@ -486,8 +473,8 @@ public override bool ShouldUpdateInputsOnResume => true;
 
             if (_sustainCount == 0)
             {
+                OnEvent(new SustainEnded());
                 WhammyFactor = 0;
-                GameManager.ChangeStemWhammyPitch(_stem, 0);
             }
         }
 
@@ -504,15 +491,6 @@ public override bool ShouldUpdateInputsOnResume => true;
         {
             var frame = new ReplayFrame(Player.Profile, EngineParams, Engine.EngineStats, ReplayInputs.ToArray());
             return (frame, Engine.EngineStats.ConstructReplayStats(Player.Profile.Name));
-        }
-
-        public override void SetStemMuteState(bool muted)
-        {
-            if (IsStemMuted != muted)
-            {
-                GameManager.ChangeStemMuteState(_stem, muted);
-                IsStemMuted = muted;
-            }
         }
 
         private void InitializeRangeShift(double time = 0)

--- a/Assets/Script/Gameplay/Player/PlayerEvent.cs
+++ b/Assets/Script/Gameplay/Player/PlayerEvent.cs
@@ -12,6 +12,7 @@ namespace YARG.Gameplay.Player
         public sealed record SustainBroken : PlayerEvent;
         public sealed record Overhit : PlayerEvent;
         public sealed record SustainEnded : PlayerEvent;
+        public sealed record StarPowerPhraseHit : PlayerEvent;
         public sealed record WhammyDuringSustain(float WhammyFactor) : PlayerEvent;
     }
 }

--- a/Assets/Script/Gameplay/Player/PlayerEvent.cs
+++ b/Assets/Script/Gameplay/Player/PlayerEvent.cs
@@ -8,7 +8,7 @@ namespace YARG.Gameplay.Player
         public sealed record ReplayTimeChanged(double Time) : PlayerEvent;
         public sealed record VisualsReset : PlayerEvent;
         public sealed record NoteHit : PlayerEvent;
-        public sealed record NoteMissed : PlayerEvent;
+        public sealed record NoteMissed(int LastCombo) : PlayerEvent;
         public sealed record SustainBroken : PlayerEvent;
         public sealed record Overhit : PlayerEvent;
         public sealed record SustainEnded : PlayerEvent;

--- a/Assets/Script/Gameplay/Player/PlayerEvent.cs
+++ b/Assets/Script/Gameplay/Player/PlayerEvent.cs
@@ -10,6 +10,7 @@ namespace YARG.Gameplay.Player
         public sealed record NoteHit : PlayerEvent;
         public sealed record NoteMissed : PlayerEvent;
         public sealed record SustainBroken : PlayerEvent;
+        public sealed record Overhit : PlayerEvent;
         public sealed record SustainEnded : PlayerEvent;
         public sealed record WhammyDuringSustain(float WhammyFactor) : PlayerEvent;
     }

--- a/Assets/Script/Gameplay/Player/PlayerEvent.cs
+++ b/Assets/Script/Gameplay/Player/PlayerEvent.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace YARG.Gameplay.Player
+{
+    public abstract record PlayerEvent
+    {
+        public sealed record StarPowerChanged(bool Active) : PlayerEvent;
+        public sealed record ReplayTimeChanged(double Time) : PlayerEvent;
+        public sealed record VisualsReset : PlayerEvent;
+        public sealed record NoteHit : PlayerEvent;
+        public sealed record NoteMissed : PlayerEvent;
+        public sealed record SustainBroken : PlayerEvent;
+        public sealed record SustainEnded : PlayerEvent;
+        public sealed record WhammyDuringSustain(float WhammyFactor) : PlayerEvent;
+    }
+}

--- a/Assets/Script/Gameplay/Player/PlayerEvent.cs
+++ b/Assets/Script/Gameplay/Player/PlayerEvent.cs
@@ -8,7 +8,7 @@ namespace YARG.Gameplay.Player
         public sealed record ReplayTimeChanged(double Time) : PlayerEvent;
         public sealed record VisualsReset : PlayerEvent;
         public sealed record NoteHit : PlayerEvent;
-        public sealed record NoteMissed(int LastCombo) : PlayerEvent;
+        public sealed record NoteMissed(bool IsComboBreak) : PlayerEvent;
         public sealed record SustainBroken : PlayerEvent;
         public sealed record Overhit : PlayerEvent;
         public sealed record SustainEnded : PlayerEvent;

--- a/Assets/Script/Gameplay/Player/PlayerEvent.cs.meta
+++ b/Assets/Script/Gameplay/Player/PlayerEvent.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: a556d670a9104163bf0dc01a0210adef
+timeCreated: 1760889284

--- a/Assets/Script/Gameplay/Player/ProKeysPlayer.cs
+++ b/Assets/Script/Gameplay/Player/ProKeysPlayer.cs
@@ -1,4 +1,4 @@
-﻿using DG.Tweening;
+using DG.Tweening;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -13,6 +13,7 @@ using YARG.Core.Logging;
 using YARG.Core.Replays;
 using YARG.Gameplay.Visuals;
 using YARG.Helpers.Extensions;
+using static YARG.Gameplay.Player.PlayerEvent;
 
 namespace YARG.Gameplay.Player
 {
@@ -278,7 +279,7 @@ namespace YARG.Gameplay.Player
             if (!finished)
             {
                 // Do we want to check if its part of a chord, and if so, if all sustains were dropped to mute?
-                SetStemMuteState(true);
+                OnEvent(new SustainBroken());
             }
         }
 
@@ -443,15 +444,6 @@ namespace YARG.Gameplay.Player
             foreach (var lane in LanePool.AllSpawned)
             {
                 (lane as LaneElement)?.OffsetXPosition(_currentOffset);
-            }
-        }
-
-        public override void SetStemMuteState(bool muted)
-        {
-            if (IsStemMuted != muted)
-            {
-                GameManager.ChangeStemMuteState(SongStem.Keys, muted);
-                IsStemMuted = muted;
             }
         }
 

--- a/Assets/Script/Gameplay/Player/ProKeysPlayer.cs
+++ b/Assets/Script/Gameplay/Player/ProKeysPlayer.cs
@@ -1,10 +1,9 @@
-using DG.Tweening;
+﻿using DG.Tweening;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 using YARG.Core;
-using YARG.Core.Audio;
 using YARG.Core.Chart;
 using YARG.Core.Engine.Keys;
 using YARG.Core.Engine.Keys.Engines;

--- a/Assets/Script/Gameplay/Player/TrackPlayer.cs
+++ b/Assets/Script/Gameplay/Player/TrackPlayer.cs
@@ -924,7 +924,7 @@ namespace YARG.Gameplay.Player
 
         protected virtual void OnNoteMissed(int index, TNote note)
         {
-            OnEvent(new NoteMissed());
+            OnEvent(new NoteMissed(LastCombo));
             if (IsFc)
             {
                 ComboMeter.SetFullCombo(false);
@@ -933,9 +933,8 @@ namespace YARG.Gameplay.Player
 
             if (!GameManager.IsSeekingReplay)
             {
-                if (LastCombo >= 10)
+                if (LastCombo >= COMBO_BREAK_THRESHOLD)
                 {
-                    GlobalAudioHandler.PlaySoundEffect(SfxSample.NoteMiss);
                     CameraPositioner.Punch();
                 }
 
@@ -956,7 +955,7 @@ namespace YARG.Gameplay.Player
                 IsFc = false;
             }
 
-            if (LastCombo >= 10)
+            if (LastCombo >= COMBO_BREAK_THRESHOLD)
             {
                 CameraPositioner.Punch();
             }

--- a/Assets/Script/Gameplay/Player/TrackPlayer.cs
+++ b/Assets/Script/Gameplay/Player/TrackPlayer.cs
@@ -15,14 +15,15 @@ using YARG.Playback;
 using YARG.Player;
 using YARG.Settings;
 using YARG.Themes;
+using static YARG.Gameplay.Player.PlayerEvent;
 
 namespace YARG.Gameplay.Player
 {
     public abstract class TrackPlayer : BasePlayer
     {
-        public const float STRIKE_LINE_POS       = -2f;
-        public const float DEFAULT_ZERO_FADE_POS = 3f;
-        public const float NOTE_SPAWN_OFFSET     = 5f;
+        public const float  STRIKE_LINE_POS       = -2f;
+        public const float  DEFAULT_ZERO_FADE_POS = 3f;
+        public const float  NOTE_SPAWN_OFFSET     = 5f;
 
         public const float TRACK_WIDTH  = 2f;
 
@@ -133,7 +134,7 @@ namespace YARG.Gameplay.Player
         {
             // "Muting a stem" isn't technically a visual,
             // but it's a form of feedback so we'll put it here.
-            SetStemMuteState(false);
+            OnEvent(new VisualsReset());
 
             ComboMeter.SetFullCombo(IsFc);
             TrackView.ForceReset();
@@ -150,7 +151,8 @@ namespace YARG.Gameplay.Player
         where TEngine : BaseEngine
         where TNote : Note<TNote>
     {
-        public TEngine Engine { get; private set; }
+
+        public TEngine      Engine { get; private set; }
 
         public override BaseEngine BaseEngine => Engine;
 
@@ -891,9 +893,9 @@ namespace YARG.Gameplay.Player
                 _autoCalibrator.RecordAccuracy(note.Time);
             }
 
+            OnEvent(new NoteHit());
             if (!GameManager.IsSeekingReplay)
             {
-                SetStemMuteState(false);
                 if (_currentMultiplier != _previousMultiplier)
                 {
                     _previousMultiplier = _currentMultiplier;
@@ -922,6 +924,7 @@ namespace YARG.Gameplay.Player
 
         protected virtual void OnNoteMissed(int index, TNote note)
         {
+            OnEvent(new NoteMissed());
             if (IsFc)
             {
                 ComboMeter.SetFullCombo(false);
@@ -930,8 +933,6 @@ namespace YARG.Gameplay.Player
 
             if (!GameManager.IsSeekingReplay)
             {
-                SetStemMuteState(true);
-
                 if (LastCombo >= 10)
                 {
                     GlobalAudioHandler.PlaySoundEffect(SfxSample.NoteMiss);

--- a/Assets/Script/Gameplay/Player/TrackPlayer.cs
+++ b/Assets/Script/Gameplay/Player/TrackPlayer.cs
@@ -924,7 +924,8 @@ namespace YARG.Gameplay.Player
 
         protected virtual void OnNoteMissed(int index, TNote note)
         {
-            OnEvent(new NoteMissed(LastCombo));
+            bool isComboBreak = LastCombo >= COMBO_BREAK_THRESHOLD;
+            OnEvent(new NoteMissed(isComboBreak));
             if (IsFc)
             {
                 ComboMeter.SetFullCombo(false);

--- a/Assets/Script/Gameplay/Player/TrackPlayer.cs
+++ b/Assets/Script/Gameplay/Player/TrackPlayer.cs
@@ -962,6 +962,8 @@ namespace YARG.Gameplay.Player
             }
 
             LastCombo = Combo;
+
+            OnEvent(new Overhit());
         }
 
         protected virtual void OnSoloStart(SoloSection solo)

--- a/Assets/Script/Gameplay/Player/VocalsPlayer.cs
+++ b/Assets/Script/Gameplay/Player/VocalsPlayer.cs
@@ -220,11 +220,7 @@ namespace YARG.Gameplay.Player
 
             engine.OnNoteMissed += (_, _) =>
             {
-                if (LastCombo >= 2)
-                {
-                    GlobalAudioHandler.PlaySoundEffect(SfxSample.NoteMiss);
-                }
-
+                OnEvent(new NoteMissed(LastCombo));
                 LastCombo = Combo;
             };
 

--- a/Assets/Script/Gameplay/Player/VocalsPlayer.cs
+++ b/Assets/Script/Gameplay/Player/VocalsPlayer.cs
@@ -14,6 +14,7 @@ using YARG.Helpers;
 using YARG.Input;
 using YARG.Player;
 using YARG.Settings;
+using static YARG.Gameplay.Player.PlayerEvent;
 
 namespace YARG.Gameplay.Player
 {

--- a/Assets/Script/Gameplay/Player/VocalsPlayer.cs
+++ b/Assets/Script/Gameplay/Player/VocalsPlayer.cs
@@ -20,6 +20,8 @@ namespace YARG.Gameplay.Player
 {
     public class VocalsPlayer : BasePlayer
     {
+        private const int COMBO_BREAK_THRESHOLD = 2;
+
         public VocalsEngineParameters EngineParams { get; private set; }
         public VocalsEngine           Engine       { get; private set; }
 
@@ -221,7 +223,8 @@ namespace YARG.Gameplay.Player
 
             engine.OnNoteMissed += (_, _) =>
             {
-                OnEvent(new NoteMissed(LastCombo));
+                bool isComboBreak = LastCombo >= COMBO_BREAK_THRESHOLD;
+                OnEvent(new NoteMissed(isComboBreak));
                 LastCombo = Combo;
             };
 

--- a/Assets/Script/Gameplay/Player/VocalsPlayer.cs
+++ b/Assets/Script/Gameplay/Player/VocalsPlayer.cs
@@ -565,11 +565,6 @@ namespace YARG.Gameplay.Player
             ResetPracticeSection();
         }
 
-        public override void SetStemMuteState(bool muted)
-        {
-            // Vocals has no stem muting
-        }
-
         protected override bool InterceptInput(ref GameInput input)
         {
             return false;

--- a/Assets/Script/Persistent/GlobalVariables.cs
+++ b/Assets/Script/Persistent/GlobalVariables.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
 using UnityEngine;
 using UnityEngine.SceneManagement;
@@ -225,5 +226,13 @@ namespace YARG
             return $"{branch} b{commitCount} ({commit})";
 #endif
         }
+
     }
+}
+
+// Fixes compiler error when using sealed records in .NET <5.0, See https://github.com/dotnet/roslyn/issues/45510
+namespace System.Runtime.CompilerServices
+{
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    internal static class IsExternalInit { }
 }

--- a/Assets/Script/Player/YargPlayer.cs
+++ b/Assets/Script/Player/YargPlayer.cs
@@ -38,8 +38,8 @@ namespace YARG.Player
         /// <remarks>Could be invalidated due abusing pauses or no fail mode.</remarks>
         public bool IsScoreValid { get; set; } = true;
 
-        public bool IsReplay { get; private set; }
-        public int ReplayIndex = -1;
+        public bool IsReplay { get; }
+        public int  ReplayIndex = -1;
 
         /// <summary>
         /// Overrides the engine parameters in the gameplay player.


### PR DESCRIPTION
YARG.Core PR: https://github.com/YARC-Official/YARG.Core/pull/322

# Audio Event System Refactor

This is a first step in reducing global state for handling per-player audio.

## Overview

This PR decouples audio from the Player using an event system. We can then consolidate audio handling in a class `PlayerAudioManager` with a lifecycle that is tied to the lifecycle of the song / players.

`PlayerAudioManager` then represents the audio manager for all players, and each player is associated internally with an `AudioHandler`.

Right now each `AudioHandler` just calls the existing global stem methods, which remain unchanged. This is so that we can do this refactor in parts without a huge PR.

## Goals

Eventually this will enable us to move the logic out of `GameManager.Audio` into this `PlayerAudioManager`, and will help us avoid having global stem states with a lifecycle tied to the application lifecycle.

## Rationale for Event System Over Composition

1. We have `Player` classes that have very deep inheritance hierarchies. For example `FiveFretGuitarPlayer -> TrackPlayer<> -> TrackPlayer -> BasePlayer`. Each level handles parts of the audio by calling the `GameManager`. Subclasses override some methods to change how the audio is handled over the default in the base class.

2. The `Player` class is already a bit of a "God class", handling Scoring Logic, Visuals, Notifications, Audio, Replays, at each level of the hierarchy.

An Event system flattens out the various player events into a single `Action` that is subscriptable, which makes it easy to understand how the audio is handled
