### PR TITLE
add song backgrounds as venue textures

### DIFF
--- a/Assets/Script/Gameplay/BackgroundManager.cs
+++ b/Assets/Script/Gameplay/BackgroundManager.cs
@@ -7,6 +7,7 @@ using UnityEngine.Rendering.RendererUtils;
 using UnityEngine.UI;
 using UnityEngine.Video;
 using YARG.Core.IO;
+using YARG.Core.Song;
 using YARG.Core.Venue;
 using YARG.Helpers.Extensions;
 using YARG.Settings;
@@ -121,11 +122,13 @@ namespace YARG.Gameplay
 #endif
                     // Hookup song-specific textures
                     var textureManager = GetComponent<TextureManager>();
+                    // Load SongBackground here to determine if textures need to be replaced
+                    var songBackground = GameManager.Song.LoadBackground();
                     foreach (var renderer in renderers)
                     {
                         foreach (var material in renderer.sharedMaterials)
                         {
-                            textureManager.ProcessMaterial(material);
+                            textureManager.ProcessMaterial(material, songBackground?.Type);
                         }
                     }
 
@@ -140,7 +143,7 @@ namespace YARG.Gameplay
 
                     if (textureManager.VideoTexFound())
                     {
-                        SetUpVideoTexture(bgInstance);
+                        SetUpVideoTexture(songBackground);
                     }
 
                     break;
@@ -180,30 +183,20 @@ namespace YARG.Gameplay
             }
         }
 
-        private void SetUpVideoTexture(GameObject bginstance)
+        private void SetUpVideoTexture(BackgroundResult songBackGround)
         {
             var textureManager = GetComponent<TextureManager>();
-            var result = GameManager.Song.LoadBackground();
-            if (result == null || result.Type == BackgroundType.Yarground)
+            if (songBackGround == null || songBackGround.Type == BackgroundType.Yarground)
             {
                 return;
             }
-            //assign background textures after confirming there is a background to render
-            var renderers = bginstance.GetComponentsInChildren<Renderer>(true);
-            foreach (var renderer in renderers)
-            {
-                foreach (var material in renderer.sharedMaterials)
-                {
-                    textureManager.AssignBackgroundTextures(material);
-                }
-            }
-            switch (result.Type)
+            switch (songBackGround.Type)
             {
                 case BackgroundType.Video:
                     //set venue source to song to enable video seeking/pausing features
                     _source = VenueSource.Song;
 
-                    switch (result.Stream)
+                    switch (songBackGround.Stream)
                     {
                         case FileStream fs:
                         {
@@ -218,7 +211,7 @@ namespace YARG.Gameplay
                             VIDEO_PATH = Path.Combine(Application.persistentDataPath, sngStream.Name);
                             using var tmp = File.OpenWrite(VIDEO_PATH);
                             File.SetAttributes(VIDEO_PATH, File.GetAttributes(VIDEO_PATH) | FileAttributes.Temporary | FileAttributes.Hidden);
-                            result.Stream.CopyTo(tmp);
+                            songBackGround.Stream.CopyTo(tmp);
                             _videoPlayer.url = VIDEO_PATH;
                             break;
                         }
@@ -234,7 +227,7 @@ namespace YARG.Gameplay
                     enabled = true;
                     break;
                 case BackgroundType.Image:
-                    var songTex = result.Image.LoadTexture(false);
+                    var songTex = songBackGround.Image.LoadTexture(false);
                     //render image background flipped to match video
                     Graphics.Blit(songTex, textureManager.GetVideoTexture(), new Vector2(1, -1), new Vector2(0, 1));
                     //clean up unused texture

--- a/Assets/Script/Gameplay/BackgroundManager.cs
+++ b/Assets/Script/Gameplay/BackgroundManager.cs
@@ -51,7 +51,7 @@ namespace YARG.Gameplay
             // We don't need to update unless we're using a video
             enabled = false;
 
-            using var result = VenueLoader.GetVenue(GameManager.Song, out _source);
+            var result = VenueLoader.GetVenue(GameManager.Song, out _source);
             if (result == null)
             {
                 return;
@@ -138,6 +138,20 @@ namespace YARG.Gameplay
                     // Destroy the default camera (venue has its own)
                     Destroy(_videoPlayer.targetCamera.gameObject);
 
+                    if (textureManager.VideoTexFound())
+                    {
+                        //set up videoPlayer to render to venue texture
+                        _videoPlayer.renderMode = VideoRenderMode.RenderTexture;
+                        _videoPlayer.targetTexture = textureManager.GetVideoTexture();
+                        //overwrite result of GetVenue with Song Background
+                        result = GameManager.Song.LoadBackground();
+                        //if song background is found and is a video load it as if it was the background
+                        if (result?.Type == BackgroundType.Video)
+                        {
+                            goto case BackgroundType.Video;
+                        }
+                    }
+
                     break;
                 case BackgroundType.Video:
                     switch (result.Stream)
@@ -173,6 +187,8 @@ namespace YARG.Gameplay
                     _backgroundImage.gameObject.SetActive(true);
                     break;
             }
+            //dispose of result manually since no no longer using "using" keyword
+            result?.Dispose();
         }
 
         private void Update()

--- a/Assets/Script/Gameplay/BackgroundManager.cs
+++ b/Assets/Script/Gameplay/BackgroundManager.cs
@@ -51,7 +51,7 @@ namespace YARG.Gameplay
             // We don't need to update unless we're using a video
             enabled = false;
 
-            var result = VenueLoader.GetVenue(GameManager.Song, out _source);
+            using var result = VenueLoader.GetVenue(GameManager.Song, out _source);
             if (result == null)
             {
                 return;
@@ -178,8 +178,6 @@ namespace YARG.Gameplay
                     _backgroundImage.gameObject.SetActive(true);
                     break;
             }
-            //dispose of result manually since no no longer using "using" keyword
-            result?.Dispose();
         }
 
         private void SetUpVideoTexture()

--- a/Assets/Script/Gameplay/BackgroundManager.cs
+++ b/Assets/Script/Gameplay/BackgroundManager.cs
@@ -218,7 +218,7 @@ namespace YARG.Gameplay
                     }
                     //set up videoPlayer to render to venue texture
                     _videoPlayer.renderMode = VideoRenderMode.RenderTexture;
-                    _videoPlayer.targetTexture = textureManager.GetVideoTexture();
+                    _videoPlayer.targetTexture = textureManager.GetVideoTexture(0, 0);
 
                     _videoPlayer.enabled = true;
                     _videoPlayer.prepareCompleted += OnVideoPrepared;
@@ -229,7 +229,7 @@ namespace YARG.Gameplay
                 case BackgroundType.Image:
                     var songTex = songBackGround.Image.LoadTexture(false);
                     //render image background flipped to match video
-                    Graphics.Blit(songTex, textureManager.GetVideoTexture(), new Vector2(1, -1), new Vector2(0, 1));
+                    Graphics.Blit(songTex, textureManager.GetVideoTexture(0, 0), new Vector2(1, -1), new Vector2(0, 1));
                     //clean up unused texture
                     Destroy(songTex);
                     return;

--- a/Assets/Script/Gameplay/BackgroundManager.cs
+++ b/Assets/Script/Gameplay/BackgroundManager.cs
@@ -140,17 +140,7 @@ namespace YARG.Gameplay
 
                     if (textureManager.VideoTexFound())
                     {
-                        //set up videoPlayer to render to venue texture
-                        _videoPlayer.renderMode = VideoRenderMode.RenderTexture;
-                        _videoPlayer.targetTexture = textureManager.GetVideoTexture();
-                        //overwrite result of GetVenue with Song Background
-                        result = GameManager.Song.LoadBackground();
-                        //if song background is found and is a video load it as if it was the background
-                        if (result?.Type == BackgroundType.Video)
-                        {
-                            _source = VenueSource.Song;
-                            goto case BackgroundType.Video;
-                        }
+                        SetUpVideoTexture();
                     }
 
                     break;
@@ -190,6 +180,64 @@ namespace YARG.Gameplay
             }
             //dispose of result manually since no no longer using "using" keyword
             result?.Dispose();
+        }
+
+        private void SetUpVideoTexture()
+        {
+            var textureManager = GetComponent<TextureManager>();
+            var result = GameManager.Song.LoadBackground();
+            if (result == null)
+            {
+                //no song specific background to render
+                return;
+            }
+            switch (result.Type)
+            {
+                case BackgroundType.Yarground:
+                    //return because only 1 yarground is supported at a time
+                    return;
+                case BackgroundType.Video:
+                    //set venue source to song to enable video seeking/pausing features
+                    _source = VenueSource.Song;
+
+                    switch (result.Stream)
+                    {
+                        case FileStream fs:
+                        {
+                            _videoPlayer.url = fs.Name;
+                            break;
+                        }
+                        case SngFileStream sngStream:
+                        {
+                            // UNFORTUNATELY, Videoplayer can't use streams, so video files
+                            // MUST BE FULLY DECRYPTED
+
+                            VIDEO_PATH = Path.Combine(Application.persistentDataPath, sngStream.Name);
+                            using var tmp = File.OpenWrite(VIDEO_PATH);
+                            File.SetAttributes(VIDEO_PATH, File.GetAttributes(VIDEO_PATH) | FileAttributes.Temporary | FileAttributes.Hidden);
+                            result.Stream.CopyTo(tmp);
+                            _videoPlayer.url = VIDEO_PATH;
+                            break;
+                        }
+                    }
+                    //set up videoPlayer to render to venue texture
+                    _videoPlayer.renderMode = VideoRenderMode.RenderTexture;
+                    _videoPlayer.targetTexture = textureManager.GetVideoTexture();
+
+                    _videoPlayer.enabled = true;
+                    _videoPlayer.prepareCompleted += OnVideoPrepared;
+                    _videoPlayer.seekCompleted += OnVideoSeeked;
+                    _videoPlayer.Prepare();
+                    enabled = true;
+                    break;
+                case BackgroundType.Image:
+                    var songTex = result.Image.LoadTexture(false);
+                    //render image background flipped to match video
+                    Graphics.Blit(songTex, textureManager.GetVideoTexture(), new Vector2(1, -1), new Vector2(0, 1));
+                    //clean up unused texture
+                    Destroy(songTex);
+                    return;
+            }
         }
 
         private void Update()

--- a/Assets/Script/Gameplay/BackgroundManager.cs
+++ b/Assets/Script/Gameplay/BackgroundManager.cs
@@ -148,6 +148,7 @@ namespace YARG.Gameplay
                         //if song background is found and is a video load it as if it was the background
                         if (result?.Type == BackgroundType.Video)
                         {
+                            _source = VenueSource.Song;
                             goto case BackgroundType.Video;
                         }
                     }

--- a/Assets/Script/Gameplay/BackgroundManager.cs
+++ b/Assets/Script/Gameplay/BackgroundManager.cs
@@ -140,7 +140,7 @@ namespace YARG.Gameplay
 
                     if (textureManager.VideoTexFound())
                     {
-                        SetUpVideoTexture();
+                        SetUpVideoTexture(bgInstance);
                     }
 
                     break;
@@ -180,20 +180,25 @@ namespace YARG.Gameplay
             }
         }
 
-        private void SetUpVideoTexture()
+        private void SetUpVideoTexture(GameObject bginstance)
         {
             var textureManager = GetComponent<TextureManager>();
             var result = GameManager.Song.LoadBackground();
-            if (result == null)
+            if (result == null || result.Type == BackgroundType.Yarground)
             {
-                //no song specific background to render
                 return;
+            }
+            //assign background textures after confirming there is a background to render
+            var renderers = bginstance.GetComponentsInChildren<Renderer>(true);
+            foreach (var renderer in renderers)
+            {
+                foreach (var material in renderer.sharedMaterials)
+                {
+                    textureManager.AssignBackgroundTextures(material);
+                }
             }
             switch (result.Type)
             {
-                case BackgroundType.Yarground:
-                    //return because only 1 yarground is supported at a time
-                    return;
                 case BackgroundType.Video:
                     //set venue source to song to enable video seeking/pausing features
                     _source = VenueSource.Song;

--- a/Assets/Script/Gameplay/BackgroundManager.cs
+++ b/Assets/Script/Gameplay/BackgroundManager.cs
@@ -161,6 +161,7 @@ namespace YARG.Gameplay
         private void SetUpVideoTexture(BackgroundResult songBackGround)
         {
             var textureManager = GetComponent<TextureManager>();
+            textureManager.CreateVideoTexture();
             if (songBackGround == null || songBackGround.Type == BackgroundType.Yarground)
             {
                 return;

--- a/Assets/Script/Gameplay/BackgroundManager.cs
+++ b/Assets/Script/Gameplay/BackgroundManager.cs
@@ -148,32 +148,7 @@ namespace YARG.Gameplay
 
                     break;
                 case BackgroundType.Video:
-                    switch (result.Stream)
-                    {
-                        case FileStream fs:
-                        {
-                            _videoPlayer.url = fs.Name;
-                            break;
-                        }
-                        case SngFileStream sngStream:
-                        {
-                            // UNFORTUNATELY, Videoplayer can't use streams, so video files
-                            // MUST BE FULLY DECRYPTED
-
-                            VIDEO_PATH = Path.Combine(Application.persistentDataPath, sngStream.Name);
-                            using var tmp = File.OpenWrite(VIDEO_PATH);
-                            File.SetAttributes(VIDEO_PATH, File.GetAttributes(VIDEO_PATH) | FileAttributes.Temporary | FileAttributes.Hidden);
-                            result.Stream.CopyTo(tmp);
-                            _videoPlayer.url = VIDEO_PATH;
-                            break;
-                        }
-                    }
-
-                    _videoPlayer.enabled = true;
-                    _videoPlayer.prepareCompleted += OnVideoPrepared;
-                    _videoPlayer.seekCompleted += OnVideoSeeked;
-                    _videoPlayer.Prepare();
-                    enabled = true;
+                    LoadVideoBackground(result);
                     break;
                 case BackgroundType.Image:
                     _backgroundImage.texture = result.Image.LoadTexture(false);
@@ -195,36 +170,11 @@ namespace YARG.Gameplay
                 case BackgroundType.Video:
                     //set venue source to song to enable video seeking/pausing features
                     _source = VenueSource.Song;
-
-                    switch (songBackGround.Stream)
-                    {
-                        case FileStream fs:
-                        {
-                            _videoPlayer.url = fs.Name;
-                            break;
-                        }
-                        case SngFileStream sngStream:
-                        {
-                            // UNFORTUNATELY, Videoplayer can't use streams, so video files
-                            // MUST BE FULLY DECRYPTED
-
-                            VIDEO_PATH = Path.Combine(Application.persistentDataPath, sngStream.Name);
-                            using var tmp = File.OpenWrite(VIDEO_PATH);
-                            File.SetAttributes(VIDEO_PATH, File.GetAttributes(VIDEO_PATH) | FileAttributes.Temporary | FileAttributes.Hidden);
-                            songBackGround.Stream.CopyTo(tmp);
-                            _videoPlayer.url = VIDEO_PATH;
-                            break;
-                        }
-                    }
                     //set up videoPlayer to render to venue texture
                     _videoPlayer.renderMode = VideoRenderMode.RenderTexture;
                     _videoPlayer.targetTexture = textureManager.GetVideoTexture(0, 0);
 
-                    _videoPlayer.enabled = true;
-                    _videoPlayer.prepareCompleted += OnVideoPrepared;
-                    _videoPlayer.seekCompleted += OnVideoSeeked;
-                    _videoPlayer.Prepare();
-                    enabled = true;
+                    LoadVideoBackground(songBackGround);
                     break;
                 case BackgroundType.Image:
                     var songTex = songBackGround.Image.LoadTexture(false);
@@ -234,6 +184,36 @@ namespace YARG.Gameplay
                     Destroy(songTex);
                     return;
             }
+        }
+
+        private void LoadVideoBackground(BackgroundResult bg)
+        {
+            switch (bg.Stream)
+            {
+                case FileStream fs:
+                {
+                    _videoPlayer.url = fs.Name;
+                    break;
+                }
+                case SngFileStream sngStream:
+                {
+                    // UNFORTUNATELY, Videoplayer can't use streams, so video files
+                    // MUST BE FULLY DECRYPTED
+
+                    VIDEO_PATH = Path.Combine(Application.persistentDataPath, sngStream.Name);
+                    using var tmp = File.OpenWrite(VIDEO_PATH);
+                    File.SetAttributes(VIDEO_PATH, File.GetAttributes(VIDEO_PATH) | FileAttributes.Temporary | FileAttributes.Hidden);
+                    bg.Stream.CopyTo(tmp);
+                    _videoPlayer.url = VIDEO_PATH;
+                    break;
+                }
+            }
+
+            _videoPlayer.enabled = true;
+            _videoPlayer.prepareCompleted += OnVideoPrepared;
+            _videoPlayer.seekCompleted += OnVideoSeeked;
+            _videoPlayer.Prepare();
+            enabled = true;
         }
 
         private void Update()

--- a/Assets/Script/Gameplay/TextureManager.cs
+++ b/Assets/Script/Gameplay/TextureManager.cs
@@ -2,6 +2,7 @@ using System;
 using Cysharp.Threading.Tasks;
 using Unity.Collections;
 using UnityEngine;
+using YARG.Core.Venue;
 using YARG.Helpers.Extensions;
 using YARG.Song;
 
@@ -39,6 +40,8 @@ namespace YARG.Gameplay
         private static int _sourceIconId = Shader.PropertyToID("_Yarg_SourceIcon");
         private static int _albumCoverId = Shader.PropertyToID("_Yarg_AlbumCover");
         private static int _videoTexId = Shader.PropertyToID("_Yarg_VideoTex");
+        private static int _imageTexId = Shader.PropertyToID("_Yarg_ImageTex");
+        private static int _backgroundTexId = Shader.PropertyToID("_Yarg_BackgroundTex");
 
         private const double MIN_DB = -100.0;
         private const double MAX_DB = -30.0;
@@ -107,7 +110,7 @@ namespace YARG.Gameplay
             return _videoTexFound;
         }
 
-        public void ProcessMaterial(Material m)
+        public void ProcessMaterial(Material m, BackgroundType? songBackgroundType)
         {
             if (m.HasTexture(_sourceIconId))
             {
@@ -121,17 +124,20 @@ namespace YARG.Gameplay
             {
                 m.SetTexture(_albumCoverId, GetAlbumArt());
             }
-            if (m.HasTexture(_videoTexId))
-            {
-                _videoTexFound = true;
-            }
-        }
-
-        public void AssignBackgroundTextures(Material m)
-        {
-            if (m.HasTexture(_videoTexId))
+            if (m.HasTexture(_videoTexId) && songBackgroundType is BackgroundType.Video)
             {
                 m.SetTexture(_videoTexId, GetVideoTexture());
+                _videoTexFound = true;
+            }
+            if (m.HasTexture(_imageTexId) && songBackgroundType is BackgroundType.Image)
+            {
+                m.SetTexture(_imageTexId, GetVideoTexture());
+                _videoTexFound = true;
+            }
+            if (m.HasTexture(_backgroundTexId) && songBackgroundType is BackgroundType.Image or BackgroundType.Video)
+            {
+                m.SetTexture(_backgroundTexId, GetVideoTexture());
+                _videoTexFound = true;
             }
         }
 

--- a/Assets/Script/Gameplay/TextureManager.cs
+++ b/Assets/Script/Gameplay/TextureManager.cs
@@ -98,7 +98,6 @@ namespace YARG.Gameplay
             {
                 _videoTexture = new RenderTexture(VIDEO_TEX_WIDTH, VIDEO_TEX_HEIGHT, 0);
                 _videoTexture.Create();
-                _videoTexFound = true;
             }
             return _videoTexture;
         }
@@ -122,6 +121,14 @@ namespace YARG.Gameplay
             {
                 m.SetTexture(_albumCoverId, GetAlbumArt());
             }
+            if (m.HasTexture(_videoTexId))
+            {
+                _videoTexFound = true;
+            }
+        }
+
+        public void AssignBackgroundTextures(Material m)
+        {
             if (m.HasTexture(_videoTexId))
             {
                 m.SetTexture(_videoTexId, GetVideoTexture());

--- a/Assets/Script/Gameplay/TextureManager.cs
+++ b/Assets/Script/Gameplay/TextureManager.cs
@@ -49,8 +49,8 @@ namespace YARG.Gameplay
         private const int FFT_SIZE_LOG = 11 /* aka log2(2048) */;
         private const int FFT_SIZE = 1 << FFT_SIZE_LOG;
         private const int FFT_TEXTURE_WIDTH = 512;
-        private const int VIDEO_TEX_WIDTH = 1280;
-        private const int VIDEO_TEX_HEIGHT = 720;
+        private int _videoTexWidth = 256;
+        private int _videoTexHeight = 144;
 
         // TODO: Get the number of active channels from the mixer instead of assuming
         //  Note that this won't _break_ if there are more channels, it will just make
@@ -95,12 +95,20 @@ namespace YARG.Gameplay
             return _soundTexture;
         }
 
-        public RenderTexture GetVideoTexture()
+        public RenderTexture GetVideoTexture(int width, int height)
         {
             if (_videoTexture == null)
             {
-                _videoTexture = new RenderTexture(VIDEO_TEX_WIDTH, VIDEO_TEX_HEIGHT, 0);
+                _videoTexture = new RenderTexture(_videoTexWidth, _videoTexHeight, 0);
                 _videoTexture.Create();
+            }
+            if (width > _videoTexture.width)
+            {
+                _videoTexture.width = width;
+            }
+            if (height > _videoTexture.height)
+            {
+                _videoTexture.width = height;
             }
             return _videoTexture;
         }
@@ -126,17 +134,20 @@ namespace YARG.Gameplay
             }
             if (m.HasTexture(_videoTexId) && songBackgroundType is BackgroundType.Video)
             {
-                m.SetTexture(_videoTexId, GetVideoTexture());
+                var matTex = m.GetTexture(_videoTexId);
+                m.SetTexture(_videoTexId, GetVideoTexture(matTex.width, matTex.height));
                 _videoTexFound = true;
             }
             if (m.HasTexture(_imageTexId) && songBackgroundType is BackgroundType.Image)
             {
-                m.SetTexture(_imageTexId, GetVideoTexture());
+                var matTex = m.GetTexture(_imageTexId);
+                m.SetTexture(_imageTexId, GetVideoTexture(matTex.width, matTex.height));
                 _videoTexFound = true;
             }
             if (m.HasTexture(_backgroundTexId) && songBackgroundType is BackgroundType.Image or BackgroundType.Video)
             {
-                m.SetTexture(_backgroundTexId, GetVideoTexture());
+                var matTex = m.GetTexture(_backgroundTexId);
+                m.SetTexture(_backgroundTexId, GetVideoTexture(matTex.width, matTex.height));
                 _videoTexFound = true;
             }
         }

--- a/Assets/Script/Gameplay/TextureManager.cs
+++ b/Assets/Script/Gameplay/TextureManager.cs
@@ -49,8 +49,8 @@ namespace YARG.Gameplay
         private const int FFT_SIZE_LOG = 11 /* aka log2(2048) */;
         private const int FFT_SIZE = 1 << FFT_SIZE_LOG;
         private const int FFT_TEXTURE_WIDTH = 512;
-        private int _videoTexWidth = 256;
-        private int _videoTexHeight = 144;
+        private const int VIDEO_TEX_WIDTH = 256;
+        private const int VIDEO_TEX_HEIGHT = 144;
 
         // TODO: Get the number of active channels from the mixer instead of assuming
         //  Note that this won't _break_ if there are more channels, it will just make
@@ -99,7 +99,7 @@ namespace YARG.Gameplay
         {
             if (_videoTexture == null)
             {
-                _videoTexture = new RenderTexture(_videoTexWidth, _videoTexHeight, 0);
+                _videoTexture = new RenderTexture(VIDEO_TEX_WIDTH, VIDEO_TEX_HEIGHT, 0);
                 _videoTexture.Create();
             }
             if (width > _videoTexture.width)
@@ -108,7 +108,7 @@ namespace YARG.Gameplay
             }
             if (height > _videoTexture.height)
             {
-                _videoTexture.width = height;
+                _videoTexture.height = height;
             }
             return _videoTexture;
         }

--- a/Assets/Script/Gameplay/TextureManager.cs
+++ b/Assets/Script/Gameplay/TextureManager.cs
@@ -100,7 +100,6 @@ namespace YARG.Gameplay
             if (_videoTexture == null)
             {
                 _videoTexture = new RenderTexture(VIDEO_TEX_WIDTH, VIDEO_TEX_HEIGHT, 0);
-                _videoTexture.Create();
             }
             if (width > _videoTexture.width)
             {
@@ -116,6 +115,14 @@ namespace YARG.Gameplay
         public bool VideoTexFound()
         {
             return _videoTexFound;
+        }
+
+        public void CreateVideoTexture()
+        {
+            if (_videoTexture != null && !_videoTexture.IsCreated())
+            {
+                _videoTexture.Create();
+            }
         }
 
         public void ProcessMaterial(Material m, BackgroundType? songBackgroundType)

--- a/Assets/Script/Gameplay/TextureManager.cs
+++ b/Assets/Script/Gameplay/TextureManager.cs
@@ -23,11 +23,14 @@ namespace YARG.Gameplay
         private Texture2D _sourceIcon = null;
         private Texture2D _albumCover = null;
         private Texture2D _soundTexture = null;
+        private RenderTexture _videoTexture = null;
         private float[] _fft = new float[FFT_SIZE / 2];
         private float[] _wave = new float[FFT_TEXTURE_WIDTH];
         private float[] _prevFft = new float[FFT_SIZE / 2];
         private float[] _rawFft = new float[FFT_SIZE * 2];
         private float[] _rawWave = new float[FFT_SIZE];
+
+        private bool _videoTexFound = false;
 
         private UniTask           _updateTask = UniTask.CompletedTask;
         private NativeArray<byte> _pixelData;
@@ -35,6 +38,7 @@ namespace YARG.Gameplay
         private static int _soundTexId = Shader.PropertyToID("_Yarg_SoundTex");
         private static int _sourceIconId = Shader.PropertyToID("_Yarg_SourceIcon");
         private static int _albumCoverId = Shader.PropertyToID("_Yarg_AlbumCover");
+        private static int _videoTexId = Shader.PropertyToID("_Yarg_VideoTex");
 
         private const double MIN_DB = -100.0;
         private const double MAX_DB = -30.0;
@@ -42,6 +46,8 @@ namespace YARG.Gameplay
         private const int FFT_SIZE_LOG = 11 /* aka log2(2048) */;
         private const int FFT_SIZE = 1 << FFT_SIZE_LOG;
         private const int FFT_TEXTURE_WIDTH = 512;
+        private const int VIDEO_TEX_WIDTH = 1280;
+        private const int VIDEO_TEX_HEIGHT = 720;
 
         // TODO: Get the number of active channels from the mixer instead of assuming
         //  Note that this won't _break_ if there are more channels, it will just make
@@ -86,6 +92,22 @@ namespace YARG.Gameplay
             return _soundTexture;
         }
 
+        public RenderTexture GetVideoTexture()
+        {
+            if (_videoTexture == null)
+            {
+                _videoTexture = new RenderTexture(VIDEO_TEX_WIDTH, VIDEO_TEX_HEIGHT, 0);
+                _videoTexture.Create();
+                _videoTexFound = true;
+            }
+            return _videoTexture;
+        }
+
+        public bool VideoTexFound()
+        {
+            return _videoTexFound;
+        }
+
         public void ProcessMaterial(Material m)
         {
             if (m.HasTexture(_sourceIconId))
@@ -99,6 +121,10 @@ namespace YARG.Gameplay
             if (m.HasTexture(_albumCoverId))
             {
                 m.SetTexture(_albumCoverId, GetAlbumArt());
+            }
+            if (m.HasTexture(_videoTexId))
+            {
+                m.SetTexture(_videoTexId, GetVideoTexture());
             }
         }
 

--- a/Assets/Script/Gameplay/TextureManager.cs
+++ b/Assets/Script/Gameplay/TextureManager.cs
@@ -192,6 +192,12 @@ namespace YARG.Gameplay
 
         protected override void GameplayDestroy()
         {
+            if (_videoTexture != null)
+            {
+                _videoTexture.Release();
+                _videoTexture.DiscardContents();
+                _videoTexture = null;
+            }
             // Dispose FFT stuff, but only after the FFT update has completed
             _ = Destroy_Async();
         }


### PR DESCRIPTION
adds song background as render texture to the texture manager

looks for _Yarg_VideoTex in venue shaders

if found will try to load the song background, if it's an image or video
- video: uses the video player normally used to render background video to render to texture instead
- image: renders the background to the texture once on load 
- default: if nothing is found the texture is black with 0 alpha so that the shader author can set a default

demo:
https://youtu.be/eR9T7Ul8WyE