### PR TITLE
Add dynamics hit effects

### DIFF
--- a/Assets/Prefabs/Gameplay/HUD/TrackView.prefab
+++ b/Assets/Prefabs/Gameplay/HUD/TrackView.prefab
@@ -560,8 +560,8 @@ MonoBehaviour:
       m_Calls: []
   m_text: 
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 19b7115073766a24aa48ceca884dcbf5, type: 2}
-  m_sharedMaterial: {fileID: 4249517445589659644, guid: 19b7115073766a24aa48ceca884dcbf5,
+  m_fontAsset: {fileID: 11400000, guid: d9dd031fb1c2f2f4fabb34137edfa885, type: 2}
+  m_sharedMaterial: {fileID: 1536850694454096710, guid: d9dd031fb1c2f2f4fabb34137edfa885,
     type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
@@ -882,8 +882,8 @@ MonoBehaviour:
       m_Calls: []
   m_text: 
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 19b7115073766a24aa48ceca884dcbf5, type: 2}
-  m_sharedMaterial: {fileID: 4249517445589659644, guid: 19b7115073766a24aa48ceca884dcbf5,
+  m_fontAsset: {fileID: 11400000, guid: d9dd031fb1c2f2f4fabb34137edfa885, type: 2}
+  m_sharedMaterial: {fileID: 1536850694454096710, guid: d9dd031fb1c2f2f4fabb34137edfa885,
     type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
@@ -1019,8 +1019,8 @@ MonoBehaviour:
       m_Calls: []
   m_text: 100%
   m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 19b7115073766a24aa48ceca884dcbf5, type: 2}
-  m_sharedMaterial: {fileID: 4249517445589659644, guid: 19b7115073766a24aa48ceca884dcbf5,
+  m_fontAsset: {fileID: 11400000, guid: d9dd031fb1c2f2f4fabb34137edfa885, type: 2}
+  m_sharedMaterial: {fileID: 1536850694454096710, guid: d9dd031fb1c2f2f4fabb34137edfa885,
     type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
@@ -1046,7 +1046,7 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 43.8
+  m_fontSize: 39.7
   m_fontSizeBase: 20
   m_fontWeight: 400
   m_enableAutoSizing: 1

--- a/Assets/Script/Gameplay/Visuals/Fret/Fret.cs
+++ b/Assets/Script/Gameplay/Visuals/Fret/Fret.cs
@@ -8,7 +8,7 @@ namespace YARG.Gameplay.Visuals
 {
     public class Fret : MonoBehaviour, IThemeBindable<ThemeFret>
     {
-        private static readonly int _fade = Shader.PropertyToID("Fade");
+        private static readonly int _fade          = Shader.PropertyToID("Fade");
         private static readonly int _emissionColor = Shader.PropertyToID("_EmissionColor");
 
         private static readonly int _hit       = Animator.StringToHash("Hit");
@@ -36,6 +36,7 @@ namespace YARG.Gameplay.Visuals
         // when transitioning between active and inactive states
         private UnityEngine.Color _originalUnityTopColor;
         private UnityEngine.Color _originalUnityInnerColor;
+        private UnityEngine.Color _originalEmissionColor;
 
         // TODO: Consider making this customizable or perhaps just a desaturated and dimmed version of the base color
         private UnityEngine.Color _inactiveColor = new(0.321f, 0.321f, 0.321f, 1.0f);
@@ -49,23 +50,33 @@ namespace YARG.Gameplay.Visuals
         private float _fadeStartTime;
         private float _fadeAmount = 0.0f;
 
+        public enum AnimType
+        {
+            CorrectNormal,
+            CorrectHard,
+            CorrectSoft,
+            TooHard,
+            TooSoft,
+        }
+
         public void Initialize(Color top, Color inner, Color particles, Color openParticles)
         {
             _originalUnityTopColor = top.ToUnityColor();
             _originalUnityInnerColor = inner.ToUnityColor();
+            _originalEmissionColor = top.ToUnityColor() * 11.5f;
 
             // Set the top material color
             foreach (var material in ThemeBind.GetColoredMaterials())
             {
-                material.color = top.ToUnityColor();
-                material.SetColor(_emissionColor, top.ToUnityColor() * 11.5f);
+                material.color = _originalUnityTopColor;
+                material.SetColor(_emissionColor, _originalEmissionColor);
                 _topMaterials.Add(material);
             }
 
             // Set the inner material color
             foreach (var material in ThemeBind.GetInnerColoredMaterials())
             {
-                material.color = inner.ToUnityColor();
+                material.color = _originalUnityInnerColor;
                 _innerMaterials.Add(material);
             }
 
@@ -88,7 +99,73 @@ namespace YARG.Gameplay.Visuals
 
         public void SetPressed(bool pressed)
         {
-            float value = pressed ? 1f : 0f;
+            SetPressed(pressed, pressed ? 1f : 0f);
+        }
+
+        public void SetPressedDrum(bool pressed, AnimType animType)
+        {
+            // Set the inner portion of the fret
+            SetPressed(pressed, pressed ? GetFretInnerBrightnessMultiplier(animType) : 0f);
+        }
+
+        public void WhitenFretColor()
+        {
+            foreach (var material in ThemeBind.GetColoredMaterials())
+            {
+                material.color = UnityEngine.Color.white;
+                material.SetColor(_emissionColor, UnityEngine.Color.white);
+            }
+
+            foreach (var material in ThemeBind.GetInnerColoredMaterials())
+            {
+                material.color = UnityEngine.Color.white;
+                material.SetColor(_emissionColor, UnityEngine.Color.white);
+            }
+
+            foreach (var light in ThemeBind.HitEffect.EffectLights)
+            {
+                light.IsBrightened = true;
+            }
+
+            foreach (var particle in ThemeBind.HitEffect.EffectParticles)
+            {
+                particle.BrightenColor();
+            }
+        }
+
+        public void RestoreFretColor()
+        {
+            foreach (var material in ThemeBind.GetColoredMaterials())
+            {
+                material.color = _originalUnityTopColor;
+                material.SetColor(_emissionColor, _originalEmissionColor);
+            }
+
+            foreach (var material in ThemeBind.GetInnerColoredMaterials())
+            {
+                material.color = _originalUnityInnerColor;
+                material.SetColor(_emissionColor, _originalEmissionColor);
+            }
+
+            foreach (var light in ThemeBind.HitEffect.EffectLights)
+            {
+                light.IsBrightened = false;
+            }
+
+            foreach (var particle in ThemeBind.HitEffect.EffectParticles)
+            {
+                particle.RestoreColor();
+            }
+        }
+
+        private float GetFretInnerBrightnessMultiplier(AnimType animType)
+        {
+            // Normal and hard should both be 1f
+            return AnimType.CorrectSoft == animType ? 0f : 1f;
+        }
+
+        public void SetPressed(bool pressed, float value)
+        {
             foreach (var material in _innerMaterials)
             {
                 material.SetFloat(_fade, value);

--- a/Assets/Script/Gameplay/Visuals/Fret/FretArray.cs
+++ b/Assets/Script/Gameplay/Visuals/Fret/FretArray.cs
@@ -154,6 +154,11 @@ namespace YARG.Gameplay.Visuals
             _frets[index].SetPressed(pressed);
         }
 
+        public void SetPressedDrum(int index, bool pressed, Fret.AnimType animType)
+        {
+            _frets[index].SetPressedDrum(pressed, animType);
+        }
+
         public void SetSustained(int index, bool sustained)
         {
             _frets[index].SetSustained(sustained);
@@ -211,6 +216,18 @@ namespace YARG.Gameplay.Visuals
             foreach (var fret in _frets)
             {
                 fret.SetSustained(false);
+            }
+        }
+
+        public void UpdateAccentColorState(int fretIndex, bool shouldWhiten)
+        {
+            if (shouldWhiten)
+            {
+                _frets[fretIndex].WhitenFretColor();
+            }
+            else
+            {
+                _frets[fretIndex].RestoreFretColor();
             }
         }
 

--- a/Assets/Script/Helpers/Authoring/EffectGroup.cs
+++ b/Assets/Script/Helpers/Authoring/EffectGroup.cs
@@ -12,36 +12,36 @@ namespace YARG.Helpers.Authoring
 
     public class EffectGroup : MonoBehaviour
     {
-        private List<EffectParticle> _effectParticles;
-        private List<EffectLight> _effectLights;
+        public List<EffectParticle> EffectParticles { get; private set; }
+        public List<EffectLight>    EffectLights    { get; private set; }
 
         private void Awake()
         {
-            _effectParticles = GetComponentsInChildren<EffectParticle>().ToList();
-            _effectLights = GetComponentsInChildren<EffectLight>().ToList();
+            EffectParticles = GetComponentsInChildren<EffectParticle>().ToList();
+            EffectLights = GetComponentsInChildren<EffectLight>().ToList();
         }
 
         public void SetColor(Color c)
         {
-            foreach (var particles in _effectParticles)
-                particles.SetColor(c);
-            foreach (var lights in _effectLights)
-                lights.SetColor(c);
+            foreach (var particles in EffectParticles)
+                particles.InitializeColor(c);
+            foreach (var lights in EffectLights)
+                lights.InitializeColor(c);
         }
 
         public void Play()
         {
-            foreach (var particles in _effectParticles)
+            foreach (var particles in EffectParticles)
                 particles.Play();
-            foreach (var lights in _effectLights)
+            foreach (var lights in EffectLights)
                 lights.Play();
         }
 
         public void Stop()
         {
-            foreach (var particles in _effectParticles)
+            foreach (var particles in EffectParticles)
                 particles.Stop();
-            foreach (var lights in _effectLights)
+            foreach (var lights in EffectLights)
                 lights.Stop();
         }
     }

--- a/Assets/Script/Helpers/Authoring/EffectLight.cs
+++ b/Assets/Script/Helpers/Authoring/EffectLight.cs
@@ -35,7 +35,12 @@ namespace YARG.Helpers.Authoring
         private Light _light;
 
         private float _initialIntensity;
-        private bool  _playing;
+
+        private float BrightIntensity => _initialIntensity * 5;
+
+        public bool IsBrightened { get; set; }
+
+        private bool _playing;
 
         private float _totalDuration;
         private float _timeRemaining;
@@ -61,7 +66,7 @@ namespace YARG.Helpers.Authoring
             // Normal mode
             if (_mode == Mode.Normal && _light.intensity > 0f)
             {
-                _light.intensity = _initialIntensity * (_timeRemaining > 0f ? 1f : 0f);
+                _light.intensity = GetIntensity() * (_timeRemaining > 0f ? 1f : 0f);
                 _timeRemaining -= Time.deltaTime;
             }
 
@@ -75,13 +80,13 @@ namespace YARG.Helpers.Authoring
             if (_mode == Mode.Wavy && _playing)
             {
                 // TODO: Maybe allow customizing this?
-                _light.intensity = _initialIntensity +
+                _light.intensity = GetIntensity() +
                     Mathf.Sin(Time.time * 30f) * 0.075f +
                     Mathf.Sin(Time.time * 40f) * 0.075f;
             }
         }
 
-        public void SetColor(Color c)
+        public void InitializeColor(Color c)
         {
             if (!_allowColoring) return;
 
@@ -90,7 +95,7 @@ namespace YARG.Helpers.Authoring
 
         public void Play()
         {
-            _light.intensity = _initialIntensity;
+            _light.intensity = GetIntensity();
             _timeRemaining = _totalDuration;
             _playing = true;
         }
@@ -103,6 +108,11 @@ namespace YARG.Helpers.Authoring
             }
 
             _playing = false;
+        }
+
+        private float GetIntensity()
+        {
+            return IsBrightened ? BrightIntensity : _initialIntensity;
         }
     }
 }

--- a/Assets/Script/Helpers/Authoring/EffectParticle.cs
+++ b/Assets/Script/Helpers/Authoring/EffectParticle.cs
@@ -28,13 +28,32 @@ namespace YARG.Helpers.Authoring
         private ParticleSystem _particleSystem;
         private ParticleSystemRenderer _particleSystemRenderer;
 
+        private Color InitialColor { get; set; }
+        private Color BrightColor  => Color.Lerp(InitialColor, Color.white, 0.75f);
+
         private void Awake()
         {
             _particleSystem = GetComponent<ParticleSystem>();
             _particleSystemRenderer = GetComponent<ParticleSystemRenderer>();
         }
 
-        public void SetColor(Color color)
+        public void InitializeColor(Color color)
+        {
+            SetColor(color);
+            InitialColor = color;
+        }
+
+        public void BrightenColor()
+        {
+            SetColor(BrightColor);
+        }
+
+        public void RestoreColor()
+        {
+            SetColor(InitialColor);
+        }
+
+        private void SetColor(Color color)
         {
             if (!_allowColoring) return;
 


### PR DESCRIPTION
## Notes

Added hit effects for correctly hit dynamics.

- Ghosts - Black out the inside of the fret, but keep lighting and fret color the same.
- Accents - Completely white out the inside and outside of the fret and multiply the light intensity by 5, but keep the light color the same.

Note that ghost note hit effects do not interrupt accent or normal notes, but normal notes do interrupt accents. This is because if the brightness decreases suddenly before the full 0.2 second animation plays out, it is a bit jarring, but the inverse is true during rolls with accents.

Also switched the solo box font from Barlow to Red Hat Display.

## Gallery

https://github.com/user-attachments/assets/60f7a6e2-cfdf-4275-a2e2-7b553813debe

## Follow-up

- Need to add an accent flame made by Venerabela to help make normal hits and accent hits a bit more distinct.
- Need to add effects for when a ghost note is hit too hard or an accent note is hit too soft (currently, if the velocity is wrong, the normal effect will play).