### PR TITLE
Fix negative input calibration messing up vocal needle

### DIFF
--- a/Assets/Script/Gameplay/Player/VocalsPlayer.cs
+++ b/Assets/Script/Gameplay/Player/VocalsPlayer.cs
@@ -392,7 +392,7 @@ namespace YARG.Gameplay.Player
             const float NEEDLE_ROT_LERP = 25f;
 
             // Get the appropriate sing time
-            var singTime = GameManager.InputTime - Player.Profile.InputCalibrationSeconds;
+            var singTime = GameManager.InputTime;
 
             // Get whether or not the player has sang within the time threshold.
             // We gotta use a threshold here because microphone inputs are passed every X seconds,


### PR DESCRIPTION
Discord issue: https://discord.com/channels/1086048856678084609/1451240998436077692/1451240998436077692

`singTime` included the profile input offset, but `_lastSingTime` did not

Because of this the threshold calculation for showing the needle would fail.

We don't actually care about the input offset for deciding when to show the needle, so the fix is to just remove the offset here for that check.

Scoring does include offset and is handled elsewhere.

