### PR TITLE
Have opaque objects overwrite fading value of transparents

### DIFF
--- a/Assets/Art/Materials/Gameplay/Notes/Sustain.mat
+++ b/Assets/Art/Materials/Gameplay/Notes/Sustain.mat
@@ -18,7 +18,7 @@ Material:
   m_LightmapFlags: 2
   m_EnableInstancingVariants: 0
   m_DoubleSidedGI: 0
-  m_CustomRenderQueue: 1976
+  m_CustomRenderQueue: 2976
   stringTagMap: {}
   disabledShaderPasses:
   - MOTIONVECTORS
@@ -106,7 +106,15 @@ Material:
         m_Texture: {fileID: 2800000, guid: fecf9fecf4644b643a35395dfd7635cf, type: 3}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
+    - _SustainWave_92ec6e0a65ae46b0b94f3e2e02ce3580_MainTex_1492724380_Texture2D:
+        m_Texture: {fileID: 2800000, guid: fecf9fecf4644b643a35395dfd7635cf, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
     - _SustainWave_ff1ec8740cbc49fe9f832cf077fc4071_MainTex_1492724380:
+        m_Texture: {fileID: 2800000, guid: 342e33d746f923d49819aa62c4aa3534, type: 3}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _SustainWave_ff1ec8740cbc49fe9f832cf077fc4071_MainTex_1492724380_Texture2D:
         m_Texture: {fileID: 2800000, guid: 342e33d746f923d49819aa62c4aa3534, type: 3}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}

--- a/Assets/Prefabs/Gameplay/Visual/TrackElements/FiveFretGuitarNote.prefab
+++ b/Assets/Prefabs/Gameplay/Visual/TrackElements/FiveFretGuitarNote.prefab
@@ -24,7 +24,6 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 861361446070616044}
-  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0.002, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
@@ -33,6 +32,7 @@ Transform:
   - {fileID: 7301780973801021488}
   - {fileID: 7211825498439339850}
   m_Father: {fileID: 0}
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &790704540839618363
 MonoBehaviour:
@@ -74,13 +74,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5594689482099579600}
-  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -0.001}
+  m_LocalPosition: {x: 0, y: 0.009999999, z: -0.001}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 861361446070616035}
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &6564187009765405389
 MonoBehaviour:
@@ -122,13 +122,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6398637443606615521}
-  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -0.001}
+  m_LocalPosition: {x: 0, y: 0.009999999, z: -0.001}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 861361446070616035}
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &6817911577054343240
 MonoBehaviour:

--- a/Assets/Prefabs/Gameplay/Visual/TrackElements/FiveLaneKeysNote.prefab
+++ b/Assets/Prefabs/Gameplay/Visual/TrackElements/FiveLaneKeysNote.prefab
@@ -24,7 +24,6 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 861361446070616044}
-  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0.002, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
@@ -33,6 +32,7 @@ Transform:
   - {fileID: 7301780973801021488}
   - {fileID: 7211825498439339850}
   m_Father: {fileID: 0}
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &9035254989615549933
 MonoBehaviour:
@@ -74,13 +74,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5594689482099579600}
-  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -0.001}
+  m_LocalPosition: {x: 0, y: 0.009999999, z: -0.001}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 861361446070616035}
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &6564187009765405389
 MonoBehaviour:
@@ -122,13 +122,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6398637443606615521}
-  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -0.001}
+  m_LocalPosition: {x: 0, y: 0.009999999, z: -0.001}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 861361446070616035}
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &6817911577054343240
 MonoBehaviour:

--- a/Assets/Prefabs/Gameplay/Visual/TrackElements/ProKeysNote.prefab
+++ b/Assets/Prefabs/Gameplay/Visual/TrackElements/ProKeysNote.prefab
@@ -24,7 +24,6 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 861361446070616044}
-  serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0.002, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
@@ -32,6 +31,7 @@ Transform:
   m_Children:
   - {fileID: 7301780973801021488}
   m_Father: {fileID: 0}
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &6346190923397245340
 MonoBehaviour:
@@ -72,13 +72,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5594689482099579600}
-  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -0.001}
+  m_LocalPosition: {x: 0, y: 0.009999999, z: -0.001}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 861361446070616035}
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &6564187009765405389
 MonoBehaviour:

--- a/Assets/Script/Gameplay/Visuals/HighwayCameraRendering.cs
+++ b/Assets/Script/Gameplay/Visuals/HighwayCameraRendering.cs
@@ -451,16 +451,27 @@ namespace YARG.Gameplay.Visuals
                 {
                     cmd.SetRenderTarget(_highwayCameraRendering._highwaysAlphaTexture);
                     var shaderTagIds = new[] { new ShaderTagId("UniversalForward") };
+                    // Draw transparents first
                     var desc = new RendererListDesc(shaderTagIds, renderingData.cullResults, renderingData.cameraData.camera)
                     {
                         sortingCriteria = SortingCriteria.RenderQueue,
-                        renderQueueRange = RenderQueueRange.all,
+                        renderQueueRange = RenderQueueRange.transparent,
                         overrideMaterial = _material
                     };
 
                     var rendererList = context.CreateRendererList(desc);
-                    //The RenderingUtils.fullscreenMesh argument specifies that the mesh to draw is a quad.
                     cmd.DrawRendererList(rendererList);
+
+                    // Now opaques
+                    var opaqueDesc = new RendererListDesc(shaderTagIds, renderingData.cullResults, renderingData.cameraData.camera)
+                    {
+                        sortingCriteria = SortingCriteria.RenderQueue,
+                        renderQueueRange = RenderQueueRange.opaque,
+                        overrideMaterial = _material
+                    };
+
+                    var opaqueRendererList = context.CreateRendererList(opaqueDesc);
+                    cmd.DrawRendererList(opaqueRendererList);
                 }
                 context.ExecuteCommandBuffer(cmd);
                 cmd.Clear();


### PR DESCRIPTION
The reason is we don't want transparent objects that are over
opaque ones to reduce fade value (as they are closer to the viewer/camera).

We do still want to render transparents in the fade calculation rendering pass
since there is a case for transparent particles that are not over the highway.

This fixes rough edges around sustain in the fading zone.

<img width="384" height="223" alt="image" src="https://github.com/user-attachments/assets/5579afd9-9577-48ac-912f-fc65d2cbd1df" />
