### PR TITLE
5LKPlayer: improve toucheffects

### DIFF
--- a/Assets/Script/Gameplay/Player/FiveLaneKeysPlayer.cs
+++ b/Assets/Script/Gameplay/Player/FiveLaneKeysPlayer.cs
@@ -313,6 +313,18 @@ namespace YARG.Assets.Script.Gameplay.Player
             return false;
         }
 
+        protected override void OnInputQueued(GameInput input)
+        {
+            base.OnInputQueued(input);
+
+            // Update the whammy factor
+            if (_sustainCount > 0 && input.GetAction<ProKeysAction>() == ProKeysAction.TouchEffects)
+            {
+                WhammyFactor = Mathf.Clamp01(input.Axis);
+                GameManager.ChangeStemWhammyPitch(_stem, WhammyFactor);
+            }
+        }
+
         protected override void InitializeSpawnedNote(IPoolable poolable, GuitarNote note)
         {
             ((FiveLaneKeysNoteElement) poolable).NoteRef = note;
@@ -381,6 +393,14 @@ namespace YARG.Assets.Script.Gameplay.Player
             if (note.FiveLaneKeysAction is not FiveLaneKeysAction.OpenNote)
             {
                 _fretArray.SetSustained((int) note.FiveLaneKeysAction, false);
+            }
+
+            _sustainCount--;
+
+            if (_sustainCount == 0)
+            {
+                WhammyFactor = 0;
+                GameManager.ChangeStemWhammyPitch(_stem, 0);
             }
         }
 

--- a/Assets/Script/Gameplay/Visuals/TrackElements/SustainLine.cs
+++ b/Assets/Script/Gameplay/Visuals/TrackElements/SustainLine.cs
@@ -1,6 +1,7 @@
 ﻿using UnityEngine;
 using YARG.Core.Engine.Guitar;
 using YARG.Core.Engine.Keys;
+using YARG.Assets.Script.Gameplay.Player;
 using YARG.Gameplay.Player;
 
 namespace YARG.Gameplay.Visuals
@@ -245,6 +246,13 @@ namespace YARG.Gameplay.Visuals
             {
                 // Make sure to lerp it to prevent jumps
                 _whammyFactor = Mathf.Lerp(_whammyFactor, guitarPlayer.WhammyFactor, Time.deltaTime * 6f);
+            }
+
+            // Update whammy factor
+            if (_player is FiveLaneKeysPlayer keysPlayer)
+            {
+                // Make sure to lerp it to prevent jumps
+                _whammyFactor = Mathf.Lerp(_whammyFactor, keysPlayer.WhammyFactor, Time.deltaTime * 6f);
             }
 
             float whammy = _whammyFactor * 1.5f;


### PR DESCRIPTION
Currently in 5 Lane Keys mode, applying touch effects (aka 'whammy') will increase star power during white notes, but will not:

- Wiggle the SustainLine
- Change the pitch of the stem

Unlike the more frequently used FiveFretGuitarPlayer, which does these two missing things. This PR copies the relavants bits from `FiveFretGuitarPlayer` to `FiveLaneKeysPlayer`. It seems like these got missed in #1089.