### PR TITLE
Update Minis fork

### DIFF
--- a/Assets/Script/Menu/ProfileInfo/EditBinds/BindGroups/ButtonBindGroup.cs
+++ b/Assets/Script/Menu/ProfileInfo/EditBinds/BindGroups/ButtonBindGroup.cs
@@ -41,7 +41,7 @@ namespace YARG.Menu.ProfileInfo
 
             foreach (var control in _binding.Bindings)
             {
-                if (control.Control is MidiNoteControl)
+                if (control.Control is MidiButtonControl)
                 {
                     _header.AddBinding<SingleMidiNoteBindView, float, ButtonBinding, SingleButtonBinding>(
                         _midiNoteViewPrefab, _binding, control);

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -330,17 +330,9 @@
       "depth": 0,
       "source": "git",
       "dependencies": {
-        "jp.keijiro.rtmidi": "1.0.4",
         "com.unity.inputsystem": "1.0.1"
       },
-      "hash": "29dee9f786d99cfae145d1972a39fb79117c1b8f"
-    },
-    "jp.keijiro.rtmidi": {
-      "version": "1.0.4",
-      "depth": 1,
-      "source": "registry",
-      "dependencies": {},
-      "url": "https://registry.npmjs.com"
+      "hash": "eb3d689d5f44daad36132debdbd5755f344775b6"
     },
     "unity-dependencies-hunter": {
       "version": "https://github.com/AlexeyPerov/Unity-Dependencies-Hunter.git#upm",


### PR DESCRIPTION
Took some time to revisit my Minis fork after I noticed that it would constantly spam errors whenever RtMidi failed to load. Following this, I made some further tweaks to improve reliability, and added support for additional MIDI messages.

[Fork repository's state as of this PR](https://github.com/TheNathannator/Minis/tree/eb3d689d5f44daad36132debdbd5755f344775b6)

### Additions

- Note aftertouch
  - Implemented by modifying the current velocity of the note, allowing it to behave like an axis.
  - Disclaimer: I don't have anything that implements aftertouch, so this implementation is speculative and may behave a little surprisingly when used with a non-default press point.
- Channel aftertouch
  - Implemented as a dedicated separate axis.
- Channel control messages
  - All sound off (CC 120)
  - Reset all controls (CC 121)
  - All notes off (CC 123-127)
- Start, Continue, and Stop messages
  - Implemented as buttons that are pressed for a single frame. They are instantaneous events in the MIDI stream, so they cannot be held.
- Active sensing
  - If a MIDI device reports active sensing, it will be respected and control states will be reset to default once disconnection is detected. Additionally, all active individual channel devices will be removed.
- System reset message
  - Resets all control state in the same manner as when active sensing times out.

### Changes

- CC 120-127 are no longer exposed as axes, as they have special functions in MIDI.
- RtMidi has been updated to v6.0.0.
- Minis' backend code is now only included on platforms that have RtMidi binaries. The public device/control classes are still always included and require no conditional compilation; this just prevents build/initialization errors on unsupported platforms.

### Fixes

- Minis' input system callbacks are cleaned up on initialization failure, so you'll no longer get logs flooded with errors whenever RtMidi can't be loaded.