### PR TITLE
Various bits of project tidy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ ExportedObj/
 *.csproj
 *.unityproj
 *.sln
+*.slnx
 *.suo
 *.tmp
 *.user

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,15 +1,15 @@
 {
     "files.exclude":
     {
-        "**/.DS_Store":true,
-        "**/.git":true,
-        "**/*.meta":true,
-        "build/":true,
-        "Build/":true,
-        "obj/":true,
-        "Obj/":true,
-        "temp/":true,
-        "Temp/":true
+        "**/.DS_Store": true,
+        "**/.git": true,
+        "**/*.meta": true,
+        "build/": true,
+        "Build/": true,
+        "obj/": true,
+        "Obj/": true,
+        "temp/": true,
+        "Temp/": true
     },
-    "dotnet.defaultSolution": "YARG.sln",
+    "dotnet.defaultSolution": "YARG.slnx"
 }

--- a/Assets/Plugins/Editor/Submodule/YARG.Editor.Submodules.asmdef
+++ b/Assets/Plugins/Editor/Submodule/YARG.Editor.Submodules.asmdef
@@ -1,0 +1,16 @@
+{
+    "name": "YARG.Editor.Submodules",
+    "rootNamespace": "",
+    "references": [],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": true,
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "Microsoft.VisualStudio.SolutionPersistence.dll"
+    ],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Assets/Plugins/Editor/Submodule/YARG.Editor.Submodules.asmdef.meta
+++ b/Assets/Plugins/Editor/Submodule/YARG.Editor.Submodules.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 15a5329b57afc0d4589a770f20d47437
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Samples.meta
+++ b/Assets/Samples.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d3c4ca45a80ab764cbf91c319c66c86b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Samples/UI Soft Mask.meta
+++ b/Assets/Samples/UI Soft Mask.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ea121e1583bfd4c43b5d58d27acffbcc
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Samples/UI Soft Mask/3.5.0.meta
+++ b/Assets/Samples/UI Soft Mask/3.5.0.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ddbd0dbf438d55041a2b6bb2c46bd186
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Samples/UI Soft Mask/3.5.0/TextMeshPro Support (Unity 6).meta
+++ b/Assets/Samples/UI Soft Mask/3.5.0/TextMeshPro Support (Unity 6).meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0c91b85f294726e4d860c2502afbe842
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Script/Gameplay/Visuals/HighwayCameraRendering.cs
+++ b/Assets/Script/Gameplay/Visuals/HighwayCameraRendering.cs
@@ -92,8 +92,11 @@ namespace YARG.Gameplay.Visuals
 
         private void RecreateHighwayOutputTexture()
         {
-            HighwaysOutputTexture?.Release();
-            HighwaysOutputTexture?.DiscardContents();
+            if (HighwaysOutputTexture != null)
+            {
+                HighwaysOutputTexture.Release();
+                HighwaysOutputTexture.DiscardContents();
+            }
 
             var descriptor = new RenderTextureDescriptor(Screen.width, Screen.height, RenderTextureFormat.DefaultHDR)
             {
@@ -279,7 +282,11 @@ namespace YARG.Gameplay.Visuals
 
         private void ResetHighwayAlphaTexture()
         {
-            _highwaysAlphaTexture?.Release();
+            if (_highwaysAlphaTexture != null)
+            {
+                _highwaysAlphaTexture.Release();
+            }
+
             float scaling = 1.0f;
             var descriptor = new RenderTextureDescriptor(
                 (int) (Screen.width * scaling), (int) (Screen.height * scaling),

--- a/Assets/packages.config
+++ b/Assets/packages.config
@@ -5,7 +5,9 @@
   <package id="ManagedBass.Fx" version="3.1.1" manuallyInstalled="true" />
   <package id="ManagedBass.Mix" version="3.1.1" manuallyInstalled="true" />
   <package id="Melanchall.DryWetMidi.Nativeless" version="7.0.0" manuallyInstalled="true" />
+  <package id="Microsoft.IO.Redist" version="6.1.3" manuallyInstalled="true" autoReferenced="false" />
   <package id="Microsoft.NETCore.Platforms" version="7.0.1" />
+  <package id="Microsoft.VisualStudio.SolutionPersistence" version="1.0.52" manuallyInstalled="true" autoReferenced="false" />
   <package id="NETStandard.Library" version="2.0.3" />
   <package id="System.Diagnostics.Tracing" version="4.3.0" manuallyInstalled="true" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" manuallyInstalled="true" />

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ SUBSYSTEM=="usb", ATTR{idVendor}=="045e", ATTR{idProduct}=="0719", MODE="0666"
    3. In Unity Hub, hit the arrow next to Add and select `Add project from disk`, then select the folder you cloned YARG to.
    4. Click on the added entry for YARG. It will warn you about a missing editor version, select 2021.3.36f1 and install it.
       - Unselect Visual Studio in the list of modules if you wish to use another editor or already have it installed.
-5. Install the [.NET SDK](https://dotnet.microsoft.com/en-us/download/visual-studio-sdks). This is required to develop and build the submodules.
+5. Install the [.NET SDK](https://dotnet.microsoft.com/en-us/download/visual-studio-sdks). This is required to develop the submodules and their supporting projects.
    - You will need the SDK specifically, not the runtime!
 6. Open the project in Unity. When prompted about Safe Mode, click "Ignore".
    - Do *not* enter Safe Mode, otherwise scripts necessary to build/install dependencies will not run, and the errors will not resolve.


### PR DESCRIPTION
- The folders containing the SoftMaskable shaders were missing their .meta files.
- There was some improper null handling in HighwayCameraRendering that caused a slow error drip while sitting on the gameplay scene in edit mode.
- YARG.Core projects are now added to the Unity-generated solution via the `Microsoft.VisualStudio.SolutionPersistence` package.
  - This technically gets rid of the .NET SDK requirement, meaning that no one should have any weird issues related to calling to it from Unity. (It should still be listed as part of setup though, since it's required for the projects surrounding YARG.Core.)
- The Visual Studio IDE package in Unity migrated to using .slnx files in 2.0.24, so the .gitignore and VS Code settings have been updated to match.