### PR TITLE
Fix whammy drift in music library and player

### DIFF
--- a/Assets/Script/Audio/Bass/BassStemMixer.cs
+++ b/Assets/Script/Audio/Bass/BassStemMixer.cs
@@ -104,7 +104,6 @@ namespace YARG.Audio.BASS
 
         protected override int Pause_Internal()
         {
-            _whammySyncTimer.Stop();
             if (!Bass.ChannelPause(_mixerHandle))
             {
                 return (int) Bass.LastError;

--- a/Assets/Script/Audio/Bass/BassStemMixer.cs
+++ b/Assets/Script/Audio/Bass/BassStemMixer.cs
@@ -68,20 +68,23 @@ namespace YARG.Audio.BASS
 
             if (IsWhammyEnabled)
             {
-                _whammySyncTimer.Start(WHAMMY_SYNC_INTERVAL_SECONDS, SyncWhammyPitch);
+                _whammySyncTimer.Start(WHAMMY_SYNC_INTERVAL_SECONDS, SyncWhammyDrift);
             }
 
             return 0;
         }
 
-        private void SyncWhammyPitch()
+        /// <summary>.
+        /// The BASS PitchShift effect causes the stem playback to drift over time.
+        /// It was discovered that we can correct the drift by setting the whammy pitch
+        /// to 0% when no pitch shift is applied.
+        /// </summary>
+        private void SyncWhammyDrift()
         {
             foreach (var channel in Channels)
             {
-                // GetWhammyPitch returns 1.0 if no pitch shift is applied
                 if (Mathf.Approximately(channel.GetWhammyPitch(), 1.0f))
                 {
-                    // Setting the pitch shift to 0.0 percent corrects sync drift when pitch shift is applied
                     channel.SetWhammyPitch(percent: 0.0f);
                 }
             }
@@ -301,7 +304,6 @@ namespace YARG.Audio.BASS
 
         protected override void SetBufferLength_Internal(int length)
         {
-            _BufferSetter(Settings.SettingsManager.Settings.EnablePlaybackBuffer.Value, length);
             _BufferSetter(SettingsManager.Settings.EnablePlaybackBuffer.Value, length);
         }
 

--- a/Assets/Script/Helpers/Timer.cs
+++ b/Assets/Script/Helpers/Timer.cs
@@ -7,31 +7,35 @@ namespace YARG.Helpers
 {
     public class Timer
     {
-        private CancellationTokenSource _cancellationTokenSource;
+        private CancellationTokenSource _cts;
+        private bool                    IsRunning => _cts != null;
 
         public void Start(float intervalSeconds, Action onTick)
         {
-            Stop();
-            _cancellationTokenSource = new CancellationTokenSource();
+            if (IsRunning)
+            {
+                return;
+            }
 
+            _cts = new CancellationTokenSource();
             UniTaskAsyncEnumerable.Timer(
                     TimeSpan.Zero,
                     TimeSpan.FromSeconds(intervalSeconds)
                 )
-                .ForEachAsync(_ => onTick?.Invoke(), _cancellationTokenSource.Token)
+                .ForEachAsync(_ => onTick?.Invoke(), _cts.Token)
                 .Forget();
         }
 
         public void Stop()
         {
-            if (_cancellationTokenSource == null)
+            if (_cts == null)
             {
                 return;
             }
 
-            _cancellationTokenSource.Cancel();
-            _cancellationTokenSource.Dispose();
-            _cancellationTokenSource = null;
+            _cts.Cancel();
+            _cts.Dispose();
+            _cts = null;
         }
     }
 }

--- a/Assets/Script/Helpers/Timer.cs
+++ b/Assets/Script/Helpers/Timer.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Threading;
+using Cysharp.Threading.Tasks;
+using Cysharp.Threading.Tasks.Linq;
+
+namespace YARG.Helpers
+{
+    public class Timer
+    {
+        private CancellationTokenSource _cancellationTokenSource;
+
+        public void Start(float intervalSeconds, Action onTick)
+        {
+            Stop();
+            _cancellationTokenSource = new CancellationTokenSource();
+
+            UniTaskAsyncEnumerable.Timer(
+                    TimeSpan.Zero,
+                    TimeSpan.FromSeconds(intervalSeconds)
+                )
+                .ForEachAsync(_ => onTick?.Invoke(), _cancellationTokenSource.Token)
+                .Forget();
+        }
+
+        public void Stop()
+        {
+            if (_cancellationTokenSource == null)
+            {
+                return;
+            }
+
+            _cancellationTokenSource.Cancel();
+            _cancellationTokenSource.Dispose();
+            _cancellationTokenSource = null;
+        }
+    }
+}

--- a/Assets/Script/Helpers/Timer.cs.meta
+++ b/Assets/Script/Helpers/Timer.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 32c94f1b16fe4b1587aaefc7aa18fa20
+timeCreated: 1761238231

--- a/Assets/Script/Playback/SongRunner.cs
+++ b/Assets/Script/Playback/SongRunner.cs
@@ -200,7 +200,6 @@ namespace YARG.Playback
         private volatile int   _syncSpeedMultiplier;
         private volatile float _syncStartDelta;
         private volatile float _syncWorstDelta;
-        private int   _counter;
 
         private readonly StemMixer _mixer;
 
@@ -377,13 +376,11 @@ namespace YARG.Playback
             const double INITIAL_SYNC_THRESH = 0.015;
             const double ADJUST_SYNC_THRESH = 0.005;
             const float SPEED_ADJUSTMENT = 0.05f;
-            const float WHAMMY_SYNC_INTERVAL = 1000;
 
             for (; !_disposed; Thread.Sleep(1))
             {
                 lock (_syncThread)
                 {
-                    _counter++;
                     double audioOffset = SongOffset - (AudioCalibration * SongSpeed);
 
                     SyncAudioTime = _mixer.GetPosition();
@@ -402,12 +399,6 @@ namespace YARG.Playback
                     if (SyncAudioTime >= _mixer.Length)
                     {
                         continue;
-                    }
-
-                    if (_counter % WHAMMY_SYNC_INTERVAL == 0)
-                    {
-                        _counter = 1;
-                        SyncWhammy();
                     }
 
                     // Account for song speed
@@ -458,18 +449,6 @@ namespace YARG.Playback
                     {
                         ResetSync();
                     }
-                }
-            }
-        }
-
-        private void SyncWhammy()
-        {
-            foreach (var channel in _mixer.Channels)
-            {
-                if (channel.GetWhammyPitch() == 0.0f)
-                {
-                    //Correct drift caused by pitch shift effect
-                    channel.SetWhammyPitch(0.0f);
                 }
             }
         }


### PR DESCRIPTION
# Sync Drift Correction Fix

Two issues being fixed here:

1. Sync drift correction was only happening in the `SongRunner` which is used only for quickplay and practice mode
2. Sync drift correction was not working right because `GetWhammyPitch` actually returns 1.0 when unpitched, whereas `SetWhammyPitch` converts a percentage, so expects 0 percent when unpitched. Our if/else was wrong for this so sync drift was not being corrected even in quickplay

This PR adds a new `Timer` class that uses `UniTask` so we can easily do something every x seconds. We then use that in the `BassStemMixer` to do sync correction while the song is playing. This fixes sync drift in quickplay and song select.

## Demonstration

**Broken:**

https://github.com/user-attachments/assets/76dc286c-35d3-4d22-b9fd-5340df9e25dc

**Fixed:**

https://github.com/user-attachments/assets/def772f3-1eaf-4915-b866-f6786cdd4e8d

Here's the test song

[Sync Drift Test.zip](https://github.com/user-attachments/files/23109393/Sync.Drift.Test.zip)

