### PR TITLE
Fix note particles not rendering on MacOS

### DIFF
--- a/Assets/Art/Shaders/ParticlesLit.shader
+++ b/Assets/Art/Shaders/ParticlesLit.shader
@@ -74,6 +74,9 @@ Shader "YargParticlesLit"
     //Particle shaders rely on "write" to CB syntax which is not supported by DXC
     #pragma never_use_dxc
 
+    // Required on Metal in all passes or shader compilation will fail
+    #include_with_pragmas "Packages/com.unity.render-pipelines.core/ShaderLibrary/FoveatedRenderingKeywords.hlsl"
+
     ENDHLSL
 
     SubShader
@@ -148,7 +151,6 @@ Shader "YargParticlesLit"
             #pragma multi_compile_fragment _ _LIGHT_COOKIES
             #pragma multi_compile _ _CLUSTER_LIGHT_LOOP
             #pragma multi_compile _ EVALUATE_SH_MIXED EVALUATE_SH_VERTEX
-            #include_with_pragmas "Packages/com.unity.render-pipelines.core/ShaderLibrary/FoveatedRenderingKeywords.hlsl"
             #include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Fog.hlsl"
             #include_with_pragmas "Packages/com.unity.render-pipelines.universal/ShaderLibrary/ProbeVolumeVariants.hlsl"
 

--- a/Assets/Art/Shaders/ParticlesUnlit.shader
+++ b/Assets/Art/Shaders/ParticlesUnlit.shader
@@ -61,6 +61,9 @@ Shader "YargParticlesUnlit"
     //Particle shaders rely on "write" to CB syntax which is not supported by DXC
     #pragma never_use_dxc
 
+    // This is required on Metal in all passes to avoid compilation errors
+    #include_with_pragmas "Packages/com.unity.render-pipelines.core/ShaderLibrary/FoveatedRenderingKeywords.hlsl"
+
     ENDHLSL
 
     SubShader


### PR DESCRIPTION
I was honestly surprised nobody reported this, since it seems to be a bug on all MacOS systems, and I can see the error occur on the MacOS runner in GitHub actions as well.

The issue was occurring because the `_FOVEATED_RENDERING_NON_UNIFORM_RASTER` keyword was not declared but was apparently used in these shaders (most likely in some include), which caused the shader to fail to build. I think this started with the move to Unity 6?

If I added the include to any one pass, the issue would just occur again in a different pass until I had covered all of them.

I tested this on Windows and Linux also, and it doesn't seem to cause any issues.

Here's the error (it's essentially the same for YargParticlesLit):
```
Shader error in 'YargParticlesUnlit': undeclared identifier '_FOVEATED_RENDERING_NON_UNIFORM_RASTER' at Projects/YARG/Library/PackageCache/com.unity.render-pipelines.core@8d70e2c352d2/ShaderLibrary/FoveatedRendering.hlsl(22) (on metal)

Compiling Subshader: 0, Pass: ForwardLit, Vertex program with <no keywords>
Platform defines: SHADER_API_DESKTOP UNITY_ENABLE_DETAIL_NORMALMAP UNITY_ENABLE_REFLECTION_BUFFERS UNITY_FRAMEBUFFER_FETCH_AVAILABLE UNITY_LIGHTMAP_FULL_HDR UNITY_LIGHT_PROBE_PROXY_VOLUME UNITY_NEEDS_RENDERPASS_FBFETCH_FALLBACK UNITY_PBS_USE_BRDF1 UNITY_SPECCUBE_BLENDING UNITY_SPECCUBE_BOX_PROJECTION UNITY_USE_DITHER_MASK_FOR_ALPHABLENDED_SHADOWS
Disabled keywords: DOTS_INSTANCING_ON FOG_EXP FOG_EXP2 FOG_LINEAR INSTANCING_ON PROBE_VOLUMES_L1 PROBE_VOLUMES_L2 PROCEDURAL_INSTANCING_ON SHADER_API_GLES30 SHADER_API_GLES31 SHADER_API_GLES32 UNITY_ASTC_NORMALMAP_ENCODING UNITY_COLORSPACE_GAMMA UNITY_HARDWARE_TIER1 UNITY_HARDWARE_TIER2 UNITY_HARDWARE_TIER3 UNITY_LIGHTMAP_DLDR_ENCODING UNITY_LIGHTMAP_RGBM_ENCODING UNITY_METAL_SHADOWS_USE_POINT_FILTERING UNITY_NO_DXT5nm UNITY_NO_SCREENSPACE_SHADOWS UNITY_PBS_USE_BRDF2 UNITY_PBS_USE_BRDF3 UNITY_PRETRANSFORM_TO_DISPLAY_ORIENTATION UNITY_UNIFIED_SHADER_PRECISION_MODEL UNITY_VIRTUAL_TEXTURING _DISTORTION_ON _FADING_ON _FLIPBOOKBLENDING_ON _NORMALMAP _SOFTPARTICLES_ON
```

And a video of the bug (taken in the unity editor, but happens on the nightly build too):

https://github.com/user-attachments/assets/bb81a4df-59a6-476e-95a3-adacd731a4d3