### PR TITLE
add toggle for venue post processing

### DIFF
--- a/Assets/Prefabs/Gameplay/HUD/Pause/QuickSettings.prefab
+++ b/Assets/Prefabs/Gameplay/HUD/Pause/QuickSettings.prefab
@@ -5,6 +5,7 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
+    serializedVersion: 3
     m_TransformParent: {fileID: 4220475145157243466}
     m_Modifications:
     - target: {fileID: 375337769934742335, guid: 81863a63e0d96cf459c263ee0ea6f98e,
@@ -154,6 +155,41 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents:
     - {fileID: 2576571026888088770, guid: 81863a63e0d96cf459c263ee0ea6f98e, type: 3}
+    m_RemovedGameObjects: []
+    m_AddedGameObjects:
+    - targetCorrespondingSourceObject: {fileID: 375337769934742335, guid: 81863a63e0d96cf459c263ee0ea6f98e,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 2756272007049743397}
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 2732038155882833699, guid: 81863a63e0d96cf459c263ee0ea6f98e,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 2466188838166874910}
+    - targetCorrespondingSourceObject: {fileID: 2732038155882833699, guid: 81863a63e0d96cf459c263ee0ea6f98e,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 2767505752476816931}
+    - targetCorrespondingSourceObject: {fileID: 2792404367123563439, guid: 81863a63e0d96cf459c263ee0ea6f98e,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 8760729487895991117}
+    - targetCorrespondingSourceObject: {fileID: 2792404367123563439, guid: 81863a63e0d96cf459c263ee0ea6f98e,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 4711204688257612194}
+    - targetCorrespondingSourceObject: {fileID: 2792404367123563439, guid: 81863a63e0d96cf459c263ee0ea6f98e,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 8041121451963607480}
+    - targetCorrespondingSourceObject: {fileID: 3586108267756431076, guid: 81863a63e0d96cf459c263ee0ea6f98e,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 4781087432946892003}
+    - targetCorrespondingSourceObject: {fileID: 3586108267756431076, guid: 81863a63e0d96cf459c263ee0ea6f98e,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 5862948351155699736}
   m_SourcePrefab: {fileID: 100100000, guid: 81863a63e0d96cf459c263ee0ea6f98e, type: 3}
 --- !u!224 &742624364121317624 stripped
 RectTransform:
@@ -218,13 +254,22 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_ShowMaskGraphic: 0
+  m_MaskingMode: 0
+  m_AlphaHitTest: 0
+  m_SoftnessRange:
+    m_Min: 0
+    m_Max: 1
   m_DownSamplingRate: 1
-  m_Softness: 1
+  m_AntiAliasingThreshold: 0
   m_Alpha: 1
-  m_IgnoreParent: 0
+  m_Softness: -1
   m_PartOfParent: 0
-  m_IgnoreSelfGraphic: 0
-  m_IgnoreSelfStencil: 0
+--- !u!224 &3023359568348455428 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 2778161148834292163, guid: 81863a63e0d96cf459c263ee0ea6f98e,
+    type: 3}
+  m_PrefabInstance: {fileID: 1115524203211064263}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &3067238732912043236 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 2732038155882833699, guid: 81863a63e0d96cf459c263ee0ea6f98e,
@@ -311,6 +356,7 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
+    serializedVersion: 3
     m_TransformParent: {fileID: 4220475146792831268}
     m_Modifications:
     - target: {fileID: 5535251001142144674, guid: 0e2af23c2e7465444a3fb84a06d425ae,
@@ -464,12 +510,22 @@ PrefabInstance:
       value: Back
       objectReference: {fileID: 0}
     m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 0e2af23c2e7465444a3fb84a06d425ae, type: 3}
+--- !u!224 &5734763326058268183 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 6846856529861592900, guid: 0e2af23c2e7465444a3fb84a06d425ae,
+    type: 3}
+  m_PrefabInstance: {fileID: 1193756682267836755}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &3413019020133249124
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
+    serializedVersion: 3
     m_TransformParent: {fileID: 4220475146792831268}
     m_Modifications:
     - target: {fileID: 5535251001142144674, guid: 0e2af23c2e7465444a3fb84a06d425ae,
@@ -628,12 +684,197 @@ PrefabInstance:
       value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 0e2af23c2e7465444a3fb84a06d425ae, type: 3}
+--- !u!224 &8095661284169053984 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 6846856529861592900, guid: 0e2af23c2e7465444a3fb84a06d425ae,
+    type: 3}
+  m_PrefabInstance: {fileID: 3413019020133249124}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &3988852077692735085
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 4220475146792831268}
+    m_Modifications:
+    - target: {fileID: 5535251001142144674, guid: 0e2af23c2e7465444a3fb84a06d425ae,
+        type: 3}
+      propertyPath: _onClick.m_PersistentCalls.m_Calls.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5535251001142144674, guid: 0e2af23c2e7465444a3fb84a06d425ae,
+        type: 3}
+      propertyPath: _onClick.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5535251001142144674, guid: 0e2af23c2e7465444a3fb84a06d425ae,
+        type: 3}
+      propertyPath: _onClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 8003136964529520852}
+    - target: {fileID: 5535251001142144674, guid: 0e2af23c2e7465444a3fb84a06d425ae,
+        type: 3}
+      propertyPath: _onClick.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 5535251001142144674, guid: 0e2af23c2e7465444a3fb84a06d425ae,
+        type: 3}
+      propertyPath: _onClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: ToggleVenuePostProcessing
+      objectReference: {fileID: 0}
+    - target: {fileID: 5535251001142144674, guid: 0e2af23c2e7465444a3fb84a06d425ae,
+        type: 3}
+      propertyPath: _onClick.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: YARG.Gameplay.HUD.QuickSettings, Assembly-CSharp
+      objectReference: {fileID: 0}
+    - target: {fileID: 5535251001142144674, guid: 0e2af23c2e7465444a3fb84a06d425ae,
+        type: 3}
+      propertyPath: _onClick.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 6846856528720448031, guid: 0e2af23c2e7465444a3fb84a06d425ae,
+        type: 3}
+      propertyPath: m_text
+      value: Disable Venue Post Processing
+      objectReference: {fileID: 0}
+    - target: {fileID: 6846856529861592900, guid: 0e2af23c2e7465444a3fb84a06d425ae,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6846856529861592900, guid: 0e2af23c2e7465444a3fb84a06d425ae,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6846856529861592900, guid: 0e2af23c2e7465444a3fb84a06d425ae,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 6846856529861592900, guid: 0e2af23c2e7465444a3fb84a06d425ae,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6846856529861592900, guid: 0e2af23c2e7465444a3fb84a06d425ae,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6846856529861592900, guid: 0e2af23c2e7465444a3fb84a06d425ae,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6846856529861592900, guid: 0e2af23c2e7465444a3fb84a06d425ae,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6846856529861592900, guid: 0e2af23c2e7465444a3fb84a06d425ae,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 750
+      objectReference: {fileID: 0}
+    - target: {fileID: 6846856529861592900, guid: 0e2af23c2e7465444a3fb84a06d425ae,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 58
+      objectReference: {fileID: 0}
+    - target: {fileID: 6846856529861592900, guid: 0e2af23c2e7465444a3fb84a06d425ae,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6846856529861592900, guid: 0e2af23c2e7465444a3fb84a06d425ae,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6846856529861592900, guid: 0e2af23c2e7465444a3fb84a06d425ae,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6846856529861592900, guid: 0e2af23c2e7465444a3fb84a06d425ae,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6846856529861592900, guid: 0e2af23c2e7465444a3fb84a06d425ae,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6846856529861592900, guid: 0e2af23c2e7465444a3fb84a06d425ae,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6846856529861592900, guid: 0e2af23c2e7465444a3fb84a06d425ae,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6846856529861592900, guid: 0e2af23c2e7465444a3fb84a06d425ae,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 375
+      objectReference: {fileID: 0}
+    - target: {fileID: 6846856529861592900, guid: 0e2af23c2e7465444a3fb84a06d425ae,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 46
+      objectReference: {fileID: 0}
+    - target: {fileID: 6846856529861592900, guid: 0e2af23c2e7465444a3fb84a06d425ae,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6846856529861592900, guid: 0e2af23c2e7465444a3fb84a06d425ae,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6846856529861592900, guid: 0e2af23c2e7465444a3fb84a06d425ae,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6846856529861592903, guid: 0e2af23c2e7465444a3fb84a06d425ae,
+        type: 3}
+      propertyPath: m_Name
+      value: Venue Post Processing Toggle
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 0e2af23c2e7465444a3fb84a06d425ae, type: 3}
+--- !u!224 &7520963447652256041 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 6846856529861592900, guid: 0e2af23c2e7465444a3fb84a06d425ae,
+    type: 3}
+  m_PrefabInstance: {fileID: 3988852077692735085}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &7520963447652256042 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6846856529861592903, guid: 0e2af23c2e7465444a3fb84a06d425ae,
+    type: 3}
+  m_PrefabInstance: {fileID: 3988852077692735085}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &4706707299059351058
 PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
+    serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
     - target: {fileID: 1393302618078186337, guid: d0426e4d1cafc1c489d1df380508ec96,
@@ -766,7 +1007,43 @@ PrefabInstance:
       propertyPath: m_text
       value: Quick Settings
       objectReference: {fileID: 0}
+    - target: {fileID: 8918172422257679858, guid: d0426e4d1cafc1c489d1df380508ec96,
+        type: 3}
+      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
+      value: 1801810542
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects:
+    - targetCorrespondingSourceObject: {fileID: 8918172423096749144, guid: d0426e4d1cafc1c489d1df380508ec96,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 3023359568348455428}
+    - targetCorrespondingSourceObject: {fileID: 8918172421510936374, guid: d0426e4d1cafc1c489d1df380508ec96,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 5734763326058268183}
+    - targetCorrespondingSourceObject: {fileID: 8918172421510936374, guid: d0426e4d1cafc1c489d1df380508ec96,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 8095661284169053984}
+    - targetCorrespondingSourceObject: {fileID: 8918172421510936374, guid: d0426e4d1cafc1c489d1df380508ec96,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 407376744541711451}
+    - targetCorrespondingSourceObject: {fileID: 8918172421510936374, guid: d0426e4d1cafc1c489d1df380508ec96,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 3974099309711397897}
+    - targetCorrespondingSourceObject: {fileID: 8918172421510936374, guid: d0426e4d1cafc1c489d1df380508ec96,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 7520963447652256041}
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 8918172421923777625, guid: d0426e4d1cafc1c489d1df380508ec96,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 8003136964529520852}
   m_SourcePrefab: {fileID: 100100000, guid: d0426e4d1cafc1c489d1df380508ec96, type: 3}
 --- !u!224 &4220475145157243466 stripped
 RectTransform:
@@ -799,7 +1076,7 @@ MonoBehaviour:
   _editHudButton: {fileID: 407376744541711448}
   _subSettingsBackButton: {fileID: 2756272007049743397}
   _noFailButton: {fileID: 3974099309711397898}
-  _failMeter: {fileID: 0}
+  _venuePostProcessingButton: {fileID: 7520963447652256042}
   _volumePauseSettingPrefab: {fileID: -8693196744517643411, guid: 24a963b7c0e99274fbace94c7c237fb0,
     type: 3}
 --- !u!224 &4220475146792831268 stripped
@@ -813,6 +1090,7 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
+    serializedVersion: 3
     m_TransformParent: {fileID: 742624364121317624}
     m_Modifications:
     - target: {fileID: 7888423432613039791, guid: 532a620ab94bd6c4d9d454f4f3725d0f,
@@ -965,7 +1243,15 @@ PrefabInstance:
       propertyPath: m_text
       value: Back
       objectReference: {fileID: 0}
+    - target: {fileID: 9127826232187365906, guid: 532a620ab94bd6c4d9d454f4f3725d0f,
+        type: 3}
+      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
+      value: 1801810542
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 532a620ab94bd6c4d9d454f4f3725d0f, type: 3}
 --- !u!224 &2756272007049743397 stripped
 RectTransform:
@@ -978,6 +1264,7 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
+    serializedVersion: 3
     m_TransformParent: {fileID: 4220475146792831268}
     m_Modifications:
     - target: {fileID: 5535251001142144674, guid: 0e2af23c2e7465444a3fb84a06d425ae,
@@ -1136,10 +1423,19 @@ PrefabInstance:
       value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 0e2af23c2e7465444a3fb84a06d425ae, type: 3}
 --- !u!1 &407376744541711448 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 6846856529861592903, guid: 0e2af23c2e7465444a3fb84a06d425ae,
+    type: 3}
+  m_PrefabInstance: {fileID: 6531241187282463519}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &407376744541711451 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 6846856529861592900, guid: 0e2af23c2e7465444a3fb84a06d425ae,
     type: 3}
   m_PrefabInstance: {fileID: 6531241187282463519}
   m_PrefabAsset: {fileID: 0}
@@ -1148,6 +1444,7 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
+    serializedVersion: 3
     m_TransformParent: {fileID: 4220475146792831268}
     m_Modifications:
     - target: {fileID: 5535251001142144674, guid: 0e2af23c2e7465444a3fb84a06d425ae,
@@ -1301,7 +1598,16 @@ PrefabInstance:
       value: No Fail Toggle
       objectReference: {fileID: 0}
     m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 0e2af23c2e7465444a3fb84a06d425ae, type: 3}
+--- !u!224 &3974099309711397897 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 6846856529861592900, guid: 0e2af23c2e7465444a3fb84a06d425ae,
+    type: 3}
+  m_PrefabInstance: {fileID: 7503628068323316557}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &3974099309711397898 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 6846856529861592903, guid: 0e2af23c2e7465444a3fb84a06d425ae,

--- a/Assets/Script/Gameplay/HUD/Pause/QuickSettings.cs
+++ b/Assets/Script/Gameplay/HUD/Pause/QuickSettings.cs
@@ -31,6 +31,8 @@ namespace YARG.Gameplay.HUD
         [Space]
         [SerializeField]
         private GameObject _noFailButton;
+        [SerializeField]
+        private GameObject _venuePostProcessingButton;
 
         [FormerlySerializedAs("_pauseVolumeSettingPrefab")]
         [Space]
@@ -39,11 +41,13 @@ namespace YARG.Gameplay.HUD
 
         private FailMeter _failMeter;
         private TextMeshProUGUI _noFailText;
+        private TextMeshProUGUI _venuePostProcessingText;
 
         protected override void OnSongStarted()
         {
             _failMeter = FindAnyObjectByType<FailMeter>();
             _noFailText = _noFailButton.GetComponentInChildren<TextMeshProUGUI>();
+            _venuePostProcessingText = _venuePostProcessingButton.GetComponentInChildren<TextMeshProUGUI>();
             _editHudButton.gameObject.SetActive(GameManager.Players.Count <= 1);
         }
 
@@ -55,6 +59,9 @@ namespace YARG.Gameplay.HUD
             _subSettingsObject.SetActive(false);
             // _noFailButton.SetActive(!SettingsManager.Settings.NoFailMode.Value);
             _noFailText.text = SettingsManager.Settings.NoFailMode.Value ? "Disable No Fail" : "Enable No Fail";
+            _venuePostProcessingText.text = SettingsManager.Settings.VenuePostProcessing.Value
+                ? "Disable Venue Post Processing"
+                : "Enable Venue Post Processing";
         }
 
         public override void Back()
@@ -79,6 +86,14 @@ namespace YARG.Gameplay.HUD
 
             // Disappear the fail meter
             _failMeter.SetActive(!SettingsManager.Settings.NoFailMode.Value);
+        }
+
+        public void ToggleVenuePostProcessing()
+        {
+            SettingsManager.Settings.VenuePostProcessing.Value = !SettingsManager.Settings.VenuePostProcessing.Value;
+            _venuePostProcessingText.text = SettingsManager.Settings.VenuePostProcessing.Value
+                ? "Disable Venue Post Processing"
+                : "Enable Venue Post Processing";
         }
 
         private void OpenSubSettings(List<string> settings)

--- a/Assets/Script/Persistent/GraphicsManager.cs
+++ b/Assets/Script/Persistent/GraphicsManager.cs
@@ -49,8 +49,6 @@ namespace YARG
             get => QualitySettings.GetQualityLevel() == 0;
         }
 
-        public bool VenuePostProcessing { get; set; }
-
         protected override void SingletonAwake()
         {
             if (!postProcessingProfile.TryGet(out bloom))

--- a/Assets/Script/Persistent/GraphicsManager.cs
+++ b/Assets/Script/Persistent/GraphicsManager.cs
@@ -49,6 +49,8 @@ namespace YARG
             get => QualitySettings.GetQualityLevel() == 0;
         }
 
+        public bool VenuePostProcessing { get; set; }
+
         protected override void SingletonAwake()
         {
             if (!postProcessingProfile.TryGet(out bloom))

--- a/Assets/Script/Settings/SettingsManager.Settings.cs
+++ b/Assets/Script/Settings/SettingsManager.Settings.cs
@@ -268,6 +268,7 @@ namespace YARG.Settings
                      YARG.VenueAntiAliasingMethod.MSAA,
                  };
 
+            public ToggleSetting VenuePostProcessing { get; } = new(true, VenuePostProcessingCallback);
             public ResolutionSetting Resolution { get; } = new(ResolutionCallback);
             public ToggleSetting FpsStats { get; } = new(false, FpsCounterCallback);
 
@@ -610,6 +611,11 @@ namespace YARG.Settings
                 }
 
                 GraphicsManager.Instance.VenueRenderScale = 1.0f / GetUpscaleRatioFromQualityMode(value);
+            }
+
+            private static void VenuePostProcessingCallback(bool value)
+            {
+                GraphicsManager.Instance.VenuePostProcessing = value;
             }
 
             private static void ResolutionCallback(Resolution? value)

--- a/Assets/Script/Settings/SettingsManager.Settings.cs
+++ b/Assets/Script/Settings/SettingsManager.Settings.cs
@@ -268,7 +268,7 @@ namespace YARG.Settings
                      YARG.VenueAntiAliasingMethod.MSAA,
                  };
 
-            public ToggleSetting VenuePostProcessing { get; } = new(true, VenuePostProcessingCallback);
+            public ToggleSetting VenuePostProcessing { get; } = new(true);
             public ResolutionSetting Resolution { get; } = new(ResolutionCallback);
             public ToggleSetting FpsStats { get; } = new(false, FpsCounterCallback);
 
@@ -611,11 +611,6 @@ namespace YARG.Settings
                 }
 
                 GraphicsManager.Instance.VenueRenderScale = 1.0f / GetUpscaleRatioFromQualityMode(value);
-            }
-
-            private static void VenuePostProcessingCallback(bool value)
-            {
-                GraphicsManager.Instance.VenuePostProcessing = value;
             }
 
             private static void ResolutionCallback(Resolution? value)

--- a/Assets/Script/Settings/SettingsManager.cs
+++ b/Assets/Script/Settings/SettingsManager.cs
@@ -140,6 +140,7 @@ namespace YARG.Settings
                 nameof(Settings.SongBackgroundOpacity),
                 nameof(Settings.VenueRenderingQuality),
                 nameof(Settings.VenueAntiAliasing),
+                nameof(Settings.VenuePostProcessing),
 
                 new HeaderMetadata("Gameplay"),
                 nameof(Settings.StaticVocalsMode),

--- a/Assets/Script/Venue/VenueCamera/CameraManager.PostProcessing.cs
+++ b/Assets/Script/Venue/VenueCamera/CameraManager.PostProcessing.cs
@@ -100,6 +100,12 @@ namespace YARG.Venue.VenueCamera
             // Reset any existing effects, because they aren't supposed to stack
             ResetCameraEffect();
 
+            //exit early if Post processing disabled
+            if (!GraphicsManager.Instance.VenuePostProcessing)
+            {
+                return;
+            }
+
             if (newEffect.Type == PreviousEffect.Type && NextEffect != null)
             {
                 // In this case, we start animating toward NextEffect now

--- a/Assets/Script/Venue/VenueCamera/CameraManager.PostProcessing.cs
+++ b/Assets/Script/Venue/VenueCamera/CameraManager.PostProcessing.cs
@@ -6,6 +6,7 @@ using UnityEngine.Rendering.Universal;
 using YARG.Core.Chart;
 using YARG.Core.Logging;
 using YARG.Gameplay;
+using YARG.Settings;
 using YARG.Venue.VolumeComponents;
 using Random = UnityEngine.Random;
 
@@ -101,7 +102,7 @@ namespace YARG.Venue.VenueCamera
             ResetCameraEffect();
 
             //exit early if Post processing disabled
-            if (!GraphicsManager.Instance.VenuePostProcessing)
+            if (!_isPostProcessingEnabled)
             {
                 return;
             }
@@ -395,6 +396,40 @@ namespace YARG.Venue.VenueCamera
 					SetPsychRB(false);
 					break;
             }
+        }
+
+        private void ResetAllEffects()
+        {
+            _colorAnimations.Clear();
+            _curveAnimations.Clear();
+            _floatAnimations.Clear();
+            _clampedFloatAnimations.Clear();
+            _clampedIntAnimations.Clear();
+            SetLowFrameRate(false);
+            SetBloom(false);
+            SetBrightness(false);
+            SetContrast(false);
+            SetPosterize(false);
+            SetInvertedColors(false);
+            SetMirror(false);
+            SetBlackAndWhite(false);
+            SetGrainy(false);
+            SetScanline(false);
+            SetSepiaTone(false);
+            SetSilverTone(false);
+            SetBlueTint(false);
+            SetGreenTint(false);
+            SetExposure(false);
+            SetChromaticAberration(false);
+            SetDesaturation(false);
+            SetDesaturatedRed(false);
+            SetDesaturatedBlue(false);
+            SetTrail(false);
+            SetPhotoNegativeRedAndBlack(false);
+            SetContrastGreen(false);
+            SetContrastBlue(false);
+            SetContrastRed(false);
+            SetPsychRB(false);
         }
 
         private void SetContrastGreen(bool enabled)
@@ -1030,6 +1065,20 @@ namespace YARG.Venue.VenueCamera
             {
                 CurrentEffect = _postProcessingEvents[_currentEventIndex];
                 SetCameraPostProcessing(CurrentEffect);
+            }
+        }
+
+        private void SetPostProcessingEnabled(bool value)
+        {
+            _isPostProcessingEnabled = value;
+            if (!value)
+            {
+                YargLogger.LogInfo("trying to remove pp");
+                ResetAllEffects();
+            }
+            else if (CurrentEffect != null)
+            {
+                SetCameraPostProcessing(new PostProcessingEvent(CurrentEffect.Type, GameManager.VisualTime, CurrentEffect.Tick));
             }
         }
     }

--- a/Assets/Script/Venue/VenueCamera/CameraManager.PostProcessing.cs
+++ b/Assets/Script/Venue/VenueCamera/CameraManager.PostProcessing.cs
@@ -91,6 +91,9 @@ namespace YARG.Venue.VenueCamera
             _invertCurveParam = new TextureCurveParameter(_invertCurve, true);
             _copierCurveParam = new TextureCurveParameter(_copierCurve, true);
             _brightCurveParam = new TextureCurveParameter(_brightCurve, true);
+
+            _isPostProcessingEnabled = SettingsManager.Settings.VenuePostProcessing.Value;
+            SettingsManager.Settings.VenuePostProcessing.OnChange += SetPostProcessingEnabled;
         }
 
         public void SetCameraPostProcessing(PostProcessingEvent newEffect)

--- a/Assets/Script/Venue/VenueCamera/CameraManager.cs
+++ b/Assets/Script/Venue/VenueCamera/CameraManager.cs
@@ -120,6 +120,8 @@ namespace YARG.Venue.VenueCamera
         private int   _cameraIndex;
         private bool  _volumeSet;
 
+        private bool _isPostProcessingEnabled;
+
         protected override void OnChartLoaded(SongChart chart)
         {
             _volumeSet = _profile != null;
@@ -506,6 +508,8 @@ namespace YARG.Venue.VenueCamera
         {
             // Enable the camera in case it happens to be disabled
             _currentCamera.enabled = true;
+
+            SettingsManager.Settings.VenuePostProcessing.OnChange -= SetPostProcessingEnabled;
             base.GameplayDestroy();
         }
 

--- a/Assets/StreamingAssets/lang/en-US.json
+++ b/Assets/StreamingAssets/lang/en-US.json
@@ -1171,6 +1171,10 @@
                     "FSR3": "FSR3"
                 }
             },
+            "VenuePostProcessing": {
+                "Name": "Venue Post-Processing",
+                "Description": "Determines if post-processing effects are applied to venue backgrounds."
+            },
             "VenueRenderingQuality": {
                 "Name": "Venue Rendering Quality",
                 "Description": "The quality/resolution to use for venue backgrounds.",


### PR DESCRIPTION
toggle for venue post processing in graphic settings and quick pause settings.

some charts give me headaches from all the post processing effects so i would like to be able to just turn them off directly while playing the chart and just turn it back on the next chart.

toggling post processing while mid song will only affect the post  processing the next time a new effect would be processed, as that was a lot simpler to implement and i just wanted something that works.

<img width="1419" height="796" alt="image" src="https://github.com/user-attachments/assets/8f2e0eff-94d7-4eb2-8eec-e9712642ca93" />

<img width="1421" height="797" alt="image" src="https://github.com/user-attachments/assets/b6312200-b297-42bd-ac51-a10df58711eb" />