### PR TITLE
Show high score card also on the first clear

### DIFF
--- a/Assets/Script/Gameplay/GameManager.cs
+++ b/Assets/Script/Gameplay/GameManager.cs
@@ -485,7 +485,7 @@ namespace YARG.Gameplay
             {
                 PlayerScores = _players.Select(player => new PlayerScoreCard
                 {
-                    IsHighScore = player.Score > player.LastHighScore,
+                    IsHighScore = player.LastHighScore == null || player.Score > player.LastHighScore.Value,
                     Player = player.Player,
                     Stats = player.BaseStats
                 }).ToArray(),


### PR DESCRIPTION
Technically it's the high score even if there was no previous score.

Alternatively, we could show something like "Song Cleared!".