### PR TITLE
Improve the score box star graphic

### DIFF
--- a/Assets/Art/Menu/Common/Stars/StarStandard.png.meta
+++ b/Assets/Art/Menu/Common/Stars/StarStandard.png.meta
@@ -35,7 +35,7 @@ TextureImporter:
     serializedVersion: 2
     filterMode: 1
     aniso: 1
-    mipBias: 0
+    mipBias: -1
     wrapU: 1
     wrapV: 1
     wrapW: 0

--- a/Assets/Art/Textures/Gameplay/ScoreBox/StarProgressEmpty.png.meta
+++ b/Assets/Art/Textures/Gameplay/ScoreBox/StarProgressEmpty.png.meta
@@ -35,7 +35,7 @@ TextureImporter:
     serializedVersion: 2
     filterMode: 1
     aniso: 1
-    mipBias: 0
+    mipBias: -1
     wrapU: 1
     wrapV: 1
     wrapW: 0

--- a/Assets/Art/Textures/Gameplay/ScoreBox/StarProgressGold.png.meta
+++ b/Assets/Art/Textures/Gameplay/ScoreBox/StarProgressGold.png.meta
@@ -35,7 +35,7 @@ TextureImporter:
     serializedVersion: 2
     filterMode: 1
     aniso: 1
-    mipBias: 0
+    mipBias: -1
     wrapU: 1
     wrapV: 1
     wrapW: 0

--- a/Assets/Prefabs/Gameplay/HUD/Star.prefab
+++ b/Assets/Prefabs/Gameplay/HUD/Star.prefab
@@ -575,7 +575,7 @@ RectTransform:
   m_AnchorMax: {x: 1, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 1.2}
-  m_Pivot: {x: 0.5, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &4689299449489518065
 CanvasRenderer:
   m_ObjectHideFlags: 0

--- a/Assets/Script/Gameplay/HUD/ScoreBox/StarDisplay.cs
+++ b/Assets/Script/Gameplay/HUD/ScoreBox/StarDisplay.cs
@@ -54,12 +54,14 @@ namespace YARG.Gameplay.HUD
             if (progress < 1)
             {
                 // Fill the star progress
+                _starProgress.enabled = true;
                 _starProgress.fillAmount = (float) progress;
             }
             else
             {
                 // Finish the star
                 _starProgress.fillAmount = 1;
+                _starProgress.enabled = false;
                 _starAnimator.Play(ANIMATION_COMPLETED);
             }
         }


### PR DESCRIPTION
This doesn't change the design, but implements a few technical tweaks to make the graphic look better. It might seem minor, but it was annoying enough for me that I wanted to do something about it. Might be only relevant if you have a screen big enough to notice.

Before:
<img width="500" height="220" alt="20260120_17h19m59s_grim" src="https://github.com/user-attachments/assets/d9179f5b-461d-4afe-822f-38a4a684e8e1" />

After:
<img width="500" height="220" alt="20260120_17h27m43s_grim" src="https://github.com/user-attachments/assets/5c9093e7-d04f-48fd-8f28-42c902fa0539" />