### PR TITLE
Fix some minor resource leaks (mostly around render textures)

### DIFF
--- a/Assets/Script/Gameplay/Visuals/HighwayCameraRendering.cs
+++ b/Assets/Script/Gameplay/Visuals/HighwayCameraRendering.cs
@@ -7,7 +7,6 @@ using UnityEngine.Rendering.Universal;
 using UnityEngine.UI;
 using YARG.Core.Logging;
 using YARG.Gameplay.Player;
-using YARG.Helpers;
 using YARG.Helpers.UI;
 using YARG.Settings;
 
@@ -302,6 +301,18 @@ namespace YARG.Gameplay.Visuals
         {
             RenderPipelineManager.beginCameraRendering -= OnPreCameraRender;
             RenderPipelineManager.endCameraRendering -= OnEndCameraRender;
+
+            if (HighwaysOutputTexture != null)
+            {
+                HighwaysOutputTexture.Release();
+                HighwaysOutputTexture.DiscardContents();
+                HighwaysOutputTexture = null;
+            }
+            if (_highwaysAlphaTexture != null)
+            {
+                _highwaysAlphaTexture.Release();
+                _highwaysAlphaTexture = null;
+            }
         }
 
         private void OnEndCameraRender(ScriptableRenderContext ctx, Camera cam)

--- a/Assets/Script/Persistent/GlobalVariables.cs
+++ b/Assets/Script/Persistent/GlobalVariables.cs
@@ -1,29 +1,22 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Linq;
-using JetBrains.Annotations;
 using UnityEngine;
 using UnityEngine.SceneManagement;
-using UnityEngine.UI;
 using YARG.Audio.BASS;
-using YARG.Core;
 using YARG.Core.Logging;
 using YARG.Core.Audio;
-using YARG.Core.Song;
 using YARG.Helpers;
 using YARG.Input;
 using YARG.Integration;
 using YARG.Localization;
 using YARG.Menu.Navigation;
-using YARG.Menu.ScoreScreen;
 using YARG.Player;
 using YARG.Playlists;
 using YARG.Replays;
 using YARG.Scores;
 using YARG.Settings;
 using YARG.Settings.Customization;
-using YARG.Song;
 
 namespace YARG
 {
@@ -145,20 +138,20 @@ namespace YARG
 #endif
         }
 
-        private void LoadSceneAdditive(SceneIndex scene)
+        private async void LoadSceneAdditive(SceneIndex scene)
         {
-            var asyncOp = SceneManager.LoadSceneAsync((int) scene, LoadSceneMode.Additive);
-
             CurrentScene = scene;
 
             GameStateFetcher.SetSceneIndex(scene);
 
-            asyncOp.completed += _ =>
-            {
-                // When complete, set the newly loaded scene to the active one
-                SceneManager.SetActiveScene(SceneManager.GetSceneByBuildIndex((int) scene));
-                Navigator.Instance.DisableMenuInputs = false;
-            };
+            await SceneManager.LoadSceneAsync((int) scene, LoadSceneMode.Additive);
+
+            // When complete, set the newly loaded scene to the active one
+            SceneManager.SetActiveScene(SceneManager.GetSceneByBuildIndex((int) scene));
+            Navigator.Instance.DisableMenuInputs = false;
+
+            await Resources.UnloadUnusedAssets();
+            GC.Collect();
         }
 
         public void LoadScene(SceneIndex scene)
@@ -177,7 +170,6 @@ namespace YARG
             {
                 LoadSceneAdditive(scene);
             }
-            GC.Collect();
         }
 
         // Due to the preprocessor, it doesn't know that an instance variable is being used

--- a/Assets/Script/Venue/VenueCamera/CameraManager.cs
+++ b/Assets/Script/Venue/VenueCamera/CameraManager.cs
@@ -506,6 +506,12 @@ namespace YARG.Venue.VenueCamera
 
         protected override void GameplayDestroy()
         {
+            // These need to be explicitly released
+            _invertCurveParam.Release();
+            _defaultCurveParam.Release();
+            _brightCurveParam.Release();
+            _copierCurveParam.Release();
+
             // Enable the camera in case it happens to be disabled
             _currentCamera.enabled = true;
 


### PR DESCRIPTION
From documentation:
    As with other "native engine object" types, it is
    important to pay attention to the lifetime of any
    render textures and release them when you are finished
    using them, as they will not be garbage collected like normal managed types.
