### PR TITLE
Added playlist information in files exported for OuvertBot and plain …

### DIFF
--- a/Assets/Script/Song/SongExport.cs
+++ b/Assets/Script/Song/SongExport.cs
@@ -19,6 +19,9 @@ namespace YARG.Song
             [JsonProperty("Album")]
             public string album;
 
+            [JsonProperty("Playlist")]
+            public string playlist;
+
             [JsonProperty("Genre")]
             public string genre;
 
@@ -46,7 +49,8 @@ namespace YARG.Song
                 {
                     string artist = RichTextUtils.StripRichTextTags(song.Artist);
                     string name = RichTextUtils.StripRichTextTags(song.Name);
-                    output.WriteLine($"{artist} - {name}");
+                    string playlist = RichTextUtils.StripRichTextTags(song.Playlist);
+                    output.WriteLine($"{artist} - {name} from {playlist}");
                 }
             }
             output.Flush();
@@ -64,6 +68,7 @@ namespace YARG.Song
                     songName = RichTextUtils.StripRichTextTags(song.Name),
                     artistName = RichTextUtils.StripRichTextTags(song.Artist),
                     album = RichTextUtils.StripRichTextTags(song.Album),
+                    playlist = RichTextUtils.StripRichTextTags(song.Playlist),
                     genre = RichTextUtils.StripRichTextTags(song.Genre),
                     charter = RichTextUtils.StripRichTextTags(song.Charter),
                     year = RichTextUtils.StripRichTextTags(song.UnmodifiedYear),


### PR DESCRIPTION
I created this branch to add the playlist information for each song into the javascript file that OuvertBot needs.  Specifically, for streamers playing YARG that have multiple versions of the same song, the streamer will know which version the requester wants to see/hear without having to bring the stream to a halt to ask the requester