### PR TITLE
Fix PK out-of-range boundaries

### DIFF
--- a/Assets/Script/Gameplay/Player/ProKeysPlayer.cs
+++ b/Assets/Script/Gameplay/Player/ProKeysPlayer.cs
@@ -292,12 +292,25 @@ namespace YARG.Gameplay.Player
         private void ShowOutOfRangeFlasher(int key)
         {
             var currentRange = _rangeShifts[_rangeShiftIndex-1];
-            if (key < currentRange.Key)
+
+            var (minimumKeyInRange, maximumKeyInRange) = currentRange.Key switch
+            {
+                ProKeysUtilities.LOW_C => (ProKeysUtilities.LOW_C, ProKeysUtilities.HIGH_E),
+                ProKeysUtilities.LOW_D => (ProKeysUtilities.LOW_C_SHARP, ProKeysUtilities.HIGH_F_SHARP),
+                ProKeysUtilities.LOW_E => (ProKeysUtilities.LOW_D_SHARP, ProKeysUtilities.HIGH_G_SHARP),
+                ProKeysUtilities.LOW_F => (ProKeysUtilities.LOW_F, ProKeysUtilities.HIGH_A_SHARP),
+                ProKeysUtilities.LOW_G => (ProKeysUtilities.LOW_F_SHARP, ProKeysUtilities.HIGH_B),
+                ProKeysUtilities.LOW_A => (ProKeysUtilities.LOW_G_SHARP, ProKeysUtilities.HIGH_C),
+                _ => (currentRange.Key, currentRange.Key + 16) // Should never happen, but might as well have a naive fallback
+            };
+
+            if (key < minimumKeyInRange)
             {
                 _leftOutOfRangeTween.Restart();
             }
-            else if (key > currentRange.Key + 16)
+            else if (key > maximumKeyInRange)
             {
+
                 _rightOutOfRangeTween.Restart();
             }
         }


### PR DESCRIPTION
[Corresponding YARG.Core PR](https://github.com/YARC-Official/YARG.Core/pull/304)
We currently calculate the minimum and maximum in-range keys (for the purpose of showing the out-of-range flasher) as `[currentRange.Key, currentRange.Key+16]`. This excludes some "edge notes" (i.e. black keys that sit on the edges of the highway) - namely, all left-side edge notes and the A# to the right of the F-A range (but no other right-side edge notes).

RB3 does not show flashers for pressing edge notes, and while they were never placed in official charts, they are used (sparingly) in official YARG content and many RB3 customs.

This change introduces explicit, case-by-case boundaries for each PK range. If we somehow have an unexpected range shift, we fall back to the old `(key, key+16)` behavior, although I imagine we've got bigger problems if that ever happens.

To prevent the logic from becoming a big mess of magic numbers, I took the liberty of adding `const int`s for each key number to `ProKeysUtilities` in YARG.Core, which is why this has a YARG.Core PR despite affecting only UI behavior.