### PR TITLE
Scale highway pop in animation delay by song speed

### DIFF
--- a/Assets/Script/Gameplay/Visuals/CameraPositioner.cs
+++ b/Assets/Script/Gameplay/Visuals/CameraPositioner.cs
@@ -233,6 +233,10 @@ namespace YARG.Gameplay.Visuals
                 ? basePlayer.transform.GetSiblingIndex() * LOCAL_ANIM_OFFSET + _globalAnimDelay
                 : 0f;
 
+            // Scale delay by song speed so animation completes in time at higher speeds
+            // Cap at 1 so slower speeds don't extend the delay
+            delay /= Mathf.Max(1f, _gameManager.SongSpeed);
+
             // TODO: This will need to be reworked when it is possible for the highway to raise and lower other
             //  than at the beginning and end of song
             _raise.PrependInterval(delay).Restart();

--- a/Assets/Script/Gameplay/Visuals/StrikelinePositioner.cs
+++ b/Assets/Script/Gameplay/Visuals/StrikelinePositioner.cs
@@ -61,6 +61,10 @@ namespace YARG.Gameplay.Visuals
                 ? basePlayer.transform.GetSiblingIndex() * LOCAL_ANIM_OFFSET + _globalAnimDelay + ANIM_FRET_ZOOM_DELAY
                 : 0f;
 
+            // Scale delay by song speed so animation completes in time at higher speeds
+            // Cap at 1 so slower speeds don't extend the delay
+            delay /= Mathf.Max(1f, _gameManager.SongSpeed);
+
             yield return DOTween.Sequence()
                 .PrependInterval(delay)
                 .Append(transform


### PR DESCRIPTION
This fixes an issue where the delay for the highway pop in was too long when playing songs on higher speeds, which means the song would start playing before we even see the strikeline.

To fix this we scale the delay by the song speed, only for when the song speed is > 100%

Video of the bug:

https://github.com/user-attachments/assets/d526aef5-1be3-47ab-a959-6fa35819acaa

Fixed:

https://github.com/user-attachments/assets/ba01b385-073a-4fbe-9f0c-e26c7b9ae152


