### PR TITLE
Preserve the current song on music library search update

### DIFF
--- a/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
+++ b/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
@@ -628,7 +628,7 @@ namespace YARG.Menu.MusicLibrary
                     newPositionStartIndex = _primaryHeaderIndex;
                 }
 
-                if (_searchField.IsUpdatedSearchLonger || _currentSong == null ||
+                if (_currentSong == null ||
                     !SetIndexTo(i => i is SongViewType view && view.SongEntry.SortBasedLocation == _currentSong.SortBasedLocation, newPositionStartIndex))
                 {
                     // Note: it may look like this is expensive, but the whole loop should only last for 4-5 iterations

--- a/Assets/Script/Menu/MusicLibrary/SongSearchingField.cs
+++ b/Assets/Script/Menu/MusicLibrary/SongSearchingField.cs
@@ -46,7 +46,6 @@ namespace YARG.Menu.MusicLibrary
 
         public bool IsSearching => !string.IsNullOrEmpty(_fullSearchQuery);
         public bool IsCurrentSearchInField => _searchQueries[_currentSearchFilter] == _searchField.text;
-        public bool IsUpdatedSearchLonger => _searchField.text.Length > _currentSearchText.Length;
         public bool IsUnspecified => _searchContext.IsUnspecified();
 
         public event Action<bool> OnSearchQueryUpdated;


### PR DESCRIPTION
Previously, updating the music library search would reset to the first song on the list. Now, it preserves the current song if possible (falling back to the first song if needed). This makes the UX better especially when clicking an artist name to filter the list.