### PR TITLE
Show active instrument filters on Music Select Screen

### DIFF
--- a/Assets/Prefabs/Menu/MusicLibrary/DifficultyRing.prefab
+++ b/Assets/Prefabs/Menu/MusicLibrary/DifficultyRing.prefab
@@ -69,6 +69,7 @@ MonoBehaviour:
   _ringPurpleColor: {r: 0.53333336, g: 0.26666668, b: 0.9843137, a: 1}
   _ringRainbowMaterial: {fileID: 2100000, guid: 38b352628af319449b76ad71b1dea81a,
     type: 2}
+  _partSelectedColor: {r: 0.18039216, g: 0.8509804, b: 1, a: 0}
 --- !u!1 &431087603098892755
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Script/Menu/DifficultySelect/DifficultySelectMenu.cs
+++ b/Assets/Script/Menu/DifficultySelect/DifficultySelectMenu.cs
@@ -84,6 +84,7 @@ namespace YARG.Menu.DifficultySelect
         private readonly List<Difficulty> _possibleDifficulties = new();
         private readonly List<Modifier>   _possibleModifiers    = new();
 
+        [NonSerialized]
         private Modifier _excusableModifiers;
 
         private int _maxHarmonyIndex = 3;

--- a/Assets/Script/Menu/MusicLibrary/DifficultyRing.cs
+++ b/Assets/Script/Menu/MusicLibrary/DifficultyRing.cs
@@ -2,7 +2,6 @@
 using UnityEngine;
 using UnityEngine.AddressableAssets;
 using UnityEngine.EventSystems;
-using UnityEngine.Serialization;
 using UnityEngine.UI;
 using YARG.Core;
 using YARG.Core.Song;
@@ -41,11 +40,16 @@ namespace YARG.Menu.MusicLibrary
         private Color _ringPurpleColor;
         [SerializeField]
         private Material _ringRainbowMaterial;
+        [SerializeField]
+        private Color _partSelectedColor;
 
         private SongSearchingField _songSearchingField;
         private Instrument _instrument;
         private int _intensity;
         private bool _active;
+
+        private const float ACTIVE_OPACITY = 1f;
+        private const float INACTIVE_OPACITY = 0.2f;
 
         private void Awake()
         {
@@ -142,35 +146,58 @@ namespace YARG.Menu.MusicLibrary
             _ringSprite.material = ringMaterial;
 
             // Set opacity
-            const float ACTIVE_OPACITY = 1f;
-            const float INACTIVE_OPACITY = 0.2f;
             if (_active)
             {
-                _instrumentIcon.color = _instrumentIcon.color.WithAlpha(ACTIVE_OPACITY);
                 _ringSprite.color = _ringSprite.color.WithAlpha(ACTIVE_OPACITY);
                 _ringBase.color = _ringBase.color.WithAlpha(ACTIVE_OPACITY);
             }
             else
             {
-                _instrumentIcon.color = _instrumentIcon.color.WithAlpha(INACTIVE_OPACITY);
                 _ringSprite.color = _ringSprite.color.WithAlpha(INACTIVE_OPACITY);
                 _ringBase.color = _ringBase.color.WithAlpha(INACTIVE_OPACITY);
             }
+
+            UpdateIconColor();
+        }
+
+        private void UpdateIconColor()
+        {
+            if (!_active)
+            {
+                _instrumentIcon.color = Color.white.WithAlpha(INACTIVE_OPACITY);
+                return;
+            }
+            if (_songSearchingField.HasInstrumentFilter(_instrument))
+            {
+                _instrumentIcon.color = _partSelectedColor.WithAlpha(ACTIVE_OPACITY);
+                return;
+            }
+            _instrumentIcon.color = Color.white.WithAlpha(ACTIVE_OPACITY);
         }
 
         public void OnPointerClick(PointerEventData eventData)
         {
-            if (_active)
+
+            if (!_active)
             {
-                if (eventData.button == PointerEventData.InputButton.Right)
-                {
-                    _songSearchingField.SetSearchInput(_instrument.ToSortAttribute(), $"\"{_intensity}\"");
-                }
-                else if (eventData.button == PointerEventData.InputButton.Left)
-                {
-                    _songSearchingField.SetSearchInput(_instrument.ToSortAttribute(), $"");
-                }
+                return;
             }
+
+            if (eventData.button == PointerEventData.InputButton.Right)
+            {
+                _songSearchingField.SetSearchInput(_instrument.ToSortAttribute(), $"\"{_intensity}\"");
+            }
+            else if (eventData.button == PointerEventData.InputButton.Left)
+            {
+                if (_instrument == Instrument.Band)
+                {
+                    // Don't allow filtering by "Band Instrument". That would be silly.
+                    return;
+                }
+                _songSearchingField.SetSearchInput(_instrument.ToSortAttribute(), $"");
+            }
+
+            UpdateIconColor();
         }
     }
 }

--- a/Assets/Script/Menu/MusicLibrary/SongSearchingField.cs
+++ b/Assets/Script/Menu/MusicLibrary/SongSearchingField.cs
@@ -7,6 +7,7 @@ using UnityEngine;
 using UnityEngine.InputSystem;
 using YARG.Core;
 using YARG.Core.Extensions;
+using YARG.Helpers.Extensions;
 using YARG.Song;
 
 namespace YARG.Menu.MusicLibrary
@@ -280,6 +281,13 @@ namespace YARG.Menu.MusicLibrary
         private void OnDisable()
         {
             _searchFilters.ClickedButton -= OnClickedSearchFilter;
+        }
+
+        public bool HasInstrumentFilter(Instrument instrument)
+        {
+            // Messy, but SongSearchingField uses _fullSearchQuery as the source of truth for filters
+            var filter = instrument.ToSortAttribute().ToString().ToLowerInvariant() + ":";
+            return _fullSearchQuery.StartsWith(filter) || _fullSearchQuery.Contains(";" + filter);
         }
     }
 }


### PR DESCRIPTION
This PR enhances the Music Select Screen to show which instrument part filters are active. These are now shown with a blue colour in the instrument difficulty rings display. Multiple filters can be active at once, in which case each affected instrument will be highlighted.

<img width="459" height="191" alt="image" src="https://github.com/user-attachments/assets/a6bf5a02-81ff-41c0-8887-5f4bdee1c491" />

Known issue: It is currently not possible to _remove_ a single instrument filter easily. The only way to do this is to clear _all_ filters by pressing the Back button.