### PR TITLE
Output device and channel selection

### DIFF
--- a/Assets/Script/Audio/Bass/BassAudioManager.cs
+++ b/Assets/Script/Audio/Bass/BassAudioManager.cs
@@ -148,10 +148,6 @@ namespace YARG.Audio.BASS
 
             SetOutputDevice("Default");
 
-            LoadSfx();
-            LoadDrumSfx(); // TODO: move drum sfx loading/disposal to song start/end respectively IF there are any drum players
-            LoadVox();
-
             var info = Bass.Info;
             PlaybackLatency = info.Latency + Bass.DeviceBufferLength + devPeriod;
             MinimumBufferLength = info.MinBufferLength + Bass.UpdatePeriod;
@@ -183,6 +179,11 @@ namespace YARG.Audio.BASS
             _currentDevice = bassDevice.Use();
 
             YargLogger.LogFormatInfo("Current BASS Device: {0}", Bass.GetDeviceInfo(Bass.CurrentDevice).Name);
+
+            // Load/reload samples
+            LoadSfx();
+            LoadDrumSfx(); // TODO: move drum sfx loading/disposal to song start/end respectively IF there are any drum players
+            LoadVox();
         }
 
 #nullable enable
@@ -197,7 +198,8 @@ namespace YARG.Audio.BASS
             {
                 return null;
             }
-            return new BassStemMixer(name, this, speed, mixerVolume, handle, clampStemVolume);
+            return new BassStemMixer(name, this, speed, mixerVolume, handle, clampStemVolume,
+                CreateOutputChannel(SettingsManager.Settings?.OutputChannelDefault.Value ?? 0));
         }
 
         protected override MicDevice? GetInputDevice(string name)
@@ -327,6 +329,8 @@ namespace YARG.Audio.BASS
         {
             YargLogger.LogInfo("Loading SFX");
 
+            SfxSamples = new SampleChannel[AudioHelpers.SfxSamples.Count];
+
             string sfxFolder = Path.Combine(Application.streamingAssetsPath, "sfx");
 
             foreach (var sample in AudioHelpers.SfxSamples)
@@ -339,7 +343,8 @@ namespace YARG.Audio.BASS
                     if (File.Exists(sfxPath))
                     {
                         var sfxSample = sample.Kind;
-                        var sfx = BassSampleChannel.Create(sfxSample, sfxPath, 8, sample.CanLoop);
+                        var sfx = BassSampleChannel.Create(sfxSample, sfxPath, 8,
+                            CreateOutputChannel(SettingsManager.Settings?.OutputChannelSfx.Value ?? 0), sample.CanLoop);
                         if (sfx != null)
                         {
                             SfxSamples[(int) sfxSample] = sfx;
@@ -357,6 +362,8 @@ namespace YARG.Audio.BASS
         {
             YargLogger.LogInfo("Loading Drum SFX");
 
+            DrumSfxSamples = new DrumSampleChannel[AudioHelpers.DrumSamples.Count];
+
             string sfxFolder = Path.Combine(Application.streamingAssetsPath, "drumSfx");
 
             foreach (var sample in AudioHelpers.DrumSamples)
@@ -368,7 +375,8 @@ namespace YARG.Audio.BASS
                     if (File.Exists(sfxPath))
                     {
                         var sfxSample = sample.Kind;
-                        var sfx = BassDrumSampleChannel.Create(sfxSample, sfxPath, 8);
+                        var sfx = BassDrumSampleChannel.Create(sfxSample, sfxPath, 8,
+                            CreateOutputChannel(SettingsManager.Settings?.OutputChannelDrumSfx.Value ?? 0));
                         if (sfx != null)
                         {
                             DrumSfxSamples[(int) sfxSample] = sfx;
@@ -384,6 +392,9 @@ namespace YARG.Audio.BASS
         private void LoadVox()
         {
             YargLogger.LogInfo("Loading VOX");
+
+            VoxSamples = new VoxSampleChannel[AudioHelpers.VoxSamples.Count];
+
             string voxFolder = Path.Combine(Application.streamingAssetsPath, "vox");
 
             foreach (var sample in AudioHelpers.VoxSamples)
@@ -395,7 +406,8 @@ namespace YARG.Audio.BASS
                     if (File.Exists(voxPath))
                     {
                         var voxSample = sample.Kind;
-                        var vox = BassVoxSampleChannel.Create(voxSample, voxPath);
+                        var vox = BassVoxSampleChannel.Create(voxSample, voxPath,
+                            CreateOutputChannel(SettingsManager.Settings?.OutputChannelVox.Value ?? 0));
 
                         if (vox != null)
                         {

--- a/Assets/Script/Audio/Bass/BassAudioManager.cs
+++ b/Assets/Script/Audio/Bass/BassAudioManager.cs
@@ -94,6 +94,7 @@ namespace YARG.Audio.BASS
         protected override ReadOnlySpan<string> SupportedFormats => FORMATS;
 
         private readonly int _opusHandle = 0;
+        private BassOutputDevice _currentDevice;
 
         public BassAudioManager()
         {
@@ -144,15 +145,8 @@ namespace YARG.Audio.BASS
                 Bass.Free();
             }
 #endif
-            if (!Bass.Init(-1, 44100, DeviceInitFlags.Default | DeviceInitFlags.Latency, IntPtr.Zero))
-            {
-                var error = Bass.LastError;
-                if (error == Errors.Already)
-                    YargLogger.LogError("BASS is already initialized! An error has occurred somewhere and Unity must be restarted!");
-                else
-                    YargLogger.LogFormatError("Failed to initialize BASS: {0}!", error);
-                return;
-            }
+
+            SetOutputDevice("Default");
 
             LoadSfx();
             LoadDrumSfx(); // TODO: move drum sfx loading/disposal to song start/end respectively IF there are any drum players
@@ -167,7 +161,28 @@ namespace YARG.Audio.BASS
             YargLogger.LogFormatInfo("BASS: {0} - BASS.FX: {1} - BASS.Mix: {2}", Bass.Version, BassFx.Version, BassMix.Version);
             YargLogger.LogFormatInfo("Update Period: {0}ms. Device Buffer Length: {1}ms. Playback Buffer Length: {2}ms. Device Playback Latency: {3}ms",
                 Bass.UpdatePeriod, Bass.DeviceBufferLength, Bass.PlaybackBufferLength, PlaybackLatency);
+
             YargLogger.LogFormatInfo("Current Device: {0}", Bass.GetDeviceInfo(Bass.CurrentDevice).Name);
+        }
+
+        protected override void SetOutputDevice(string name)
+        {
+            int currentDevice = Bass.CurrentDevice;
+
+            OutputDevice? device = GetOutputDevice(name);
+            if (device == null || device is not BassOutputDevice bassDevice || bassDevice.DeviceId == currentDevice)
+            {
+                return;
+            }
+
+            YargLogger.LogFormatInfo("Changing BASS Device to: {0}", bassDevice.DisplayName);
+
+            base.SetOutputDevice(bassDevice.DisplayName);
+
+            _currentDevice?.Dispose();
+            _currentDevice = bassDevice.Use();
+
+            YargLogger.LogFormatInfo("Current BASS Device: {0}", Bass.GetDeviceInfo(Bass.CurrentDevice).Name);
         }
 
 #nullable enable
@@ -200,7 +215,7 @@ namespace YARG.Audio.BASS
                 // if (!typeWhitelist.Contains(info.Type) || info.Name == "Default") continue;
                 if (info.Name == "Default" || info.Name != name) continue;
 
-                return CreateDevice(deviceIndex, name);
+                return CreateInputDevice(deviceIndex, name);
             }
             return null;
         }
@@ -242,12 +257,58 @@ namespace YARG.Audio.BASS
         }
 
 #nullable enable
-        protected override MicDevice? CreateDevice(int deviceId, string name)
+        protected override MicDevice? CreateInputDevice(int deviceId, string name)
 #nullable disable
         {
             var device = BassMicDevice.Create(deviceId, name);
             device?.SetMonitoringLevel(SettingsManager.Settings.VocalMonitoring.Value);
             return device;
+        }
+
+#nullable enable
+        protected override OutputDevice? CreateOutputDevice(int deviceId, string name)
+#nullable disable
+        {
+            return BassOutputDevice.Create(deviceId, name);
+        }
+
+        protected override List<(int id, string name)> GetAllOutputDevices()
+        {
+            var devices = new List<(int id, string name)>();
+
+            for (int deviceIndex = 1; Bass.GetDeviceInfo(deviceIndex, out var info); deviceIndex++)
+            {
+                // Ignore disabled devices
+                if (!info.IsEnabled) continue;
+
+                // Ignore loopback devices, they're potentially confusing and can cause feedback loops
+                if (info.IsLoopback) continue;
+
+                devices.Add((deviceIndex, info.Name));
+            }
+
+            return devices;
+        }
+
+#nullable enable
+        protected override OutputDevice? GetOutputDevice(string name)
+#nullable disable
+        {
+            for (int deviceIndex = 0; Bass.GetDeviceInfo(deviceIndex, out var info); deviceIndex++)
+            {
+                // Ignore disabled devices
+                if (!info.IsEnabled) continue;
+
+                // Ignore loopback devices, they're potentially confusing and can cause feedback loops
+                if (info.IsLoopback) continue;
+
+                // Ensure device names match
+                if (info.Name != name) continue;
+
+                return CreateOutputDevice(deviceIndex, name);
+            }
+
+            return null;
         }
 
         private void LoadSfx()

--- a/Assets/Script/Audio/Bass/BassAudioManager.cs
+++ b/Assets/Script/Audio/Bass/BassAudioManager.cs
@@ -266,6 +266,13 @@ namespace YARG.Audio.BASS
         }
 
 #nullable enable
+        protected override OutputChannel? CreateOutputChannel(int channelId)
+#nullable disable
+        {
+            return BassOutputChannel.Create(channelId);
+        }
+
+#nullable enable
         protected override OutputDevice? CreateOutputDevice(int deviceId, string name)
 #nullable disable
         {
@@ -288,6 +295,11 @@ namespace YARG.Audio.BASS
             }
 
             return devices;
+        }
+
+        protected override int GetOutputChannelCount()
+        {
+            return BassHelpers.GetOutputChannelCount();
         }
 
 #nullable enable

--- a/Assets/Script/Audio/Bass/BassDrumSampleChannel.cs
+++ b/Assets/Script/Audio/Bass/BassDrumSampleChannel.cs
@@ -9,7 +9,7 @@ namespace YARG.Audio.BASS
     public sealed class BassDrumSampleChannel : DrumSampleChannel
     {
 #nullable enable
-        public static BassDrumSampleChannel? Create(DrumSfxSample sample, string path, int playbackCount)
+        public static BassDrumSampleChannel? Create(DrumSfxSample sample, string path, int playbackCount, OutputChannel? outputChannel)
 #nullable disable
         {
             int handle = Bass.SampleLoad(path, 0, 0, playbackCount, BassFlags.Decode);
@@ -27,17 +27,22 @@ namespace YARG.Audio.BASS
                 return null;
             }
 
-            return new BassDrumSampleChannel(handle, channel, sample, path, playbackCount);
+            return new BassDrumSampleChannel(handle, channel, sample, path, playbackCount, outputChannel);
         }
 
         private readonly int _sfxHandle;
         private readonly int _channel;
 
-        private BassDrumSampleChannel(int handle, int channel, DrumSfxSample sample, string path, int playbackCount)
+#nullable enable
+        private OutputChannel? _outputChannel;
+
+        private BassDrumSampleChannel(int handle, int channel, DrumSfxSample sample, string path, int playbackCount, OutputChannel? outputChannel)
             : base(sample, path, playbackCount)
+#nullable disable
         {
             _sfxHandle = handle;
             _channel = channel;
+            SetOutputChannel_Internal(outputChannel);
         }
 
         protected override void Play_Internal()
@@ -60,6 +65,8 @@ namespace YARG.Audio.BASS
         protected override void SetOutputChannel_Internal(OutputChannel? channel)
 #nullable disable
         {
+            _outputChannel = channel;
+
             BassHelpers.UpdateOutputChannels(_channel, channel);
         }
 

--- a/Assets/Script/Audio/Bass/BassDrumSampleChannel.cs
+++ b/Assets/Script/Audio/Bass/BassDrumSampleChannel.cs
@@ -56,6 +56,13 @@ namespace YARG.Audio.BASS
             }
         }
 
+#nullable enable
+        protected override void SetOutputChannel_Internal(OutputChannel? channel)
+#nullable disable
+        {
+            BassHelpers.UpdateOutputChannels(_channel, channel);
+        }
+
         protected override void DisposeUnmanagedResources()
         {
             Bass.SampleFree(_sfxHandle);

--- a/Assets/Script/Audio/Bass/BassHelpers.cs
+++ b/Assets/Script/Audio/Bass/BassHelpers.cs
@@ -3,6 +3,7 @@ using ManagedBass;
 using ManagedBass.DirectX8;
 using ManagedBass.Fx;
 using UnityEngine;
+using YARG.Core.Audio;
 using YARG.Core.Logging;
 
 namespace YARG.Audio.BASS
@@ -147,6 +148,47 @@ namespace YARG.Audio.BASS
             }
 
             return true;
+        }
+
+        public static int GetOutputChannelCount()
+        {
+            Bass.GetInfo(out BassInfo info);
+
+            return info.SpeakerCount;
+        }
+
+#nullable enable
+        public static void UpdateOutputChannels(int stream, OutputChannel? channel)
+#nullable disable
+        {
+            BassFlags allChannels = BassFlags.SpeakerPair1
+                | BassFlags.SpeakerPair2
+                | BassFlags.SpeakerPair3
+                | BassFlags.SpeakerPair4
+                | BassFlags.SpeakerPair5
+                | BassFlags.SpeakerPair6
+                | BassFlags.SpeakerPair7
+                | BassFlags.SpeakerPair8
+                | BassFlags.SpeakerPair9
+                | BassFlags.SpeakerPair10
+                | BassFlags.SpeakerPair11
+                | BassFlags.SpeakerPair12
+                | BassFlags.SpeakerPair13
+                | BassFlags.SpeakerPair14
+                | BassFlags.SpeakerPair15
+            ;
+
+            // Reset all output channels - do this before determining if channel is null to catch
+            // switching from a valid channel back to all channels
+            Bass.ChannelFlags(stream, 0, allChannels);
+
+            if (channel == null || channel is not BassOutputChannel bassChannel)
+            {
+                return;
+            }
+
+            // Add channel(s)
+            Bass.ChannelFlags(stream, bassChannel.Flags, bassChannel.Flags);
         }
     }
 }

--- a/Assets/Script/Audio/Bass/BassOutputChannel.cs
+++ b/Assets/Script/Audio/Bass/BassOutputChannel.cs
@@ -1,0 +1,52 @@
+using ManagedBass;
+using YARG.Core.Audio;
+
+namespace YARG.Audio.BASS
+{
+    public sealed class BassOutputChannel : OutputChannel
+    {
+        public readonly BassFlags Flags;
+
+#nullable enable
+        internal static BassOutputChannel? Create(int channelId)
+#nullable disable
+        {
+            BassFlags? channel = channelId switch
+            {
+                // Front speakers, left + right
+                1 or 2 => BassFlags.SpeakerPair1,
+                // Rear speakers
+                3 or 4 => BassFlags.SpeakerPair2,
+                // Center and LFE speaker
+                5 or 6 => BassFlags.SpeakerPair3,
+                // Rear center speakers for 7.1
+                7 or 8 => BassFlags.SpeakerPair4,
+                9 or 10 => BassFlags.SpeakerPair5,
+                11 or 12 => BassFlags.SpeakerPair6,
+                13 or 14 => BassFlags.SpeakerPair7,
+                15 or 16 => BassFlags.SpeakerPair8,
+                17 or 18 => BassFlags.SpeakerPair9,
+                19 or 20 => BassFlags.SpeakerPair10,
+                21 or 22 => BassFlags.SpeakerPair11,
+                23 or 24 => BassFlags.SpeakerPair12,
+                25 or 26 => BassFlags.SpeakerPair13,
+                27 or 28 => BassFlags.SpeakerPair14,
+                29 or 30 => BassFlags.SpeakerPair15,
+                // Unknown pair
+                _ => null,
+            };
+
+            if (channel == null) {
+                return null;
+            }
+
+            return new BassOutputChannel((BassFlags)channel, channelId);
+        }
+
+        private BassOutputChannel(BassFlags flags, int channelId)
+            : base(channelId)
+        {
+            Flags = flags;
+        }
+    }
+}

--- a/Assets/Script/Audio/Bass/BassOutputChannel.cs.meta
+++ b/Assets/Script/Audio/Bass/BassOutputChannel.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f1a090a27069f406fa5b63b619fc5736

--- a/Assets/Script/Audio/Bass/BassOutputDevice.cs
+++ b/Assets/Script/Audio/Bass/BassOutputDevice.cs
@@ -1,0 +1,50 @@
+using ManagedBass;
+using System;
+using YARG.Core.Audio;
+using YARG.Core.Logging;
+
+namespace YARG.Audio.BASS
+{
+    public sealed class BassOutputDevice : OutputDevice
+    {
+        public readonly int DeviceId;
+
+#nullable enable
+        internal static BassOutputDevice? Create(int deviceId, string name)
+#nullable disable
+        {
+            if (!Bass.Init(deviceId, 44100, DeviceInitFlags.Default | DeviceInitFlags.Latency, IntPtr.Zero))
+            {
+                var error = Bass.LastError;
+                if (Bass.LastError != Errors.Already)
+                {
+                    YargLogger.LogFormatError("Failed to initialize BASS device: {0}!", Bass.LastError);
+
+                    return null;
+                }
+            }
+
+            return new BassOutputDevice(Bass.CurrentDevice, name);
+        }
+
+        public BassOutputDevice Use()
+        {
+            Bass.CurrentDevice = DeviceId;
+
+            return this;
+        }
+
+        private BassOutputDevice(int deviceId, string name)
+            : base(name)
+        {
+            DeviceId = deviceId;
+            Use();
+        }
+
+        protected override void DisposeManagedResources()
+        {
+            Bass.CurrentDevice = DeviceId;
+            Bass.Free();
+        }
+    }
+}

--- a/Assets/Script/Audio/Bass/BassOutputDevice.cs.meta
+++ b/Assets/Script/Audio/Bass/BassOutputDevice.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9f9789cf467314c279a1d786c186b67f

--- a/Assets/Script/Audio/Bass/BassSampleChannel.cs
+++ b/Assets/Script/Audio/Bass/BassSampleChannel.cs
@@ -206,6 +206,13 @@ namespace YARG.Audio.BASS
             }
         }
 
+        #nullable enable
+        protected override void SetOutputChannel_Internal(OutputChannel? channel)
+#nullable disable
+        {
+            BassHelpers.UpdateOutputChannels(_channel, channel);
+        }
+
         protected override void EndCallback_Internal(int _, int __, int ___, IntPtr ____)
         {
             var sfxSample = AudioHelpers.SfxSamples[(int) Sample];

--- a/Assets/Script/Audio/Bass/BassSampleChannel.cs
+++ b/Assets/Script/Audio/Bass/BassSampleChannel.cs
@@ -11,7 +11,7 @@ namespace YARG.Audio.BASS
     {
 #nullable enable
         public static BassSampleChannel? Create(SfxSample sample, string path, int playbackCount,
-            bool loop = false)
+            OutputChannel? outputChannel, bool loop = false)
 #nullable disable
         {
             BassFlags flags = 0;
@@ -44,7 +44,7 @@ namespace YARG.Audio.BASS
                 YargLogger.LogFormatError("Failed to set {0} volume: {1}!", sample, Bass.LastError);
             }
 
-            return new BassSampleChannel(handle, channel, sample, path, playbackCount);
+            return new BassSampleChannel(handle, channel, sample, path, playbackCount, outputChannel);
         }
 
         private readonly int _sfxHandle;
@@ -55,12 +55,17 @@ namespace YARG.Audio.BASS
 
         private int _syncHandle;
 
-        private BassSampleChannel(int handle, int channel, SfxSample sample, string path, int playbackCount)
+#nullable enable
+        private OutputChannel? _outputChannel;
+
+        private BassSampleChannel(int handle, int channel, SfxSample sample, string path, int playbackCount, OutputChannel? outputChannel)
             : base(sample, path, playbackCount)
+#nullable disable
         {
             _sfxHandle = handle;
             _channel = channel;
             _lastPlaybackTime = -1;
+            SetOutputChannel_Internal(outputChannel);
         }
 
         protected override void Play_Internal(double duration)
@@ -206,10 +211,12 @@ namespace YARG.Audio.BASS
             }
         }
 
-        #nullable enable
+#nullable enable
         protected override void SetOutputChannel_Internal(OutputChannel? channel)
 #nullable disable
         {
+            _outputChannel = channel;
+
             BassHelpers.UpdateOutputChannels(_channel, channel);
         }
 

--- a/Assets/Script/Audio/Bass/BassStemMixer.cs
+++ b/Assets/Script/Audio/Bass/BassStemMixer.cs
@@ -50,6 +50,10 @@ namespace YARG.Audio.BASS
         private readonly List<StemData> _stemDatas = new();
         private          int            _longestHandle;
 
+#nullable enable
+        private OutputChannel? _outputChannel;
+#nullable disable
+
         public override event Action SongEnd
         {
             add
@@ -76,8 +80,10 @@ namespace YARG.Audio.BASS
             }
         }
 
-        internal BassStemMixer(string name, BassAudioManager manager, float speed, double volume, int handle, bool clampStemVolume)
+#nullable enable
+        internal BassStemMixer(string name, BassAudioManager manager, float speed, double volume, int handle, bool clampStemVolume, OutputChannel? outputChannel)
             : base(name, manager, clampStemVolume)
+#nullable disable
         {
             _tempoStreamHandle = BassFx.TempoCreate(handle, BassFlags.SampleOverrideLowestVolume);
             if (_tempoStreamHandle == 0)
@@ -88,6 +94,7 @@ namespace YARG.Audio.BASS
 
             _mixerHandle = handle;
             _whammySyncTimer = new Timer();
+            SetOutputChannel_Internal(outputChannel);
             SetVolume_Internal(volume);
             SetSpeed_Internal(speed, true);
         }
@@ -339,6 +346,8 @@ namespace YARG.Audio.BASS
         protected override void SetOutputChannel_Internal(OutputChannel? channel)
 #nullable disable
         {
+            _outputChannel = channel;
+
             BassHelpers.UpdateOutputChannels(_tempoStreamHandle, channel);
         }
 

--- a/Assets/Script/Audio/Bass/BassStemMixer.cs
+++ b/Assets/Script/Audio/Bass/BassStemMixer.cs
@@ -335,6 +335,45 @@ namespace YARG.Audio.BASS
             return true;
         }
 
+        protected override void SetOutputDevice_Internal(OutputDevice device)
+        {
+            if (device is not BassOutputDevice bassDevice)
+            {
+                return;
+            }
+
+            foreach (StemData stemData in _stemDatas)
+            {
+                if (!Bass.ChannelSetDevice(stemData.ReverbHandles.Stream, bassDevice.DeviceId))
+                {
+                    YargLogger.LogFormatError("Failed to change device for reverb handle: {0}", Bass.LastError);
+                }
+
+                if (!Bass.ChannelSetDevice(stemData.StreamHandles.Stream, bassDevice.DeviceId))
+                {
+                    YargLogger.LogFormatError("Failed to change device for stream handle: {0}", Bass.LastError);
+                }
+            }
+
+            foreach (int handle in _sourceHandles)
+            {
+                if (!Bass.ChannelSetDevice(handle, bassDevice.DeviceId))
+                {
+                    YargLogger.LogFormatError("Failed to change device for source handle: {0}", Bass.LastError);
+                }
+            }
+
+            if (_mixerHandle != 0 && !Bass.ChannelSetDevice(_mixerHandle, bassDevice.DeviceId))
+            {
+                YargLogger.LogFormatError("Failed to change device for mixer handle: {0}", Bass.LastError);
+            }
+
+            if (_tempoStreamHandle != 0 && !Bass.ChannelSetDevice(_tempoStreamHandle, bassDevice.DeviceId))
+            {
+                YargLogger.LogFormatError("Failed to change device for tempo stream handle: {0}", Bass.LastError);
+            }
+        }
+
         private bool AddChannelsToMixer(IEnumerable<StemData> stemStreamDataList)
         {
             foreach (var stemStreamData in stemStreamDataList)

--- a/Assets/Script/Audio/Bass/BassStemMixer.cs
+++ b/Assets/Script/Audio/Bass/BassStemMixer.cs
@@ -335,6 +335,13 @@ namespace YARG.Audio.BASS
             return true;
         }
 
+#nullable enable
+        protected override void SetOutputChannel_Internal(OutputChannel? channel)
+#nullable disable
+        {
+            BassHelpers.UpdateOutputChannels(_tempoStreamHandle, channel);
+        }
+
         protected override void SetOutputDevice_Internal(OutputDevice device)
         {
             if (device is not BassOutputDevice bassDevice)

--- a/Assets/Script/Audio/Bass/BassVoxSampleChannel.cs
+++ b/Assets/Script/Audio/Bass/BassVoxSampleChannel.cs
@@ -122,6 +122,13 @@ namespace YARG.Audio.BASS
             }
         }
 
+        #nullable enable
+        protected override void SetOutputChannel_Internal(OutputChannel? channel)
+#nullable disable
+        {
+            BassHelpers.UpdateOutputChannels(_channel, channel);
+        }
+
         protected override bool IsPlaying_Internal()
         {
             return Bass.ChannelIsActive(_channel) == PlaybackState.Playing;

--- a/Assets/Script/Audio/Bass/BassVoxSampleChannel.cs
+++ b/Assets/Script/Audio/Bass/BassVoxSampleChannel.cs
@@ -23,7 +23,9 @@ namespace YARG.Audio.BASS
         private readonly        int                         _sampleHandle;
         private static          bool                        _queueActive;
 
-        public static BassVoxSampleChannel? Create(VoxSample sample, string path)
+#nullable enable
+        public static BassVoxSampleChannel? Create(VoxSample sample, string path, OutputChannel? outputChannel)
+#nullable disable
         {
             int handle = Bass.SampleLoad(path, 0, 0, 2, BassFlags.Decode);
             if (handle == 0)
@@ -46,7 +48,7 @@ namespace YARG.Audio.BASS
                 YargLogger.LogFormatError("Failed to set {0} volume: {1}!", sample, Bass.LastError);
             }
 
-            return new BassVoxSampleChannel(handle, channel, sample, path);
+            return new BassVoxSampleChannel(handle, channel, sample, path, outputChannel);
         }
 
         private static void QueuePlayback(BassVoxSampleChannel channel)
@@ -84,11 +86,16 @@ namespace YARG.Audio.BASS
 
         private readonly int    _channel;
 
-        private BassVoxSampleChannel(int handle, int channel, VoxSample sample, string path)
+#nullable enable
+        private OutputChannel? _outputChannel;
+
+        private BassVoxSampleChannel(int handle, int channel, VoxSample sample, string path, OutputChannel? outputChannel)
             : base(sample, path)
+#nullable disable
         {
             _sampleHandle = handle;
             _channel = channel;
+            SetOutputChannel_Internal(outputChannel);
             Channels.Add(this);
         }
 
@@ -122,10 +129,12 @@ namespace YARG.Audio.BASS
             }
         }
 
-        #nullable enable
+#nullable enable
         protected override void SetOutputChannel_Internal(OutputChannel? channel)
 #nullable disable
         {
+            _outputChannel = channel;
+
             BassHelpers.UpdateOutputChannels(_channel, channel);
         }
 

--- a/Assets/Script/Menu/ProfileList/ProfileView.cs
+++ b/Assets/Script/Menu/ProfileList/ProfileView.cs
@@ -201,7 +201,7 @@ namespace YARG.Menu.ProfileList
                 devicesAvailable = true;
                 dialog.AddListButton(microphone.name, () =>
                 {
-                    var device = GlobalAudioHandler.CreateDevice(microphone.id, microphone.name);
+                    var device = GlobalAudioHandler.CreateInputDevice(microphone.id, microphone.name);
                     player.Bindings.AddMicrophone(device);
                     selectedDevice = true;
                 });

--- a/Assets/Script/Settings/SettingsManager.Settings.cs
+++ b/Assets/Script/Settings/SettingsManager.Settings.cs
@@ -483,6 +483,32 @@ namespace YARG.Settings
             };
 
             public OutputDeviceSetting OutputDevice { get; } = new("Default", OutputDeviceCallback);
+            public OutputChannelDefaultSetting OutputChannelDefault { get; } = new(1, OutputChannelDefaultCallback);
+            public OutputChannelSetting OutputChannelDrumSfx { get; } = new(-1, OutputChannelDrumSfxCallback);
+            public OutputChannelSetting OutputChannelSfx { get; } = new(-1, OutputChannelSfxCallback);
+            public OutputChannelSetting OutputChannelVox { get; } = new(-1, OutputChannelVoxCallback);
+            #endregion
+
+            #region Helpers
+            private static void resetChannelSetting(OutputChannelSetting channelSetting, SongStem stem, int defaultValue = -1)
+            {
+                channelSetting.UpdateValues();
+
+                // Only change value if the current value exceeds the number of available channels on the device
+                int currentValue = channelSetting.Value;
+                if (currentValue > GlobalAudioHandler.GetOutputChannelCount())
+                {
+                    channelSetting.Value = defaultValue;
+                    setOutputChannel(channelSetting, stem);
+                }
+
+                SettingsMenu.Instance.RefreshAndKeepPosition();
+            }
+
+            private static void setOutputChannel(OutputChannelSetting channelSetting, SongStem stem)
+            {
+                GlobalAudioHandler.SetOutputChannel(stem, channelSetting.Value == -1 ? Settings.OutputChannelDefault.Value : channelSetting.Value);
+            }
             #endregion
 
             #region Callbacks
@@ -692,6 +718,55 @@ namespace YARG.Settings
                 }
 
                 GlobalAudioHandler.SetOutputDevice(name);
+
+                resetChannelSetting(Settings.OutputChannelDefault, SongStem.Master, 1);
+                resetChannelSetting(Settings.OutputChannelDrumSfx, SongStem.DrumSfx);
+                resetChannelSetting(Settings.OutputChannelSfx, SongStem.Sfx);
+                resetChannelSetting(Settings.OutputChannelVox, SongStem.VoxSample);
+            }
+
+            private static void OutputChannelDefaultCallback(int channelId)
+            {
+                // Unity saves this information automatically
+                if (!IsInitialized)
+                {
+                    return;
+                }
+
+                GlobalAudioHandler.SetOutputChannel(SongStem.Master, channelId);
+            }
+
+            private static void OutputChannelDrumSfxCallback(int channelId)
+            {
+                // Unity saves this information automatically
+                if (!IsInitialized)
+                {
+                    return;
+                }
+
+                setOutputChannel(Settings.OutputChannelDrumSfx, SongStem.DrumSfx);
+            }
+
+            private static void OutputChannelSfxCallback(int channelId)
+            {
+                // Unity saves this information automatically
+                if (!IsInitialized)
+                {
+                    return;
+                }
+
+                setOutputChannel(Settings.OutputChannelSfx, SongStem.Sfx);
+            }
+
+            private static void OutputChannelVoxCallback(int channelId)
+            {
+                // Unity saves this information automatically
+                if (!IsInitialized)
+                {
+                    return;
+                }
+
+                setOutputChannel(Settings.OutputChannelVox, SongStem.VoxSample);
             }
             #endregion
         }

--- a/Assets/Script/Settings/SettingsManager.Settings.cs
+++ b/Assets/Script/Settings/SettingsManager.Settings.cs
@@ -482,6 +482,7 @@ namespace YARG.Settings
                 BandComboType.Strict
             };
 
+            public OutputDeviceSetting OutputDevice { get; } = new("Default", OutputDeviceCallback);
             #endregion
 
             #region Callbacks
@@ -680,6 +681,17 @@ namespace YARG.Settings
                     YargLogger.LogFormatInfo("Description for device {0}:\n{1}\n", device.displayName,
                         item2: device.description.ToJson());
                 }
+            }
+
+            private static void OutputDeviceCallback(string name)
+            {
+                // Unity saves this information automatically
+                if (!IsInitialized)
+                {
+                    return;
+                }
+
+                GlobalAudioHandler.SetOutputDevice(name);
             }
             #endregion
         }

--- a/Assets/Script/Settings/SettingsManager.Settings.cs
+++ b/Assets/Script/Settings/SettingsManager.Settings.cs
@@ -734,6 +734,10 @@ namespace YARG.Settings
                 }
 
                 GlobalAudioHandler.SetOutputChannel(SongStem.Master, channelId);
+
+                setOutputChannel(Settings.OutputChannelDrumSfx, SongStem.DrumSfx);
+                setOutputChannel(Settings.OutputChannelSfx, SongStem.Sfx);
+                setOutputChannel(Settings.OutputChannelVox, SongStem.VoxSample);
             }
 
             private static void OutputChannelDrumSfxCallback(int channelId)

--- a/Assets/Script/Settings/SettingsManager.cs
+++ b/Assets/Script/Settings/SettingsManager.cs
@@ -229,6 +229,10 @@ namespace YARG.Settings
                 nameof(Settings.DataStreamEnable),
                 new HeaderMetadata("OutputConfiguration"),
                 nameof(Settings.OutputDevice),
+                nameof(Settings.OutputChannelDefault),
+                nameof(Settings.OutputChannelDrumSfx),
+                nameof(Settings.OutputChannelSfx),
+                nameof(Settings.OutputChannelVox),
             }
         };
 

--- a/Assets/Script/Settings/SettingsManager.cs
+++ b/Assets/Script/Settings/SettingsManager.cs
@@ -227,6 +227,8 @@ namespace YARG.Settings
                 new HeaderMetadata("Other"),
                 nameof(Settings.BandComboTypeSetting),
                 nameof(Settings.DataStreamEnable),
+                new HeaderMetadata("OutputConfiguration"),
+                nameof(Settings.OutputDevice),
             }
         };
 

--- a/Assets/Script/Settings/Types/OutputChannelDefaultSetting.cs
+++ b/Assets/Script/Settings/Types/OutputChannelDefaultSetting.cs
@@ -1,0 +1,18 @@
+using System;
+using YARG.Core.Audio;
+using YARG.Localization;
+
+namespace YARG.Settings.Types
+{
+    public class OutputChannelDefaultSetting : OutputChannelSetting
+    {
+        public OutputChannelDefaultSetting(int value, Action<int> onChange = null) : base(value, onChange)
+        {
+        }
+
+        public override void UpdateValues()
+        {
+            ResetValues();
+        }
+    }
+}

--- a/Assets/Script/Settings/Types/OutputChannelDefaultSetting.cs.meta
+++ b/Assets/Script/Settings/Types/OutputChannelDefaultSetting.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 534414fa1b2a5477fb05b11fbeb93761

--- a/Assets/Script/Settings/Types/OutputChannelSetting.cs
+++ b/Assets/Script/Settings/Types/OutputChannelSetting.cs
@@ -1,0 +1,53 @@
+using System;
+using YARG.Core.Audio;
+using YARG.Localization;
+
+namespace YARG.Settings.Types
+{
+    public class OutputChannelSetting : DropdownSetting<int>
+    {
+        public OutputChannelSetting(int value, Action<int> onChange = null) : base(value, onChange, localizable: false)
+        {
+        }
+
+        public override void UpdateValues()
+        {
+            ResetValues();
+
+            // Add "same as default" option
+            _possibleValues.Insert(0, -1);
+        }
+
+        public override string ValueToString(int value)
+        {
+            // Handle "same as default" channel
+            if (value == -1)
+            {
+                return Localize.Key("Settings.Setting.OutputChannels.Default");
+            }
+
+            // Channels are paired, if channelIndex == channelCount then it might be a set up such
+            // as 4.1 (5 speakers) therefore the final channel will be "5" rather than "5 & 6".
+            return value == GlobalAudioHandler.GetOutputChannelCount() ?
+                Localize.KeyFormat(
+                    "Settings.Setting.OutputChannels.Mono",
+                    value
+                ) : Localize.KeyFormat(
+                    "Settings.Setting.OutputChannels.Stereo",
+                    value,
+                    value + 1
+                );
+        }
+
+        protected void ResetValues()
+        {
+            _possibleValues.Clear();
+
+            // Speakers are paired so increment each speaker by two
+            for (int channelIndex = 1; channelIndex < GlobalAudioHandler.GetOutputChannelCount(); channelIndex += 2)
+            {
+                _possibleValues.Add(channelIndex);
+            }
+        }
+    }
+}

--- a/Assets/Script/Settings/Types/OutputChannelSetting.cs.meta
+++ b/Assets/Script/Settings/Types/OutputChannelSetting.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f11049ebd8ac346fabdbc96f7abb7f0b

--- a/Assets/Script/Settings/Types/OutputDeviceSetting.cs
+++ b/Assets/Script/Settings/Types/OutputDeviceSetting.cs
@@ -1,0 +1,22 @@
+using System;
+using YARG.Core.Audio;
+
+namespace YARG.Settings.Types
+{
+    public class OutputDeviceSetting : DropdownSetting<string>
+    {
+        public OutputDeviceSetting(string value, Action<string> onChange = null) : base(value, onChange, localizable: false)
+        {
+        }
+
+        public override void UpdateValues()
+        {
+            _possibleValues.Clear();
+
+            foreach ((int, string name) device in GlobalAudioHandler.GetAllOutputDevices())
+            {
+                _possibleValues.Add(device.name);
+            }
+        }
+    }
+}

--- a/Assets/Script/Settings/Types/OutputDeviceSetting.cs.meta
+++ b/Assets/Script/Settings/Types/OutputDeviceSetting.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4f62eb1c1eaec4692886abdd12e08cec

--- a/Assets/StreamingAssets/lang/en-US.json
+++ b/Assets/StreamingAssets/lang/en-US.json
@@ -1043,6 +1043,27 @@
                     "Sparse": "50, 100, 250, 500, 750, ..."
                 }
             },
+            "OutputChannelDefault": {
+                "Name": "Default Channel(s)",
+                "Description": "The default output channel(s) to use for instruments and sounds."
+            },
+            "OutputChannelDrumSfx": {
+                "Name": "Drum SFX",
+                "Description": "The output channel(s) to use for drum sound effects."
+            },
+            "OutputChannelSfx": {
+                "Name": "SFX",
+                "Description": "The output channel(s) to use for other sound effects."
+            },
+            "OutputChannelVox": {
+                "Name": "Vox Samples",
+                "Description": "The output channel(s) to use for score screen sound effects."
+            },
+            "OutputChannels": {
+                "Default": "Use Default Channel(s)",
+                "Mono": "{0}",
+                "Stereo": "{0} & {1}"
+            },
             "OutputDevice": {
                 "Name": "Output Device",
                 "Description": "The interface to use when playing sounds."

--- a/Assets/StreamingAssets/lang/en-US.json
+++ b/Assets/StreamingAssets/lang/en-US.json
@@ -751,7 +751,8 @@
             "AdvancedDMXSettings": "Advanced sACN and DMX settings",
             "Experimental": "Experimental",
             "HUD": "HUD",
-            "Gameplay": "Gameplay"
+            "Gameplay": "Gameplay",
+            "OutputConfiguration": "Output Configuration"
         },
         "Button": {
             "CopyCurrentSongJsonFilePath": "Copy Current Song Json File Path",
@@ -1041,6 +1042,10 @@
                     "Frequent": "50, 100, 200, 300, ...",
                     "Sparse": "50, 100, 250, 500, 750, ..."
                 }
+            },
+            "OutputDevice": {
+                "Name": "Output Device",
+                "Description": "The interface to use when playing sounds."
             },
             "PlayAShowTimeout": {
                 "Name": "Show Selection Timeout",

--- a/Assets/StreamingAssets/lang/es-ES.json
+++ b/Assets/StreamingAssets/lang/es-ES.json
@@ -720,6 +720,27 @@
                     "Sparse": "50, 100, 250, 500, 750, ..."
                 }
             },
+            "OutputChannelDefault": {
+                "Name": "Default Channel(s)",
+                "Description": "The default output channel(s) to use for instruments and sounds."
+            },
+            "OutputChannelDrumSfx": {
+                "Name": "Drum SFX",
+                "Description": "The output channel(s) to use for drum sound effects."
+            },
+            "OutputChannelSfx": {
+                "Name": "SFX",
+                "Description": "The output channel(s) to use for other sound effects."
+            },
+            "OutputChannelVox": {
+                "Name": "Vox Samples",
+                "Description": "The output channel(s) to use for score screen sound effects."
+            },
+            "OutputChannels": {
+                "Default": "Use Default Channel(s)",
+                "Mono": "{0}",
+                "Stereo": "{0} & {1}"
+            },
             "OutputDevice": {
                 "Name": "Output Device",
                 "Description": "The interface to use when playing sounds."

--- a/Assets/StreamingAssets/lang/es-ES.json
+++ b/Assets/StreamingAssets/lang/es-ES.json
@@ -469,7 +469,8 @@
             "AdvancedDMXChannels": "Advanced DMX Channels",
             "StatusBar": "Status Bar",
             "AdvancedDMXSettings": "Advanced sACN and DMX settings",
-            "Experimental": "Experimental"
+            "Experimental": "Experimental",
+            "OutputConfiguration": "Output Configuration"
         },
         "Button": {
             "CopyCurrentSongJsonFilePath": "Copy Current Song Json File Path",
@@ -718,6 +719,10 @@
                     "Frequent": "50, 100, 200, 300, ...",
                     "Sparse": "50, 100, 250, 500, 750, ..."
                 }
+            },
+            "OutputDevice": {
+                "Name": "Output Device",
+                "Description": "The interface to use when playing sounds."
             },
             "PreviewVolume": {
                 "Name": "Preview Volume",

--- a/Assets/StreamingAssets/lang/ja-JP.json
+++ b/Assets/StreamingAssets/lang/ja-JP.json
@@ -720,6 +720,27 @@
                     "Sparse": "50, 100, 250, 500, 750, ..."
                 }
             },
+            "OutputChannelDefault": {
+                "Name": "Default Channel(s)",
+                "Description": "The default output channel(s) to use for instruments and sounds."
+            },
+            "OutputChannelDrumSfx": {
+                "Name": "Drum SFX",
+                "Description": "The output channel(s) to use for drum sound effects."
+            },
+            "OutputChannelSfx": {
+                "Name": "SFX",
+                "Description": "The output channel(s) to use for other sound effects."
+            },
+            "OutputChannelVox": {
+                "Name": "Vox Samples",
+                "Description": "The output channel(s) to use for score screen sound effects."
+            },
+            "OutputChannels": {
+                "Default": "Use Default Channel(s)",
+                "Mono": "{0}",
+                "Stereo": "{0} & {1}"
+            },
             "OutputDevice": {
                 "Name": "Output Device",
                 "Description": "The interface to use when playing sounds."

--- a/Assets/StreamingAssets/lang/ja-JP.json
+++ b/Assets/StreamingAssets/lang/ja-JP.json
@@ -469,7 +469,8 @@
             "AdvancedDMXChannels": "Advanced DMX Channels",
             "StatusBar": "Status Bar",
             "AdvancedDMXSettings": "Advanced sACN and DMX settings",
-            "Experimental": "Experimental"
+            "Experimental": "Experimental",
+            "OutputConfiguration": "Output Configuration"
         },
         "Button": {
             "CopyCurrentSongJsonFilePath": "Copy Current Song Json File Path",
@@ -718,6 +719,10 @@
                     "Frequent": "50, 100, 200, 300, ...",
                     "Sparse": "50, 100, 250, 500, 750, ..."
                 }
+            },
+            "OutputDevice": {
+                "Name": "Output Device",
+                "Description": "The interface to use when playing sounds."
             },
             "PreviewVolume": {
                 "Name": "Preview Volume",

--- a/Assets/StreamingAssets/lang/pt-BR.json
+++ b/Assets/StreamingAssets/lang/pt-BR.json
@@ -469,7 +469,8 @@
             "AdvancedDMXChannels": "Advanced DMX Channels",
             "StatusBar": "Status Bar",
             "AdvancedDMXSettings": "Advanced sACN and DMX settings",
-            "Experimental": "Experimental"
+            "Experimental": "Experimental",
+            "OutputConfiguration": "Output Configuration"
         },
         "Button": {
             "CopyCurrentSongJsonFilePath": "Copy Current Song Json File Path",
@@ -714,6 +715,10 @@
                     "Frequent": "50, 100, 200, 300, ...",
                     "Sparse": "50, 100, 250, 500, 750, ..."
                 }
+            },
+            "OutputDevice": {
+                "Name": "Output Device",
+                "Description": "The interface to use when playing sounds."
             },
             "PreviewVolume": {
                 "Name": "Preview Volume",

--- a/Assets/StreamingAssets/lang/pt-BR.json
+++ b/Assets/StreamingAssets/lang/pt-BR.json
@@ -716,6 +716,27 @@
                     "Sparse": "50, 100, 250, 500, 750, ..."
                 }
             },
+            "OutputChannelDefault": {
+                "Name": "Default Channel(s)",
+                "Description": "The default output channel(s) to use for instruments and sounds."
+            },
+            "OutputChannelDrumSfx": {
+                "Name": "Drum SFX",
+                "Description": "The output channel(s) to use for drum sound effects."
+            },
+            "OutputChannelSfx": {
+                "Name": "SFX",
+                "Description": "The output channel(s) to use for other sound effects."
+            },
+            "OutputChannelVox": {
+                "Name": "Vox Samples",
+                "Description": "The output channel(s) to use for score screen sound effects."
+            },
+            "OutputChannels": {
+                "Default": "Use Default Channel(s)",
+                "Mono": "{0}",
+                "Stereo": "{0} & {1}"
+            },
             "OutputDevice": {
                 "Name": "Output Device",
                 "Description": "The interface to use when playing sounds."

--- a/Assets/StreamingAssets/lang/pt-PT.json
+++ b/Assets/StreamingAssets/lang/pt-PT.json
@@ -720,6 +720,27 @@
                     "Sparse": "50, 100, 250, 500, 750, ..."
                 }
             },
+            "OutputChannelDefault": {
+                "Name": "Default Channel(s)",
+                "Description": "The default output channel(s) to use for instruments and sounds."
+            },
+            "OutputChannelDrumSfx": {
+                "Name": "Drum SFX",
+                "Description": "The output channel(s) to use for drum sound effects."
+            },
+            "OutputChannelSfx": {
+                "Name": "SFX",
+                "Description": "The output channel(s) to use for other sound effects."
+            },
+            "OutputChannelVox": {
+                "Name": "Vox Samples",
+                "Description": "The output channel(s) to use for score screen sound effects."
+            },
+            "OutputChannels": {
+                "Default": "Use Default Channel(s)",
+                "Mono": "{0}",
+                "Stereo": "{0} & {1}"
+            },
             "OutputDevice": {
                 "Name": "Output Device",
                 "Description": "The interface to use when playing sounds."

--- a/Assets/StreamingAssets/lang/pt-PT.json
+++ b/Assets/StreamingAssets/lang/pt-PT.json
@@ -469,7 +469,8 @@
             "AdvancedDMXChannels": "Advanced DMX Channels",
             "StatusBar": "Status Bar",
             "AdvancedDMXSettings": "Advanced sACN and DMX settings",
-            "Experimental": "Experimental"
+            "Experimental": "Experimental",
+            "OutputConfiguration": "Output Configuration"
         },
         "Button": {
             "CopyCurrentSongJsonFilePath": "Copy Current Song Json File Path",
@@ -718,6 +719,10 @@
                     "Frequent": "50, 100, 200, 300, ...",
                     "Sparse": "50, 100, 250, 500, 750, ..."
                 }
+            },
+            "OutputDevice": {
+                "Name": "Output Device",
+                "Description": "The interface to use when playing sounds."
             },
             "PreviewVolume": {
                 "Name": "Preview Volume",


### PR DESCRIPTION
**Experimental**

* Allows output device to be selected independently of the operating system default.
* When using a device which supports multiple channels, audio can be routed independently
 
Channel routing is especially useful for hardware mixers, DAWs, and other cases where you just want main track audio + VST sounds to be output to the main/recording channel, but still want atmosphere like crowd noise or [metronome clicks](https://github.com/YARC-Official/YARG/pull/1242) to go into your IEMs.

Device selection:
<img width="2053" height="885" alt="Screenshot 2026-01-04 at 12 07 32 am" src="https://github.com/user-attachments/assets/0c597a63-b239-49b8-b677-deeceb1efdba" />

Channel selection based on support from device:
<img width="2051" height="887" alt="Screenshot 2026-01-04 at 12 07 43 am" src="https://github.com/user-attachments/assets/99d37796-d385-4d2c-ba6c-4b7378276de0" />
<img width="2047" height="885" alt="Screenshot 2026-01-04 at 12 07 57 am" src="https://github.com/user-attachments/assets/eb56dd29-ba0c-4e52-856a-6d01570e0b7f" />

Handles are updated in real time when selection is made, previous devices are disposed of correctly to ensure memory isn't leaked.

Requires https://github.com/YARC-Official/YARG.Core/pull/314

Resolves [YARG-102](https://yarg.youtrack.cloud/issue/YARG-102/Audio-output-device-setting)