### PR TITLE
Fix background image/video rendering

### DIFF
--- a/Assets/Scenes/Gameplay.unity
+++ b/Assets/Scenes/Gameplay.unity
@@ -1444,6 +1444,7 @@ MonoBehaviour:
   _videoPlayer: {fileID: 218824352}
   _backgroundImage: {fileID: 1773048783}
   _backgroundDimmer: {fileID: 1038164713}
+  _venueOutput: {fileID: 879254558}
 --- !u!114 &318454377
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -4707,7 +4708,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &879254557
 RectTransform:
   m_ObjectHideFlags: 0

--- a/Assets/Script/Gameplay/BackgroundManager.cs
+++ b/Assets/Script/Gameplay/BackgroundManager.cs
@@ -3,7 +3,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using Cysharp.Threading.Tasks;
 using UnityEngine;
-using UnityEngine.Rendering.RendererUtils;
 using UnityEngine.UI;
 using UnityEngine.Video;
 using YARG.Core.IO;
@@ -30,6 +29,9 @@ namespace YARG.Gameplay
 
         [SerializeField]
         private Image _backgroundDimmer;
+
+        [SerializeField]
+        private RawImage _venueOutput;
 
         private BackgroundType _type;
         private VenueSource _source;
@@ -68,6 +70,7 @@ namespace YARG.Gameplay
                     var bundle = AssetBundle.LoadFromStream(result.Stream);
                     AssetBundle shaderBundle = null;
 
+                    _venueOutput.gameObject.SetActive(true);
                     // KEEP THIS PATH LOWERCASE
                     // Breaks things for other platforms, because Unity
                     var bg = (GameObject) await bundle.LoadAssetAsync<GameObject>(

--- a/Assets/Script/Gameplay/VenueCameraRenderer.cs
+++ b/Assets/Script/Gameplay/VenueCameraRenderer.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Threading;
-using Cysharp.Threading.Tasks;
 using UnityEngine;
 using UnityEngine.Rendering;
 using UnityEngine.Rendering.Universal;


### PR DESCRIPTION
It was hidden under opaque venue output texture (that is unused when using song-specific background)

The only change in gameplay scene is a new field for venue  output on background  manager and disabling gameobject of venue output.