### PR TITLE
Fix Xbox One instrument crashes (bump HIDrogen to v0.5.2)

### DIFF
--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -31,7 +31,7 @@
     "com.lukestilson.openvat": "https://github.com/sharpen3d/openvat-unity.git",
     "com.marijnzwemmer.unity-toolbar-extender": "1.4.2",
     "com.starasgames.tmpro-dynamic-data-cleaner": "1.0.0",
-    "com.thenathannator.hidrogen": "0.5.0",
+    "com.thenathannator.hidrogen": "0.5.2",
     "com.thenathannator.plasticband": "0.9.0",
     "com.unity.2d.sprite": "1.0.0",
     "com.unity.addressables": "2.7.4",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -59,7 +59,7 @@
       "url": "https://package.openupm.com"
     },
     "com.thenathannator.hidrogen": {
-      "version": "0.5.0",
+      "version": "0.5.2",
       "depth": 0,
       "source": "registry",
       "dependencies": {


### PR DESCRIPTION
Turns out the crashing was never truly a Microsoft problem in the first place, and the issue could have been fixed much sooner had I realized more early on what was actually happening. Oh well, at least it's finally fixed now :3

(and yes, this is skipping v0.5.1 because there were some oversights i had to quickly fix. whoops!)