### PR TITLE
Reduce aggressiveness of automatic vocal scroll speed adjustment

### DIFF
--- a/Assets/Script/Gameplay/Player/Vocals/VocalTrack.cs
+++ b/Assets/Script/Gameplay/Player/Vocals/VocalTrack.cs
@@ -325,7 +325,7 @@ namespace YARG.Gameplay.Player
                             // ...but HARM2 gets HARM3 as a merged part
                             _staticPhraseTrackers[i] = new StaticPhraseTracker(GetVocalPhrasePairs(parts[i], parts[i+1]));
                             break;
-                        // Do nothing for HARM3, because it's being handled by HARM2
+                            // Do nothing for HARM3, because it's being handled by HARM2
                     }
                 }
                 _staticPhraseQueues[i] = new Queue<VocalStaticLyricPhraseElement>();
@@ -652,11 +652,11 @@ namespace YARG.Gameplay.Player
             // passing the threshold in the first place)
             int severity = (((int)greatestOffset - THRESHOLD) / 200) + 1;
 
-            return 1f + (severity * 0.3f);
+            return 1f + (severity * 0.2f);
         }
 
         // Necessary for combining HARM2 and HARM3 in two-lane view
-        #nullable enable
+#nullable enable
         public struct VocalPhrasePair
         {
             public double Tick;
@@ -775,6 +775,6 @@ namespace YARG.Gameplay.Player
 
             return phrasePairs;
         }
-        #nullable disable
+#nullable disable
     }
 }


### PR DESCRIPTION
Reduces the aggressiveness of the logic that increases vocal scroll speed for songs with fast lyrics (and no manually-set vocal scroll speed value). The original tunings were all rough guesses, and in practice they've turned out to be too aggressive. This reduction from `0.3f` to `0.2f` should be more reasonable.