### PR TITLE
Simplify multichannel stems in BassStemMixer

### DIFF
--- a/Assets/Script/Audio/Bass/BassAudioManager.cs
+++ b/Assets/Script/Audio/Bass/BassAudioManager.cs
@@ -24,7 +24,7 @@ namespace YARG.Audio.BASS
 
             int[]? channelMap = null;
 #nullable disable
-            if (indices != null)
+            if (indices.Length > 0)
             {
                 channelMap = new int[indices.Length + 1];
                 for (int i = 0; i < indices.Length; ++i)
@@ -199,7 +199,7 @@ namespace YARG.Audio.BASS
             {
                 return null;
             }
-            return new BassStemMixer(name, this, speed, mixerVolume, handle, clampStemVolume, normalize, 
+            return new BassStemMixer(name, this, speed, mixerVolume, handle, clampStemVolume, normalize,
                 CreateOutputChannel(SettingsManager.Settings?.OutputChannelDefault.Value ?? 0));
         }
 
@@ -657,23 +657,22 @@ namespace YARG.Audio.BASS
         }
 
 #nullable enable
-        internal static bool CreateSplitStreams(int sourceStream, int[] channelMap, out StreamHandle? streamHandles, out StreamHandle? reverbHandles)
+        internal static (StreamHandle Stream, StreamHandle Reverb)? CreateSplitStreams(int sourceStream, int[] channelMap)
 #nullable disable
         {
-            streamHandles = StreamHandle.Create(sourceStream, channelMap);
+            var streamHandles = StreamHandle.Create(sourceStream, channelMap);
             if (streamHandles == null)
             {
-                reverbHandles = null;
-                return false;
+                return null;
             }
 
-            reverbHandles = StreamHandle.Create(sourceStream, channelMap);
+            var reverbHandles = StreamHandle.Create(sourceStream, channelMap);
             if (reverbHandles == null)
             {
                 streamHandles.Dispose();
-                return false;
+                return null;
             }
-            return true;
+            return (streamHandles, reverbHandles);
         }
 
         internal static PitchShiftParametersStruct SetPitchParams(SongStem stem, float speed, StreamHandle streamHandles, StreamHandle reverbHandles)

--- a/Assets/Script/Audio/Bass/BassNormalizer.cs
+++ b/Assets/Script/Audio/Bass/BassNormalizer.cs
@@ -77,7 +77,7 @@ namespace YARG.Audio.BASS
 
             foreach (var stemInfo in stemInfos)
             {
-                var volumeMatrix = stemInfo.GetVolumeMatrix();
+                var volumeMatrix = BassStemMixer.BuildVolumeMatrix(stemInfo);
                 if (volumeMatrix != null)
                 {
                     int[] channelMap = stemInfo.Indices.Append(-1).ToArray();

--- a/Assets/Script/Audio/Bass/BassStemChannel.cs
+++ b/Assets/Script/Audio/Bass/BassStemChannel.cs
@@ -95,7 +95,7 @@ namespace YARG.Audio.BASS
             bool success = BassMix.ChannelSetPosition(_streamHandles.Stream, bytes, PositionFlags.Bytes | PositionFlags.MixerReset);
             if (!success)
             {
-                YargLogger.LogFormatError("Failed to seek to position {0} (bytes {1}, length {2}!", position, bytes, _length);
+                YargLogger.LogFormatError("Failed to seek to position {0} (bytes {1}, length {2}: {3}!", position, bytes, _length, Bass.LastError);
             }
         }
 

--- a/Assets/Script/Gameplay/GameManager.Audio.cs
+++ b/Assets/Script/Gameplay/GameManager.Audio.cs
@@ -66,20 +66,12 @@ namespace YARG.Gameplay
             {
                 return _stem switch
                 {
-                    SongStem.Guitar => SettingsManager.Settings.GuitarVolume.Value,
-                    SongStem.Rhythm => SettingsManager.Settings.RhythmVolume.Value,
-                    SongStem.Bass   => SettingsManager.Settings.BassVolume.Value,
-                    SongStem.Keys   => SettingsManager.Settings.KeysVolume.Value,
-                    SongStem.Drums
-                        or SongStem.Drums1
-                        or SongStem.Drums2
-                        or SongStem.Drums3
-                        or SongStem.Drums4
-                        => SettingsManager.Settings.DrumsVolume.Value,
-                    SongStem.Vocals
-                        or SongStem.Vocals1
-                        or SongStem.Vocals2
-                        => SettingsManager.Settings.VocalsVolume.Value,
+                    SongStem.Guitar    => SettingsManager.Settings.GuitarVolume.Value,
+                    SongStem.Rhythm    => SettingsManager.Settings.RhythmVolume.Value,
+                    SongStem.Bass      => SettingsManager.Settings.BassVolume.Value,
+                    SongStem.Keys      => SettingsManager.Settings.KeysVolume.Value,
+                    SongStem.Drums     => SettingsManager.Settings.DrumsVolume.Value,
+                    SongStem.Vocals    => SettingsManager.Settings.VocalsVolume.Value,
                     SongStem.Song      => SettingsManager.Settings.SongVolume.Value,
                     SongStem.Crowd     => SettingsManager.Settings.CrowdVolume.Value,
                     SongStem.Sfx       => SettingsManager.Settings.SfxVolume.Value,

--- a/Assets/Script/Gameplay/GameManager.Audio.cs
+++ b/Assets/Script/Gameplay/GameManager.Audio.cs
@@ -109,24 +109,7 @@ namespace YARG.Gameplay
             foreach (var channel in _mixer.Channels)
             {
                 var stemState = new StemState(channel.Stem);
-                switch (channel.Stem)
-                {
-                    case SongStem.Drums:
-                    case SongStem.Drums1:
-                    case SongStem.Drums2:
-                    case SongStem.Drums3:
-                    case SongStem.Drums4:
-                        _stemStates.TryAdd(SongStem.Drums, stemState);
-                        break;
-                    case SongStem.Vocals:
-                    case SongStem.Vocals1:
-                    case SongStem.Vocals2:
-                        _stemStates.TryAdd(SongStem.Vocals, stemState);
-                        break;
-                    default:
-                        _stemStates.Add(channel.Stem, stemState);
-                        break;
-                }
+                _stemStates.Add(channel.Stem, stemState);
             }
 
             _backgroundStem = _stemStates.Count > 1 ? SongStem.Song : _stemStates.First().Key;


### PR DESCRIPTION
Corresponds to https://github.com/YARC-Official/YARG.Core/pull/300

Previously we would add stems like `drums1`, `drums2` to the `BassStemMixer`

This complicated handling of things like volume for player settings, as we had to collapse `drums1` and `drums2` into a single `drums` `SongStem` in various places

This PR changes the mixer so that we use `BassMix` own internal routing to handle multichannel stems under a single `SongStem`

So, there is no longer a concept of `SongStem.Drums1` as we never need individual control of that stem.

This also reduces cpu (though probably not noticeably) as we no longer have to apply several reverbs to all of the drums stems or vocals stems