### PR TITLE
Fix NullReferenceException in color profile editor

### DIFF
--- a/Assets/Script/Settings/Metadata/Tabs/PresetSubTab.Generic.cs
+++ b/Assets/Script/Settings/Metadata/Tabs/PresetSubTab.Generic.cs
@@ -219,6 +219,12 @@ namespace YARG.Settings.Metadata
                 {
                     foreach (var field in _fields)
                     {
+                        if (field.ParentField is null)
+                        {
+                            YargLogger.LogFormatDebug("Unexpected null parent field for {0}", field.Field);
+                            continue;
+                        }
+
                         if (_subSection is not null && field.ParentField.Name != _subSection)
                         {
                             continue;


### PR DESCRIPTION
Previously the color profile editor looked like this for me (not showing any rows):
<img width="2312" height="2160" alt="20251207_15h11m55s_grim" src="https://github.com/user-attachments/assets/3a8f1410-adfa-4967-9272-769825ad7850" />

The log showed this NullReferenceException for that:
```
NullReferenceException: Object reference not set to an instance of an object
  at YARG.Settings.Metadata.PresetSubTab`1[T].BuildSettingTab (UnityEngine.Transform settingContainer, YARG.Menu.Navigation.NavigationGroup navGroup) [0x0018a] in <8b3470de56354032bec2fb9139b05fa6>:0
  at YARG.Settings.Metadata.PresetsTab.BuildSettingTab (UnityEngine.Transform settingContainer, YARG.Menu.Navigation.NavigationGroup navGroup) [0x00146] in <8b3470de56354032bec2fb9139b05fa6>:0
  at YARG.Menu.Settings.SettingsMenu.UpdateSettings (System.Boolean resetScroll) [0x00020] in <8b3470de56354032bec2fb9139b05fa6>:0
  at YARG.Menu.Settings.SettingsMenu.Refresh () [0x00000] in <8b3470de56354032bec2fb9139b05fa6>:0
  at YARG.Menu.Settings.PresetDropdown.OnDropdownChange () [0x00028] in <8b3470de56354032bec2fb9139b05fa6>:0
  at UnityEngine.Events.InvokableCall.Invoke () [0x00010] in <e50034186c57439ea461644cd311e533>:0
  at UnityEngine.Events.UnityEvent`1[T0].Invoke (T0 arg0) [0x00049] in <e50034186c57439ea461644cd311e533>:0
  at TMPro.TMP_Dropdown.SetValue (System.Int32 value, System.Boolean sendCallback) [0x0006d] in <a6d382ce31d44a1da0f4910919be2761>:0
  at TMPro.TMP_Dropdown.set_value (System.Int32 value) [0x00000] in <a6d382ce31d44a1da0f4910919be2761>:0
  at TMPro.TMP_Dropdown.OnSelectItem (UnityEngine.UI.Toggle toggle) [0x00144] in <a6d382ce31d44a1da0f4910919be2761>:0
  at TMPro.TMP_Dropdown+<>c__DisplayClass76_1.<Show>b__2 (System.Boolean x) [0x00011] in <a6d382ce31d44a1da0f4910919be2761>:0
  at UnityEngine.Events.InvokableCall`1[T1].Invoke (T1 args0) [0x00010] in <e50034186c57439ea461644cd311e533>:0
  at UnityEngine.Events.UnityEvent`1[T0].Invoke (T0 arg0) [0x00025] in <e50034186c57439ea461644cd311e533>:0
  at UnityEngine.UI.Toggle.Set (System.Boolean value, System.Boolean sendCallback) [0x00087] in <0e42b4a19c5b44d5849a9f9062c4fa13>:0
  at UnityEngine.UI.Toggle.set_isOn (System.Boolean value) [0x00000] in <0e42b4a19c5b44d5849a9f9062c4fa13>:0
  at UnityEngine.UI.Toggle.InternalToggle () [0x00018] in <0e42b4a19c5b44d5849a9f9062c4fa13>:0
  at UnityEngine.UI.Toggle.OnPointerClick (UnityEngine.EventSystems.PointerEventData eventData) [0x00009] in <0e42b4a19c5b44d5849a9f9062c4fa13>:0
  at UnityEngine.EventSystems.ExecuteEvents.Execute (UnityEngine.EventSystems.IPointerClickHandler handler, UnityEngine.EventSystems.BaseEventData eventData) [0x00007] in <0e42b4a19c5b44d5849a9f9062c4fa13>:0
  at UnityEngine.EventSystems.ExecuteEvents.Execute[T] (UnityEngine.GameObject target, UnityEngine.EventSystems.BaseEventData eventData, UnityEngine.EventSystems.ExecuteEvents+EventFunction`1[T1] functor) [0x00067] in <0e42b4a19c5b44d5849a9f9062c4fa13>:0
```

This was caused by `field.ParentField` being null on the line that the commit changes. It was null for the following fields:
- DefaultPurple
- DefaultGreen
- DefaultRed
- DefaultYellow
- DefaultBlue
- DefaultOrange
- DefaultRedCymbal
- DefaultYellowCymbal
- DefaultBlueCymbal
- DefaultGreenCymbal
- DefaultStarpower
- DefaultPurpleActivationNote
- DefaultRedActivationNote
- DefaultYellowActivationNote
- DefaultBlueActivationNote
- DefaultOrangeActivationNote
- DefaultGreenActivationNote
- DefaultMetal
- DefaultMetalStarPower
- DefaultMiss

This commit properly checks for null and hides those fields. Now the color profile editor works correctly for me.