### PR TITLE
Increase view of the highway rendering camera

### DIFF
--- a/Assets/Script/Gameplay/Visuals/HighwayCameraRendering.cs
+++ b/Assets/Script/Gameplay/Visuals/HighwayCameraRendering.cs
@@ -168,11 +168,11 @@ namespace YARG.Gameplay.Visuals
                 var x = position.x;
                 if (float.IsNaN(maxWorld) || maxWorld < x + 1)
                 {
-                    maxWorld = x + 1;
+                    maxWorld = x + 5;
                 }
                 if (float.IsNaN(minWorld) || minWorld > x - 1)
                 {
-                    minWorld = x - 1;
+                    minWorld = x - 5;
                 }
             }
 


### PR DESCRIPTION
This prevents track effects on the edges of the screen to be culled away.