### PR TITLE
Fix non-deterministic high-score selection in SQLite queries

### DIFF
--- a/Assets/Script/Scores/ScoreDatabase.cs
+++ b/Assets/Script/Scores/ScoreDatabase.cs
@@ -220,17 +220,26 @@ namespace YARG.Scores
         public List<GameRecord> QueryBandHighScores()
         {
             return Query<GameRecord>(
-                @"SELECT *, MAX(BandScore) FROM GameRecords
-                WHERE PlayedWithReplay = 0
-                GROUP BY GameRecords.SongChecksum"
+                @"SELECT gr.* FROM GameRecords gr
+                WHERE gr.PlayedWithReplay = 0
+                    AND gr.Id = (
+                        SELECT gr2.Id FROM GameRecords gr2
+                        WHERE gr2.PlayedWithReplay = 0
+                            AND gr2.SongChecksum = gr.SongChecksum
+                        ORDER BY gr2.BandScore DESC
+                        LIMIT 1
+                    )"
             );
         }
 
         public GameRecord QueryBandSongHighScore(HashWrapper songChecksum)
         {
             return FindWithQuery<GameRecord>(
-                @"SELECT *, MAX(BandScore) FROM GameRecords
-                WHERE SongChecksum = ? AND PlayedWithReplay = 0",
+                @"SELECT * FROM GameRecords
+                WHERE SongChecksum = ?
+                    AND PlayedWithReplay = 0
+                ORDER BY BandScore DESC
+                LIMIT 1",
                 songChecksum.HashBytes
             );
         }
@@ -251,22 +260,27 @@ namespace YARG.Scores
             bool highestDifficultyOnly
         )
         {
-            string difficultyClause = "";
-            if (highestDifficultyOnly)
-            {
-                difficultyClause = "Difficulty DESC,";
-            }
+            string orderBy = highestDifficultyOnly
+                ? "ps2.Difficulty DESC, ps2.Score DESC"
+                : "ps2.Score DESC";
 
-            string query = $@"SELECT * FROM (
-                SELECT * FROM PlayerScores
-                    INNER JOIN GameRecords
-                ON PlayerScores.GameRecordId = GameRecords.Id
-                WHERE PlayerId = ?
-                    AND Instrument = ?
-                    AND IsReplay = 0
-                ORDER BY {difficultyClause} Score DESC
-              )
-              GROUP BY SongChecksum";
+            string query = $@"SELECT ps.* FROM PlayerScores ps
+                INNER JOIN GameRecords gr
+                    ON ps.GameRecordId = gr.Id
+                WHERE ps.PlayerId = ?
+                    AND ps.Instrument = ?
+                    AND ps.IsReplay = 0
+                    AND ps.Id = (
+                        SELECT ps2.Id FROM PlayerScores ps2
+                            INNER JOIN GameRecords gr2
+                                ON ps2.GameRecordId = gr2.Id
+                        WHERE ps2.PlayerId = ps.PlayerId
+                            AND ps2.Instrument = ps.Instrument
+                            AND ps2.IsReplay = 0
+                            AND gr2.SongChecksum = gr.SongChecksum
+                        ORDER BY {orderBy}
+                        LIMIT 1
+                    )";
 
             return Query<PlayerScoreRecord>(
                 query,
@@ -281,22 +295,27 @@ namespace YARG.Scores
             bool highestDifficultyOnly
         )
         {
-            string difficultyClause = "";
-            if (highestDifficultyOnly)
-            {
-                difficultyClause = "Difficulty DESC,";
-            }
+            string orderBy = highestDifficultyOnly
+                ? "ps2.Difficulty DESC, ps2.Percent DESC, ps2.IsFc DESC"
+                : "ps2.Percent DESC, ps2.IsFc DESC";
 
-            string query = $@"SELECT * FROM (
-                SELECT * FROM PlayerScores
-                    INNER JOIN GameRecords
-                ON PlayerScores.GameRecordId = GameRecords.Id
-                WHERE PlayerId = ?
-                    AND Instrument = ?
-                    AND IsReplay = 0
-                ORDER BY {difficultyClause} Percent DESC, IsFc DESC
-              )
-              GROUP BY SongChecksum";
+            string query = $@"SELECT ps.* FROM PlayerScores ps
+                INNER JOIN GameRecords gr
+                    ON ps.GameRecordId = gr.Id
+                WHERE ps.PlayerId = ?
+                    AND ps.Instrument = ?
+                    AND ps.IsReplay = 0
+                    AND ps.Id = (
+                        SELECT ps2.Id FROM PlayerScores ps2
+                            INNER JOIN GameRecords gr2
+                                ON ps2.GameRecordId = gr2.Id
+                        WHERE ps2.PlayerId = ps.PlayerId
+                            AND ps2.Instrument = ps.Instrument
+                            AND ps2.IsReplay = 0
+                            AND gr2.SongChecksum = gr.SongChecksum
+                        ORDER BY {orderBy}
+                        LIMIT 1
+                    )";
 
             var result = Query<PlayerScoreRecord>(
                 query,
@@ -417,22 +436,24 @@ namespace YARG.Scores
 
         public List<PlayerScoreWithChecksum> QueryPlayerBestStars(YargProfile profile, bool highestDifficultyOnly)
         {
-            string query = $@"SELECT * FROM (
-                SELECT * FROM PlayerScores
-                    INNER JOIN GameRecords
-                ON PlayerScores.GameRecordId = GameRecords.Id
-                WHERE PlayerId = ?
-                    AND Instrument = ?";
+            string difficultyFilter = highestDifficultyOnly ? "" : " AND ps.Difficulty = ?";
+            string subDifficultyFilter = highestDifficultyOnly ? "" : " AND ps2.Difficulty = ps.Difficulty";
 
-            if (!highestDifficultyOnly)
-            {
-                query += @"
-                    AND PlayerScores.Difficulty = ?";
-            }
-            query += @"
-                ORDER BY PlayerScores.Stars DESC
-                )
-                GROUP BY SongChecksum";
+            string query = $@"SELECT ps.*, gr.SongChecksum FROM PlayerScores ps
+                INNER JOIN GameRecords gr
+                    ON ps.GameRecordId = gr.Id
+                WHERE ps.PlayerId = ?
+                    AND ps.Instrument = ?{difficultyFilter}
+                    AND ps.Id = (
+                        SELECT ps2.Id FROM PlayerScores ps2
+                            INNER JOIN GameRecords gr2
+                                ON ps2.GameRecordId = gr2.Id
+                        WHERE ps2.PlayerId = ps.PlayerId
+                            AND ps2.Instrument = ps.Instrument{subDifficultyFilter}
+                            AND gr2.SongChecksum = gr.SongChecksum
+                        ORDER BY ps2.Stars DESC
+                        LIMIT 1
+                    )";
 
             return highestDifficultyOnly
                 ? Query<PlayerScoreWithChecksum>(


### PR DESCRIPTION
The previous queries relied on GROUP BY without proper aggregation, which lets SQLite return an arbitrary row for each song; that could be a lower score/stars/percent than the true best. This commit replaces those grouped queries with deterministic lookups using ORDER BY ... LIMIT 1.