### PR TITLE
Show percentage scores with one decimal

### DIFF
--- a/Assets/Prefabs/Menu/MusicLibrary/Instrument Difficulty.prefab
+++ b/Assets/Prefabs/Menu/MusicLibrary/Instrument Difficulty.prefab
@@ -297,8 +297,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 16, y: 0}
-  m_SizeDelta: {x: 56, y: 28}
+  m_AnchoredPosition: {x: 19, y: 0}
+  m_SizeDelta: {x: 70, y: 28}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &7345415684953432056
 CanvasRenderer:
@@ -362,7 +362,7 @@ MonoBehaviour:
   m_fontSizeMin: 18
   m_fontSizeMax: 72
   m_fontStyle: 0
-  m_HorizontalAlignment: 2
+  m_HorizontalAlignment: 4
   m_VerticalAlignment: 1024
   m_textAlignment: 65535
   m_characterSpacing: 0
@@ -372,7 +372,7 @@ MonoBehaviour:
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_TextWrappingMode: 1
+  m_TextWrappingMode: 0
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}

--- a/Assets/Prefabs/Menu/MusicLibrary/SongView.prefab
+++ b/Assets/Prefabs/Menu/MusicLibrary/SongView.prefab
@@ -2809,7 +2809,7 @@ MonoBehaviour:
   m_IgnoreLayout: 0
   m_MinWidth: -1
   m_MinHeight: -1
-  m_PreferredWidth: 120
+  m_PreferredWidth: 150
   m_PreferredHeight: -1
   m_FlexibleWidth: -1
   m_FlexibleHeight: -1
@@ -3823,7 +3823,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3714506624951436115, guid: 2757d4382315f8a46a8a0c2e76c0f881, type: 3}
       propertyPath: m_SizeDelta.x
-      value: 130
+      value: 150
       objectReference: {fileID: 0}
     - target: {fileID: 3714506624951436115, guid: 2757d4382315f8a46a8a0c2e76c0f881, type: 3}
       propertyPath: m_SizeDelta.y
@@ -3932,7 +3932,7 @@ MonoBehaviour:
   m_IgnoreLayout: 0
   m_MinWidth: -1
   m_MinHeight: -1
-  m_PreferredWidth: 120.00094
+  m_PreferredWidth: 150.00094
   m_PreferredHeight: 36
   m_FlexibleWidth: -1
   m_FlexibleHeight: 0

--- a/Assets/Script/Menu/MusicLibrary/InstrumentDifficultyView.cs
+++ b/Assets/Script/Menu/MusicLibrary/InstrumentDifficultyView.cs
@@ -33,7 +33,8 @@ namespace YARG.Menu.MusicLibrary
             _difficultyIcon.sprite = difficultyIcon;
 
             // Set percent value
-            _percentText.text = $"{Math.Floor(scoreInfo.Percent * 100)}%";
+            var percent = Mathf.Floor(scoreInfo.Percent * 1000f) / 10f;
+            _percentText.text = $"{percent:0.0}%";
             _percentText.color = scoreInfo.IsFc ? _fcGold : Color.white;
         }
     }

--- a/Assets/Script/Menu/ScoreScreen/ScoreCards/ScoreCard.cs
+++ b/Assets/Script/Menu/ScoreScreen/ScoreCards/ScoreCard.cs
@@ -116,8 +116,8 @@ namespace YARG.Menu.ScoreScreen
             _difficulty.text = Player.Profile.CurrentDifficulty.ToDisplayName();
 
             // Set percent
-            _accuracyPercent.text = $"{Mathf.FloorToInt(Stats.Percent * 100f)}%";
-
+            var percent = Mathf.Floor(Stats.Percent * 1000f) / 10f;
+            _accuracyPercent.text = $"{percent:0.0}%";
 
             // Set background and foreground colors
             if (Player.Profile.IsBot)


### PR DESCRIPTION
I just want to see more precision, especially scores like `99.7%` instead of just `99%`.

<img width="3840" height="2160" alt="20260115_19h57m54s_grim" src="https://github.com/user-attachments/assets/a5757146-09f2-4e17-9eb3-6d057d7ad3e0" />
<img width="3840" height="2160" alt="20260115_19h52m09s_grim" src="https://github.com/user-attachments/assets/a89fdb01-2c5a-4918-9182-bed28e5828da" />
