### PR TITLE
Fix SP sunburst effect breaking when multiplier increase/decrease sequence is already running

### DIFF
--- a/Assets/Script/Gameplay/Visuals/SunburstEffects.cs
+++ b/Assets/Script/Gameplay/Visuals/SunburstEffects.cs
@@ -1,4 +1,4 @@
-using DG.Tweening;
+﻿using DG.Tweening;
 using UnityEngine;
 using YARG.Playback;
 using YARG.Settings;
@@ -236,10 +236,18 @@ namespace YARG.Gameplay.Visuals
                 return;
             }
 
-            // Ensure that the disable tween isn't still running
+            // Ensure that any tweens that hide the sunburst are not still running
             if (_sunburstDisableSequence.IsPlaying())
             {
                 _sunburstDisableSequence.Complete(false);
+            }
+            if (_multiplierIncreaseSequence.IsPlaying())
+            {
+                _multiplierIncreaseSequence.Complete(false);
+            }
+            if (_multiplierDecreaseSequence.IsPlaying())
+            {
+                _multiplierDecreaseSequence.Complete(false);
             }
 
             // We need to make sure that we're set up for starpower before we start the sequence


### PR DESCRIPTION
If you either reach a higher multiplier (e.g. 2x -> 3x) or miss and lose your multiplier, and immediately activate star power while that DOTween Sequence is still running, the sunburst effects will be invisible until both SP ends, and you miss (or increase your multiplier, somehow).

In the [original PR](#1032) this was fixed, but the fix was only for the groove start transition (groove enable during SP disable), whereas this PR fixes SP being enabled during multiplier change.

Adding `.AppendCallback(SetStarpowerSunburst);` to the SP sequence does fix the issue, but leads to a flicker in the animation, as it gets hidden, then unhidden slightly after.

There is probably a more sophisticated way to solve this, but in my testing just completing the multiplier sequences if they are running seems to work.

Test chart (use the drums chart, not guitar):
[Sunburst Test.zip](https://github.com/user-attachments/files/24777029/Sunburst.Test.zip)
