### PR TITLE
limit venue lighting to venue layer

### DIFF
--- a/Assets/Script/Gameplay/BackgroundManager.cs
+++ b/Assets/Script/Gameplay/BackgroundManager.cs
@@ -134,6 +134,7 @@ namespace YARG.Gameplay
                     bundleBackgroundManager.Bundle = bundle;
                     bundleBackgroundManager.ShaderBundle = shaderBundle;
                     bundleBackgroundManager.SetupVenueCamera(bgInstance);
+                    bundleBackgroundManager.LimitVenueLights(bgInstance);
 
                     // Destroy the default camera (venue has its own)
                     Destroy(_videoPlayer.targetCamera.gameObject);

--- a/Assets/Script/Venue/BundleBackgroundManager.cs
+++ b/Assets/Script/Venue/BundleBackgroundManager.cs
@@ -20,7 +20,9 @@ namespace YARG.Venue
         public const string BACKGROUND_SHADER_BUNDLE_NAME = "_metal_shaders.bytes";
         public const string BACKGOUND_OSX_MATERIAL_PREFIX = "_metal_";
 
-        private const int VENUE_LAYER_NUMBER = 9;
+        private const string VENUE_LAYER_NAME = "Venue";
+
+        private int _venueLayerNumber = -1;
 
         // DO NOT CHANGE the name of this! I *know* it doesn't follow naming conventions, but it will also break existing
         // venues if we do change it.
@@ -36,6 +38,7 @@ namespace YARG.Venue
         {
             // Move object out of the way, so its effects don't collide with the tracks
             transform.position += Vector3.forward * 10_000f;
+            _venueLayerNumber = LayerMask.NameToLayer(VENUE_LAYER_NAME);
         }
 
         public void SetupVenueCamera(GameObject bgInstance)
@@ -58,7 +61,12 @@ namespace YARG.Venue
 
         public void LimitVenueLights(GameObject bgInstance)
         {
-            int venueLayer = 1 << VENUE_LAYER_NUMBER;
+            if (_venueLayerNumber == -1)
+            {
+                return;
+            }
+
+            int venueLayer = 1 << _venueLayerNumber;
 
             Light[] lights = bgInstance.GetComponentsInChildren<Light>(true);
 

--- a/Assets/Script/Venue/BundleBackgroundManager.cs
+++ b/Assets/Script/Venue/BundleBackgroundManager.cs
@@ -20,6 +20,8 @@ namespace YARG.Venue
         public const string BACKGROUND_SHADER_BUNDLE_NAME = "_metal_shaders.bytes";
         public const string BACKGOUND_OSX_MATERIAL_PREFIX = "_metal_";
 
+        private const int VENUE_LAYER_NUMBER = 9;
+
         // DO NOT CHANGE the name of this! I *know* it doesn't follow naming conventions, but it will also break existing
         // venues if we do change it.
         //
@@ -51,6 +53,18 @@ namespace YARG.Venue
                 fsrManager.enabled = false;
                 fsrManager.textureParentObject = bgInstance;
                 fsrManager.enabled = true;
+            }
+        }
+
+        public void LimitVenueLights(GameObject bgInstance)
+        {
+            int venueLayer = 1 << VENUE_LAYER_NUMBER;
+
+            Light[] lights = bgInstance.GetComponentsInChildren<Light>(true);
+
+            foreach (var light in lights)
+            {
+                light.cullingMask = venueLayer;
             }
         }
 


### PR DESCRIPTION
this change iterates over all light object in the loaded venue to set the culling mask to only render the lighting on the actual venue.
this fixes the lighting for venues with extremely bright directional lights affecting the highway.
this is the same method of culling as currently used by gameplay lighting to exclude the venue layer just reversed.

an example of a brightened highway before the change
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/afddf88a-1793-49d3-8500-4a9f7f56b879" />