### PR TITLE
Fix issues with hud position not saving for top elements

### DIFF
--- a/Assets/Script/Gameplay/HUD/Dragging/DraggableHudElement.cs
+++ b/Assets/Script/Gameplay/HUD/Dragging/DraggableHudElement.cs
@@ -36,6 +36,8 @@ namespace YARG.Gameplay.HUD
         private bool _isSelected;
         private bool _isDragging;
 
+        public bool HasCustomPosition => _storedPosition != _originalPosition;
+
         protected override void OnSongStarted()
         {
             if (GameManager.Players.Count > 1)
@@ -165,6 +167,7 @@ namespace YARG.Gameplay.HUD
 
         private void SavePosition()
         {
+            _storedPosition = _rectTransform.anchoredPosition;
             _manager.PositionProfile.SaveElementPosition(_draggableElementName,
                 _rectTransform.anchoredPosition);
         }

--- a/Assets/Script/Gameplay/HUD/TrackView.cs
+++ b/Assets/Script/Gameplay/HUD/TrackView.cs
@@ -50,7 +50,7 @@ namespace YARG.Gameplay.HUD
             Vector2 position = _highwayRenderer.GetTrackPositionScreenSpace(highwayIndex, 0.5f, CENTER_ELEMENT_DEPTH);
             _centerElementContainer.transform.position = position;
 
-            if (_topDraggable?.HasCustomPosition == false)
+            if (_topDraggable != null && _topDraggable.HasCustomPosition == false)
             {
                 // Place top elements at 100% depth plus n screen independent units up to avoid highway overlap
                 var extraOffset = TOP_ELEMENT_EXTRA_OFFSET * Screen.height / 1000f;

--- a/Assets/Script/Gameplay/HUD/TrackView.cs
+++ b/Assets/Script/Gameplay/HUD/TrackView.cs
@@ -29,10 +29,14 @@ namespace YARG.Gameplay.HUD
         private Vector3 _lastTrackPlayerPosition;
 
         private const float CENTER_ELEMENT_DEPTH = 0.35f;
+        private const float TOP_ELEMENT_EXTRA_OFFSET = 8f;
+
+        private DraggableHudElement _topDraggable;
 
         public void Initialize(HighwayCameraRendering highwayRenderer)
         {
             _highwayRenderer = highwayRenderer;
+            _topDraggable = _topElementContainer.GetComponent<DraggableHudElement>();
         }
 
         public void UpdateHUDPosition(int highwayIndex, int highwayCount)
@@ -46,10 +50,13 @@ namespace YARG.Gameplay.HUD
             Vector2 position = _highwayRenderer.GetTrackPositionScreenSpace(highwayIndex, 0.5f, CENTER_ELEMENT_DEPTH);
             _centerElementContainer.transform.position = position;
 
-            // Place top elements at 100% depth plus screen independent units up to avoid highway overlap
-            var extraOffset = 8 * Screen.height / 1000f;
-            Vector2 position2 = _highwayRenderer.GetTrackPositionScreenSpace(highwayIndex, 0.5f, 1.0f).AddY(extraOffset);
-            _topElementContainer.position = position2;
+            if (_topDraggable?.HasCustomPosition == false)
+            {
+                // Place top elements at 100% depth plus n screen independent units up to avoid highway overlap
+                var extraOffset = TOP_ELEMENT_EXTRA_OFFSET * Screen.height / 1000f;
+                Vector2 position2 = _highwayRenderer.GetTrackPositionScreenSpace(highwayIndex, 0.5f, 1.0f).AddY(extraOffset);
+                _topElementContainer.position = position2;
+            }
         }
 
         public void UpdateCountdown(double countdownLength, double endTime)


### PR DESCRIPTION
This fixes issues with the top elements not saving position when manually repositioned

This happened because those elements depended on the position of the track, which can change, so it was being reset each frame

Fix is to check if the user moved the hud element, and in that case stop updating the position each frame