### PR TITLE
Fix issue where missing a star power note broke inputs

### DIFF
--- a/Assets/Script/Gameplay/Visuals/TrackElements/Drums/FiveLaneDrumsNoteElement.cs
+++ b/Assets/Script/Gameplay/Visuals/TrackElements/Drums/FiveLaneDrumsNoteElement.cs
@@ -114,11 +114,14 @@ namespace YARG.Gameplay.Visuals
                 color = colors.GetNoteStarPowerColor(pad);
             }
 
-            // Set the note color
-            NoteGroup.SetColorWithEmission(color.ToUnityColor(), colorNoStarPower.ToUnityColor());
+            // Set the note color if not hidden
+            if (!NoteRef.WasHit)
+            {
+                NoteGroup.SetColorWithEmission(color.ToUnityColor(), colorNoStarPower.ToUnityColor());
 
-            // Set the metal color
-            NoteGroup.SetMetalColor(colors.GetMetalColor(IsStarPowerVisible).ToUnityColor());
+                // Set the metal color
+                NoteGroup.SetMetalColor(colors.GetMetalColor(IsStarPowerVisible).ToUnityColor());
+            }
         }
     }
 }

--- a/Assets/Script/Gameplay/Visuals/TrackElements/Drums/FourLaneDrumsNoteElement.cs
+++ b/Assets/Script/Gameplay/Visuals/TrackElements/Drums/FourLaneDrumsNoteElement.cs
@@ -122,11 +122,14 @@ namespace YARG.Gameplay.Visuals
                 color = colors.GetNoteStarPowerColor(pad);
             }
 
-            // Set the note color
-            NoteGroup.SetColorWithEmission(color.ToUnityColor(), colorNoStarPower.ToUnityColor());
+            // Set the note color if not hidden
+            if (!NoteRef.WasHit)
+            {
+                NoteGroup.SetColorWithEmission(color.ToUnityColor(), colorNoStarPower.ToUnityColor());
 
-            // Set the metal color
-            NoteGroup.SetMetalColor(colors.GetMetalColor(IsStarPowerVisible).ToUnityColor());
+                // Set the metal color
+                NoteGroup.SetMetalColor(colors.GetMetalColor(IsStarPowerVisible).ToUnityColor());
+            }
         }
     }
 }

--- a/Assets/Script/Gameplay/Visuals/TrackElements/FiveLaneKeys/FiveLaneKeysNoteElement.cs
+++ b/Assets/Script/Gameplay/Visuals/TrackElements/FiveLaneKeys/FiveLaneKeysNoteElement.cs
@@ -173,11 +173,14 @@ namespace YARG.Gameplay.Visuals
                 color = colors.Miss;
             }
 
-            // Set the note color
-            NoteGroup.SetColorWithEmission(color.ToUnityColor(), colorNoStarPower.ToUnityColor());
+            // Set the note color if not hidden
+            if (!NoteRef.WasHit)
+            {
+                NoteGroup.SetColorWithEmission(color.ToUnityColor(), colorNoStarPower.ToUnityColor());
 
-            // Set the metal color
-            NoteGroup.SetMetalColor(colors.GetMetalColor(NoteRef.IsStarPower).ToUnityColor());
+                // Set the metal color
+                NoteGroup.SetMetalColor(colors.GetMetalColor(NoteRef.IsStarPower).ToUnityColor());
+            }
 
             // The rest of this method is for sustain only
             if (!NoteRef.IsSustain) return;

--- a/Assets/Script/Gameplay/Visuals/TrackElements/Guitar/FiveFretGuitarNoteElement.cs
+++ b/Assets/Script/Gameplay/Visuals/TrackElements/Guitar/FiveFretGuitarNoteElement.cs
@@ -178,11 +178,14 @@ namespace YARG.Gameplay.Visuals
                 color = colors.Miss;
             }
 
-            // Set the note color
-            NoteGroup.SetColorWithEmission(color.ToUnityColor(), colorNoStarPower.ToUnityColor());
+            // Set the note color if not hidden
+            if (!NoteRef.WasHit)
+            {
+                NoteGroup.SetColorWithEmission(color.ToUnityColor(), colorNoStarPower.ToUnityColor());
 
-            // Set the metal color
-            NoteGroup.SetMetalColor(colors.GetMetalColor(IsStarPowerVisible).ToUnityColor());
+                // Set the metal color
+                NoteGroup.SetMetalColor(colors.GetMetalColor(IsStarPowerVisible).ToUnityColor());
+            }
 
             // The rest of this method is for sustain only
             if (!NoteRef.IsSustain) return;

--- a/Assets/Script/Gameplay/Visuals/TrackElements/ProKeys/ProKeysNoteElement.cs
+++ b/Assets/Script/Gameplay/Visuals/TrackElements/ProKeys/ProKeysNoteElement.cs
@@ -163,8 +163,11 @@ namespace YARG.Gameplay.Visuals
                 ? colorStarPower
                 : colorNoStarPower;
 
-            NoteGroup.SetColorWithEmission(color, colorNoStarPower);
-            NoteGroup.SetMetalColor(colors.GetMetalColor(IsStarPowerVisible).ToUnityColor());
+            if (!NoteRef.WasHit)
+            {
+                NoteGroup.SetColorWithEmission(color, colorNoStarPower);
+                NoteGroup.SetMetalColor(colors.GetMetalColor(IsStarPowerVisible).ToUnityColor());
+            }
 
             if (!NoteRef.IsSustain) return;
 


### PR DESCRIPTION
Discord issue: https://discord.com/channels/1086048856678084609/1440742564960403476/1440742564960403476

**To repro this issue:**
1. Create a guitar profile using circular theme
2. Select a song which starts with several star power notes immediately
3. Hit one of the star power notes
3. Miss the next star power note

Observe that inputs no longer work

**The cause:**

When using circular theme, the note model changes when missing a star power sequence.

We have an optimization in place which prevents us from changing note models on notes that have already been hit, since they are hidden.

So when we miss the first note, the models change except for the hidden note.

Immediately after this we try to set the color on the notes.  This causes an exception on the hidden notes because the new note model has not been initialized.

The fix is to check if the note was hit before attempting to change the color.

We also add this logic on all set color calls since it is an easy optimization.