### PR TITLE
Failed to load audio error fix for playable CON files with missing stems

### DIFF
--- a/Assets/Script/Audio/Bass/BassStemMixer.cs
+++ b/Assets/Script/Audio/Bass/BassStemMixer.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -305,9 +305,15 @@ namespace YARG.Audio.BASS
                     out var reverbHandles))
                 {
                     YargLogger.LogFormatError("Failed to load stem {0}: {1}!", stemInfo.Stem, Bass.LastError);
-                    return false;
+                    continue;
                 }
                 stemDatas.Add(new StemData(stemInfo.Stem, stemInfo.GetVolumeMatrix(), streamHandles!, reverbHandles!));
+            }
+
+            if (!stemDatas.Any())
+            {
+                YargLogger.LogError("Failed to load any stems!");
+                return false;
             }
 
             if (!AddChannelsToMixer(stemDatas))


### PR DESCRIPTION
There was an issue introduced in the b3292 build that caused CON / exCON files with missing stems to become unplayable, resulting in a "Failed to load audio!" error when attempting to select an affected song from the library. This change will now load all of the available stems in the CON / exCON file, and will only result in an error if no stems in the file are present.