### PR TITLE
Fix 360 keytar mapping (#f6ad910c bugfix)

### DIFF
--- a/Assets/Script/Input/Bindings/Defaults/BindingCollection.ProKeyboard.cs
+++ b/Assets/Script/Input/Bindings/Defaults/BindingCollection.ProKeyboard.cs
@@ -11,26 +11,26 @@ namespace YARG.Input
             switch (Mode)
             {
                 case GameMode.FiveFretGuitar:
-                    AddBinding(ProKeysAction.GreenKey, keyboard.key1);
-                    AddBinding(ProKeysAction.RedKey, keyboard.key3);
-                    AddBinding(ProKeysAction.YellowKey, keyboard.key5);
-                    AddBinding(ProKeysAction.BlueKey, keyboard.key6);
-                    AddBinding(ProKeysAction.OrangeKey, keyboard.key8);
+                    AddBinding(GuitarAction.GreenFret, keyboard.key1);
+                    AddBinding(GuitarAction.RedFret, keyboard.key3);
+                    AddBinding(GuitarAction.YellowFret, keyboard.key5);
+                    AddBinding(GuitarAction.BlueFret, keyboard.key6);
+                    AddBinding(GuitarAction.OrangeFret, keyboard.key8);
 
-                    AddBinding(ProKeysAction.GreenKey, keyboard.key13);
-                    AddBinding(ProKeysAction.RedKey, keyboard.key15);
-                    AddBinding(ProKeysAction.YellowKey, keyboard.key17);
-                    AddBinding(ProKeysAction.BlueKey, keyboard.key18);
-                    AddBinding(ProKeysAction.OrangeKey, keyboard.key20);
+                    AddBinding(GuitarAction.GreenFret, keyboard.key13);
+                    AddBinding(GuitarAction.RedFret, keyboard.key15);
+                    AddBinding(GuitarAction.YellowFret, keyboard.key17);
+                    AddBinding(GuitarAction.BlueFret, keyboard.key18);
+                    AddBinding(GuitarAction.OrangeFret, keyboard.key20);
 
-                    AddBinding(ProKeysAction.GreenKey, keyboard.key25);
+                    AddBinding(GuitarAction.GreenFret, keyboard.key25);
 
-                    AddBinding(ProKeysAction.StarPower, keyboard.overdrive);
-                    AddBinding(ProKeysAction.StarPower, keyboard.selectButton);
-                    AddBinding(ProKeysAction.StarPower, keyboard.digitalPedal);
+                    AddBinding(GuitarAction.StarPower, keyboard.overdrive);
+                    AddBinding(GuitarAction.StarPower, keyboard.selectButton);
+                    AddBinding(GuitarAction.StarPower, keyboard.digitalPedal);
 
-                    AddBinding(ProKeysAction.TouchEffects, keyboard.touchStrip);
-                    AddBinding(ProKeysAction.TouchEffects, keyboard.analogPedal);
+                    AddBinding(GuitarAction.Whammy, keyboard.touchStrip);
+                    AddBinding(GuitarAction.Whammy, keyboard.analogPedal);
                     return true;
 
                 case GameMode.ProKeys:


### PR DESCRIPTION
Since the 5LK merge (#1089), my 360 RB3 Keytar has not automatically picked up the button mappings it did in the previous commit, throwing this error instead.

```
Exception: Tried to auto-assign control Button:/XInputProKeyboard/key1 to action GreenKey, but no binding exists for it!
  at YARG.Input.BindingCollection.AddBinding[TAction] (TAction action, UnityEngine.InputSystem.InputControl control, YARG.Input.ActuationSettings settings) [0x00053] in /YARG/Assets/Script/Input/Bindings/BindingCollection.Defaults.cs:94 
  at YARG.Input.BindingCollection.AddBinding[TAction] (TAction action, UnityEngine.InputSystem.InputControl control) [0x00000] in /YARG/Assets/Script/Input/Bindings/BindingCollection.Defaults.cs:76 
  at YARG.Input.BindingCollection.SetDefaultGameplayBindings (PlasticBand.Devices.ProKeyboard keyboard) [0x0002b] in /YARG/Assets/Script/Input/Bindings/Defaults/BindingCollection.ProKeyboard.cs:14 
  at YARG.Input.BindingCollection.SetDefaultBindings (PlasticBand.Devices.ProKeyboard keyboard) [0x00000] in /YARG/Assets/Script/Input/Bindings/BindingCollection.Defaults.cs:70 
  at YARG.Input.BindingCollection.SetDefaultBindings (UnityEngine.InputSystem.InputDevice device) [0x000ab] in /YARG/Assets/Script/Input/Bindings/BindingCollection.Defaults.cs:25 
  at YARG.Input.ProfileBindings.SetDefaultBinds (UnityEngine.InputSystem.InputDevice device) [0x00025] in /YARG/Assets/Script/Input/Bindings/ProfileBindings.cs:301 
  at YARG.Menu.ProfileList.ProfileView+<>c__DisplayClass19_1.<PromptAddDevice>b__0 () [0x00040] in /YARG/Assets/Script/Menu/ProfileList/ProfileView.cs:178 
  at System.Runtime.CompilerServices.AsyncMethodBuilderCore+<>c.<ThrowAsync>b__7_0 (System.Object state) [0x00000] in <f454a34cf10643dd8ecf460d9908373b>:0 
  at UnityEngine.UnitySynchronizationContext+WorkRequest.Invoke () [0x00002] in /Users/bokken/build/output/unity/unity/Runtime/Export/Scripting/UnitySynchronizationContext.cs:153 
  at UnityEngine.UnitySynchronizationContext.Exec () [0x00056] in /Users/bokken/build/output/unity/unity/Runtime/Export/Scripting/UnitySynchronizationContext.cs:83 
  at UnityEngine.UnitySynchronizationContext.ExecuteTasks () [0x00014] in /Users/bokken/build/output/unity/unity/Runtime/Export/Scripting/UnitySynchronizationContext.cs:107 

(Filename: Assets/Script/Input/Bindings/BindingCollection.Defaults.cs Line: 94)
```


This PR does fix the issue, but as I'm not super familiar with the code here, I would appreciate a sanity check from @wyrdough or @Frickitickitavi first :)