### PR TITLE
Fix issue where practice mode with range shifts didnt start when no notes

### DIFF
--- a/Assets/Script/Gameplay/Player/FiveFretGuitarPlayer.cs
+++ b/Assets/Script/Gameplay/Player/FiveFretGuitarPlayer.cs
@@ -533,7 +533,7 @@ namespace YARG.Gameplay.Player
             }
 
             // Now that we know there is at least one range shift, figure out if it is after the first note
-            if (_allRangeShiftEvents[0].Time > Notes[0].Time)
+            if (Notes.Count > 0 && _allRangeShiftEvents[0].Time > Notes[0].Time)
             {
                 firstShiftAfterFirstNote = true;
             }

--- a/Assets/Script/Gameplay/Player/FiveLaneKeysPlayer.cs
+++ b/Assets/Script/Gameplay/Player/FiveLaneKeysPlayer.cs
@@ -443,7 +443,7 @@ namespace YARG.Assets.Script.Gameplay.Player
             }
 
             // Now that we know there is at least one range shift, figure out if it is after the first note
-            if (_allRangeShiftEvents[0].Time > Notes[0].Time)
+            if (Notes.Count > 0 && _allRangeShiftEvents[0].Time > Notes[0].Time)
             {
                 firstShiftAfterFirstNote = true;
             }


### PR DESCRIPTION
When playing five fret guitar on medium
Song: Sadness (feat. Sapphire Noel)

1. Go to Practice
2. Try to start section Verse 1A

Unable to start the section and we get exception

**Cause:**
This was caused by the code attempting to access the first note in the InitializeRangeShift function without first checking if any notes actually existed.