### PR TITLE
Fix build failure

### DIFF
--- a/Assets/Resources/TMP_Sprite (SoftMaskable).shader
+++ b/Assets/Resources/TMP_Sprite (SoftMaskable).shader
@@ -104,7 +104,7 @@ Shader "Hidden/TextMeshPro/Sprite (SoftMaskable)"
 					color.a *= UnityGet2DClipping(IN.worldPosition.xy, _ClipRect);
 				#endif
 
-                color.a *= SoftMask(IN.vertex, IN.worldPosition);
+                color.a *= SoftMask(IN.vertex, IN.worldPosition, color.a);
 
 				#ifdef UNITY_UI_ALPHACLIP
 					clip (color.a - 0.001);


### PR DESCRIPTION
UI Soft Mask was upgraded from 1.0.2 to 3.5.0 in https://github.com/YARC-Official/YARG/commit/c5706f4a687c66ac6ba096773d11127e970aaeda this leads to build failure:
<img width="1188" height="114" alt="Screenshot_20251125_194149" src="https://github.com/user-attachments/assets/43a9f081-ceb2-412b-aa82-b1dade2477b8" />

The third point from https://github.com/mob-sakai/SoftMaskForUGUI?tab=readme-ov-file#-upgrade-all-assets-for-v3 is enough for the build to go through