### PR TITLE
Fix ordering of players on the fail meter

### DIFF
--- a/Assets/Script/Gameplay/HUD/FailMeter.cs
+++ b/Assets/Script/Gameplay/HUD/FailMeter.cs
@@ -100,7 +100,7 @@ namespace YARG.Gameplay.HUD
 
 
             // attach the slider instances to the scene and apply the correct icon
-            for (int i = 0; i < _players.Count; i++)
+            for (int i = _players.Count - 1; i >= 0; i--)
             {
                 _playerSliders[i] = Instantiate(_sliderPrefab, _sliderContainer);
                 _needleSliders[i] = Instantiate(_needlePrefab, _sliderContainer);
@@ -152,11 +152,11 @@ namespace YARG.Gameplay.HUD
                 UpdateMeterFill();
             }
 
-            for (var i = 0; i < _players.Count; i++)
+            for (var i = _players.Count - 1; i >= 0; i--)
             {
                 int overlap = 0;
                 // Check if we will overlap another icon
-                for (var j = i; j < _players.Count; j++)
+                for (var j = i; j >= 0; j--)
                 {
                     if (j == i)
                     {


### PR DESCRIPTION
## Notes

Very small change to make the ordering of icons on the fail meter match the order of the highways / player order.

## Gallery

<img width="1840" height="1107" alt="Screenshot 2025-11-12 at 4 30 12 PM" src="https://github.com/user-attachments/assets/5ff9c991-0918-4478-8e19-c908a4d6ac73" />
