### PR TITLE
Fix issue where solo box was overlapping track

### DIFF
--- a/Assets/Scenes/Gameplay.unity
+++ b/Assets/Scenes/Gameplay.unity
@@ -93,10 +93,8 @@ LightmapSettings:
     m_ExportTrainingData: 0
     m_TrainingDataDestination: TrainingData
     m_LightProbeSampleCountMultiplier: 4
-  m_LightingDataAsset: {fileID: 112000000, guid: afa2442e5d810ad48a077f8d3ff8d2d5,
-    type: 2}
-  m_LightingSettings: {fileID: 4890085278179872738, guid: c261231216937354480cc047d8386db6,
-    type: 2}
+  m_LightingDataAsset: {fileID: 112000000, guid: afa2442e5d810ad48a077f8d3ff8d2d5, type: 2}
+  m_LightingSettings: {fileID: 4890085278179872738, guid: c261231216937354480cc047d8386db6, type: 2}
 --- !u!196 &4
 NavMeshSettings:
   serializedVersion: 2
@@ -327,8 +325,7 @@ MonoBehaviour:
     Very Nice.'
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: ae170e91fd29a90479e906ddffb1d8ee, type: 2}
-  m_sharedMaterial: {fileID: -5480317595949376055, guid: ae170e91fd29a90479e906ddffb1d8ee,
-    type: 2}
+  m_sharedMaterial: {fileID: -5480317595949376055, guid: ae170e91fd29a90479e906ddffb1d8ee, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -448,8 +445,7 @@ MonoBehaviour:
   _onEditModeChanged:
     m_PersistentCalls:
       m_Calls: []
-  _draggingDisplayPrefab: {fileID: 5730308542642054521, guid: 2a82983eb1a960843bd5603736f9b042,
-    type: 3}
+  _draggingDisplayPrefab: {fileID: 5730308542642054521, guid: 2a82983eb1a960843bd5603736f9b042, type: 3}
 --- !u!1 &124424924
 GameObject:
   m_ObjectHideFlags: 0
@@ -510,8 +506,7 @@ MonoBehaviour:
   m_text: 0/0
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 04973a14f12bf384f8093a8b70f63fcb, type: 2}
-  m_sharedMaterial: {fileID: -7155836927947826254, guid: 04973a14f12bf384f8093a8b70f63fcb,
-    type: 2}
+  m_sharedMaterial: {fileID: -7155836927947826254, guid: 04973a14f12bf384f8093a8b70f63fcb, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -922,8 +917,7 @@ MonoBehaviour:
   m_text: 100%
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 04973a14f12bf384f8093a8b70f63fcb, type: 2}
-  m_sharedMaterial: {fileID: -7155836927947826254, guid: 04973a14f12bf384f8093a8b70f63fcb,
-    type: 2}
+  m_sharedMaterial: {fileID: -7155836927947826254, guid: 04973a14f12bf384f8093a8b70f63fcb, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -1134,8 +1128,7 @@ MonoBehaviour:
   m_text: Section
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 21db4751dd6d460499117f8c2d3de781, type: 2}
-  m_sharedMaterial: {fileID: 1134014722335189955, guid: 21db4751dd6d460499117f8c2d3de781,
-    type: 2}
+  m_sharedMaterial: {fileID: 1134014722335189955, guid: 21db4751dd6d460499117f8c2d3de781, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -1387,17 +1380,12 @@ MonoBehaviour:
   _failMeter: {fileID: 368522003}
   <VocalTrack>k__BackingField: {fileID: 1312797156}
   ShowIndex: 0
-  _fiveFretGuitarPrefab: {fileID: 7381119128095886790, guid: 0f7a37c9e4abcad4da73b7603d4b7596,
-    type: 3}
+  _fiveFretGuitarPrefab: {fileID: 7381119128095886790, guid: 0f7a37c9e4abcad4da73b7603d4b7596, type: 3}
   _sixFretGuitarPrefab: {fileID: 0}
-  _fourLaneDrumsPrefab: {fileID: 7508612376246159914, guid: 14dfc37fcbd6e0c4ba41507437a52fea,
-    type: 3}
-  _fiveLaneDrumsPrefab: {fileID: 7912406415472637727, guid: b98748e11cf38534c814f11da4eaa863,
-    type: 3}
-  _proKeysPrefab: {fileID: 7381119128095886790, guid: 52322b4e39d4f9349a65c60a07fc1b3a,
-    type: 3}
-  _fiveLaneKeysPrefab: {fileID: 7381119128095886790, guid: 6117371a3e2df654494387fa6a3fd64a,
-    type: 3}
+  _fourLaneDrumsPrefab: {fileID: 7508612376246159914, guid: 14dfc37fcbd6e0c4ba41507437a52fea, type: 3}
+  _fiveLaneDrumsPrefab: {fileID: 7912406415472637727, guid: b98748e11cf38534c814f11da4eaa863, type: 3}
+  _proKeysPrefab: {fileID: 7381119128095886790, guid: 52322b4e39d4f9349a65c60a07fc1b3a, type: 3}
+  _fiveLaneKeysPrefab: {fileID: 7381119128095886790, guid: 6117371a3e2df654494387fa6a3fd64a, type: 3}
   _proGuitarPrefab: {fileID: 0}
 --- !u!4 &318454372
 Transform:
@@ -1503,394 +1491,315 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 484523227}
     m_Modifications:
-    - target: {fileID: 227366190812778480, guid: 039fee0ec42345d4f88c0625255415d4,
-        type: 3}
+    - target: {fileID: 227366190812778480, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 157.1503
       objectReference: {fileID: 0}
-    - target: {fileID: 1316070552520417479, guid: 039fee0ec42345d4f88c0625255415d4,
-        type: 3}
+    - target: {fileID: 1316070552520417479, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       propertyPath: m_AnchorMax.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1316070552520417479, guid: 039fee0ec42345d4f88c0625255415d4,
-        type: 3}
+    - target: {fileID: 1316070552520417479, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1316070552520417479, guid: 039fee0ec42345d4f88c0625255415d4,
-        type: 3}
+    - target: {fileID: 1316070552520417479, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1316070552520417479, guid: 039fee0ec42345d4f88c0625255415d4,
-        type: 3}
+    - target: {fileID: 1316070552520417479, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1316070552520417479, guid: 039fee0ec42345d4f88c0625255415d4,
-        type: 3}
+    - target: {fileID: 1316070552520417479, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1316070552520417479, guid: 039fee0ec42345d4f88c0625255415d4,
-        type: 3}
+    - target: {fileID: 1316070552520417479, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1335195020114372814, guid: 039fee0ec42345d4f88c0625255415d4,
-        type: 3}
+    - target: {fileID: 1335195020114372814, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1335195020114372814, guid: 039fee0ec42345d4f88c0625255415d4,
-        type: 3}
+    - target: {fileID: 1335195020114372814, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1682100932150968561, guid: 039fee0ec42345d4f88c0625255415d4,
-        type: 3}
+    - target: {fileID: 1682100932150968561, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1682100932150968561, guid: 039fee0ec42345d4f88c0625255415d4,
-        type: 3}
+    - target: {fileID: 1682100932150968561, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1682100932150968561, guid: 039fee0ec42345d4f88c0625255415d4,
-        type: 3}
+    - target: {fileID: 1682100932150968561, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1682100932150968561, guid: 039fee0ec42345d4f88c0625255415d4,
-        type: 3}
+    - target: {fileID: 1682100932150968561, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1682100932476655723, guid: 039fee0ec42345d4f88c0625255415d4,
-        type: 3}
+    - target: {fileID: 1682100932476655723, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       propertyPath: m_AnchorMax.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1682100932476655723, guid: 039fee0ec42345d4f88c0625255415d4,
-        type: 3}
+    - target: {fileID: 1682100932476655723, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1682100932476655723, guid: 039fee0ec42345d4f88c0625255415d4,
-        type: 3}
+    - target: {fileID: 1682100932476655723, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1682100932476655723, guid: 039fee0ec42345d4f88c0625255415d4,
-        type: 3}
+    - target: {fileID: 1682100932476655723, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1682100933276730677, guid: 039fee0ec42345d4f88c0625255415d4,
-        type: 3}
+    - target: {fileID: 1682100933276730677, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       propertyPath: m_Pivot.x
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1682100933276730677, guid: 039fee0ec42345d4f88c0625255415d4,
-        type: 3}
+    - target: {fileID: 1682100933276730677, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       propertyPath: m_Pivot.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1682100933276730677, guid: 039fee0ec42345d4f88c0625255415d4,
-        type: 3}
+    - target: {fileID: 1682100933276730677, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       propertyPath: m_RootOrder
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1682100933276730677, guid: 039fee0ec42345d4f88c0625255415d4,
-        type: 3}
+    - target: {fileID: 1682100933276730677, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       propertyPath: m_AnchorMax.x
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1682100933276730677, guid: 039fee0ec42345d4f88c0625255415d4,
-        type: 3}
+    - target: {fileID: 1682100933276730677, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1682100933276730677, guid: 039fee0ec42345d4f88c0625255415d4,
-        type: 3}
+    - target: {fileID: 1682100933276730677, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       propertyPath: m_AnchorMin.x
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1682100933276730677, guid: 039fee0ec42345d4f88c0625255415d4,
-        type: 3}
+    - target: {fileID: 1682100933276730677, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1682100933276730677, guid: 039fee0ec42345d4f88c0625255415d4,
-        type: 3}
+    - target: {fileID: 1682100933276730677, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       propertyPath: m_SizeDelta.x
       value: 375
       objectReference: {fileID: 0}
-    - target: {fileID: 1682100933276730677, guid: 039fee0ec42345d4f88c0625255415d4,
-        type: 3}
+    - target: {fileID: 1682100933276730677, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1682100933276730677, guid: 039fee0ec42345d4f88c0625255415d4,
-        type: 3}
+    - target: {fileID: 1682100933276730677, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1682100933276730677, guid: 039fee0ec42345d4f88c0625255415d4,
-        type: 3}
+    - target: {fileID: 1682100933276730677, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1682100933276730677, guid: 039fee0ec42345d4f88c0625255415d4,
-        type: 3}
+    - target: {fileID: 1682100933276730677, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1682100933276730677, guid: 039fee0ec42345d4f88c0625255415d4,
-        type: 3}
+    - target: {fileID: 1682100933276730677, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 1682100933276730677, guid: 039fee0ec42345d4f88c0625255415d4,
-        type: 3}
+    - target: {fileID: 1682100933276730677, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 1682100933276730677, guid: 039fee0ec42345d4f88c0625255415d4,
-        type: 3}
+    - target: {fileID: 1682100933276730677, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 1682100933276730677, guid: 039fee0ec42345d4f88c0625255415d4,
-        type: 3}
+    - target: {fileID: 1682100933276730677, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1682100933276730677, guid: 039fee0ec42345d4f88c0625255415d4,
-        type: 3}
+    - target: {fileID: 1682100933276730677, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1682100933276730677, guid: 039fee0ec42345d4f88c0625255415d4,
-        type: 3}
+    - target: {fileID: 1682100933276730677, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1682100933276730677, guid: 039fee0ec42345d4f88c0625255415d4,
-        type: 3}
+    - target: {fileID: 1682100933276730677, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1682100933276730677, guid: 039fee0ec42345d4f88c0625255415d4,
-        type: 3}
+    - target: {fileID: 1682100933276730677, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1682100933276730678, guid: 039fee0ec42345d4f88c0625255415d4,
-        type: 3}
+    - target: {fileID: 1682100933276730678, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       propertyPath: m_Name
       value: ScoreDisplay
       objectReference: {fileID: 0}
-    - target: {fileID: 1811523672907012699, guid: 039fee0ec42345d4f88c0625255415d4,
-        type: 3}
+    - target: {fileID: 1811523672907012699, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       propertyPath: m_AnchorMax.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1811523672907012699, guid: 039fee0ec42345d4f88c0625255415d4,
-        type: 3}
+    - target: {fileID: 1811523672907012699, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1811523672907012699, guid: 039fee0ec42345d4f88c0625255415d4,
-        type: 3}
+    - target: {fileID: 1811523672907012699, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1811523672907012699, guid: 039fee0ec42345d4f88c0625255415d4,
-        type: 3}
+    - target: {fileID: 1811523672907012699, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2364672318743719202, guid: 039fee0ec42345d4f88c0625255415d4,
-        type: 3}
+    - target: {fileID: 2364672318743719202, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2364672318743719202, guid: 039fee0ec42345d4f88c0625255415d4,
-        type: 3}
+    - target: {fileID: 2364672318743719202, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2364672318743719202, guid: 039fee0ec42345d4f88c0625255415d4,
-        type: 3}
+    - target: {fileID: 2364672318743719202, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2364672318743719202, guid: 039fee0ec42345d4f88c0625255415d4,
-        type: 3}
+    - target: {fileID: 2364672318743719202, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2517693471320601084, guid: 039fee0ec42345d4f88c0625255415d4,
-        type: 3}
+    - target: {fileID: 2517693471320601084, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 142.36191
       objectReference: {fileID: 0}
-    - target: {fileID: 2640522790579517911, guid: 039fee0ec42345d4f88c0625255415d4,
-        type: 3}
+    - target: {fileID: 2640522790579517911, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2640522790579517911, guid: 039fee0ec42345d4f88c0625255415d4,
-        type: 3}
+    - target: {fileID: 2640522790579517911, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2640522790579517911, guid: 039fee0ec42345d4f88c0625255415d4,
-        type: 3}
+    - target: {fileID: 2640522790579517911, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2640522790579517911, guid: 039fee0ec42345d4f88c0625255415d4,
-        type: 3}
+    - target: {fileID: 2640522790579517911, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2682894101143787795, guid: 039fee0ec42345d4f88c0625255415d4,
-        type: 3}
+    - target: {fileID: 2682894101143787795, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: -142.36188
       objectReference: {fileID: 0}
-    - target: {fileID: 2741204457898369597, guid: 039fee0ec42345d4f88c0625255415d4,
-        type: 3}
+    - target: {fileID: 2741204457898369597, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2741204457898369597, guid: 039fee0ec42345d4f88c0625255415d4,
-        type: 3}
+    - target: {fileID: 2741204457898369597, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2741204457898369597, guid: 039fee0ec42345d4f88c0625255415d4,
-        type: 3}
+    - target: {fileID: 2741204457898369597, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2741204457898369597, guid: 039fee0ec42345d4f88c0625255415d4,
-        type: 3}
+    - target: {fileID: 2741204457898369597, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2811724150528936072, guid: 039fee0ec42345d4f88c0625255415d4,
-        type: 3}
+    - target: {fileID: 2811724150528936072, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: -157.1503
       objectReference: {fileID: 0}
-    - target: {fileID: 2822374579689219237, guid: 039fee0ec42345d4f88c0625255415d4,
-        type: 3}
+    - target: {fileID: 2822374579689219237, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       propertyPath: m_AspectRatio
       value: 1.6326531
       objectReference: {fileID: 0}
-    - target: {fileID: 4345241489645973008, guid: 039fee0ec42345d4f88c0625255415d4,
-        type: 3}
+    - target: {fileID: 4345241489645973008, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       propertyPath: m_LocalScale.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4345241489645973008, guid: 039fee0ec42345d4f88c0625255415d4,
-        type: 3}
+    - target: {fileID: 4345241489645973008, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4345241489645973008, guid: 039fee0ec42345d4f88c0625255415d4,
-        type: 3}
+    - target: {fileID: 4345241489645973008, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       propertyPath: m_ConstrainProportionsScale
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4902638801293819549, guid: 039fee0ec42345d4f88c0625255415d4,
-        type: 3}
+    - target: {fileID: 4902638801293819549, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       propertyPath: m_Sprite
       value: 
-      objectReference: {fileID: 21300000, guid: ee6de1c1959ebcd4da10808ad235607a,
-        type: 3}
-    - target: {fileID: 4902638801293819549, guid: 039fee0ec42345d4f88c0625255415d4,
-        type: 3}
+      objectReference: {fileID: 21300000, guid: ee6de1c1959ebcd4da10808ad235607a, type: 3}
+    - target: {fileID: 4902638801293819549, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       propertyPath: m_Enabled
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4902638801293819549, guid: 039fee0ec42345d4f88c0625255415d4,
-        type: 3}
+    - target: {fileID: 4902638801293819549, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       propertyPath: m_UseSpriteMesh
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5682201937321367265, guid: 039fee0ec42345d4f88c0625255415d4,
-        type: 3}
+    - target: {fileID: 5682201937321367265, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       propertyPath: m_AnchorMax.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5682201937321367265, guid: 039fee0ec42345d4f88c0625255415d4,
-        type: 3}
+    - target: {fileID: 5682201937321367265, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5682201937321367265, guid: 039fee0ec42345d4f88c0625255415d4,
-        type: 3}
+    - target: {fileID: 5682201937321367265, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6081917654220247207, guid: 039fee0ec42345d4f88c0625255415d4,
-        type: 3}
+    - target: {fileID: 6081917654220247207, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 157.1503
       objectReference: {fileID: 0}
-    - target: {fileID: 6248039931172562418, guid: 039fee0ec42345d4f88c0625255415d4,
-        type: 3}
+    - target: {fileID: 6248039931172562418, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       propertyPath: m_SizeDelta.x
       value: -22.000011
       objectReference: {fileID: 0}
-    - target: {fileID: 6248039931172562418, guid: 039fee0ec42345d4f88c0625255415d4,
-        type: 3}
+    - target: {fileID: 6248039931172562418, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: -11.000006
       objectReference: {fileID: 0}
-    - target: {fileID: 6275240589393950520, guid: 039fee0ec42345d4f88c0625255415d4,
-        type: 3}
+    - target: {fileID: 6275240589393950520, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: -157.1503
       objectReference: {fileID: 0}
-    - target: {fileID: 7328250424041952305, guid: 039fee0ec42345d4f88c0625255415d4,
-        type: 3}
+    - target: {fileID: 7328250424041952305, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 142.36188
       objectReference: {fileID: 0}
-    - target: {fileID: 8416298410881916005, guid: 039fee0ec42345d4f88c0625255415d4,
-        type: 3}
+    - target: {fileID: 8416298410881916005, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8416298410881916005, guid: 039fee0ec42345d4f88c0625255415d4,
-        type: 3}
+    - target: {fileID: 8416298410881916005, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8416298410881916005, guid: 039fee0ec42345d4f88c0625255415d4,
-        type: 3}
+    - target: {fileID: 8416298410881916005, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8416298410881916005, guid: 039fee0ec42345d4f88c0625255415d4,
-        type: 3}
+    - target: {fileID: 8416298410881916005, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8915388482217552038, guid: 039fee0ec42345d4f88c0625255415d4,
-        type: 3}
+    - target: {fileID: 8915388482217552038, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       propertyPath: m_text
       value: <mspace=0.538em>99x
       objectReference: {fileID: 0}
-    - target: {fileID: 9151995171417952487, guid: 039fee0ec42345d4f88c0625255415d4,
-        type: 3}
+    - target: {fileID: 9151995171417952487, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 157.1503
       objectReference: {fileID: 0}
@@ -1898,39 +1807,31 @@ PrefabInstance:
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 3593172417950958894, guid: 039fee0ec42345d4f88c0625255415d4,
-        type: 3}
+    - targetCorrespondingSourceObject: {fileID: 3593172417950958894, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       insertIndex: -1
       addedObject: {fileID: 0}
-    - targetCorrespondingSourceObject: {fileID: 2120540831725165441, guid: 039fee0ec42345d4f88c0625255415d4,
-        type: 3}
+    - targetCorrespondingSourceObject: {fileID: 2120540831725165441, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       insertIndex: -1
       addedObject: {fileID: 0}
-    - targetCorrespondingSourceObject: {fileID: 7953424110739011922, guid: 039fee0ec42345d4f88c0625255415d4,
-        type: 3}
+    - targetCorrespondingSourceObject: {fileID: 7953424110739011922, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       insertIndex: -1
       addedObject: {fileID: 0}
-    - targetCorrespondingSourceObject: {fileID: 3669380178010122580, guid: 039fee0ec42345d4f88c0625255415d4,
-        type: 3}
+    - targetCorrespondingSourceObject: {fileID: 3669380178010122580, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       insertIndex: -1
       addedObject: {fileID: 0}
-    - targetCorrespondingSourceObject: {fileID: 908135978695701862, guid: 039fee0ec42345d4f88c0625255415d4,
-        type: 3}
+    - targetCorrespondingSourceObject: {fileID: 908135978695701862, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       insertIndex: -1
       addedObject: {fileID: 0}
-    - targetCorrespondingSourceObject: {fileID: 920019327054538305, guid: 039fee0ec42345d4f88c0625255415d4,
-        type: 3}
+    - targetCorrespondingSourceObject: {fileID: 920019327054538305, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       insertIndex: -1
       addedObject: {fileID: 0}
-    - targetCorrespondingSourceObject: {fileID: 6244827274338962148, guid: 039fee0ec42345d4f88c0625255415d4,
-        type: 3}
+    - targetCorrespondingSourceObject: {fileID: 6244827274338962148, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       insertIndex: -1
       addedObject: {fileID: 0}
   m_SourcePrefab: {fileID: 100100000, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
 --- !u!224 &329669832 stripped
 RectTransform:
-  m_CorrespondingSourceObject: {fileID: 1682100933276730677, guid: 039fee0ec42345d4f88c0625255415d4,
-    type: 3}
+  m_CorrespondingSourceObject: {fileID: 1682100933276730677, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
   m_PrefabInstance: {fileID: 329669831}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &343105999
@@ -1941,268 +1842,215 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 1323155441}
     m_Modifications:
-    - target: {fileID: 567501787953327268, guid: 96978c95a41e1f34bb1292218fac0fb1,
-        type: 3}
+    - target: {fileID: 567501787953327268, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 567501787953327268, guid: 96978c95a41e1f34bb1292218fac0fb1,
-        type: 3}
+    - target: {fileID: 567501787953327268, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 567501787953327268, guid: 96978c95a41e1f34bb1292218fac0fb1,
-        type: 3}
+    - target: {fileID: 567501787953327268, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
       propertyPath: m_SizeDelta.x
       value: 750
       objectReference: {fileID: 0}
-    - target: {fileID: 567501787953327268, guid: 96978c95a41e1f34bb1292218fac0fb1,
-        type: 3}
+    - target: {fileID: 567501787953327268, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 375
       objectReference: {fileID: 0}
-    - target: {fileID: 567501787953327268, guid: 96978c95a41e1f34bb1292218fac0fb1,
-        type: 3}
+    - target: {fileID: 567501787953327268, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -155
       objectReference: {fileID: 0}
-    - target: {fileID: 1375503429705721076, guid: 96978c95a41e1f34bb1292218fac0fb1,
-        type: 3}
+    - target: {fileID: 1375503429705721076, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1375503429705721076, guid: 96978c95a41e1f34bb1292218fac0fb1,
-        type: 3}
+    - target: {fileID: 1375503429705721076, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1375503429705721076, guid: 96978c95a41e1f34bb1292218fac0fb1,
-        type: 3}
+    - target: {fileID: 1375503429705721076, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
       propertyPath: m_SizeDelta.x
       value: 750
       objectReference: {fileID: 0}
-    - target: {fileID: 1375503429705721076, guid: 96978c95a41e1f34bb1292218fac0fb1,
-        type: 3}
+    - target: {fileID: 1375503429705721076, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 375
       objectReference: {fileID: 0}
-    - target: {fileID: 1375503429705721076, guid: 96978c95a41e1f34bb1292218fac0fb1,
-        type: 3}
+    - target: {fileID: 1375503429705721076, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -218
       objectReference: {fileID: 0}
-    - target: {fileID: 1809313104668657118, guid: 96978c95a41e1f34bb1292218fac0fb1,
-        type: 3}
+    - target: {fileID: 1809313104668657118, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1809313104668657118, guid: 96978c95a41e1f34bb1292218fac0fb1,
-        type: 3}
+    - target: {fileID: 1809313104668657118, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1809313104668657118, guid: 96978c95a41e1f34bb1292218fac0fb1,
-        type: 3}
+    - target: {fileID: 1809313104668657118, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
       propertyPath: m_SizeDelta.x
       value: 750
       objectReference: {fileID: 0}
-    - target: {fileID: 1809313104668657118, guid: 96978c95a41e1f34bb1292218fac0fb1,
-        type: 3}
+    - target: {fileID: 1809313104668657118, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 375
       objectReference: {fileID: 0}
-    - target: {fileID: 1809313104668657118, guid: 96978c95a41e1f34bb1292218fac0fb1,
-        type: 3}
+    - target: {fileID: 1809313104668657118, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -281
       objectReference: {fileID: 0}
-    - target: {fileID: 5062416941184210017, guid: 96978c95a41e1f34bb1292218fac0fb1,
-        type: 3}
+    - target: {fileID: 5062416941184210017, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5062416941184210017, guid: 96978c95a41e1f34bb1292218fac0fb1,
-        type: 3}
+    - target: {fileID: 5062416941184210017, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5062416941184210017, guid: 96978c95a41e1f34bb1292218fac0fb1,
-        type: 3}
+    - target: {fileID: 5062416941184210017, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
       propertyPath: m_SizeDelta.x
       value: 750
       objectReference: {fileID: 0}
-    - target: {fileID: 5062416941184210017, guid: 96978c95a41e1f34bb1292218fac0fb1,
-        type: 3}
+    - target: {fileID: 5062416941184210017, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 375
       objectReference: {fileID: 0}
-    - target: {fileID: 5062416941184210017, guid: 96978c95a41e1f34bb1292218fac0fb1,
-        type: 3}
+    - target: {fileID: 5062416941184210017, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -92
       objectReference: {fileID: 0}
-    - target: {fileID: 6546681381148955564, guid: 96978c95a41e1f34bb1292218fac0fb1,
-        type: 3}
+    - target: {fileID: 6546681381148955564, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
       propertyPath: m_Name
       value: QuickPlayPause
       objectReference: {fileID: 0}
-    - target: {fileID: 6546681381148955564, guid: 96978c95a41e1f34bb1292218fac0fb1,
-        type: 3}
+    - target: {fileID: 6546681381148955564, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
       propertyPath: m_IsActive
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6546681381148955567, guid: 96978c95a41e1f34bb1292218fac0fb1,
-        type: 3}
+    - target: {fileID: 6546681381148955567, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
       propertyPath: m_Pivot.x
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 6546681381148955567, guid: 96978c95a41e1f34bb1292218fac0fb1,
-        type: 3}
+    - target: {fileID: 6546681381148955567, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 6546681381148955567, guid: 96978c95a41e1f34bb1292218fac0fb1,
-        type: 3}
+    - target: {fileID: 6546681381148955567, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
       propertyPath: m_RootOrder
       value: 2
       objectReference: {fileID: 0}
-    - target: {fileID: 6546681381148955567, guid: 96978c95a41e1f34bb1292218fac0fb1,
-        type: 3}
+    - target: {fileID: 6546681381148955567, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
       propertyPath: m_AnchorMax.x
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6546681381148955567, guid: 96978c95a41e1f34bb1292218fac0fb1,
-        type: 3}
+    - target: {fileID: 6546681381148955567, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6546681381148955567, guid: 96978c95a41e1f34bb1292218fac0fb1,
-        type: 3}
+    - target: {fileID: 6546681381148955567, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
       propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6546681381148955567, guid: 96978c95a41e1f34bb1292218fac0fb1,
-        type: 3}
+    - target: {fileID: 6546681381148955567, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6546681381148955567, guid: 96978c95a41e1f34bb1292218fac0fb1,
-        type: 3}
+    - target: {fileID: 6546681381148955567, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6546681381148955567, guid: 96978c95a41e1f34bb1292218fac0fb1,
-        type: 3}
+    - target: {fileID: 6546681381148955567, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
       propertyPath: m_SizeDelta.y
       value: -250
       objectReference: {fileID: 0}
-    - target: {fileID: 6546681381148955567, guid: 96978c95a41e1f34bb1292218fac0fb1,
-        type: 3}
+    - target: {fileID: 6546681381148955567, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6546681381148955567, guid: 96978c95a41e1f34bb1292218fac0fb1,
-        type: 3}
+    - target: {fileID: 6546681381148955567, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6546681381148955567, guid: 96978c95a41e1f34bb1292218fac0fb1,
-        type: 3}
+    - target: {fileID: 6546681381148955567, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6546681381148955567, guid: 96978c95a41e1f34bb1292218fac0fb1,
-        type: 3}
+    - target: {fileID: 6546681381148955567, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6546681381148955567, guid: 96978c95a41e1f34bb1292218fac0fb1,
-        type: 3}
+    - target: {fileID: 6546681381148955567, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6546681381148955567, guid: 96978c95a41e1f34bb1292218fac0fb1,
-        type: 3}
+    - target: {fileID: 6546681381148955567, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6546681381148955567, guid: 96978c95a41e1f34bb1292218fac0fb1,
-        type: 3}
+    - target: {fileID: 6546681381148955567, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6546681381148955567, guid: 96978c95a41e1f34bb1292218fac0fb1,
-        type: 3}
+    - target: {fileID: 6546681381148955567, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6546681381148955567, guid: 96978c95a41e1f34bb1292218fac0fb1,
-        type: 3}
+    - target: {fileID: 6546681381148955567, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -125
       objectReference: {fileID: 0}
-    - target: {fileID: 6546681381148955567, guid: 96978c95a41e1f34bb1292218fac0fb1,
-        type: 3}
+    - target: {fileID: 6546681381148955567, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6546681381148955567, guid: 96978c95a41e1f34bb1292218fac0fb1,
-        type: 3}
+    - target: {fileID: 6546681381148955567, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6546681381148955567, guid: 96978c95a41e1f34bb1292218fac0fb1,
-        type: 3}
+    - target: {fileID: 6546681381148955567, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7202430947735908284, guid: 96978c95a41e1f34bb1292218fac0fb1,
-        type: 3}
+    - target: {fileID: 7202430947735908284, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7202430947735908284, guid: 96978c95a41e1f34bb1292218fac0fb1,
-        type: 3}
+    - target: {fileID: 7202430947735908284, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7202430947735908284, guid: 96978c95a41e1f34bb1292218fac0fb1,
-        type: 3}
+    - target: {fileID: 7202430947735908284, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
       propertyPath: m_SizeDelta.x
       value: 750
       objectReference: {fileID: 0}
-    - target: {fileID: 7202430947735908284, guid: 96978c95a41e1f34bb1292218fac0fb1,
-        type: 3}
+    - target: {fileID: 7202430947735908284, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 375
       objectReference: {fileID: 0}
-    - target: {fileID: 7202430947735908284, guid: 96978c95a41e1f34bb1292218fac0fb1,
-        type: 3}
+    - target: {fileID: 7202430947735908284, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -344
       objectReference: {fileID: 0}
-    - target: {fileID: 8831732612347581242, guid: 96978c95a41e1f34bb1292218fac0fb1,
-        type: 3}
+    - target: {fileID: 8831732612347581242, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8831732612347581242, guid: 96978c95a41e1f34bb1292218fac0fb1,
-        type: 3}
+    - target: {fileID: 8831732612347581242, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8831732612347581242, guid: 96978c95a41e1f34bb1292218fac0fb1,
-        type: 3}
+    - target: {fileID: 8831732612347581242, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
       propertyPath: m_SizeDelta.x
       value: 750
       objectReference: {fileID: 0}
-    - target: {fileID: 8831732612347581242, guid: 96978c95a41e1f34bb1292218fac0fb1,
-        type: 3}
+    - target: {fileID: 8831732612347581242, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 375
       objectReference: {fileID: 0}
-    - target: {fileID: 8831732612347581242, guid: 96978c95a41e1f34bb1292218fac0fb1,
-        type: 3}
+    - target: {fileID: 8831732612347581242, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -29
       objectReference: {fileID: 0}
@@ -2213,8 +2061,7 @@ PrefabInstance:
   m_SourcePrefab: {fileID: 100100000, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
 --- !u!224 &343106000 stripped
 RectTransform:
-  m_CorrespondingSourceObject: {fileID: 6546681381148955567, guid: 96978c95a41e1f34bb1292218fac0fb1,
-    type: 3}
+  m_CorrespondingSourceObject: {fileID: 6546681381148955567, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
   m_PrefabInstance: {fileID: 343105999}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &354419372
@@ -2225,118 +2072,95 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 1323155441}
     m_Modifications:
-    - target: {fileID: 4006097793978072117, guid: 303b1a6a6e4a69c478f59759e786787d,
-        type: 3}
+    - target: {fileID: 4006097793978072117, guid: 303b1a6a6e4a69c478f59759e786787d, type: 3}
       propertyPath: m_Pivot.x
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 4006097793978072117, guid: 303b1a6a6e4a69c478f59759e786787d,
-        type: 3}
+    - target: {fileID: 4006097793978072117, guid: 303b1a6a6e4a69c478f59759e786787d, type: 3}
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 4006097793978072117, guid: 303b1a6a6e4a69c478f59759e786787d,
-        type: 3}
+    - target: {fileID: 4006097793978072117, guid: 303b1a6a6e4a69c478f59759e786787d, type: 3}
       propertyPath: m_RootOrder
       value: 7
       objectReference: {fileID: 0}
-    - target: {fileID: 4006097793978072117, guid: 303b1a6a6e4a69c478f59759e786787d,
-        type: 3}
+    - target: {fileID: 4006097793978072117, guid: 303b1a6a6e4a69c478f59759e786787d, type: 3}
       propertyPath: m_AnchorMax.x
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4006097793978072117, guid: 303b1a6a6e4a69c478f59759e786787d,
-        type: 3}
+    - target: {fileID: 4006097793978072117, guid: 303b1a6a6e4a69c478f59759e786787d, type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4006097793978072117, guid: 303b1a6a6e4a69c478f59759e786787d,
-        type: 3}
+    - target: {fileID: 4006097793978072117, guid: 303b1a6a6e4a69c478f59759e786787d, type: 3}
       propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4006097793978072117, guid: 303b1a6a6e4a69c478f59759e786787d,
-        type: 3}
+    - target: {fileID: 4006097793978072117, guid: 303b1a6a6e4a69c478f59759e786787d, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4006097793978072117, guid: 303b1a6a6e4a69c478f59759e786787d,
-        type: 3}
+    - target: {fileID: 4006097793978072117, guid: 303b1a6a6e4a69c478f59759e786787d, type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4006097793978072117, guid: 303b1a6a6e4a69c478f59759e786787d,
-        type: 3}
+    - target: {fileID: 4006097793978072117, guid: 303b1a6a6e4a69c478f59759e786787d, type: 3}
       propertyPath: m_SizeDelta.y
       value: -250
       objectReference: {fileID: 0}
-    - target: {fileID: 4006097793978072117, guid: 303b1a6a6e4a69c478f59759e786787d,
-        type: 3}
+    - target: {fileID: 4006097793978072117, guid: 303b1a6a6e4a69c478f59759e786787d, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4006097793978072117, guid: 303b1a6a6e4a69c478f59759e786787d,
-        type: 3}
+    - target: {fileID: 4006097793978072117, guid: 303b1a6a6e4a69c478f59759e786787d, type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4006097793978072117, guid: 303b1a6a6e4a69c478f59759e786787d,
-        type: 3}
+    - target: {fileID: 4006097793978072117, guid: 303b1a6a6e4a69c478f59759e786787d, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4006097793978072117, guid: 303b1a6a6e4a69c478f59759e786787d,
-        type: 3}
+    - target: {fileID: 4006097793978072117, guid: 303b1a6a6e4a69c478f59759e786787d, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4006097793978072117, guid: 303b1a6a6e4a69c478f59759e786787d,
-        type: 3}
+    - target: {fileID: 4006097793978072117, guid: 303b1a6a6e4a69c478f59759e786787d, type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4006097793978072117, guid: 303b1a6a6e4a69c478f59759e786787d,
-        type: 3}
+    - target: {fileID: 4006097793978072117, guid: 303b1a6a6e4a69c478f59759e786787d, type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4006097793978072117, guid: 303b1a6a6e4a69c478f59759e786787d,
-        type: 3}
+    - target: {fileID: 4006097793978072117, guid: 303b1a6a6e4a69c478f59759e786787d, type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4006097793978072117, guid: 303b1a6a6e4a69c478f59759e786787d,
-        type: 3}
+    - target: {fileID: 4006097793978072117, guid: 303b1a6a6e4a69c478f59759e786787d, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4006097793978072117, guid: 303b1a6a6e4a69c478f59759e786787d,
-        type: 3}
+    - target: {fileID: 4006097793978072117, guid: 303b1a6a6e4a69c478f59759e786787d, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -125
       objectReference: {fileID: 0}
-    - target: {fileID: 4006097793978072117, guid: 303b1a6a6e4a69c478f59759e786787d,
-        type: 3}
+    - target: {fileID: 4006097793978072117, guid: 303b1a6a6e4a69c478f59759e786787d, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4006097793978072117, guid: 303b1a6a6e4a69c478f59759e786787d,
-        type: 3}
+    - target: {fileID: 4006097793978072117, guid: 303b1a6a6e4a69c478f59759e786787d, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4006097793978072117, guid: 303b1a6a6e4a69c478f59759e786787d,
-        type: 3}
+    - target: {fileID: 4006097793978072117, guid: 303b1a6a6e4a69c478f59759e786787d, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4006097793978072118, guid: 303b1a6a6e4a69c478f59759e786787d,
-        type: 3}
+    - target: {fileID: 4006097793978072118, guid: 303b1a6a6e4a69c478f59759e786787d, type: 3}
       propertyPath: m_Name
       value: SetlistPause
       objectReference: {fileID: 0}
-    - target: {fileID: 4006097793978072118, guid: 303b1a6a6e4a69c478f59759e786787d,
-        type: 3}
+    - target: {fileID: 4006097793978072118, guid: 303b1a6a6e4a69c478f59759e786787d, type: 3}
       propertyPath: m_IsActive
       value: 0
       objectReference: {fileID: 0}
@@ -2347,20 +2171,17 @@ PrefabInstance:
   m_SourcePrefab: {fileID: 100100000, guid: 303b1a6a6e4a69c478f59759e786787d, type: 3}
 --- !u!224 &354419373 stripped
 RectTransform:
-  m_CorrespondingSourceObject: {fileID: 4006097793978072117, guid: 303b1a6a6e4a69c478f59759e786787d,
-    type: 3}
+  m_CorrespondingSourceObject: {fileID: 4006097793978072117, guid: 303b1a6a6e4a69c478f59759e786787d, type: 3}
   m_PrefabInstance: {fileID: 354419372}
   m_PrefabAsset: {fileID: 0}
 --- !u!224 &368522001 stripped
 RectTransform:
-  m_CorrespondingSourceObject: {fileID: 8712046426310438027, guid: d0b16d99b827a28449b37e491eb7cd45,
-    type: 3}
+  m_CorrespondingSourceObject: {fileID: 8712046426310438027, guid: d0b16d99b827a28449b37e491eb7cd45, type: 3}
   m_PrefabInstance: {fileID: 1792480618}
   m_PrefabAsset: {fileID: 0}
 --- !u!114 &368522003 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 8712046426310438029, guid: d0b16d99b827a28449b37e491eb7cd45,
-    type: 3}
+  m_CorrespondingSourceObject: {fileID: 8712046426310438029, guid: d0b16d99b827a28449b37e491eb7cd45, type: 3}
   m_PrefabInstance: {fileID: 1792480618}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}
@@ -2377,193 +2198,155 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 1323155441}
     m_Modifications:
-    - target: {fileID: 407376744541711451, guid: 4855f4c81d54b8647b7db7f687c7ee43,
-        type: 3}
+    - target: {fileID: 407376744541711451, guid: 4855f4c81d54b8647b7db7f687c7ee43, type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 407376744541711451, guid: 4855f4c81d54b8647b7db7f687c7ee43,
-        type: 3}
+    - target: {fileID: 407376744541711451, guid: 4855f4c81d54b8647b7db7f687c7ee43, type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 407376744541711451, guid: 4855f4c81d54b8647b7db7f687c7ee43,
-        type: 3}
+    - target: {fileID: 407376744541711451, guid: 4855f4c81d54b8647b7db7f687c7ee43, type: 3}
       propertyPath: m_SizeDelta.x
       value: 750
       objectReference: {fileID: 0}
-    - target: {fileID: 407376744541711451, guid: 4855f4c81d54b8647b7db7f687c7ee43,
-        type: 3}
+    - target: {fileID: 407376744541711451, guid: 4855f4c81d54b8647b7db7f687c7ee43, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 375
       objectReference: {fileID: 0}
-    - target: {fileID: 407376744541711451, guid: 4855f4c81d54b8647b7db7f687c7ee43,
-        type: 3}
+    - target: {fileID: 407376744541711451, guid: 4855f4c81d54b8647b7db7f687c7ee43, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -155
       objectReference: {fileID: 0}
-    - target: {fileID: 4220475146329657928, guid: 4855f4c81d54b8647b7db7f687c7ee43,
-        type: 3}
+    - target: {fileID: 4220475146329657928, guid: 4855f4c81d54b8647b7db7f687c7ee43, type: 3}
       propertyPath: m_Pivot.x
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 4220475146329657928, guid: 4855f4c81d54b8647b7db7f687c7ee43,
-        type: 3}
+    - target: {fileID: 4220475146329657928, guid: 4855f4c81d54b8647b7db7f687c7ee43, type: 3}
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 4220475146329657928, guid: 4855f4c81d54b8647b7db7f687c7ee43,
-        type: 3}
+    - target: {fileID: 4220475146329657928, guid: 4855f4c81d54b8647b7db7f687c7ee43, type: 3}
       propertyPath: m_RootOrder
       value: 6
       objectReference: {fileID: 0}
-    - target: {fileID: 4220475146329657928, guid: 4855f4c81d54b8647b7db7f687c7ee43,
-        type: 3}
+    - target: {fileID: 4220475146329657928, guid: 4855f4c81d54b8647b7db7f687c7ee43, type: 3}
       propertyPath: m_AnchorMax.x
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4220475146329657928, guid: 4855f4c81d54b8647b7db7f687c7ee43,
-        type: 3}
+    - target: {fileID: 4220475146329657928, guid: 4855f4c81d54b8647b7db7f687c7ee43, type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4220475146329657928, guid: 4855f4c81d54b8647b7db7f687c7ee43,
-        type: 3}
+    - target: {fileID: 4220475146329657928, guid: 4855f4c81d54b8647b7db7f687c7ee43, type: 3}
       propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4220475146329657928, guid: 4855f4c81d54b8647b7db7f687c7ee43,
-        type: 3}
+    - target: {fileID: 4220475146329657928, guid: 4855f4c81d54b8647b7db7f687c7ee43, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4220475146329657928, guid: 4855f4c81d54b8647b7db7f687c7ee43,
-        type: 3}
+    - target: {fileID: 4220475146329657928, guid: 4855f4c81d54b8647b7db7f687c7ee43, type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4220475146329657928, guid: 4855f4c81d54b8647b7db7f687c7ee43,
-        type: 3}
+    - target: {fileID: 4220475146329657928, guid: 4855f4c81d54b8647b7db7f687c7ee43, type: 3}
       propertyPath: m_SizeDelta.y
       value: -250
       objectReference: {fileID: 0}
-    - target: {fileID: 4220475146329657928, guid: 4855f4c81d54b8647b7db7f687c7ee43,
-        type: 3}
+    - target: {fileID: 4220475146329657928, guid: 4855f4c81d54b8647b7db7f687c7ee43, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4220475146329657928, guid: 4855f4c81d54b8647b7db7f687c7ee43,
-        type: 3}
+    - target: {fileID: 4220475146329657928, guid: 4855f4c81d54b8647b7db7f687c7ee43, type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4220475146329657928, guid: 4855f4c81d54b8647b7db7f687c7ee43,
-        type: 3}
+    - target: {fileID: 4220475146329657928, guid: 4855f4c81d54b8647b7db7f687c7ee43, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4220475146329657928, guid: 4855f4c81d54b8647b7db7f687c7ee43,
-        type: 3}
+    - target: {fileID: 4220475146329657928, guid: 4855f4c81d54b8647b7db7f687c7ee43, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4220475146329657928, guid: 4855f4c81d54b8647b7db7f687c7ee43,
-        type: 3}
+    - target: {fileID: 4220475146329657928, guid: 4855f4c81d54b8647b7db7f687c7ee43, type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4220475146329657928, guid: 4855f4c81d54b8647b7db7f687c7ee43,
-        type: 3}
+    - target: {fileID: 4220475146329657928, guid: 4855f4c81d54b8647b7db7f687c7ee43, type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4220475146329657928, guid: 4855f4c81d54b8647b7db7f687c7ee43,
-        type: 3}
+    - target: {fileID: 4220475146329657928, guid: 4855f4c81d54b8647b7db7f687c7ee43, type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4220475146329657928, guid: 4855f4c81d54b8647b7db7f687c7ee43,
-        type: 3}
+    - target: {fileID: 4220475146329657928, guid: 4855f4c81d54b8647b7db7f687c7ee43, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4220475146329657928, guid: 4855f4c81d54b8647b7db7f687c7ee43,
-        type: 3}
+    - target: {fileID: 4220475146329657928, guid: 4855f4c81d54b8647b7db7f687c7ee43, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -125
       objectReference: {fileID: 0}
-    - target: {fileID: 4220475146329657928, guid: 4855f4c81d54b8647b7db7f687c7ee43,
-        type: 3}
+    - target: {fileID: 4220475146329657928, guid: 4855f4c81d54b8647b7db7f687c7ee43, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4220475146329657928, guid: 4855f4c81d54b8647b7db7f687c7ee43,
-        type: 3}
+    - target: {fileID: 4220475146329657928, guid: 4855f4c81d54b8647b7db7f687c7ee43, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4220475146329657928, guid: 4855f4c81d54b8647b7db7f687c7ee43,
-        type: 3}
+    - target: {fileID: 4220475146329657928, guid: 4855f4c81d54b8647b7db7f687c7ee43, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4220475146329657931, guid: 4855f4c81d54b8647b7db7f687c7ee43,
-        type: 3}
+    - target: {fileID: 4220475146329657931, guid: 4855f4c81d54b8647b7db7f687c7ee43, type: 3}
       propertyPath: m_Name
       value: QuickSettings
       objectReference: {fileID: 0}
-    - target: {fileID: 4220475146329657931, guid: 4855f4c81d54b8647b7db7f687c7ee43,
-        type: 3}
+    - target: {fileID: 4220475146329657931, guid: 4855f4c81d54b8647b7db7f687c7ee43, type: 3}
       propertyPath: m_IsActive
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5734763326058268183, guid: 4855f4c81d54b8647b7db7f687c7ee43,
-        type: 3}
+    - target: {fileID: 5734763326058268183, guid: 4855f4c81d54b8647b7db7f687c7ee43, type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5734763326058268183, guid: 4855f4c81d54b8647b7db7f687c7ee43,
-        type: 3}
+    - target: {fileID: 5734763326058268183, guid: 4855f4c81d54b8647b7db7f687c7ee43, type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5734763326058268183, guid: 4855f4c81d54b8647b7db7f687c7ee43,
-        type: 3}
+    - target: {fileID: 5734763326058268183, guid: 4855f4c81d54b8647b7db7f687c7ee43, type: 3}
       propertyPath: m_SizeDelta.x
       value: 750
       objectReference: {fileID: 0}
-    - target: {fileID: 5734763326058268183, guid: 4855f4c81d54b8647b7db7f687c7ee43,
-        type: 3}
+    - target: {fileID: 5734763326058268183, guid: 4855f4c81d54b8647b7db7f687c7ee43, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 375
       objectReference: {fileID: 0}
-    - target: {fileID: 5734763326058268183, guid: 4855f4c81d54b8647b7db7f687c7ee43,
-        type: 3}
+    - target: {fileID: 5734763326058268183, guid: 4855f4c81d54b8647b7db7f687c7ee43, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -29
       objectReference: {fileID: 0}
-    - target: {fileID: 8095661284169053984, guid: 4855f4c81d54b8647b7db7f687c7ee43,
-        type: 3}
+    - target: {fileID: 8095661284169053984, guid: 4855f4c81d54b8647b7db7f687c7ee43, type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8095661284169053984, guid: 4855f4c81d54b8647b7db7f687c7ee43,
-        type: 3}
+    - target: {fileID: 8095661284169053984, guid: 4855f4c81d54b8647b7db7f687c7ee43, type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8095661284169053984, guid: 4855f4c81d54b8647b7db7f687c7ee43,
-        type: 3}
+    - target: {fileID: 8095661284169053984, guid: 4855f4c81d54b8647b7db7f687c7ee43, type: 3}
       propertyPath: m_SizeDelta.x
       value: 750
       objectReference: {fileID: 0}
-    - target: {fileID: 8095661284169053984, guid: 4855f4c81d54b8647b7db7f687c7ee43,
-        type: 3}
+    - target: {fileID: 8095661284169053984, guid: 4855f4c81d54b8647b7db7f687c7ee43, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 375
       objectReference: {fileID: 0}
-    - target: {fileID: 8095661284169053984, guid: 4855f4c81d54b8647b7db7f687c7ee43,
-        type: 3}
+    - target: {fileID: 8095661284169053984, guid: 4855f4c81d54b8647b7db7f687c7ee43, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -92
       objectReference: {fileID: 0}
@@ -2574,8 +2357,7 @@ PrefabInstance:
   m_SourcePrefab: {fileID: 100100000, guid: 4855f4c81d54b8647b7db7f687c7ee43, type: 3}
 --- !u!224 &387423407 stripped
 RectTransform:
-  m_CorrespondingSourceObject: {fileID: 4220475146329657928, guid: 4855f4c81d54b8647b7db7f687c7ee43,
-    type: 3}
+  m_CorrespondingSourceObject: {fileID: 4220475146329657928, guid: 4855f4c81d54b8647b7db7f687c7ee43, type: 3}
   m_PrefabInstance: {fileID: 387423406}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &396166999
@@ -2586,713 +2368,571 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 397042284}
     m_Modifications:
-    - target: {fileID: 923944859560468810, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 923944859560468810, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 923944859560468810, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 923944859560468810, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 923944859560468810, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 923944859560468810, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 50
       objectReference: {fileID: 0}
-    - target: {fileID: 923944859560468810, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 923944859560468810, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -145
       objectReference: {fileID: 0}
-    - target: {fileID: 1015521776706112280, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 1015521776706112280, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1015521776706112280, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 1015521776706112280, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1015521776706112280, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 1015521776706112280, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 50
       objectReference: {fileID: 0}
-    - target: {fileID: 1015521776706112280, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 1015521776706112280, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -145
       objectReference: {fileID: 0}
-    - target: {fileID: 1804228161284093612, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 1804228161284093612, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1804228161284093612, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 1804228161284093612, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1804228161284093612, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 1804228161284093612, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 50
       objectReference: {fileID: 0}
-    - target: {fileID: 1804228161284093612, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 1804228161284093612, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -80
       objectReference: {fileID: 0}
-    - target: {fileID: 1863211756566059682, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 1863211756566059682, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1863211756566059682, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 1863211756566059682, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1863211756566059682, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 1863211756566059682, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_SizeDelta.y
       value: 160
       objectReference: {fileID: 0}
-    - target: {fileID: 1863211756566059682, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 1863211756566059682, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 250
       objectReference: {fileID: 0}
-    - target: {fileID: 1863211756566059682, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 1863211756566059682, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -50
       objectReference: {fileID: 0}
-    - target: {fileID: 2003185583018712318, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 2003185583018712318, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2003185583018712318, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 2003185583018712318, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2003185583018712318, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 2003185583018712318, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 50
       objectReference: {fileID: 0}
-    - target: {fileID: 2003185583018712318, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 2003185583018712318, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -80
       objectReference: {fileID: 0}
-    - target: {fileID: 2032747772109177108, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 2032747772109177108, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2032747772109177108, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 2032747772109177108, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2032747772109177108, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 2032747772109177108, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 50
       objectReference: {fileID: 0}
-    - target: {fileID: 2032747772109177108, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 2032747772109177108, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -15
       objectReference: {fileID: 0}
-    - target: {fileID: 2229453393495288646, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 2229453393495288646, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2229453393495288646, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 2229453393495288646, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2229453393495288646, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 2229453393495288646, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 50
       objectReference: {fileID: 0}
-    - target: {fileID: 2229453393495288646, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 2229453393495288646, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -15
       objectReference: {fileID: 0}
-    - target: {fileID: 2530718889766638275, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 2530718889766638275, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2530718889766638275, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 2530718889766638275, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2530718889766638275, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 2530718889766638275, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_SizeDelta.y
       value: 160
       objectReference: {fileID: 0}
-    - target: {fileID: 2530718889766638275, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 2530718889766638275, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 50
       objectReference: {fileID: 0}
-    - target: {fileID: 2530718889766638275, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 2530718889766638275, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -50
       objectReference: {fileID: 0}
-    - target: {fileID: 2570460951685009712, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 2570460951685009712, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2570460951685009712, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 2570460951685009712, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2570460951685009712, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 2570460951685009712, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 50
       objectReference: {fileID: 0}
-    - target: {fileID: 2570460951685009712, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 2570460951685009712, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -15
       objectReference: {fileID: 0}
-    - target: {fileID: 2618112443279854810, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 2618112443279854810, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2618112443279854810, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 2618112443279854810, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2618112443279854810, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 2618112443279854810, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 50
       objectReference: {fileID: 0}
-    - target: {fileID: 2618112443279854810, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 2618112443279854810, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -80
       objectReference: {fileID: 0}
-    - target: {fileID: 2989169099748620477, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 2989169099748620477, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2989169099748620477, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 2989169099748620477, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2989169099748620477, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 2989169099748620477, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 50
       objectReference: {fileID: 0}
-    - target: {fileID: 2989169099748620477, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 2989169099748620477, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -80
       objectReference: {fileID: 0}
-    - target: {fileID: 3351472579802850647, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 3351472579802850647, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3351472579802850647, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 3351472579802850647, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3351472579802850647, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 3351472579802850647, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 50
       objectReference: {fileID: 0}
-    - target: {fileID: 3351472579802850647, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 3351472579802850647, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -15
       objectReference: {fileID: 0}
-    - target: {fileID: 3412701907868381659, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 3412701907868381659, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3412701907868381659, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 3412701907868381659, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3412701907868381659, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 3412701907868381659, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 50
       objectReference: {fileID: 0}
-    - target: {fileID: 3412701907868381659, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 3412701907868381659, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -145
       objectReference: {fileID: 0}
-    - target: {fileID: 3696148239668228462, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 3696148239668228462, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3696148239668228462, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 3696148239668228462, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3696148239668228462, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 3696148239668228462, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 50
       objectReference: {fileID: 0}
-    - target: {fileID: 3696148239668228462, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 3696148239668228462, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -145
       objectReference: {fileID: 0}
-    - target: {fileID: 4053914855838518383, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 4053914855838518383, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4053914855838518383, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 4053914855838518383, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4053914855838518383, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 4053914855838518383, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 50
       objectReference: {fileID: 0}
-    - target: {fileID: 4053914855838518383, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 4053914855838518383, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -80
       objectReference: {fileID: 0}
-    - target: {fileID: 4496163825672963337, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 4496163825672963337, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4496163825672963337, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 4496163825672963337, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4496163825672963337, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 4496163825672963337, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 50
       objectReference: {fileID: 0}
-    - target: {fileID: 4496163825672963337, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 4496163825672963337, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -145
       objectReference: {fileID: 0}
-    - target: {fileID: 4550537150001708835, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 4550537150001708835, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_Name
       value: FiveFretViewer
       objectReference: {fileID: 0}
-    - target: {fileID: 4550537150001708835, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 4550537150001708835, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_IsActive
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4592297151973052805, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 4592297151973052805, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4592297151973052805, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 4592297151973052805, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4592297151973052805, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 4592297151973052805, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 50
       objectReference: {fileID: 0}
-    - target: {fileID: 4592297151973052805, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 4592297151973052805, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -15
       objectReference: {fileID: 0}
-    - target: {fileID: 4773576581307856199, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 4773576581307856199, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_Pivot.x
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 4773576581307856199, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 4773576581307856199, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 4773576581307856199, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 4773576581307856199, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_RootOrder
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4773576581307856199, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 4773576581307856199, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchorMax.x
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 4773576581307856199, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 4773576581307856199, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4773576581307856199, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 4773576581307856199, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchorMin.x
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 4773576581307856199, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 4773576581307856199, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4773576581307856199, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 4773576581307856199, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_SizeDelta.x
       value: 700
       objectReference: {fileID: 0}
-    - target: {fileID: 4773576581307856199, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 4773576581307856199, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_SizeDelta.y
       value: 100
       objectReference: {fileID: 0}
-    - target: {fileID: 4773576581307856199, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 4773576581307856199, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4773576581307856199, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 4773576581307856199, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4773576581307856199, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 4773576581307856199, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4773576581307856199, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 4773576581307856199, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4773576581307856199, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 4773576581307856199, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4773576581307856199, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 4773576581307856199, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4773576581307856199, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 4773576581307856199, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4773576581307856199, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 4773576581307856199, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4773576581307856199, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 4773576581307856199, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -207
       objectReference: {fileID: 0}
-    - target: {fileID: 4773576581307856199, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 4773576581307856199, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4773576581307856199, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 4773576581307856199, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4773576581307856199, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 4773576581307856199, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4809495223790543464, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 4809495223790543464, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4809495223790543464, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 4809495223790543464, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4809495223790543464, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 4809495223790543464, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_SizeDelta.y
       value: 160
       objectReference: {fileID: 0}
-    - target: {fileID: 4809495223790543464, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 4809495223790543464, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 150
       objectReference: {fileID: 0}
-    - target: {fileID: 4809495223790543464, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 4809495223790543464, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -50
       objectReference: {fileID: 0}
-    - target: {fileID: 5249931034455656470, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 5249931034455656470, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5249931034455656470, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 5249931034455656470, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5249931034455656470, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 5249931034455656470, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 50
       objectReference: {fileID: 0}
-    - target: {fileID: 5249931034455656470, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 5249931034455656470, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -80
       objectReference: {fileID: 0}
-    - target: {fileID: 5702396662984218108, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 5702396662984218108, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5702396662984218108, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 5702396662984218108, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5702396662984218108, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 5702396662984218108, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 50
       objectReference: {fileID: 0}
-    - target: {fileID: 5702396662984218108, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 5702396662984218108, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -15
       objectReference: {fileID: 0}
-    - target: {fileID: 5733096055400551951, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 5733096055400551951, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5733096055400551951, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 5733096055400551951, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5733096055400551951, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 5733096055400551951, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_SizeDelta.y
       value: 160
       objectReference: {fileID: 0}
-    - target: {fileID: 5733096055400551951, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 5733096055400551951, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 650
       objectReference: {fileID: 0}
-    - target: {fileID: 5733096055400551951, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 5733096055400551951, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -50
       objectReference: {fileID: 0}
-    - target: {fileID: 6018793775768344250, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 6018793775768344250, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6018793775768344250, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 6018793775768344250, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6018793775768344250, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 6018793775768344250, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_SizeDelta.y
       value: 160
       objectReference: {fileID: 0}
-    - target: {fileID: 6018793775768344250, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 6018793775768344250, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 350
       objectReference: {fileID: 0}
-    - target: {fileID: 6018793775768344250, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 6018793775768344250, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -50
       objectReference: {fileID: 0}
-    - target: {fileID: 6901128905896408482, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 6901128905896408482, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6901128905896408482, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 6901128905896408482, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6901128905896408482, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 6901128905896408482, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 50
       objectReference: {fileID: 0}
-    - target: {fileID: 6901128905896408482, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 6901128905896408482, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -145
       objectReference: {fileID: 0}
-    - target: {fileID: 7277854903345118659, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 7277854903345118659, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7277854903345118659, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 7277854903345118659, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7277854903345118659, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 7277854903345118659, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 50
       objectReference: {fileID: 0}
-    - target: {fileID: 7277854903345118659, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 7277854903345118659, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -145
       objectReference: {fileID: 0}
-    - target: {fileID: 8073218781510207019, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 8073218781510207019, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8073218781510207019, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 8073218781510207019, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8073218781510207019, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 8073218781510207019, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_SizeDelta.y
       value: 160
       objectReference: {fileID: 0}
-    - target: {fileID: 8073218781510207019, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 8073218781510207019, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 450
       objectReference: {fileID: 0}
-    - target: {fileID: 8073218781510207019, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 8073218781510207019, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -50
       objectReference: {fileID: 0}
-    - target: {fileID: 8223043098546897015, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 8223043098546897015, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8223043098546897015, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 8223043098546897015, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8223043098546897015, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 8223043098546897015, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 50
       objectReference: {fileID: 0}
-    - target: {fileID: 8223043098546897015, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 8223043098546897015, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -80
       objectReference: {fileID: 0}
-    - target: {fileID: 8272141569167338617, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 8272141569167338617, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8272141569167338617, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 8272141569167338617, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8272141569167338617, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 8272141569167338617, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_SizeDelta.y
       value: 160
       objectReference: {fileID: 0}
-    - target: {fileID: 8272141569167338617, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 8272141569167338617, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 550
       objectReference: {fileID: 0}
-    - target: {fileID: 8272141569167338617, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 8272141569167338617, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -50
       objectReference: {fileID: 0}
-    - target: {fileID: 8495871208499633565, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 8495871208499633565, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8495871208499633565, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 8495871208499633565, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8495871208499633565, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 8495871208499633565, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 50
       objectReference: {fileID: 0}
-    - target: {fileID: 8495871208499633565, guid: 72eef77c01b66604696836c2b02cb1e1,
-        type: 3}
+    - target: {fileID: 8495871208499633565, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -15
       objectReference: {fileID: 0}
@@ -3364,83 +3004,67 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 1517088745}
     m_Modifications:
-    - target: {fileID: 3967995507941194808, guid: 249f3206655c65946a0f15b17834fca4,
-        type: 3}
+    - target: {fileID: 3967995507941194808, guid: 249f3206655c65946a0f15b17834fca4, type: 3}
       propertyPath: m_RootOrder
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3967995507941194808, guid: 249f3206655c65946a0f15b17834fca4,
-        type: 3}
+    - target: {fileID: 3967995507941194808, guid: 249f3206655c65946a0f15b17834fca4, type: 3}
       propertyPath: m_LocalScale.x
       value: 1.5
       objectReference: {fileID: 0}
-    - target: {fileID: 3967995507941194808, guid: 249f3206655c65946a0f15b17834fca4,
-        type: 3}
+    - target: {fileID: 3967995507941194808, guid: 249f3206655c65946a0f15b17834fca4, type: 3}
       propertyPath: m_LocalScale.y
       value: 1.5
       objectReference: {fileID: 0}
-    - target: {fileID: 3967995507941194808, guid: 249f3206655c65946a0f15b17834fca4,
-        type: 3}
+    - target: {fileID: 3967995507941194808, guid: 249f3206655c65946a0f15b17834fca4, type: 3}
       propertyPath: m_LocalScale.z
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3967995507941194808, guid: 249f3206655c65946a0f15b17834fca4,
-        type: 3}
+    - target: {fileID: 3967995507941194808, guid: 249f3206655c65946a0f15b17834fca4, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3967995507941194808, guid: 249f3206655c65946a0f15b17834fca4,
-        type: 3}
+    - target: {fileID: 3967995507941194808, guid: 249f3206655c65946a0f15b17834fca4, type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3967995507941194808, guid: 249f3206655c65946a0f15b17834fca4,
-        type: 3}
+    - target: {fileID: 3967995507941194808, guid: 249f3206655c65946a0f15b17834fca4, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3967995507941194808, guid: 249f3206655c65946a0f15b17834fca4,
-        type: 3}
+    - target: {fileID: 3967995507941194808, guid: 249f3206655c65946a0f15b17834fca4, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3967995507941194808, guid: 249f3206655c65946a0f15b17834fca4,
-        type: 3}
+    - target: {fileID: 3967995507941194808, guid: 249f3206655c65946a0f15b17834fca4, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 3967995507941194808, guid: 249f3206655c65946a0f15b17834fca4,
-        type: 3}
+    - target: {fileID: 3967995507941194808, guid: 249f3206655c65946a0f15b17834fca4, type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 3967995507941194808, guid: 249f3206655c65946a0f15b17834fca4,
-        type: 3}
+    - target: {fileID: 3967995507941194808, guid: 249f3206655c65946a0f15b17834fca4, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 3967995507941194808, guid: 249f3206655c65946a0f15b17834fca4,
-        type: 3}
+    - target: {fileID: 3967995507941194808, guid: 249f3206655c65946a0f15b17834fca4, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3967995507941194808, guid: 249f3206655c65946a0f15b17834fca4,
-        type: 3}
+    - target: {fileID: 3967995507941194808, guid: 249f3206655c65946a0f15b17834fca4, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3967995507941194808, guid: 249f3206655c65946a0f15b17834fca4,
-        type: 3}
+    - target: {fileID: 3967995507941194808, guid: 249f3206655c65946a0f15b17834fca4, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3967995507941194808, guid: 249f3206655c65946a0f15b17834fca4,
-        type: 3}
+    - target: {fileID: 3967995507941194808, guid: 249f3206655c65946a0f15b17834fca4, type: 3}
       propertyPath: m_ConstrainProportionsScale
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4618290287218134900, guid: 249f3206655c65946a0f15b17834fca4,
-        type: 3}
+    - target: {fileID: 4618290287218134900, guid: 249f3206655c65946a0f15b17834fca4, type: 3}
       propertyPath: m_Name
       value: CountdownDisplay
       objectReference: {fileID: 0}
@@ -3451,8 +3075,7 @@ PrefabInstance:
   m_SourcePrefab: {fileID: 100100000, guid: 249f3206655c65946a0f15b17834fca4, type: 3}
 --- !u!114 &412813830 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 4549246668167681472, guid: 249f3206655c65946a0f15b17834fca4,
-    type: 3}
+  m_CorrespondingSourceObject: {fileID: 4549246668167681472, guid: 249f3206655c65946a0f15b17834fca4, type: 3}
   m_PrefabInstance: {fileID: 412813829}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}
@@ -3463,14 +3086,12 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
 --- !u!4 &412813831 stripped
 Transform:
-  m_CorrespondingSourceObject: {fileID: 3967995507941194808, guid: 249f3206655c65946a0f15b17834fca4,
-    type: 3}
+  m_CorrespondingSourceObject: {fileID: 3967995507941194808, guid: 249f3206655c65946a0f15b17834fca4, type: 3}
   m_PrefabInstance: {fileID: 412813829}
   m_PrefabAsset: {fileID: 0}
 --- !u!1 &417575064 stripped
 GameObject:
-  m_CorrespondingSourceObject: {fileID: 1682100933276730678, guid: 039fee0ec42345d4f88c0625255415d4,
-    type: 3}
+  m_CorrespondingSourceObject: {fileID: 1682100933276730678, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
   m_PrefabInstance: {fileID: 329669831}
   m_PrefabAsset: {fileID: 0}
 --- !u!1 &417693871
@@ -3533,8 +3154,7 @@ MonoBehaviour:
   m_text: 
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 04973a14f12bf384f8093a8b70f63fcb, type: 2}
-  m_sharedMaterial: {fileID: -7155836927947826254, guid: 04973a14f12bf384f8093a8b70f63fcb,
-    type: 2}
+  m_sharedMaterial: {fileID: -7155836927947826254, guid: 04973a14f12bf384f8093a8b70f63fcb, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -3667,7 +3287,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Texture: {fileID: 892436425}
+  m_Texture: {fileID: 1963028385}
   m_UVRect:
     serializedVersion: 2
     x: 0
@@ -3690,118 +3310,95 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 1323155441}
     m_Modifications:
-    - target: {fileID: 3138315878222825538, guid: 52629a15f11ae49448efe5f7f4af230c,
-        type: 3}
+    - target: {fileID: 3138315878222825538, guid: 52629a15f11ae49448efe5f7f4af230c, type: 3}
       propertyPath: m_Pivot.x
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 3138315878222825538, guid: 52629a15f11ae49448efe5f7f4af230c,
-        type: 3}
+    - target: {fileID: 3138315878222825538, guid: 52629a15f11ae49448efe5f7f4af230c, type: 3}
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 3138315878222825538, guid: 52629a15f11ae49448efe5f7f4af230c,
-        type: 3}
+    - target: {fileID: 3138315878222825538, guid: 52629a15f11ae49448efe5f7f4af230c, type: 3}
       propertyPath: m_RootOrder
       value: 4
       objectReference: {fileID: 0}
-    - target: {fileID: 3138315878222825538, guid: 52629a15f11ae49448efe5f7f4af230c,
-        type: 3}
+    - target: {fileID: 3138315878222825538, guid: 52629a15f11ae49448efe5f7f4af230c, type: 3}
       propertyPath: m_AnchorMax.x
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3138315878222825538, guid: 52629a15f11ae49448efe5f7f4af230c,
-        type: 3}
+    - target: {fileID: 3138315878222825538, guid: 52629a15f11ae49448efe5f7f4af230c, type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3138315878222825538, guid: 52629a15f11ae49448efe5f7f4af230c,
-        type: 3}
+    - target: {fileID: 3138315878222825538, guid: 52629a15f11ae49448efe5f7f4af230c, type: 3}
       propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3138315878222825538, guid: 52629a15f11ae49448efe5f7f4af230c,
-        type: 3}
+    - target: {fileID: 3138315878222825538, guid: 52629a15f11ae49448efe5f7f4af230c, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3138315878222825538, guid: 52629a15f11ae49448efe5f7f4af230c,
-        type: 3}
+    - target: {fileID: 3138315878222825538, guid: 52629a15f11ae49448efe5f7f4af230c, type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3138315878222825538, guid: 52629a15f11ae49448efe5f7f4af230c,
-        type: 3}
+    - target: {fileID: 3138315878222825538, guid: 52629a15f11ae49448efe5f7f4af230c, type: 3}
       propertyPath: m_SizeDelta.y
       value: -250
       objectReference: {fileID: 0}
-    - target: {fileID: 3138315878222825538, guid: 52629a15f11ae49448efe5f7f4af230c,
-        type: 3}
+    - target: {fileID: 3138315878222825538, guid: 52629a15f11ae49448efe5f7f4af230c, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3138315878222825538, guid: 52629a15f11ae49448efe5f7f4af230c,
-        type: 3}
+    - target: {fileID: 3138315878222825538, guid: 52629a15f11ae49448efe5f7f4af230c, type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3138315878222825538, guid: 52629a15f11ae49448efe5f7f4af230c,
-        type: 3}
+    - target: {fileID: 3138315878222825538, guid: 52629a15f11ae49448efe5f7f4af230c, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3138315878222825538, guid: 52629a15f11ae49448efe5f7f4af230c,
-        type: 3}
+    - target: {fileID: 3138315878222825538, guid: 52629a15f11ae49448efe5f7f4af230c, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3138315878222825538, guid: 52629a15f11ae49448efe5f7f4af230c,
-        type: 3}
+    - target: {fileID: 3138315878222825538, guid: 52629a15f11ae49448efe5f7f4af230c, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 3138315878222825538, guid: 52629a15f11ae49448efe5f7f4af230c,
-        type: 3}
+    - target: {fileID: 3138315878222825538, guid: 52629a15f11ae49448efe5f7f4af230c, type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 3138315878222825538, guid: 52629a15f11ae49448efe5f7f4af230c,
-        type: 3}
+    - target: {fileID: 3138315878222825538, guid: 52629a15f11ae49448efe5f7f4af230c, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 3138315878222825538, guid: 52629a15f11ae49448efe5f7f4af230c,
-        type: 3}
+    - target: {fileID: 3138315878222825538, guid: 52629a15f11ae49448efe5f7f4af230c, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3138315878222825538, guid: 52629a15f11ae49448efe5f7f4af230c,
-        type: 3}
+    - target: {fileID: 3138315878222825538, guid: 52629a15f11ae49448efe5f7f4af230c, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -125
       objectReference: {fileID: 0}
-    - target: {fileID: 3138315878222825538, guid: 52629a15f11ae49448efe5f7f4af230c,
-        type: 3}
+    - target: {fileID: 3138315878222825538, guid: 52629a15f11ae49448efe5f7f4af230c, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3138315878222825538, guid: 52629a15f11ae49448efe5f7f4af230c,
-        type: 3}
+    - target: {fileID: 3138315878222825538, guid: 52629a15f11ae49448efe5f7f4af230c, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3138315878222825538, guid: 52629a15f11ae49448efe5f7f4af230c,
-        type: 3}
+    - target: {fileID: 3138315878222825538, guid: 52629a15f11ae49448efe5f7f4af230c, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3138315878222825539, guid: 52629a15f11ae49448efe5f7f4af230c,
-        type: 3}
+    - target: {fileID: 3138315878222825539, guid: 52629a15f11ae49448efe5f7f4af230c, type: 3}
       propertyPath: m_Name
       value: SelectSections
       objectReference: {fileID: 0}
-    - target: {fileID: 3138315878222825539, guid: 52629a15f11ae49448efe5f7f4af230c,
-        type: 3}
+    - target: {fileID: 3138315878222825539, guid: 52629a15f11ae49448efe5f7f4af230c, type: 3}
       propertyPath: m_IsActive
       value: 0
       objectReference: {fileID: 0}
@@ -3812,8 +3409,7 @@ PrefabInstance:
   m_SourcePrefab: {fileID: 100100000, guid: 52629a15f11ae49448efe5f7f4af230c, type: 3}
 --- !u!224 &459816309 stripped
 RectTransform:
-  m_CorrespondingSourceObject: {fileID: 3138315878222825538, guid: 52629a15f11ae49448efe5f7f4af230c,
-    type: 3}
+  m_CorrespondingSourceObject: {fileID: 3138315878222825538, guid: 52629a15f11ae49448efe5f7f4af230c, type: 3}
   m_PrefabInstance: {fileID: 459816308}
   m_PrefabAsset: {fileID: 0}
 --- !u!1 &477816501
@@ -3876,8 +3472,7 @@ MonoBehaviour:
   m_text: 0%
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 04973a14f12bf384f8093a8b70f63fcb, type: 2}
-  m_sharedMaterial: {fileID: -7155836927947826254, guid: 04973a14f12bf384f8093a8b70f63fcb,
-    type: 2}
+  m_sharedMaterial: {fileID: -7155836927947826254, guid: 04973a14f12bf384f8093a8b70f63fcb, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -4050,8 +3645,7 @@ MonoBehaviour:
   _onEditModeChanged:
     m_PersistentCalls:
       m_Calls: []
-  _draggingDisplayPrefab: {fileID: 5730308542642054521, guid: 2a82983eb1a960843bd5603736f9b042,
-    type: 3}
+  _draggingDisplayPrefab: {fileID: 5730308542642054521, guid: 2a82983eb1a960843bd5603736f9b042, type: 3}
 --- !u!1 &523103389
 GameObject:
   m_ObjectHideFlags: 0
@@ -4112,8 +3706,7 @@ MonoBehaviour:
   m_text: Speed
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 21db4751dd6d460499117f8c2d3de781, type: 2}
-  m_sharedMaterial: {fileID: 1134014722335189955, guid: 21db4751dd6d460499117f8c2d3de781,
-    type: 2}
+  m_sharedMaterial: {fileID: 1134014722335189955, guid: 21db4751dd6d460499117f8c2d3de781, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -4380,8 +3973,7 @@ MonoBehaviour:
   m_text: Album
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: d9dd031fb1c2f2f4fabb34137edfa885, type: 2}
-  m_sharedMaterial: {fileID: 1536850694454096710, guid: d9dd031fb1c2f2f4fabb34137edfa885,
-    type: 2}
+  m_sharedMaterial: {fileID: 1536850694454096710, guid: d9dd031fb1c2f2f4fabb34137edfa885, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -4593,8 +4185,7 @@ MonoBehaviour:
   m_text: Song Name
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: d9dd031fb1c2f2f4fabb34137edfa885, type: 2}
-  m_sharedMaterial: {fileID: 1536850694454096710, guid: d9dd031fb1c2f2f4fabb34137edfa885,
-    type: 2}
+  m_sharedMaterial: {fileID: 1536850694454096710, guid: d9dd031fb1c2f2f4fabb34137edfa885, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -4730,8 +4321,7 @@ MonoBehaviour:
   m_text: Best
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 21db4751dd6d460499117f8c2d3de781, type: 2}
-  m_sharedMaterial: {fileID: 1134014722335189955, guid: 21db4751dd6d460499117f8c2d3de781,
-    type: 2}
+  m_sharedMaterial: {fileID: 1134014722335189955, guid: 21db4751dd6d460499117f8c2d3de781, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -4873,8 +4463,7 @@ MonoBehaviour:
   m_ReverseArrangement: 0
 --- !u!224 &793838894 stripped
 RectTransform:
-  m_CorrespondingSourceObject: {fileID: 4773576581307856199, guid: 72eef77c01b66604696836c2b02cb1e1,
-    type: 3}
+  m_CorrespondingSourceObject: {fileID: 4773576581307856199, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
   m_PrefabInstance: {fileID: 396166999}
   m_PrefabAsset: {fileID: 0}
 --- !u!1 &820110413
@@ -5136,43 +4725,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 879254556}
   m_CullTransparentMesh: 1
---- !u!84 &892436425
-RenderTexture:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: 
-  m_ImageContentsHash:
-    serializedVersion: 2
-    Hash: 00000000000000000000000000000000
-  m_IsAlphaChannelOptional: 0
-  serializedVersion: 6
-  m_Width: 2375
-  m_Height: 1336
-  m_AntiAliasing: 1
-  m_MipCount: -1
-  m_DepthStencilFormat: 0
-  m_ColorFormat: 48
-  m_MipMap: 0
-  m_GenerateMips: 1
-  m_SRGB: 0
-  m_UseDynamicScale: 0
-  m_UseDynamicScaleExplicit: 0
-  m_BindMS: 0
-  m_EnableCompatibleFormat: 1
-  m_EnableRandomWrite: 0
-  m_TextureSettings:
-    serializedVersion: 2
-    m_FilterMode: 1
-    m_Aniso: 1
-    m_MipBias: 0
-    m_WrapU: 1
-    m_WrapV: 1
-    m_WrapW: 1
-  m_Dimension: 2
-  m_VolumeDepth: 1
-  m_ShadowSamplingMode: 2
 --- !u!1001 &922548496
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -5181,233 +4733,187 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 1212139298}
     m_Modifications:
-    - target: {fileID: 2006855537152082164, guid: f8c143f8514898b4fb85fbadc18550c0,
-        type: 3}
+    - target: {fileID: 2006855537152082164, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2006855537152082164, guid: f8c143f8514898b4fb85fbadc18550c0,
-        type: 3}
+    - target: {fileID: 2006855537152082164, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2006855537152082164, guid: f8c143f8514898b4fb85fbadc18550c0,
-        type: 3}
+    - target: {fileID: 2006855537152082164, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2006855537152082164, guid: f8c143f8514898b4fb85fbadc18550c0,
-        type: 3}
+    - target: {fileID: 2006855537152082164, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2006855537152082164, guid: f8c143f8514898b4fb85fbadc18550c0,
-        type: 3}
+    - target: {fileID: 2006855537152082164, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2006855537152082164, guid: f8c143f8514898b4fb85fbadc18550c0,
-        type: 3}
+    - target: {fileID: 2006855537152082164, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2933889975780695480, guid: f8c143f8514898b4fb85fbadc18550c0,
-        type: 3}
+    - target: {fileID: 2933889975780695480, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2933889975780695480, guid: f8c143f8514898b4fb85fbadc18550c0,
-        type: 3}
+    - target: {fileID: 2933889975780695480, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2933889975780695480, guid: f8c143f8514898b4fb85fbadc18550c0,
-        type: 3}
+    - target: {fileID: 2933889975780695480, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2933889975780695480, guid: f8c143f8514898b4fb85fbadc18550c0,
-        type: 3}
+    - target: {fileID: 2933889975780695480, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5322898957872382039, guid: f8c143f8514898b4fb85fbadc18550c0,
-        type: 3}
+    - target: {fileID: 5322898957872382039, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6915276943068997200, guid: f8c143f8514898b4fb85fbadc18550c0,
-        type: 3}
+    - target: {fileID: 6915276943068997200, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6915276943068997200, guid: f8c143f8514898b4fb85fbadc18550c0,
-        type: 3}
+    - target: {fileID: 6915276943068997200, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6915276943068997200, guid: f8c143f8514898b4fb85fbadc18550c0,
-        type: 3}
+    - target: {fileID: 6915276943068997200, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6915276943068997200, guid: f8c143f8514898b4fb85fbadc18550c0,
-        type: 3}
+    - target: {fileID: 6915276943068997200, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6915276943068997200, guid: f8c143f8514898b4fb85fbadc18550c0,
-        type: 3}
+    - target: {fileID: 6915276943068997200, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6915276943068997200, guid: f8c143f8514898b4fb85fbadc18550c0,
-        type: 3}
+    - target: {fileID: 6915276943068997200, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7226651616191308852, guid: f8c143f8514898b4fb85fbadc18550c0,
-        type: 3}
+    - target: {fileID: 7226651616191308852, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7226651616191308852, guid: f8c143f8514898b4fb85fbadc18550c0,
-        type: 3}
+    - target: {fileID: 7226651616191308852, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7226651616191308852, guid: f8c143f8514898b4fb85fbadc18550c0,
-        type: 3}
+    - target: {fileID: 7226651616191308852, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7226651616191308852, guid: f8c143f8514898b4fb85fbadc18550c0,
-        type: 3}
+    - target: {fileID: 7226651616191308852, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7226651616191308852, guid: f8c143f8514898b4fb85fbadc18550c0,
-        type: 3}
+    - target: {fileID: 7226651616191308852, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7226651616191308852, guid: f8c143f8514898b4fb85fbadc18550c0,
-        type: 3}
+    - target: {fileID: 7226651616191308852, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7369758456864847373, guid: f8c143f8514898b4fb85fbadc18550c0,
-        type: 3}
+    - target: {fileID: 7369758456864847373, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
       propertyPath: m_Name
       value: ReplayViewer
       objectReference: {fileID: 0}
-    - target: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0,
-        type: 3}
+    - target: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
       propertyPath: m_Pivot.x
       value: 0.49999997
       objectReference: {fileID: 0}
-    - target: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0,
-        type: 3}
+    - target: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
       propertyPath: m_Pivot.y
       value: 0.49999997
       objectReference: {fileID: 0}
-    - target: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0,
-        type: 3}
+    - target: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
       propertyPath: m_RootOrder
       value: 7
       objectReference: {fileID: 0}
-    - target: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0,
-        type: 3}
+    - target: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
       propertyPath: m_AnchorMax.x
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0,
-        type: 3}
+    - target: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0,
-        type: 3}
+    - target: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
       propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0,
-        type: 3}
+    - target: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0,
-        type: 3}
+    - target: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0,
-        type: 3}
+    - target: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0,
-        type: 3}
+    - target: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0,
-        type: 3}
+    - target: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0,
-        type: 3}
+    - target: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0,
-        type: 3}
+    - target: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0,
-        type: 3}
+    - target: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0,
-        type: 3}
+    - target: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0,
-        type: 3}
+    - target: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0,
-        type: 3}
+    - target: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0,
-        type: 3}
+    - target: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0,
-        type: 3}
+    - target: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0,
-        type: 3}
+    - target: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0,
-        type: 3}
+    - target: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8431678723656029144, guid: f8c143f8514898b4fb85fbadc18550c0,
-        type: 3}
+    - target: {fileID: 8431678723656029144, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
@@ -5418,14 +4924,12 @@ PrefabInstance:
   m_SourcePrefab: {fileID: 100100000, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
 --- !u!224 &922548497 stripped
 RectTransform:
-  m_CorrespondingSourceObject: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0,
-    type: 3}
+  m_CorrespondingSourceObject: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
   m_PrefabInstance: {fileID: 922548496}
   m_PrefabAsset: {fileID: 0}
 --- !u!114 &922548498 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 5703792185782102541, guid: f8c143f8514898b4fb85fbadc18550c0,
-    type: 3}
+  m_CorrespondingSourceObject: {fileID: 5703792185782102541, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
   m_PrefabInstance: {fileID: 922548496}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}
@@ -5442,123 +4946,99 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 1323155441}
     m_Modifications:
-    - target: {fileID: 4293127954770772634, guid: baa7a80387dc41d469efe3686d4a6375,
-        type: 3}
+    - target: {fileID: 4293127954770772634, guid: baa7a80387dc41d469efe3686d4a6375, type: 3}
       propertyPath: <Menu>k__BackingField
       value: 8
       objectReference: {fileID: 0}
-    - target: {fileID: 5981333258937755041, guid: baa7a80387dc41d469efe3686d4a6375,
-        type: 3}
+    - target: {fileID: 5981333258937755041, guid: baa7a80387dc41d469efe3686d4a6375, type: 3}
       propertyPath: m_Pivot.x
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 5981333258937755041, guid: baa7a80387dc41d469efe3686d4a6375,
-        type: 3}
+    - target: {fileID: 5981333258937755041, guid: baa7a80387dc41d469efe3686d4a6375, type: 3}
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 5981333258937755041, guid: baa7a80387dc41d469efe3686d4a6375,
-        type: 3}
+    - target: {fileID: 5981333258937755041, guid: baa7a80387dc41d469efe3686d4a6375, type: 3}
       propertyPath: m_RootOrder
       value: 8
       objectReference: {fileID: 0}
-    - target: {fileID: 5981333258937755041, guid: baa7a80387dc41d469efe3686d4a6375,
-        type: 3}
+    - target: {fileID: 5981333258937755041, guid: baa7a80387dc41d469efe3686d4a6375, type: 3}
       propertyPath: m_AnchorMax.x
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5981333258937755041, guid: baa7a80387dc41d469efe3686d4a6375,
-        type: 3}
+    - target: {fileID: 5981333258937755041, guid: baa7a80387dc41d469efe3686d4a6375, type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5981333258937755041, guid: baa7a80387dc41d469efe3686d4a6375,
-        type: 3}
+    - target: {fileID: 5981333258937755041, guid: baa7a80387dc41d469efe3686d4a6375, type: 3}
       propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5981333258937755041, guid: baa7a80387dc41d469efe3686d4a6375,
-        type: 3}
+    - target: {fileID: 5981333258937755041, guid: baa7a80387dc41d469efe3686d4a6375, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5981333258937755041, guid: baa7a80387dc41d469efe3686d4a6375,
-        type: 3}
+    - target: {fileID: 5981333258937755041, guid: baa7a80387dc41d469efe3686d4a6375, type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5981333258937755041, guid: baa7a80387dc41d469efe3686d4a6375,
-        type: 3}
+    - target: {fileID: 5981333258937755041, guid: baa7a80387dc41d469efe3686d4a6375, type: 3}
       propertyPath: m_SizeDelta.y
       value: -250
       objectReference: {fileID: 0}
-    - target: {fileID: 5981333258937755041, guid: baa7a80387dc41d469efe3686d4a6375,
-        type: 3}
+    - target: {fileID: 5981333258937755041, guid: baa7a80387dc41d469efe3686d4a6375, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5981333258937755041, guid: baa7a80387dc41d469efe3686d4a6375,
-        type: 3}
+    - target: {fileID: 5981333258937755041, guid: baa7a80387dc41d469efe3686d4a6375, type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5981333258937755041, guid: baa7a80387dc41d469efe3686d4a6375,
-        type: 3}
+    - target: {fileID: 5981333258937755041, guid: baa7a80387dc41d469efe3686d4a6375, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5981333258937755041, guid: baa7a80387dc41d469efe3686d4a6375,
-        type: 3}
+    - target: {fileID: 5981333258937755041, guid: baa7a80387dc41d469efe3686d4a6375, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5981333258937755041, guid: baa7a80387dc41d469efe3686d4a6375,
-        type: 3}
+    - target: {fileID: 5981333258937755041, guid: baa7a80387dc41d469efe3686d4a6375, type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5981333258937755041, guid: baa7a80387dc41d469efe3686d4a6375,
-        type: 3}
+    - target: {fileID: 5981333258937755041, guid: baa7a80387dc41d469efe3686d4a6375, type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5981333258937755041, guid: baa7a80387dc41d469efe3686d4a6375,
-        type: 3}
+    - target: {fileID: 5981333258937755041, guid: baa7a80387dc41d469efe3686d4a6375, type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5981333258937755041, guid: baa7a80387dc41d469efe3686d4a6375,
-        type: 3}
+    - target: {fileID: 5981333258937755041, guid: baa7a80387dc41d469efe3686d4a6375, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5981333258937755041, guid: baa7a80387dc41d469efe3686d4a6375,
-        type: 3}
+    - target: {fileID: 5981333258937755041, guid: baa7a80387dc41d469efe3686d4a6375, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -125
       objectReference: {fileID: 0}
-    - target: {fileID: 5981333258937755041, guid: baa7a80387dc41d469efe3686d4a6375,
-        type: 3}
+    - target: {fileID: 5981333258937755041, guid: baa7a80387dc41d469efe3686d4a6375, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5981333258937755041, guid: baa7a80387dc41d469efe3686d4a6375,
-        type: 3}
+    - target: {fileID: 5981333258937755041, guid: baa7a80387dc41d469efe3686d4a6375, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5981333258937755041, guid: baa7a80387dc41d469efe3686d4a6375,
-        type: 3}
+    - target: {fileID: 5981333258937755041, guid: baa7a80387dc41d469efe3686d4a6375, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5981333258937755042, guid: baa7a80387dc41d469efe3686d4a6375,
-        type: 3}
+    - target: {fileID: 5981333258937755042, guid: baa7a80387dc41d469efe3686d4a6375, type: 3}
       propertyPath: m_Name
       value: FailPause
       objectReference: {fileID: 0}
-    - target: {fileID: 5981333258937755042, guid: baa7a80387dc41d469efe3686d4a6375,
-        type: 3}
+    - target: {fileID: 5981333258937755042, guid: baa7a80387dc41d469efe3686d4a6375, type: 3}
       propertyPath: m_IsActive
       value: 0
       objectReference: {fileID: 0}
@@ -5569,8 +5049,7 @@ PrefabInstance:
   m_SourcePrefab: {fileID: 100100000, guid: baa7a80387dc41d469efe3686d4a6375, type: 3}
 --- !u!224 &943800969 stripped
 RectTransform:
-  m_CorrespondingSourceObject: {fileID: 5981333258937755041, guid: baa7a80387dc41d469efe3686d4a6375,
-    type: 3}
+  m_CorrespondingSourceObject: {fileID: 5981333258937755041, guid: baa7a80387dc41d469efe3686d4a6375, type: 3}
   m_PrefabInstance: {fileID: 943800968}
   m_PrefabAsset: {fileID: 0}
 --- !u!1 &970019644
@@ -5722,343 +5201,275 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 1323155441}
     m_Modifications:
-    - target: {fileID: 132419825530296480, guid: e3d517531b8487141a8a955f24e85a1c,
-        type: 3}
+    - target: {fileID: 132419825530296480, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 132419825530296480, guid: e3d517531b8487141a8a955f24e85a1c,
-        type: 3}
+    - target: {fileID: 132419825530296480, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 132419825530296480, guid: e3d517531b8487141a8a955f24e85a1c,
-        type: 3}
+    - target: {fileID: 132419825530296480, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
       propertyPath: m_SizeDelta.x
       value: 750
       objectReference: {fileID: 0}
-    - target: {fileID: 132419825530296480, guid: e3d517531b8487141a8a955f24e85a1c,
-        type: 3}
+    - target: {fileID: 132419825530296480, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 375
       objectReference: {fileID: 0}
-    - target: {fileID: 132419825530296480, guid: e3d517531b8487141a8a955f24e85a1c,
-        type: 3}
+    - target: {fileID: 132419825530296480, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -470
       objectReference: {fileID: 0}
-    - target: {fileID: 628753446950880641, guid: e3d517531b8487141a8a955f24e85a1c,
-        type: 3}
+    - target: {fileID: 628753446950880641, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 628753446950880641, guid: e3d517531b8487141a8a955f24e85a1c,
-        type: 3}
+    - target: {fileID: 628753446950880641, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 628753446950880641, guid: e3d517531b8487141a8a955f24e85a1c,
-        type: 3}
+    - target: {fileID: 628753446950880641, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
       propertyPath: m_SizeDelta.x
       value: 750
       objectReference: {fileID: 0}
-    - target: {fileID: 628753446950880641, guid: e3d517531b8487141a8a955f24e85a1c,
-        type: 3}
+    - target: {fileID: 628753446950880641, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 375
       objectReference: {fileID: 0}
-    - target: {fileID: 628753446950880641, guid: e3d517531b8487141a8a955f24e85a1c,
-        type: 3}
+    - target: {fileID: 628753446950880641, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -29
       objectReference: {fileID: 0}
-    - target: {fileID: 1144209813281861628, guid: e3d517531b8487141a8a955f24e85a1c,
-        type: 3}
+    - target: {fileID: 1144209813281861628, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1144209813281861628, guid: e3d517531b8487141a8a955f24e85a1c,
-        type: 3}
+    - target: {fileID: 1144209813281861628, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1144209813281861628, guid: e3d517531b8487141a8a955f24e85a1c,
-        type: 3}
+    - target: {fileID: 1144209813281861628, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
       propertyPath: m_SizeDelta.x
       value: 750
       objectReference: {fileID: 0}
-    - target: {fileID: 1144209813281861628, guid: e3d517531b8487141a8a955f24e85a1c,
-        type: 3}
+    - target: {fileID: 1144209813281861628, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 375
       objectReference: {fileID: 0}
-    - target: {fileID: 1144209813281861628, guid: e3d517531b8487141a8a955f24e85a1c,
-        type: 3}
+    - target: {fileID: 1144209813281861628, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -155
       objectReference: {fileID: 0}
-    - target: {fileID: 2872069603678488960, guid: e3d517531b8487141a8a955f24e85a1c,
-        type: 3}
+    - target: {fileID: 2872069603678488960, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2872069603678488960, guid: e3d517531b8487141a8a955f24e85a1c,
-        type: 3}
+    - target: {fileID: 2872069603678488960, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2872069603678488960, guid: e3d517531b8487141a8a955f24e85a1c,
-        type: 3}
+    - target: {fileID: 2872069603678488960, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
       propertyPath: m_SizeDelta.x
       value: 750
       objectReference: {fileID: 0}
-    - target: {fileID: 2872069603678488960, guid: e3d517531b8487141a8a955f24e85a1c,
-        type: 3}
+    - target: {fileID: 2872069603678488960, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 375
       objectReference: {fileID: 0}
-    - target: {fileID: 2872069603678488960, guid: e3d517531b8487141a8a955f24e85a1c,
-        type: 3}
+    - target: {fileID: 2872069603678488960, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -92
       objectReference: {fileID: 0}
-    - target: {fileID: 3317591240376291203, guid: e3d517531b8487141a8a955f24e85a1c,
-        type: 3}
+    - target: {fileID: 3317591240376291203, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3317591240376291203, guid: e3d517531b8487141a8a955f24e85a1c,
-        type: 3}
+    - target: {fileID: 3317591240376291203, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3317591240376291203, guid: e3d517531b8487141a8a955f24e85a1c,
-        type: 3}
+    - target: {fileID: 3317591240376291203, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
       propertyPath: m_SizeDelta.x
       value: 750
       objectReference: {fileID: 0}
-    - target: {fileID: 3317591240376291203, guid: e3d517531b8487141a8a955f24e85a1c,
-        type: 3}
+    - target: {fileID: 3317591240376291203, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 375
       objectReference: {fileID: 0}
-    - target: {fileID: 3317591240376291203, guid: e3d517531b8487141a8a955f24e85a1c,
-        type: 3}
+    - target: {fileID: 3317591240376291203, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -281
       objectReference: {fileID: 0}
-    - target: {fileID: 6355455761800452810, guid: e3d517531b8487141a8a955f24e85a1c,
-        type: 3}
+    - target: {fileID: 6355455761800452810, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6355455761800452810, guid: e3d517531b8487141a8a955f24e85a1c,
-        type: 3}
+    - target: {fileID: 6355455761800452810, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6355455761800452810, guid: e3d517531b8487141a8a955f24e85a1c,
-        type: 3}
+    - target: {fileID: 6355455761800452810, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
       propertyPath: m_SizeDelta.x
       value: 750
       objectReference: {fileID: 0}
-    - target: {fileID: 6355455761800452810, guid: e3d517531b8487141a8a955f24e85a1c,
-        type: 3}
+    - target: {fileID: 6355455761800452810, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 375
       objectReference: {fileID: 0}
-    - target: {fileID: 6355455761800452810, guid: e3d517531b8487141a8a955f24e85a1c,
-        type: 3}
+    - target: {fileID: 6355455761800452810, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -407
       objectReference: {fileID: 0}
-    - target: {fileID: 6864359232142243101, guid: e3d517531b8487141a8a955f24e85a1c,
-        type: 3}
+    - target: {fileID: 6864359232142243101, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6864359232142243101, guid: e3d517531b8487141a8a955f24e85a1c,
-        type: 3}
+    - target: {fileID: 6864359232142243101, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6864359232142243101, guid: e3d517531b8487141a8a955f24e85a1c,
-        type: 3}
+    - target: {fileID: 6864359232142243101, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
       propertyPath: m_SizeDelta.x
       value: 750
       objectReference: {fileID: 0}
-    - target: {fileID: 6864359232142243101, guid: e3d517531b8487141a8a955f24e85a1c,
-        type: 3}
+    - target: {fileID: 6864359232142243101, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 375
       objectReference: {fileID: 0}
-    - target: {fileID: 6864359232142243101, guid: e3d517531b8487141a8a955f24e85a1c,
-        type: 3}
+    - target: {fileID: 6864359232142243101, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -344
       objectReference: {fileID: 0}
-    - target: {fileID: 7476284975017015384, guid: e3d517531b8487141a8a955f24e85a1c,
-        type: 3}
+    - target: {fileID: 7476284975017015384, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7476284975017015384, guid: e3d517531b8487141a8a955f24e85a1c,
-        type: 3}
+    - target: {fileID: 7476284975017015384, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7476284975017015384, guid: e3d517531b8487141a8a955f24e85a1c,
-        type: 3}
+    - target: {fileID: 7476284975017015384, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
       propertyPath: m_SizeDelta.x
       value: 750
       objectReference: {fileID: 0}
-    - target: {fileID: 7476284975017015384, guid: e3d517531b8487141a8a955f24e85a1c,
-        type: 3}
+    - target: {fileID: 7476284975017015384, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 375
       objectReference: {fileID: 0}
-    - target: {fileID: 7476284975017015384, guid: e3d517531b8487141a8a955f24e85a1c,
-        type: 3}
+    - target: {fileID: 7476284975017015384, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -218
       objectReference: {fileID: 0}
-    - target: {fileID: 8520012361836660394, guid: e3d517531b8487141a8a955f24e85a1c,
-        type: 3}
+    - target: {fileID: 8520012361836660394, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8520012361836660394, guid: e3d517531b8487141a8a955f24e85a1c,
-        type: 3}
+    - target: {fileID: 8520012361836660394, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8520012361836660394, guid: e3d517531b8487141a8a955f24e85a1c,
-        type: 3}
+    - target: {fileID: 8520012361836660394, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
       propertyPath: m_SizeDelta.x
       value: 750
       objectReference: {fileID: 0}
-    - target: {fileID: 8520012361836660394, guid: e3d517531b8487141a8a955f24e85a1c,
-        type: 3}
+    - target: {fileID: 8520012361836660394, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 375
       objectReference: {fileID: 0}
-    - target: {fileID: 8520012361836660394, guid: e3d517531b8487141a8a955f24e85a1c,
-        type: 3}
+    - target: {fileID: 8520012361836660394, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -533
       objectReference: {fileID: 0}
-    - target: {fileID: 8687143271907180245, guid: e3d517531b8487141a8a955f24e85a1c,
-        type: 3}
+    - target: {fileID: 8687143271907180245, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
       propertyPath: m_Name
       value: PracticePause
       objectReference: {fileID: 0}
-    - target: {fileID: 8687143271907180245, guid: e3d517531b8487141a8a955f24e85a1c,
-        type: 3}
+    - target: {fileID: 8687143271907180245, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
       propertyPath: m_IsActive
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8687143271907180246, guid: e3d517531b8487141a8a955f24e85a1c,
-        type: 3}
+    - target: {fileID: 8687143271907180246, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
       propertyPath: m_Pivot.x
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 8687143271907180246, guid: e3d517531b8487141a8a955f24e85a1c,
-        type: 3}
+    - target: {fileID: 8687143271907180246, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 8687143271907180246, guid: e3d517531b8487141a8a955f24e85a1c,
-        type: 3}
+    - target: {fileID: 8687143271907180246, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
       propertyPath: m_RootOrder
       value: 3
       objectReference: {fileID: 0}
-    - target: {fileID: 8687143271907180246, guid: e3d517531b8487141a8a955f24e85a1c,
-        type: 3}
+    - target: {fileID: 8687143271907180246, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
       propertyPath: m_AnchorMax.x
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8687143271907180246, guid: e3d517531b8487141a8a955f24e85a1c,
-        type: 3}
+    - target: {fileID: 8687143271907180246, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8687143271907180246, guid: e3d517531b8487141a8a955f24e85a1c,
-        type: 3}
+    - target: {fileID: 8687143271907180246, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
       propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8687143271907180246, guid: e3d517531b8487141a8a955f24e85a1c,
-        type: 3}
+    - target: {fileID: 8687143271907180246, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8687143271907180246, guid: e3d517531b8487141a8a955f24e85a1c,
-        type: 3}
+    - target: {fileID: 8687143271907180246, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8687143271907180246, guid: e3d517531b8487141a8a955f24e85a1c,
-        type: 3}
+    - target: {fileID: 8687143271907180246, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
       propertyPath: m_SizeDelta.y
       value: -250
       objectReference: {fileID: 0}
-    - target: {fileID: 8687143271907180246, guid: e3d517531b8487141a8a955f24e85a1c,
-        type: 3}
+    - target: {fileID: 8687143271907180246, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8687143271907180246, guid: e3d517531b8487141a8a955f24e85a1c,
-        type: 3}
+    - target: {fileID: 8687143271907180246, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8687143271907180246, guid: e3d517531b8487141a8a955f24e85a1c,
-        type: 3}
+    - target: {fileID: 8687143271907180246, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8687143271907180246, guid: e3d517531b8487141a8a955f24e85a1c,
-        type: 3}
+    - target: {fileID: 8687143271907180246, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8687143271907180246, guid: e3d517531b8487141a8a955f24e85a1c,
-        type: 3}
+    - target: {fileID: 8687143271907180246, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8687143271907180246, guid: e3d517531b8487141a8a955f24e85a1c,
-        type: 3}
+    - target: {fileID: 8687143271907180246, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8687143271907180246, guid: e3d517531b8487141a8a955f24e85a1c,
-        type: 3}
+    - target: {fileID: 8687143271907180246, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8687143271907180246, guid: e3d517531b8487141a8a955f24e85a1c,
-        type: 3}
+    - target: {fileID: 8687143271907180246, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8687143271907180246, guid: e3d517531b8487141a8a955f24e85a1c,
-        type: 3}
+    - target: {fileID: 8687143271907180246, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -125
       objectReference: {fileID: 0}
-    - target: {fileID: 8687143271907180246, guid: e3d517531b8487141a8a955f24e85a1c,
-        type: 3}
+    - target: {fileID: 8687143271907180246, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8687143271907180246, guid: e3d517531b8487141a8a955f24e85a1c,
-        type: 3}
+    - target: {fileID: 8687143271907180246, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8687143271907180246, guid: e3d517531b8487141a8a955f24e85a1c,
-        type: 3}
+    - target: {fileID: 8687143271907180246, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
@@ -6069,8 +5480,7 @@ PrefabInstance:
   m_SourcePrefab: {fileID: 100100000, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
 --- !u!224 &1041685787 stripped
 RectTransform:
-  m_CorrespondingSourceObject: {fileID: 8687143271907180246, guid: e3d517531b8487141a8a955f24e85a1c,
-    type: 3}
+  m_CorrespondingSourceObject: {fileID: 8687143271907180246, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
   m_PrefabInstance: {fileID: 1041685786}
   m_PrefabAsset: {fileID: 0}
 --- !u!1 &1047079480
@@ -6148,8 +5558,7 @@ MonoBehaviour:
   _onEditModeChanged:
     m_PersistentCalls:
       m_Calls: []
-  _draggingDisplayPrefab: {fileID: 8670888432685319550, guid: d9f80531f3f74e94083d15499b97d33c,
-    type: 3}
+  _draggingDisplayPrefab: {fileID: 8670888432685319550, guid: d9f80531f3f74e94083d15499b97d33c, type: 3}
 --- !u!1 &1061222912
 GameObject:
   m_ObjectHideFlags: 0
@@ -6210,8 +5619,7 @@ MonoBehaviour:
   m_text: Accuracy
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 21db4751dd6d460499117f8c2d3de781, type: 2}
-  m_sharedMaterial: {fileID: 1134014722335189955, guid: 21db4751dd6d460499117f8c2d3de781,
-    type: 2}
+  m_sharedMaterial: {fileID: 1134014722335189955, guid: 21db4751dd6d460499117f8c2d3de781, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -6347,8 +5755,7 @@ MonoBehaviour:
   m_text: 0%
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 04973a14f12bf384f8093a8b70f63fcb, type: 2}
-  m_sharedMaterial: {fileID: -7155836927947826254, guid: 04973a14f12bf384f8093a8b70f63fcb,
-    type: 2}
+  m_sharedMaterial: {fileID: -7155836927947826254, guid: 04973a14f12bf384f8093a8b70f63fcb, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -6652,8 +6059,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
 --- !u!114 &1312797156 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 5801866611232935394, guid: f09d7030713b2e34dbc210e5e014add2,
-    type: 3}
+  m_CorrespondingSourceObject: {fileID: 5801866611232935394, guid: f09d7030713b2e34dbc210e5e014add2, type: 3}
   m_PrefabInstance: {fileID: 5801866609987599366}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}
@@ -6903,10 +6309,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d91557b093c94541a16865d7aea2083f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _trackViewPrefab: {fileID: 504031665406120138, guid: 06628de4f7ccad849a699ee59bdd2f37,
-    type: 3}
-  _vocalHudPrefab: {fileID: 3517124488286897926, guid: 6447755fd93bf6b4dbcb391c82737397,
-    type: 3}
+  _trackViewPrefab: {fileID: 504031665406120138, guid: 06628de4f7ccad849a699ee59bdd2f37, type: 3}
+  _vocalHudPrefab: {fileID: 3517124488286897926, guid: 6447755fd93bf6b4dbcb391c82737397, type: 3}
   _highwayCameraRendering: {fileID: 1516249583}
   _vocalImage: {fileID: 626807278}
   _vocalHudParent: {fileID: 1338572397}
@@ -7058,263 +6462,211 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 1323155441}
     m_Modifications:
-    - target: {fileID: 154592444964813920, guid: 7efe71303a450f348a4c71ec8eea331f,
-        type: 3}
+    - target: {fileID: 154592444964813920, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 154592444964813920, guid: 7efe71303a450f348a4c71ec8eea331f,
-        type: 3}
+    - target: {fileID: 154592444964813920, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 154592444964813920, guid: 7efe71303a450f348a4c71ec8eea331f,
-        type: 3}
+    - target: {fileID: 154592444964813920, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
       propertyPath: m_SizeDelta.x
       value: 750
       objectReference: {fileID: 0}
-    - target: {fileID: 154592444964813920, guid: 7efe71303a450f348a4c71ec8eea331f,
-        type: 3}
+    - target: {fileID: 154592444964813920, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 375
       objectReference: {fileID: 0}
-    - target: {fileID: 154592444964813920, guid: 7efe71303a450f348a4c71ec8eea331f,
-        type: 3}
+    - target: {fileID: 154592444964813920, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -155
       objectReference: {fileID: 0}
-    - target: {fileID: 3255133668864834793, guid: 7efe71303a450f348a4c71ec8eea331f,
-        type: 3}
+    - target: {fileID: 3255133668864834793, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3255133668864834793, guid: 7efe71303a450f348a4c71ec8eea331f,
-        type: 3}
+    - target: {fileID: 3255133668864834793, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3255133668864834793, guid: 7efe71303a450f348a4c71ec8eea331f,
-        type: 3}
+    - target: {fileID: 3255133668864834793, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
       propertyPath: m_SizeDelta.x
       value: 750
       objectReference: {fileID: 0}
-    - target: {fileID: 3255133668864834793, guid: 7efe71303a450f348a4c71ec8eea331f,
-        type: 3}
+    - target: {fileID: 3255133668864834793, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 375
       objectReference: {fileID: 0}
-    - target: {fileID: 3255133668864834793, guid: 7efe71303a450f348a4c71ec8eea331f,
-        type: 3}
+    - target: {fileID: 3255133668864834793, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -29
       objectReference: {fileID: 0}
-    - target: {fileID: 5730081093640278258, guid: 7efe71303a450f348a4c71ec8eea331f,
-        type: 3}
+    - target: {fileID: 5730081093640278258, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5730081093640278258, guid: 7efe71303a450f348a4c71ec8eea331f,
-        type: 3}
+    - target: {fileID: 5730081093640278258, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5730081093640278258, guid: 7efe71303a450f348a4c71ec8eea331f,
-        type: 3}
+    - target: {fileID: 5730081093640278258, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
       propertyPath: m_SizeDelta.x
       value: 750
       objectReference: {fileID: 0}
-    - target: {fileID: 5730081093640278258, guid: 7efe71303a450f348a4c71ec8eea331f,
-        type: 3}
+    - target: {fileID: 5730081093640278258, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 375
       objectReference: {fileID: 0}
-    - target: {fileID: 5730081093640278258, guid: 7efe71303a450f348a4c71ec8eea331f,
-        type: 3}
+    - target: {fileID: 5730081093640278258, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -218
       objectReference: {fileID: 0}
-    - target: {fileID: 5764441561947984321, guid: 7efe71303a450f348a4c71ec8eea331f,
-        type: 3}
+    - target: {fileID: 5764441561947984321, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
       propertyPath: m_Pivot.x
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 5764441561947984321, guid: 7efe71303a450f348a4c71ec8eea331f,
-        type: 3}
+    - target: {fileID: 5764441561947984321, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 5764441561947984321, guid: 7efe71303a450f348a4c71ec8eea331f,
-        type: 3}
+    - target: {fileID: 5764441561947984321, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
       propertyPath: m_RootOrder
       value: 5
       objectReference: {fileID: 0}
-    - target: {fileID: 5764441561947984321, guid: 7efe71303a450f348a4c71ec8eea331f,
-        type: 3}
+    - target: {fileID: 5764441561947984321, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
       propertyPath: m_AnchorMax.x
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5764441561947984321, guid: 7efe71303a450f348a4c71ec8eea331f,
-        type: 3}
+    - target: {fileID: 5764441561947984321, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5764441561947984321, guid: 7efe71303a450f348a4c71ec8eea331f,
-        type: 3}
+    - target: {fileID: 5764441561947984321, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
       propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5764441561947984321, guid: 7efe71303a450f348a4c71ec8eea331f,
-        type: 3}
+    - target: {fileID: 5764441561947984321, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5764441561947984321, guid: 7efe71303a450f348a4c71ec8eea331f,
-        type: 3}
+    - target: {fileID: 5764441561947984321, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5764441561947984321, guid: 7efe71303a450f348a4c71ec8eea331f,
-        type: 3}
+    - target: {fileID: 5764441561947984321, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
       propertyPath: m_SizeDelta.y
       value: -250
       objectReference: {fileID: 0}
-    - target: {fileID: 5764441561947984321, guid: 7efe71303a450f348a4c71ec8eea331f,
-        type: 3}
+    - target: {fileID: 5764441561947984321, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5764441561947984321, guid: 7efe71303a450f348a4c71ec8eea331f,
-        type: 3}
+    - target: {fileID: 5764441561947984321, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5764441561947984321, guid: 7efe71303a450f348a4c71ec8eea331f,
-        type: 3}
+    - target: {fileID: 5764441561947984321, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5764441561947984321, guid: 7efe71303a450f348a4c71ec8eea331f,
-        type: 3}
+    - target: {fileID: 5764441561947984321, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5764441561947984321, guid: 7efe71303a450f348a4c71ec8eea331f,
-        type: 3}
+    - target: {fileID: 5764441561947984321, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5764441561947984321, guid: 7efe71303a450f348a4c71ec8eea331f,
-        type: 3}
+    - target: {fileID: 5764441561947984321, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5764441561947984321, guid: 7efe71303a450f348a4c71ec8eea331f,
-        type: 3}
+    - target: {fileID: 5764441561947984321, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5764441561947984321, guid: 7efe71303a450f348a4c71ec8eea331f,
-        type: 3}
+    - target: {fileID: 5764441561947984321, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5764441561947984321, guid: 7efe71303a450f348a4c71ec8eea331f,
-        type: 3}
+    - target: {fileID: 5764441561947984321, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -125
       objectReference: {fileID: 0}
-    - target: {fileID: 5764441561947984321, guid: 7efe71303a450f348a4c71ec8eea331f,
-        type: 3}
+    - target: {fileID: 5764441561947984321, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5764441561947984321, guid: 7efe71303a450f348a4c71ec8eea331f,
-        type: 3}
+    - target: {fileID: 5764441561947984321, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5764441561947984321, guid: 7efe71303a450f348a4c71ec8eea331f,
-        type: 3}
+    - target: {fileID: 5764441561947984321, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5764441561947984322, guid: 7efe71303a450f348a4c71ec8eea331f,
-        type: 3}
+    - target: {fileID: 5764441561947984322, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
       propertyPath: m_Name
       value: ReplayPause
       objectReference: {fileID: 0}
-    - target: {fileID: 5764441561947984322, guid: 7efe71303a450f348a4c71ec8eea331f,
-        type: 3}
+    - target: {fileID: 5764441561947984322, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
       propertyPath: m_IsActive
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7580215650778954327, guid: 7efe71303a450f348a4c71ec8eea331f,
-        type: 3}
+    - target: {fileID: 7580215650778954327, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7580215650778954327, guid: 7efe71303a450f348a4c71ec8eea331f,
-        type: 3}
+    - target: {fileID: 7580215650778954327, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7580215650778954327, guid: 7efe71303a450f348a4c71ec8eea331f,
-        type: 3}
+    - target: {fileID: 7580215650778954327, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
       propertyPath: m_SizeDelta.x
       value: 750
       objectReference: {fileID: 0}
-    - target: {fileID: 7580215650778954327, guid: 7efe71303a450f348a4c71ec8eea331f,
-        type: 3}
+    - target: {fileID: 7580215650778954327, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 375
       objectReference: {fileID: 0}
-    - target: {fileID: 7580215650778954327, guid: 7efe71303a450f348a4c71ec8eea331f,
-        type: 3}
+    - target: {fileID: 7580215650778954327, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -281
       objectReference: {fileID: 0}
-    - target: {fileID: 7929139973946126061, guid: 7efe71303a450f348a4c71ec8eea331f,
-        type: 3}
+    - target: {fileID: 7929139973946126061, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7929139973946126061, guid: 7efe71303a450f348a4c71ec8eea331f,
-        type: 3}
+    - target: {fileID: 7929139973946126061, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7929139973946126061, guid: 7efe71303a450f348a4c71ec8eea331f,
-        type: 3}
+    - target: {fileID: 7929139973946126061, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
       propertyPath: m_SizeDelta.x
       value: 750
       objectReference: {fileID: 0}
-    - target: {fileID: 7929139973946126061, guid: 7efe71303a450f348a4c71ec8eea331f,
-        type: 3}
+    - target: {fileID: 7929139973946126061, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -373
       objectReference: {fileID: 0}
-    - target: {fileID: 8153367324949550618, guid: 7efe71303a450f348a4c71ec8eea331f,
-        type: 3}
+    - target: {fileID: 8153367324949550618, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8153367324949550618, guid: 7efe71303a450f348a4c71ec8eea331f,
-        type: 3}
+    - target: {fileID: 8153367324949550618, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8153367324949550618, guid: 7efe71303a450f348a4c71ec8eea331f,
-        type: 3}
+    - target: {fileID: 8153367324949550618, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
       propertyPath: m_SizeDelta.x
       value: 750
       objectReference: {fileID: 0}
-    - target: {fileID: 8153367324949550618, guid: 7efe71303a450f348a4c71ec8eea331f,
-        type: 3}
+    - target: {fileID: 8153367324949550618, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 375
       objectReference: {fileID: 0}
-    - target: {fileID: 8153367324949550618, guid: 7efe71303a450f348a4c71ec8eea331f,
-        type: 3}
+    - target: {fileID: 8153367324949550618, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -92
       objectReference: {fileID: 0}
@@ -7325,8 +6677,7 @@ PrefabInstance:
   m_SourcePrefab: {fileID: 100100000, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
 --- !u!224 &1405426188 stripped
 RectTransform:
-  m_CorrespondingSourceObject: {fileID: 5764441561947984321, guid: 7efe71303a450f348a4c71ec8eea331f,
-    type: 3}
+  m_CorrespondingSourceObject: {fileID: 5764441561947984321, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
   m_PrefabInstance: {fileID: 1405426187}
   m_PrefabAsset: {fileID: 0}
 --- !u!1 &1494490346
@@ -7390,8 +6741,7 @@ MonoBehaviour:
   m_text: Song Source
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: d9dd031fb1c2f2f4fabb34137edfa885, type: 2}
-  m_sharedMaterial: {fileID: 1536850694454096710, guid: d9dd031fb1c2f2f4fabb34137edfa885,
-    type: 2}
+  m_sharedMaterial: {fileID: 1536850694454096710, guid: d9dd031fb1c2f2f4fabb34137edfa885, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -7584,7 +6934,7 @@ Camera:
     serializedVersion: 2
     m_Bits: 503
   m_RenderingPath: -1
-  m_TargetTexture: {fileID: 892436425}
+  m_TargetTexture: {fileID: 1963028385}
   m_TargetDisplay: 0
   m_TargetEye: 3
   m_HDR: 1
@@ -7844,8 +7194,7 @@ MonoBehaviour:
   m_text: This is where the lyrics are displayed
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: d9dd031fb1c2f2f4fabb34137edfa885, type: 2}
-  m_sharedMaterial: {fileID: 1536850694454096710, guid: d9dd031fb1c2f2f4fabb34137edfa885,
-    type: 2}
+  m_sharedMaterial: {fileID: 1536850694454096710, guid: d9dd031fb1c2f2f4fabb34137edfa885, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -7981,8 +7330,7 @@ MonoBehaviour:
   m_text: Notes
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 21db4751dd6d460499117f8c2d3de781, type: 2}
-  m_sharedMaterial: {fileID: 1134014722335189955, guid: 21db4751dd6d460499117f8c2d3de781,
-    type: 2}
+  m_sharedMaterial: {fileID: 1134014722335189955, guid: 21db4751dd6d460499117f8c2d3de781, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -8379,113 +7727,91 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 397042284}
     m_Modifications:
-    - target: {fileID: 8712046426310438026, guid: d0b16d99b827a28449b37e491eb7cd45,
-        type: 3}
+    - target: {fileID: 8712046426310438026, guid: d0b16d99b827a28449b37e491eb7cd45, type: 3}
       propertyPath: m_Name
       value: FailMeter
       objectReference: {fileID: 0}
-    - target: {fileID: 8712046426310438027, guid: d0b16d99b827a28449b37e491eb7cd45,
-        type: 3}
+    - target: {fileID: 8712046426310438027, guid: d0b16d99b827a28449b37e491eb7cd45, type: 3}
       propertyPath: m_Pivot.x
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 8712046426310438027, guid: d0b16d99b827a28449b37e491eb7cd45,
-        type: 3}
+    - target: {fileID: 8712046426310438027, guid: d0b16d99b827a28449b37e491eb7cd45, type: 3}
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 8712046426310438027, guid: d0b16d99b827a28449b37e491eb7cd45,
-        type: 3}
+    - target: {fileID: 8712046426310438027, guid: d0b16d99b827a28449b37e491eb7cd45, type: 3}
       propertyPath: m_RootOrder
       value: 4
       objectReference: {fileID: 0}
-    - target: {fileID: 8712046426310438027, guid: d0b16d99b827a28449b37e491eb7cd45,
-        type: 3}
+    - target: {fileID: 8712046426310438027, guid: d0b16d99b827a28449b37e491eb7cd45, type: 3}
       propertyPath: m_AnchorMax.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8712046426310438027, guid: d0b16d99b827a28449b37e491eb7cd45,
-        type: 3}
+    - target: {fileID: 8712046426310438027, guid: d0b16d99b827a28449b37e491eb7cd45, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 8712046426310438027, guid: d0b16d99b827a28449b37e491eb7cd45,
-        type: 3}
+    - target: {fileID: 8712046426310438027, guid: d0b16d99b827a28449b37e491eb7cd45, type: 3}
       propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8712046426310438027, guid: d0b16d99b827a28449b37e491eb7cd45,
-        type: 3}
+    - target: {fileID: 8712046426310438027, guid: d0b16d99b827a28449b37e491eb7cd45, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 8712046426310438027, guid: d0b16d99b827a28449b37e491eb7cd45,
-        type: 3}
+    - target: {fileID: 8712046426310438027, guid: d0b16d99b827a28449b37e491eb7cd45, type: 3}
       propertyPath: m_SizeDelta.x
       value: 24
       objectReference: {fileID: 0}
-    - target: {fileID: 8712046426310438027, guid: d0b16d99b827a28449b37e491eb7cd45,
-        type: 3}
+    - target: {fileID: 8712046426310438027, guid: d0b16d99b827a28449b37e491eb7cd45, type: 3}
       propertyPath: m_SizeDelta.y
       value: 385
       objectReference: {fileID: 0}
-    - target: {fileID: 8712046426310438027, guid: d0b16d99b827a28449b37e491eb7cd45,
-        type: 3}
+    - target: {fileID: 8712046426310438027, guid: d0b16d99b827a28449b37e491eb7cd45, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8712046426310438027, guid: d0b16d99b827a28449b37e491eb7cd45,
-        type: 3}
+    - target: {fileID: 8712046426310438027, guid: d0b16d99b827a28449b37e491eb7cd45, type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8712046426310438027, guid: d0b16d99b827a28449b37e491eb7cd45,
-        type: 3}
+    - target: {fileID: 8712046426310438027, guid: d0b16d99b827a28449b37e491eb7cd45, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8712046426310438027, guid: d0b16d99b827a28449b37e491eb7cd45,
-        type: 3}
+    - target: {fileID: 8712046426310438027, guid: d0b16d99b827a28449b37e491eb7cd45, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8712046426310438027, guid: d0b16d99b827a28449b37e491eb7cd45,
-        type: 3}
+    - target: {fileID: 8712046426310438027, guid: d0b16d99b827a28449b37e491eb7cd45, type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8712046426310438027, guid: d0b16d99b827a28449b37e491eb7cd45,
-        type: 3}
+    - target: {fileID: 8712046426310438027, guid: d0b16d99b827a28449b37e491eb7cd45, type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8712046426310438027, guid: d0b16d99b827a28449b37e491eb7cd45,
-        type: 3}
+    - target: {fileID: 8712046426310438027, guid: d0b16d99b827a28449b37e491eb7cd45, type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8712046426310438027, guid: d0b16d99b827a28449b37e491eb7cd45,
-        type: 3}
+    - target: {fileID: 8712046426310438027, guid: d0b16d99b827a28449b37e491eb7cd45, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 40
       objectReference: {fileID: 0}
-    - target: {fileID: 8712046426310438027, guid: d0b16d99b827a28449b37e491eb7cd45,
-        type: 3}
+    - target: {fileID: 8712046426310438027, guid: d0b16d99b827a28449b37e491eb7cd45, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8712046426310438027, guid: d0b16d99b827a28449b37e491eb7cd45,
-        type: 3}
+    - target: {fileID: 8712046426310438027, guid: d0b16d99b827a28449b37e491eb7cd45, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8712046426310438027, guid: d0b16d99b827a28449b37e491eb7cd45,
-        type: 3}
+    - target: {fileID: 8712046426310438027, guid: d0b16d99b827a28449b37e491eb7cd45, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8712046426310438027, guid: d0b16d99b827a28449b37e491eb7cd45,
-        type: 3}
+    - target: {fileID: 8712046426310438027, guid: d0b16d99b827a28449b37e491eb7cd45, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
@@ -8629,8 +7955,7 @@ MonoBehaviour:
   m_text: Change Speed
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 21db4751dd6d460499117f8c2d3de781, type: 2}
-  m_sharedMaterial: {fileID: 1134014722335189955, guid: 21db4751dd6d460499117f8c2d3de781,
-    type: 2}
+  m_sharedMaterial: {fileID: 1134014722335189955, guid: 21db4751dd6d460499117f8c2d3de781, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -8901,8 +8226,7 @@ MonoBehaviour:
   m_text: Song Artist
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: d9dd031fb1c2f2f4fabb34137edfa885, type: 2}
-  m_sharedMaterial: {fileID: 1536850694454096710, guid: d9dd031fb1c2f2f4fabb34137edfa885,
-    type: 2}
+  m_sharedMaterial: {fileID: 1536850694454096710, guid: d9dd031fb1c2f2f4fabb34137edfa885, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -9083,8 +8407,7 @@ MonoBehaviour:
   m_text: This is where the next lyrics are displayed
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: d9dd031fb1c2f2f4fabb34137edfa885, type: 2}
-  m_sharedMaterial: {fileID: 1536850694454096710, guid: d9dd031fb1c2f2f4fabb34137edfa885,
-    type: 2}
+  m_sharedMaterial: {fileID: 1536850694454096710, guid: d9dd031fb1c2f2f4fabb34137edfa885, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -9261,6 +8584,43 @@ MonoBehaviour:
   m_ChildScaleWidth: 0
   m_ChildScaleHeight: 0
   m_ReverseArrangement: 0
+--- !u!84 &1963028385
+RenderTexture:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_ImageContentsHash:
+    serializedVersion: 2
+    Hash: 00000000000000000000000000000000
+  m_IsAlphaChannelOptional: 0
+  serializedVersion: 6
+  m_Width: 2451
+  m_Height: 1304
+  m_AntiAliasing: 1
+  m_MipCount: -1
+  m_DepthStencilFormat: 0
+  m_ColorFormat: 48
+  m_MipMap: 0
+  m_GenerateMips: 1
+  m_SRGB: 0
+  m_UseDynamicScale: 0
+  m_UseDynamicScaleExplicit: 0
+  m_BindMS: 0
+  m_EnableCompatibleFormat: 1
+  m_EnableRandomWrite: 0
+  m_TextureSettings:
+    serializedVersion: 2
+    m_FilterMode: 1
+    m_Aniso: 1
+    m_MipBias: 0
+    m_WrapU: 1
+    m_WrapV: 1
+    m_WrapW: 1
+  m_Dimension: 2
+  m_VolumeDepth: 1
+  m_ShadowSamplingMode: 2
 --- !u!1 &2075200648
 GameObject:
   m_ObjectHideFlags: 0
@@ -9609,8 +8969,7 @@ MonoBehaviour:
   m_text: Restart Section
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 21db4751dd6d460499117f8c2d3de781, type: 2}
-  m_sharedMaterial: {fileID: 1134014722335189955, guid: 21db4751dd6d460499117f8c2d3de781,
-    type: 2}
+  m_sharedMaterial: {fileID: 1134014722335189955, guid: 21db4751dd6d460499117f8c2d3de781, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -9694,68 +9053,55 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 5801866611232935394, guid: f09d7030713b2e34dbc210e5e014add2,
-        type: 3}
+    - target: {fileID: 5801866611232935394, guid: f09d7030713b2e34dbc210e5e014add2, type: 3}
       propertyPath: _countdownDisplay
       value: 
       objectReference: {fileID: 412813830}
-    - target: {fileID: 5801866611232935397, guid: f09d7030713b2e34dbc210e5e014add2,
-        type: 3}
+    - target: {fileID: 5801866611232935397, guid: f09d7030713b2e34dbc210e5e014add2, type: 3}
       propertyPath: m_RootOrder
       value: 7
       objectReference: {fileID: 0}
-    - target: {fileID: 5801866611232935397, guid: f09d7030713b2e34dbc210e5e014add2,
-        type: 3}
+    - target: {fileID: 5801866611232935397, guid: f09d7030713b2e34dbc210e5e014add2, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5801866611232935397, guid: f09d7030713b2e34dbc210e5e014add2,
-        type: 3}
+    - target: {fileID: 5801866611232935397, guid: f09d7030713b2e34dbc210e5e014add2, type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5801866611232935397, guid: f09d7030713b2e34dbc210e5e014add2,
-        type: 3}
+    - target: {fileID: 5801866611232935397, guid: f09d7030713b2e34dbc210e5e014add2, type: 3}
       propertyPath: m_LocalPosition.z
       value: -20
       objectReference: {fileID: 0}
-    - target: {fileID: 5801866611232935397, guid: f09d7030713b2e34dbc210e5e014add2,
-        type: 3}
+    - target: {fileID: 5801866611232935397, guid: f09d7030713b2e34dbc210e5e014add2, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5801866611232935397, guid: f09d7030713b2e34dbc210e5e014add2,
-        type: 3}
+    - target: {fileID: 5801866611232935397, guid: f09d7030713b2e34dbc210e5e014add2, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 5801866611232935397, guid: f09d7030713b2e34dbc210e5e014add2,
-        type: 3}
+    - target: {fileID: 5801866611232935397, guid: f09d7030713b2e34dbc210e5e014add2, type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 5801866611232935397, guid: f09d7030713b2e34dbc210e5e014add2,
-        type: 3}
+    - target: {fileID: 5801866611232935397, guid: f09d7030713b2e34dbc210e5e014add2, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 5801866611232935397, guid: f09d7030713b2e34dbc210e5e014add2,
-        type: 3}
+    - target: {fileID: 5801866611232935397, guid: f09d7030713b2e34dbc210e5e014add2, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5801866611232935397, guid: f09d7030713b2e34dbc210e5e014add2,
-        type: 3}
+    - target: {fileID: 5801866611232935397, guid: f09d7030713b2e34dbc210e5e014add2, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5801866611232935397, guid: f09d7030713b2e34dbc210e5e014add2,
-        type: 3}
+    - target: {fileID: 5801866611232935397, guid: f09d7030713b2e34dbc210e5e014add2, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5801866611232935399, guid: f09d7030713b2e34dbc210e5e014add2,
-        type: 3}
+    - target: {fileID: 5801866611232935399, guid: f09d7030713b2e34dbc210e5e014add2, type: 3}
       propertyPath: m_Name
       value: VocalTrack
       objectReference: {fileID: 0}

--- a/Assets/Scenes/Gameplay.unity
+++ b/Assets/Scenes/Gameplay.unity
@@ -280,7 +280,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!224 &103030101
 RectTransform:
   m_ObjectHideFlags: 0
@@ -1334,7 +1334,7 @@ MonoBehaviour:
     m_Right: 0
     m_Top: 0
     m_Bottom: 0
-  m_ChildAlignment: 4
+  m_ChildAlignment: 1
   m_Spacing: 0
   m_ChildForceExpandWidth: 1
   m_ChildForceExpandHeight: 1
@@ -2369,43 +2369,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2399e3981e2db8e45abb7734d762cddc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!84 &384353436
-RenderTexture:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: 
-  m_ImageContentsHash:
-    serializedVersion: 2
-    Hash: 00000000000000000000000000000000
-  m_IsAlphaChannelOptional: 0
-  serializedVersion: 6
-  m_Width: 2299
-  m_Height: 1057
-  m_AntiAliasing: 1
-  m_MipCount: -1
-  m_DepthStencilFormat: 0
-  m_ColorFormat: 48
-  m_MipMap: 0
-  m_GenerateMips: 1
-  m_SRGB: 0
-  m_UseDynamicScale: 0
-  m_UseDynamicScaleExplicit: 0
-  m_BindMS: 0
-  m_EnableCompatibleFormat: 1
-  m_EnableRandomWrite: 0
-  m_TextureSettings:
-    serializedVersion: 2
-    m_FilterMode: 1
-    m_Aniso: 1
-    m_MipBias: 0
-    m_WrapU: 1
-    m_WrapV: 1
-    m_WrapW: 1
-  m_Dimension: 2
-  m_VolumeDepth: 1
-  m_ShadowSamplingMode: 2
 --- !u!1001 &387423406
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -3392,7 +3355,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b8c498d3c7f26fe4b8c41ba7170e9c73, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _topPaddingForVocals: 140
+  _topPaddingForVocals: 215
 --- !u!1001 &412813829
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -3704,7 +3667,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Texture: {fileID: 384353436}
+  m_Texture: {fileID: 892436425}
   m_UVRect:
     serializedVersion: 2
     x: 0
@@ -5173,6 +5136,43 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 879254556}
   m_CullTransparentMesh: 1
+--- !u!84 &892436425
+RenderTexture:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_ImageContentsHash:
+    serializedVersion: 2
+    Hash: 00000000000000000000000000000000
+  m_IsAlphaChannelOptional: 0
+  serializedVersion: 6
+  m_Width: 2375
+  m_Height: 1336
+  m_AntiAliasing: 1
+  m_MipCount: -1
+  m_DepthStencilFormat: 0
+  m_ColorFormat: 48
+  m_MipMap: 0
+  m_GenerateMips: 1
+  m_SRGB: 0
+  m_UseDynamicScale: 0
+  m_UseDynamicScaleExplicit: 0
+  m_BindMS: 0
+  m_EnableCompatibleFormat: 1
+  m_EnableRandomWrite: 0
+  m_TextureSettings:
+    serializedVersion: 2
+    m_FilterMode: 1
+    m_Aniso: 1
+    m_MipBias: 0
+    m_WrapU: 1
+    m_WrapV: 1
+    m_WrapW: 1
+  m_Dimension: 2
+  m_VolumeDepth: 1
+  m_ShadowSamplingMode: 2
 --- !u!1001 &922548496
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -7584,7 +7584,7 @@ Camera:
     serializedVersion: 2
     m_Bits: 503
   m_RenderingPath: -1
-  m_TargetTexture: {fileID: 384353436}
+  m_TargetTexture: {fileID: 892436425}
   m_TargetDisplay: 0
   m_TargetEye: 3
   m_HDR: 1
@@ -8114,7 +8114,7 @@ MonoBehaviour:
     m_Right: 0
     m_Top: 0
     m_Bottom: 0
-  m_ChildAlignment: 4
+  m_ChildAlignment: 1
   m_Spacing: 40
   m_ChildForceExpandWidth: 1
   m_ChildForceExpandHeight: 1

--- a/Assets/Scenes/Gameplay.unity
+++ b/Assets/Scenes/Gameplay.unity
@@ -93,8 +93,10 @@ LightmapSettings:
     m_ExportTrainingData: 0
     m_TrainingDataDestination: TrainingData
     m_LightProbeSampleCountMultiplier: 4
-  m_LightingDataAsset: {fileID: 112000000, guid: afa2442e5d810ad48a077f8d3ff8d2d5, type: 2}
-  m_LightingSettings: {fileID: 4890085278179872738, guid: c261231216937354480cc047d8386db6, type: 2}
+  m_LightingDataAsset: {fileID: 112000000, guid: afa2442e5d810ad48a077f8d3ff8d2d5,
+    type: 2}
+  m_LightingSettings: {fileID: 4890085278179872738, guid: c261231216937354480cc047d8386db6,
+    type: 2}
 --- !u!196 &4
 NavMeshSettings:
   serializedVersion: 2
@@ -154,7 +156,7 @@ RectTransform:
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 86, y: 50}
+  m_SizeDelta: {x: 68, y: 50}
   m_Pivot: {x: 0.5, y: 1.0000002}
 --- !u!114 &62529481
 MonoBehaviour:
@@ -166,8 +168,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -242,8 +244,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 59f8146938fff824cb5fd77236b75775, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Padding:
     m_Left: 0
     m_Right: 0
@@ -278,7 +280,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &103030101
 RectTransform:
   m_ObjectHideFlags: 0
@@ -308,8 +310,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -325,7 +327,8 @@ MonoBehaviour:
     Very Nice.'
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: ae170e91fd29a90479e906ddffb1d8ee, type: 2}
-  m_sharedMaterial: {fileID: -5480317595949376055, guid: ae170e91fd29a90479e906ddffb1d8ee, type: 2}
+  m_sharedMaterial: {fileID: -5480317595949376055, guid: ae170e91fd29a90479e906ddffb1d8ee,
+    type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -411,8 +414,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 8e5de85e872a41eda7f9e32a94dd1cdf, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   _canvasGroup: {fileID: 103030105}
   _text: {fileID: 103030102}
 --- !u!225 &103030105
@@ -437,15 +440,16 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 26c69184c4c94e07a1c1a5403823ba9a, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   _draggableElementName: songInfo
   _horizontal: 1
   _vertical: 1
   _onEditModeChanged:
     m_PersistentCalls:
       m_Calls: []
-  _draggingDisplayPrefab: {fileID: 5730308542642054521, guid: 2a82983eb1a960843bd5603736f9b042, type: 3}
+  _draggingDisplayPrefab: {fileID: 5730308542642054521, guid: 2a82983eb1a960843bd5603736f9b042,
+    type: 3}
 --- !u!1 &124424924
 GameObject:
   m_ObjectHideFlags: 0
@@ -493,8 +497,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -506,7 +510,8 @@ MonoBehaviour:
   m_text: 0/0
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 04973a14f12bf384f8093a8b70f63fcb, type: 2}
-  m_sharedMaterial: {fileID: -7155836927947826254, guid: 04973a14f12bf384f8093a8b70f63fcb, type: 2}
+  m_sharedMaterial: {fileID: -7155836927947826254, guid: 04973a14f12bf384f8093a8b70f63fcb,
+    type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -606,19 +611,19 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 131105196}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 2121478002}
   - {fileID: 1180388673}
-  m_Father: {fileID: 820110414}
+  m_Father: {fileID: 1728396987}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 250, y: 60}
+  m_SizeDelta: {x: 250, y: 63.6642}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &131105198
 MonoBehaviour:
@@ -630,15 +635,15 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 59f8146938fff824cb5fd77236b75775, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Padding:
     m_Left: 0
     m_Right: 0
     m_Top: 0
     m_Bottom: 0
   m_ChildAlignment: 4
-  m_Spacing: 15
+  m_Spacing: 5
   m_ChildForceExpandWidth: 1
   m_ChildForceExpandHeight: 1
   m_ChildControlWidth: 0
@@ -693,8 +698,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 0, g: 0, b: 0, a: 0.50980395}
   m_RaycastTarget: 0
@@ -757,7 +762,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 250, y: 60}
+  m_SizeDelta: {x: 250, y: 69.0275}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &189938503
 MonoBehaviour:
@@ -769,15 +774,15 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 59f8146938fff824cb5fd77236b75775, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Padding:
     m_Left: 0
     m_Right: 0
     m_Top: 0
     m_Bottom: 0
   m_ChildAlignment: 4
-  m_Spacing: 15
+  m_Spacing: 10
   m_ChildForceExpandWidth: 1
   m_ChildForceExpandHeight: 1
   m_ChildControlWidth: 0
@@ -832,8 +837,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 1344c3c82d62a2a41a3576d8abb8e3ea, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 0}
   m_RaycastTarget: 1
@@ -904,8 +909,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -917,7 +922,8 @@ MonoBehaviour:
   m_text: 100%
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 04973a14f12bf384f8093a8b70f63fcb, type: 2}
-  m_sharedMaterial: {fileID: -7155836927947826254, guid: 04973a14f12bf384f8093a8b70f63fcb, type: 2}
+  m_sharedMaterial: {fileID: -7155836927947826254, guid: 04973a14f12bf384f8093a8b70f63fcb,
+    type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -1040,8 +1046,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 0
@@ -1115,8 +1121,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -1128,7 +1134,8 @@ MonoBehaviour:
   m_text: Section
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 21db4751dd6d460499117f8c2d3de781, type: 2}
-  m_sharedMaterial: {fileID: 1134014722335189955, guid: 21db4751dd6d460499117f8c2d3de781, type: 2}
+  m_sharedMaterial: {fileID: 1134014722335189955, guid: 21db4751dd6d460499117f8c2d3de781,
+    type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -1247,7 +1254,7 @@ VideoPlayer:
   - {fileID: 0}
   m_DirectAudioVolumes:
   - 1
-  m_Url:
+  m_Url: 
   m_EnabledAudioTracks: 01
   m_DirectAudioMutes: 00
   m_ControlledAudioTrackCount: 1
@@ -1320,8 +1327,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 59f8146938fff824cb5fd77236b75775, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Padding:
     m_Left: 0
     m_Right: 0
@@ -1369,8 +1376,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 5f9d6d58525b4d22961cb5f7264164de, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   IsSeekingReplay: 0
   _trackViewManager: {fileID: 1330928978}
   _replayController: {fileID: 922548498}
@@ -1380,12 +1387,17 @@ MonoBehaviour:
   _failMeter: {fileID: 368522003}
   <VocalTrack>k__BackingField: {fileID: 1312797156}
   ShowIndex: 0
-  _fiveFretGuitarPrefab: {fileID: 7381119128095886790, guid: 0f7a37c9e4abcad4da73b7603d4b7596, type: 3}
+  _fiveFretGuitarPrefab: {fileID: 7381119128095886790, guid: 0f7a37c9e4abcad4da73b7603d4b7596,
+    type: 3}
   _sixFretGuitarPrefab: {fileID: 0}
-  _fourLaneDrumsPrefab: {fileID: 7508612376246159914, guid: 14dfc37fcbd6e0c4ba41507437a52fea, type: 3}
-  _fiveLaneDrumsPrefab: {fileID: 7912406415472637727, guid: b98748e11cf38534c814f11da4eaa863, type: 3}
-  _proKeysPrefab: {fileID: 7381119128095886790, guid: 52322b4e39d4f9349a65c60a07fc1b3a, type: 3}
-  _fiveLaneKeysPrefab: {fileID: 7381119128095886790, guid: 6117371a3e2df654494387fa6a3fd64a, type: 3}
+  _fourLaneDrumsPrefab: {fileID: 7508612376246159914, guid: 14dfc37fcbd6e0c4ba41507437a52fea,
+    type: 3}
+  _fiveLaneDrumsPrefab: {fileID: 7912406415472637727, guid: b98748e11cf38534c814f11da4eaa863,
+    type: 3}
+  _proKeysPrefab: {fileID: 7381119128095886790, guid: 52322b4e39d4f9349a65c60a07fc1b3a,
+    type: 3}
+  _fiveLaneKeysPrefab: {fileID: 7381119128095886790, guid: 6117371a3e2df654494387fa6a3fd64a,
+    type: 3}
   _proGuitarPrefab: {fileID: 0}
 --- !u!4 &318454372
 Transform:
@@ -1412,8 +1424,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 77fa4d8f39844ad5b9a74e1ebad7564d, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &318454374
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1424,8 +1436,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 0ab4511ef62e4e2a8326d21167a29a43, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   _pauseMenu: {fileID: 1323155442}
   _practiceHud: {fileID: 1316571463}
   _scoreDisplayObject: {fileID: 417575064}
@@ -1439,8 +1451,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 790199f1ac28455ca9536a5df8d11f40, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   _videoPlayer: {fileID: 218824352}
   _backgroundImage: {fileID: 1773048783}
   _backgroundDimmer: {fileID: 1038164713}
@@ -1455,8 +1467,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: e59b27f1aacb384409394db184ff559b, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &318454378
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1467,8 +1479,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: e6d192ef911719df88b8096bff081d07, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   FFTSmoothingFactor: 0.8
   WaveSmoothingFactor: 0.5
 --- !u!114 &318454379
@@ -1481,8 +1493,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 51c694cbcf0967e498788ca5708560e6, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &329669831
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1491,315 +1503,394 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 484523227}
     m_Modifications:
-    - target: {fileID: 227366190812778480, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+    - target: {fileID: 227366190812778480, guid: 039fee0ec42345d4f88c0625255415d4,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 157.1503
       objectReference: {fileID: 0}
-    - target: {fileID: 1316070552520417479, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+    - target: {fileID: 1316070552520417479, guid: 039fee0ec42345d4f88c0625255415d4,
+        type: 3}
       propertyPath: m_AnchorMax.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1316070552520417479, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+    - target: {fileID: 1316070552520417479, guid: 039fee0ec42345d4f88c0625255415d4,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1316070552520417479, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+    - target: {fileID: 1316070552520417479, guid: 039fee0ec42345d4f88c0625255415d4,
+        type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1316070552520417479, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+    - target: {fileID: 1316070552520417479, guid: 039fee0ec42345d4f88c0625255415d4,
+        type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1316070552520417479, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+    - target: {fileID: 1316070552520417479, guid: 039fee0ec42345d4f88c0625255415d4,
+        type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1316070552520417479, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+    - target: {fileID: 1316070552520417479, guid: 039fee0ec42345d4f88c0625255415d4,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1335195020114372814, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+    - target: {fileID: 1335195020114372814, guid: 039fee0ec42345d4f88c0625255415d4,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1335195020114372814, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+    - target: {fileID: 1335195020114372814, guid: 039fee0ec42345d4f88c0625255415d4,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1682100932150968561, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+    - target: {fileID: 1682100932150968561, guid: 039fee0ec42345d4f88c0625255415d4,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1682100932150968561, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+    - target: {fileID: 1682100932150968561, guid: 039fee0ec42345d4f88c0625255415d4,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1682100932150968561, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+    - target: {fileID: 1682100932150968561, guid: 039fee0ec42345d4f88c0625255415d4,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1682100932150968561, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+    - target: {fileID: 1682100932150968561, guid: 039fee0ec42345d4f88c0625255415d4,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1682100932476655723, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+    - target: {fileID: 1682100932476655723, guid: 039fee0ec42345d4f88c0625255415d4,
+        type: 3}
       propertyPath: m_AnchorMax.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1682100932476655723, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+    - target: {fileID: 1682100932476655723, guid: 039fee0ec42345d4f88c0625255415d4,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1682100932476655723, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+    - target: {fileID: 1682100932476655723, guid: 039fee0ec42345d4f88c0625255415d4,
+        type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1682100932476655723, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+    - target: {fileID: 1682100932476655723, guid: 039fee0ec42345d4f88c0625255415d4,
+        type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1682100933276730677, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+    - target: {fileID: 1682100933276730677, guid: 039fee0ec42345d4f88c0625255415d4,
+        type: 3}
       propertyPath: m_Pivot.x
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1682100933276730677, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+    - target: {fileID: 1682100933276730677, guid: 039fee0ec42345d4f88c0625255415d4,
+        type: 3}
       propertyPath: m_Pivot.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1682100933276730677, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+    - target: {fileID: 1682100933276730677, guid: 039fee0ec42345d4f88c0625255415d4,
+        type: 3}
       propertyPath: m_RootOrder
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1682100933276730677, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+    - target: {fileID: 1682100933276730677, guid: 039fee0ec42345d4f88c0625255415d4,
+        type: 3}
       propertyPath: m_AnchorMax.x
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1682100933276730677, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+    - target: {fileID: 1682100933276730677, guid: 039fee0ec42345d4f88c0625255415d4,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1682100933276730677, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+    - target: {fileID: 1682100933276730677, guid: 039fee0ec42345d4f88c0625255415d4,
+        type: 3}
       propertyPath: m_AnchorMin.x
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1682100933276730677, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+    - target: {fileID: 1682100933276730677, guid: 039fee0ec42345d4f88c0625255415d4,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1682100933276730677, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+    - target: {fileID: 1682100933276730677, guid: 039fee0ec42345d4f88c0625255415d4,
+        type: 3}
       propertyPath: m_SizeDelta.x
       value: 375
       objectReference: {fileID: 0}
-    - target: {fileID: 1682100933276730677, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+    - target: {fileID: 1682100933276730677, guid: 039fee0ec42345d4f88c0625255415d4,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1682100933276730677, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+    - target: {fileID: 1682100933276730677, guid: 039fee0ec42345d4f88c0625255415d4,
+        type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1682100933276730677, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+    - target: {fileID: 1682100933276730677, guid: 039fee0ec42345d4f88c0625255415d4,
+        type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1682100933276730677, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+    - target: {fileID: 1682100933276730677, guid: 039fee0ec42345d4f88c0625255415d4,
+        type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1682100933276730677, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+    - target: {fileID: 1682100933276730677, guid: 039fee0ec42345d4f88c0625255415d4,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 1682100933276730677, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+    - target: {fileID: 1682100933276730677, guid: 039fee0ec42345d4f88c0625255415d4,
+        type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 1682100933276730677, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+    - target: {fileID: 1682100933276730677, guid: 039fee0ec42345d4f88c0625255415d4,
+        type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 1682100933276730677, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+    - target: {fileID: 1682100933276730677, guid: 039fee0ec42345d4f88c0625255415d4,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1682100933276730677, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+    - target: {fileID: 1682100933276730677, guid: 039fee0ec42345d4f88c0625255415d4,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1682100933276730677, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+    - target: {fileID: 1682100933276730677, guid: 039fee0ec42345d4f88c0625255415d4,
+        type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1682100933276730677, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+    - target: {fileID: 1682100933276730677, guid: 039fee0ec42345d4f88c0625255415d4,
+        type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1682100933276730677, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+    - target: {fileID: 1682100933276730677, guid: 039fee0ec42345d4f88c0625255415d4,
+        type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1682100933276730678, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+    - target: {fileID: 1682100933276730678, guid: 039fee0ec42345d4f88c0625255415d4,
+        type: 3}
       propertyPath: m_Name
       value: ScoreDisplay
       objectReference: {fileID: 0}
-    - target: {fileID: 1811523672907012699, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+    - target: {fileID: 1811523672907012699, guid: 039fee0ec42345d4f88c0625255415d4,
+        type: 3}
       propertyPath: m_AnchorMax.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1811523672907012699, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+    - target: {fileID: 1811523672907012699, guid: 039fee0ec42345d4f88c0625255415d4,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1811523672907012699, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+    - target: {fileID: 1811523672907012699, guid: 039fee0ec42345d4f88c0625255415d4,
+        type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 1811523672907012699, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+    - target: {fileID: 1811523672907012699, guid: 039fee0ec42345d4f88c0625255415d4,
+        type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2364672318743719202, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+    - target: {fileID: 2364672318743719202, guid: 039fee0ec42345d4f88c0625255415d4,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2364672318743719202, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+    - target: {fileID: 2364672318743719202, guid: 039fee0ec42345d4f88c0625255415d4,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2364672318743719202, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+    - target: {fileID: 2364672318743719202, guid: 039fee0ec42345d4f88c0625255415d4,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2364672318743719202, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+    - target: {fileID: 2364672318743719202, guid: 039fee0ec42345d4f88c0625255415d4,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2517693471320601084, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+    - target: {fileID: 2517693471320601084, guid: 039fee0ec42345d4f88c0625255415d4,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 142.36191
       objectReference: {fileID: 0}
-    - target: {fileID: 2640522790579517911, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+    - target: {fileID: 2640522790579517911, guid: 039fee0ec42345d4f88c0625255415d4,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2640522790579517911, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+    - target: {fileID: 2640522790579517911, guid: 039fee0ec42345d4f88c0625255415d4,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2640522790579517911, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+    - target: {fileID: 2640522790579517911, guid: 039fee0ec42345d4f88c0625255415d4,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2640522790579517911, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+    - target: {fileID: 2640522790579517911, guid: 039fee0ec42345d4f88c0625255415d4,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2682894101143787795, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+    - target: {fileID: 2682894101143787795, guid: 039fee0ec42345d4f88c0625255415d4,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: -142.36188
       objectReference: {fileID: 0}
-    - target: {fileID: 2741204457898369597, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+    - target: {fileID: 2741204457898369597, guid: 039fee0ec42345d4f88c0625255415d4,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2741204457898369597, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+    - target: {fileID: 2741204457898369597, guid: 039fee0ec42345d4f88c0625255415d4,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2741204457898369597, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+    - target: {fileID: 2741204457898369597, guid: 039fee0ec42345d4f88c0625255415d4,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2741204457898369597, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+    - target: {fileID: 2741204457898369597, guid: 039fee0ec42345d4f88c0625255415d4,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2811724150528936072, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+    - target: {fileID: 2811724150528936072, guid: 039fee0ec42345d4f88c0625255415d4,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: -157.1503
       objectReference: {fileID: 0}
-    - target: {fileID: 2822374579689219237, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+    - target: {fileID: 2822374579689219237, guid: 039fee0ec42345d4f88c0625255415d4,
+        type: 3}
       propertyPath: m_AspectRatio
       value: 1.6326531
       objectReference: {fileID: 0}
-    - target: {fileID: 4345241489645973008, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+    - target: {fileID: 4345241489645973008, guid: 039fee0ec42345d4f88c0625255415d4,
+        type: 3}
       propertyPath: m_LocalScale.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4345241489645973008, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+    - target: {fileID: 4345241489645973008, guid: 039fee0ec42345d4f88c0625255415d4,
+        type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4345241489645973008, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+    - target: {fileID: 4345241489645973008, guid: 039fee0ec42345d4f88c0625255415d4,
+        type: 3}
       propertyPath: m_ConstrainProportionsScale
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4902638801293819549, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+    - target: {fileID: 4902638801293819549, guid: 039fee0ec42345d4f88c0625255415d4,
+        type: 3}
       propertyPath: m_Sprite
-      value:
-      objectReference: {fileID: 21300000, guid: ee6de1c1959ebcd4da10808ad235607a, type: 3}
-    - target: {fileID: 4902638801293819549, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+      value: 
+      objectReference: {fileID: 21300000, guid: ee6de1c1959ebcd4da10808ad235607a,
+        type: 3}
+    - target: {fileID: 4902638801293819549, guid: 039fee0ec42345d4f88c0625255415d4,
+        type: 3}
       propertyPath: m_Enabled
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4902638801293819549, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+    - target: {fileID: 4902638801293819549, guid: 039fee0ec42345d4f88c0625255415d4,
+        type: 3}
       propertyPath: m_UseSpriteMesh
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5682201937321367265, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+    - target: {fileID: 5682201937321367265, guid: 039fee0ec42345d4f88c0625255415d4,
+        type: 3}
       propertyPath: m_AnchorMax.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5682201937321367265, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+    - target: {fileID: 5682201937321367265, guid: 039fee0ec42345d4f88c0625255415d4,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5682201937321367265, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+    - target: {fileID: 5682201937321367265, guid: 039fee0ec42345d4f88c0625255415d4,
+        type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6081917654220247207, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+    - target: {fileID: 6081917654220247207, guid: 039fee0ec42345d4f88c0625255415d4,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 157.1503
       objectReference: {fileID: 0}
-    - target: {fileID: 6248039931172562418, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+    - target: {fileID: 6248039931172562418, guid: 039fee0ec42345d4f88c0625255415d4,
+        type: 3}
       propertyPath: m_SizeDelta.x
       value: -22.000011
       objectReference: {fileID: 0}
-    - target: {fileID: 6248039931172562418, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+    - target: {fileID: 6248039931172562418, guid: 039fee0ec42345d4f88c0625255415d4,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: -11.000006
       objectReference: {fileID: 0}
-    - target: {fileID: 6275240589393950520, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+    - target: {fileID: 6275240589393950520, guid: 039fee0ec42345d4f88c0625255415d4,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: -157.1503
       objectReference: {fileID: 0}
-    - target: {fileID: 7328250424041952305, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+    - target: {fileID: 7328250424041952305, guid: 039fee0ec42345d4f88c0625255415d4,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 142.36188
       objectReference: {fileID: 0}
-    - target: {fileID: 8416298410881916005, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+    - target: {fileID: 8416298410881916005, guid: 039fee0ec42345d4f88c0625255415d4,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8416298410881916005, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+    - target: {fileID: 8416298410881916005, guid: 039fee0ec42345d4f88c0625255415d4,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8416298410881916005, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+    - target: {fileID: 8416298410881916005, guid: 039fee0ec42345d4f88c0625255415d4,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8416298410881916005, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+    - target: {fileID: 8416298410881916005, guid: 039fee0ec42345d4f88c0625255415d4,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8915388482217552038, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+    - target: {fileID: 8915388482217552038, guid: 039fee0ec42345d4f88c0625255415d4,
+        type: 3}
       propertyPath: m_text
       value: <mspace=0.538em>99x
       objectReference: {fileID: 0}
-    - target: {fileID: 9151995171417952487, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+    - target: {fileID: 9151995171417952487, guid: 039fee0ec42345d4f88c0625255415d4,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 157.1503
       objectReference: {fileID: 0}
@@ -1807,31 +1898,39 @@ PrefabInstance:
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 3593172417950958894, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+    - targetCorrespondingSourceObject: {fileID: 3593172417950958894, guid: 039fee0ec42345d4f88c0625255415d4,
+        type: 3}
       insertIndex: -1
       addedObject: {fileID: 0}
-    - targetCorrespondingSourceObject: {fileID: 2120540831725165441, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+    - targetCorrespondingSourceObject: {fileID: 2120540831725165441, guid: 039fee0ec42345d4f88c0625255415d4,
+        type: 3}
       insertIndex: -1
       addedObject: {fileID: 0}
-    - targetCorrespondingSourceObject: {fileID: 7953424110739011922, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+    - targetCorrespondingSourceObject: {fileID: 7953424110739011922, guid: 039fee0ec42345d4f88c0625255415d4,
+        type: 3}
       insertIndex: -1
       addedObject: {fileID: 0}
-    - targetCorrespondingSourceObject: {fileID: 3669380178010122580, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+    - targetCorrespondingSourceObject: {fileID: 3669380178010122580, guid: 039fee0ec42345d4f88c0625255415d4,
+        type: 3}
       insertIndex: -1
       addedObject: {fileID: 0}
-    - targetCorrespondingSourceObject: {fileID: 908135978695701862, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+    - targetCorrespondingSourceObject: {fileID: 908135978695701862, guid: 039fee0ec42345d4f88c0625255415d4,
+        type: 3}
       insertIndex: -1
       addedObject: {fileID: 0}
-    - targetCorrespondingSourceObject: {fileID: 920019327054538305, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+    - targetCorrespondingSourceObject: {fileID: 920019327054538305, guid: 039fee0ec42345d4f88c0625255415d4,
+        type: 3}
       insertIndex: -1
       addedObject: {fileID: 0}
-    - targetCorrespondingSourceObject: {fileID: 6244827274338962148, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+    - targetCorrespondingSourceObject: {fileID: 6244827274338962148, guid: 039fee0ec42345d4f88c0625255415d4,
+        type: 3}
       insertIndex: -1
       addedObject: {fileID: 0}
   m_SourcePrefab: {fileID: 100100000, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
 --- !u!224 &329669832 stripped
 RectTransform:
-  m_CorrespondingSourceObject: {fileID: 1682100933276730677, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+  m_CorrespondingSourceObject: {fileID: 1682100933276730677, guid: 039fee0ec42345d4f88c0625255415d4,
+    type: 3}
   m_PrefabInstance: {fileID: 329669831}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &343105999
@@ -1842,215 +1941,268 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 1323155441}
     m_Modifications:
-    - target: {fileID: 567501787953327268, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
+    - target: {fileID: 567501787953327268, guid: 96978c95a41e1f34bb1292218fac0fb1,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 567501787953327268, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
+    - target: {fileID: 567501787953327268, guid: 96978c95a41e1f34bb1292218fac0fb1,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 567501787953327268, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
+    - target: {fileID: 567501787953327268, guid: 96978c95a41e1f34bb1292218fac0fb1,
+        type: 3}
       propertyPath: m_SizeDelta.x
       value: 750
       objectReference: {fileID: 0}
-    - target: {fileID: 567501787953327268, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
+    - target: {fileID: 567501787953327268, guid: 96978c95a41e1f34bb1292218fac0fb1,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 375
       objectReference: {fileID: 0}
-    - target: {fileID: 567501787953327268, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
+    - target: {fileID: 567501787953327268, guid: 96978c95a41e1f34bb1292218fac0fb1,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -155
       objectReference: {fileID: 0}
-    - target: {fileID: 1375503429705721076, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
+    - target: {fileID: 1375503429705721076, guid: 96978c95a41e1f34bb1292218fac0fb1,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1375503429705721076, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
+    - target: {fileID: 1375503429705721076, guid: 96978c95a41e1f34bb1292218fac0fb1,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1375503429705721076, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
+    - target: {fileID: 1375503429705721076, guid: 96978c95a41e1f34bb1292218fac0fb1,
+        type: 3}
       propertyPath: m_SizeDelta.x
       value: 750
       objectReference: {fileID: 0}
-    - target: {fileID: 1375503429705721076, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
+    - target: {fileID: 1375503429705721076, guid: 96978c95a41e1f34bb1292218fac0fb1,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 375
       objectReference: {fileID: 0}
-    - target: {fileID: 1375503429705721076, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
+    - target: {fileID: 1375503429705721076, guid: 96978c95a41e1f34bb1292218fac0fb1,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -218
       objectReference: {fileID: 0}
-    - target: {fileID: 1809313104668657118, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
+    - target: {fileID: 1809313104668657118, guid: 96978c95a41e1f34bb1292218fac0fb1,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1809313104668657118, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
+    - target: {fileID: 1809313104668657118, guid: 96978c95a41e1f34bb1292218fac0fb1,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1809313104668657118, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
+    - target: {fileID: 1809313104668657118, guid: 96978c95a41e1f34bb1292218fac0fb1,
+        type: 3}
       propertyPath: m_SizeDelta.x
       value: 750
       objectReference: {fileID: 0}
-    - target: {fileID: 1809313104668657118, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
+    - target: {fileID: 1809313104668657118, guid: 96978c95a41e1f34bb1292218fac0fb1,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 375
       objectReference: {fileID: 0}
-    - target: {fileID: 1809313104668657118, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
+    - target: {fileID: 1809313104668657118, guid: 96978c95a41e1f34bb1292218fac0fb1,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -281
       objectReference: {fileID: 0}
-    - target: {fileID: 5062416941184210017, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
+    - target: {fileID: 5062416941184210017, guid: 96978c95a41e1f34bb1292218fac0fb1,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5062416941184210017, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
+    - target: {fileID: 5062416941184210017, guid: 96978c95a41e1f34bb1292218fac0fb1,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5062416941184210017, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
+    - target: {fileID: 5062416941184210017, guid: 96978c95a41e1f34bb1292218fac0fb1,
+        type: 3}
       propertyPath: m_SizeDelta.x
       value: 750
       objectReference: {fileID: 0}
-    - target: {fileID: 5062416941184210017, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
+    - target: {fileID: 5062416941184210017, guid: 96978c95a41e1f34bb1292218fac0fb1,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 375
       objectReference: {fileID: 0}
-    - target: {fileID: 5062416941184210017, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
+    - target: {fileID: 5062416941184210017, guid: 96978c95a41e1f34bb1292218fac0fb1,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -92
       objectReference: {fileID: 0}
-    - target: {fileID: 6546681381148955564, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
+    - target: {fileID: 6546681381148955564, guid: 96978c95a41e1f34bb1292218fac0fb1,
+        type: 3}
       propertyPath: m_Name
       value: QuickPlayPause
       objectReference: {fileID: 0}
-    - target: {fileID: 6546681381148955564, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
+    - target: {fileID: 6546681381148955564, guid: 96978c95a41e1f34bb1292218fac0fb1,
+        type: 3}
       propertyPath: m_IsActive
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6546681381148955567, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
+    - target: {fileID: 6546681381148955567, guid: 96978c95a41e1f34bb1292218fac0fb1,
+        type: 3}
       propertyPath: m_Pivot.x
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 6546681381148955567, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
+    - target: {fileID: 6546681381148955567, guid: 96978c95a41e1f34bb1292218fac0fb1,
+        type: 3}
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 6546681381148955567, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
+    - target: {fileID: 6546681381148955567, guid: 96978c95a41e1f34bb1292218fac0fb1,
+        type: 3}
       propertyPath: m_RootOrder
       value: 2
       objectReference: {fileID: 0}
-    - target: {fileID: 6546681381148955567, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
+    - target: {fileID: 6546681381148955567, guid: 96978c95a41e1f34bb1292218fac0fb1,
+        type: 3}
       propertyPath: m_AnchorMax.x
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6546681381148955567, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
+    - target: {fileID: 6546681381148955567, guid: 96978c95a41e1f34bb1292218fac0fb1,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6546681381148955567, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
+    - target: {fileID: 6546681381148955567, guid: 96978c95a41e1f34bb1292218fac0fb1,
+        type: 3}
       propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6546681381148955567, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
+    - target: {fileID: 6546681381148955567, guid: 96978c95a41e1f34bb1292218fac0fb1,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6546681381148955567, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
+    - target: {fileID: 6546681381148955567, guid: 96978c95a41e1f34bb1292218fac0fb1,
+        type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6546681381148955567, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
+    - target: {fileID: 6546681381148955567, guid: 96978c95a41e1f34bb1292218fac0fb1,
+        type: 3}
       propertyPath: m_SizeDelta.y
       value: -250
       objectReference: {fileID: 0}
-    - target: {fileID: 6546681381148955567, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
+    - target: {fileID: 6546681381148955567, guid: 96978c95a41e1f34bb1292218fac0fb1,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6546681381148955567, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
+    - target: {fileID: 6546681381148955567, guid: 96978c95a41e1f34bb1292218fac0fb1,
+        type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6546681381148955567, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
+    - target: {fileID: 6546681381148955567, guid: 96978c95a41e1f34bb1292218fac0fb1,
+        type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6546681381148955567, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
+    - target: {fileID: 6546681381148955567, guid: 96978c95a41e1f34bb1292218fac0fb1,
+        type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6546681381148955567, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
+    - target: {fileID: 6546681381148955567, guid: 96978c95a41e1f34bb1292218fac0fb1,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6546681381148955567, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
+    - target: {fileID: 6546681381148955567, guid: 96978c95a41e1f34bb1292218fac0fb1,
+        type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6546681381148955567, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
+    - target: {fileID: 6546681381148955567, guid: 96978c95a41e1f34bb1292218fac0fb1,
+        type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6546681381148955567, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
+    - target: {fileID: 6546681381148955567, guid: 96978c95a41e1f34bb1292218fac0fb1,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6546681381148955567, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
+    - target: {fileID: 6546681381148955567, guid: 96978c95a41e1f34bb1292218fac0fb1,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -125
       objectReference: {fileID: 0}
-    - target: {fileID: 6546681381148955567, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
+    - target: {fileID: 6546681381148955567, guid: 96978c95a41e1f34bb1292218fac0fb1,
+        type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6546681381148955567, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
+    - target: {fileID: 6546681381148955567, guid: 96978c95a41e1f34bb1292218fac0fb1,
+        type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6546681381148955567, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
+    - target: {fileID: 6546681381148955567, guid: 96978c95a41e1f34bb1292218fac0fb1,
+        type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7202430947735908284, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
+    - target: {fileID: 7202430947735908284, guid: 96978c95a41e1f34bb1292218fac0fb1,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7202430947735908284, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
+    - target: {fileID: 7202430947735908284, guid: 96978c95a41e1f34bb1292218fac0fb1,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7202430947735908284, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
+    - target: {fileID: 7202430947735908284, guid: 96978c95a41e1f34bb1292218fac0fb1,
+        type: 3}
       propertyPath: m_SizeDelta.x
       value: 750
       objectReference: {fileID: 0}
-    - target: {fileID: 7202430947735908284, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
+    - target: {fileID: 7202430947735908284, guid: 96978c95a41e1f34bb1292218fac0fb1,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 375
       objectReference: {fileID: 0}
-    - target: {fileID: 7202430947735908284, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
+    - target: {fileID: 7202430947735908284, guid: 96978c95a41e1f34bb1292218fac0fb1,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -344
       objectReference: {fileID: 0}
-    - target: {fileID: 8831732612347581242, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
+    - target: {fileID: 8831732612347581242, guid: 96978c95a41e1f34bb1292218fac0fb1,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8831732612347581242, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
+    - target: {fileID: 8831732612347581242, guid: 96978c95a41e1f34bb1292218fac0fb1,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8831732612347581242, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
+    - target: {fileID: 8831732612347581242, guid: 96978c95a41e1f34bb1292218fac0fb1,
+        type: 3}
       propertyPath: m_SizeDelta.x
       value: 750
       objectReference: {fileID: 0}
-    - target: {fileID: 8831732612347581242, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
+    - target: {fileID: 8831732612347581242, guid: 96978c95a41e1f34bb1292218fac0fb1,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 375
       objectReference: {fileID: 0}
-    - target: {fileID: 8831732612347581242, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
+    - target: {fileID: 8831732612347581242, guid: 96978c95a41e1f34bb1292218fac0fb1,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -29
       objectReference: {fileID: 0}
@@ -2061,7 +2213,8 @@ PrefabInstance:
   m_SourcePrefab: {fileID: 100100000, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
 --- !u!224 &343106000 stripped
 RectTransform:
-  m_CorrespondingSourceObject: {fileID: 6546681381148955567, guid: 96978c95a41e1f34bb1292218fac0fb1, type: 3}
+  m_CorrespondingSourceObject: {fileID: 6546681381148955567, guid: 96978c95a41e1f34bb1292218fac0fb1,
+    type: 3}
   m_PrefabInstance: {fileID: 343105999}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &354419372
@@ -2072,95 +2225,118 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 1323155441}
     m_Modifications:
-    - target: {fileID: 4006097793978072117, guid: 303b1a6a6e4a69c478f59759e786787d, type: 3}
+    - target: {fileID: 4006097793978072117, guid: 303b1a6a6e4a69c478f59759e786787d,
+        type: 3}
       propertyPath: m_Pivot.x
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 4006097793978072117, guid: 303b1a6a6e4a69c478f59759e786787d, type: 3}
+    - target: {fileID: 4006097793978072117, guid: 303b1a6a6e4a69c478f59759e786787d,
+        type: 3}
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 4006097793978072117, guid: 303b1a6a6e4a69c478f59759e786787d, type: 3}
+    - target: {fileID: 4006097793978072117, guid: 303b1a6a6e4a69c478f59759e786787d,
+        type: 3}
       propertyPath: m_RootOrder
       value: 7
       objectReference: {fileID: 0}
-    - target: {fileID: 4006097793978072117, guid: 303b1a6a6e4a69c478f59759e786787d, type: 3}
+    - target: {fileID: 4006097793978072117, guid: 303b1a6a6e4a69c478f59759e786787d,
+        type: 3}
       propertyPath: m_AnchorMax.x
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4006097793978072117, guid: 303b1a6a6e4a69c478f59759e786787d, type: 3}
+    - target: {fileID: 4006097793978072117, guid: 303b1a6a6e4a69c478f59759e786787d,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4006097793978072117, guid: 303b1a6a6e4a69c478f59759e786787d, type: 3}
+    - target: {fileID: 4006097793978072117, guid: 303b1a6a6e4a69c478f59759e786787d,
+        type: 3}
       propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4006097793978072117, guid: 303b1a6a6e4a69c478f59759e786787d, type: 3}
+    - target: {fileID: 4006097793978072117, guid: 303b1a6a6e4a69c478f59759e786787d,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4006097793978072117, guid: 303b1a6a6e4a69c478f59759e786787d, type: 3}
+    - target: {fileID: 4006097793978072117, guid: 303b1a6a6e4a69c478f59759e786787d,
+        type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4006097793978072117, guid: 303b1a6a6e4a69c478f59759e786787d, type: 3}
+    - target: {fileID: 4006097793978072117, guid: 303b1a6a6e4a69c478f59759e786787d,
+        type: 3}
       propertyPath: m_SizeDelta.y
       value: -250
       objectReference: {fileID: 0}
-    - target: {fileID: 4006097793978072117, guid: 303b1a6a6e4a69c478f59759e786787d, type: 3}
+    - target: {fileID: 4006097793978072117, guid: 303b1a6a6e4a69c478f59759e786787d,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4006097793978072117, guid: 303b1a6a6e4a69c478f59759e786787d, type: 3}
+    - target: {fileID: 4006097793978072117, guid: 303b1a6a6e4a69c478f59759e786787d,
+        type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4006097793978072117, guid: 303b1a6a6e4a69c478f59759e786787d, type: 3}
+    - target: {fileID: 4006097793978072117, guid: 303b1a6a6e4a69c478f59759e786787d,
+        type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4006097793978072117, guid: 303b1a6a6e4a69c478f59759e786787d, type: 3}
+    - target: {fileID: 4006097793978072117, guid: 303b1a6a6e4a69c478f59759e786787d,
+        type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4006097793978072117, guid: 303b1a6a6e4a69c478f59759e786787d, type: 3}
+    - target: {fileID: 4006097793978072117, guid: 303b1a6a6e4a69c478f59759e786787d,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4006097793978072117, guid: 303b1a6a6e4a69c478f59759e786787d, type: 3}
+    - target: {fileID: 4006097793978072117, guid: 303b1a6a6e4a69c478f59759e786787d,
+        type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4006097793978072117, guid: 303b1a6a6e4a69c478f59759e786787d, type: 3}
+    - target: {fileID: 4006097793978072117, guid: 303b1a6a6e4a69c478f59759e786787d,
+        type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4006097793978072117, guid: 303b1a6a6e4a69c478f59759e786787d, type: 3}
+    - target: {fileID: 4006097793978072117, guid: 303b1a6a6e4a69c478f59759e786787d,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4006097793978072117, guid: 303b1a6a6e4a69c478f59759e786787d, type: 3}
+    - target: {fileID: 4006097793978072117, guid: 303b1a6a6e4a69c478f59759e786787d,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -125
       objectReference: {fileID: 0}
-    - target: {fileID: 4006097793978072117, guid: 303b1a6a6e4a69c478f59759e786787d, type: 3}
+    - target: {fileID: 4006097793978072117, guid: 303b1a6a6e4a69c478f59759e786787d,
+        type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4006097793978072117, guid: 303b1a6a6e4a69c478f59759e786787d, type: 3}
+    - target: {fileID: 4006097793978072117, guid: 303b1a6a6e4a69c478f59759e786787d,
+        type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4006097793978072117, guid: 303b1a6a6e4a69c478f59759e786787d, type: 3}
+    - target: {fileID: 4006097793978072117, guid: 303b1a6a6e4a69c478f59759e786787d,
+        type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4006097793978072118, guid: 303b1a6a6e4a69c478f59759e786787d, type: 3}
+    - target: {fileID: 4006097793978072118, guid: 303b1a6a6e4a69c478f59759e786787d,
+        type: 3}
       propertyPath: m_Name
       value: SetlistPause
       objectReference: {fileID: 0}
-    - target: {fileID: 4006097793978072118, guid: 303b1a6a6e4a69c478f59759e786787d, type: 3}
+    - target: {fileID: 4006097793978072118, guid: 303b1a6a6e4a69c478f59759e786787d,
+        type: 3}
       propertyPath: m_IsActive
       value: 0
       objectReference: {fileID: 0}
@@ -2171,25 +2347,65 @@ PrefabInstance:
   m_SourcePrefab: {fileID: 100100000, guid: 303b1a6a6e4a69c478f59759e786787d, type: 3}
 --- !u!224 &354419373 stripped
 RectTransform:
-  m_CorrespondingSourceObject: {fileID: 4006097793978072117, guid: 303b1a6a6e4a69c478f59759e786787d, type: 3}
+  m_CorrespondingSourceObject: {fileID: 4006097793978072117, guid: 303b1a6a6e4a69c478f59759e786787d,
+    type: 3}
   m_PrefabInstance: {fileID: 354419372}
   m_PrefabAsset: {fileID: 0}
 --- !u!224 &368522001 stripped
 RectTransform:
-  m_CorrespondingSourceObject: {fileID: 8712046426310438027, guid: d0b16d99b827a28449b37e491eb7cd45, type: 3}
+  m_CorrespondingSourceObject: {fileID: 8712046426310438027, guid: d0b16d99b827a28449b37e491eb7cd45,
+    type: 3}
   m_PrefabInstance: {fileID: 1792480618}
   m_PrefabAsset: {fileID: 0}
 --- !u!114 &368522003 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 8712046426310438029, guid: d0b16d99b827a28449b37e491eb7cd45, type: 3}
+  m_CorrespondingSourceObject: {fileID: 8712046426310438029, guid: d0b16d99b827a28449b37e491eb7cd45,
+    type: 3}
   m_PrefabInstance: {fileID: 1792480618}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 2399e3981e2db8e45abb7734d762cddc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!84 &384353436
+RenderTexture:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_ImageContentsHash:
+    serializedVersion: 2
+    Hash: 00000000000000000000000000000000
+  m_IsAlphaChannelOptional: 0
+  serializedVersion: 6
+  m_Width: 2299
+  m_Height: 1057
+  m_AntiAliasing: 1
+  m_MipCount: -1
+  m_DepthStencilFormat: 0
+  m_ColorFormat: 48
+  m_MipMap: 0
+  m_GenerateMips: 1
+  m_SRGB: 0
+  m_UseDynamicScale: 0
+  m_UseDynamicScaleExplicit: 0
+  m_BindMS: 0
+  m_EnableCompatibleFormat: 1
+  m_EnableRandomWrite: 0
+  m_TextureSettings:
+    serializedVersion: 2
+    m_FilterMode: 1
+    m_Aniso: 1
+    m_MipBias: 0
+    m_WrapU: 1
+    m_WrapV: 1
+    m_WrapW: 1
+  m_Dimension: 2
+  m_VolumeDepth: 1
+  m_ShadowSamplingMode: 2
 --- !u!1001 &387423406
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2198,155 +2414,193 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 1323155441}
     m_Modifications:
-    - target: {fileID: 407376744541711451, guid: 4855f4c81d54b8647b7db7f687c7ee43, type: 3}
+    - target: {fileID: 407376744541711451, guid: 4855f4c81d54b8647b7db7f687c7ee43,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 407376744541711451, guid: 4855f4c81d54b8647b7db7f687c7ee43, type: 3}
+    - target: {fileID: 407376744541711451, guid: 4855f4c81d54b8647b7db7f687c7ee43,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 407376744541711451, guid: 4855f4c81d54b8647b7db7f687c7ee43, type: 3}
+    - target: {fileID: 407376744541711451, guid: 4855f4c81d54b8647b7db7f687c7ee43,
+        type: 3}
       propertyPath: m_SizeDelta.x
       value: 750
       objectReference: {fileID: 0}
-    - target: {fileID: 407376744541711451, guid: 4855f4c81d54b8647b7db7f687c7ee43, type: 3}
+    - target: {fileID: 407376744541711451, guid: 4855f4c81d54b8647b7db7f687c7ee43,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 375
       objectReference: {fileID: 0}
-    - target: {fileID: 407376744541711451, guid: 4855f4c81d54b8647b7db7f687c7ee43, type: 3}
+    - target: {fileID: 407376744541711451, guid: 4855f4c81d54b8647b7db7f687c7ee43,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -155
       objectReference: {fileID: 0}
-    - target: {fileID: 4220475146329657928, guid: 4855f4c81d54b8647b7db7f687c7ee43, type: 3}
+    - target: {fileID: 4220475146329657928, guid: 4855f4c81d54b8647b7db7f687c7ee43,
+        type: 3}
       propertyPath: m_Pivot.x
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 4220475146329657928, guid: 4855f4c81d54b8647b7db7f687c7ee43, type: 3}
+    - target: {fileID: 4220475146329657928, guid: 4855f4c81d54b8647b7db7f687c7ee43,
+        type: 3}
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 4220475146329657928, guid: 4855f4c81d54b8647b7db7f687c7ee43, type: 3}
+    - target: {fileID: 4220475146329657928, guid: 4855f4c81d54b8647b7db7f687c7ee43,
+        type: 3}
       propertyPath: m_RootOrder
       value: 6
       objectReference: {fileID: 0}
-    - target: {fileID: 4220475146329657928, guid: 4855f4c81d54b8647b7db7f687c7ee43, type: 3}
+    - target: {fileID: 4220475146329657928, guid: 4855f4c81d54b8647b7db7f687c7ee43,
+        type: 3}
       propertyPath: m_AnchorMax.x
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4220475146329657928, guid: 4855f4c81d54b8647b7db7f687c7ee43, type: 3}
+    - target: {fileID: 4220475146329657928, guid: 4855f4c81d54b8647b7db7f687c7ee43,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4220475146329657928, guid: 4855f4c81d54b8647b7db7f687c7ee43, type: 3}
+    - target: {fileID: 4220475146329657928, guid: 4855f4c81d54b8647b7db7f687c7ee43,
+        type: 3}
       propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4220475146329657928, guid: 4855f4c81d54b8647b7db7f687c7ee43, type: 3}
+    - target: {fileID: 4220475146329657928, guid: 4855f4c81d54b8647b7db7f687c7ee43,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4220475146329657928, guid: 4855f4c81d54b8647b7db7f687c7ee43, type: 3}
+    - target: {fileID: 4220475146329657928, guid: 4855f4c81d54b8647b7db7f687c7ee43,
+        type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4220475146329657928, guid: 4855f4c81d54b8647b7db7f687c7ee43, type: 3}
+    - target: {fileID: 4220475146329657928, guid: 4855f4c81d54b8647b7db7f687c7ee43,
+        type: 3}
       propertyPath: m_SizeDelta.y
       value: -250
       objectReference: {fileID: 0}
-    - target: {fileID: 4220475146329657928, guid: 4855f4c81d54b8647b7db7f687c7ee43, type: 3}
+    - target: {fileID: 4220475146329657928, guid: 4855f4c81d54b8647b7db7f687c7ee43,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4220475146329657928, guid: 4855f4c81d54b8647b7db7f687c7ee43, type: 3}
+    - target: {fileID: 4220475146329657928, guid: 4855f4c81d54b8647b7db7f687c7ee43,
+        type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4220475146329657928, guid: 4855f4c81d54b8647b7db7f687c7ee43, type: 3}
+    - target: {fileID: 4220475146329657928, guid: 4855f4c81d54b8647b7db7f687c7ee43,
+        type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4220475146329657928, guid: 4855f4c81d54b8647b7db7f687c7ee43, type: 3}
+    - target: {fileID: 4220475146329657928, guid: 4855f4c81d54b8647b7db7f687c7ee43,
+        type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4220475146329657928, guid: 4855f4c81d54b8647b7db7f687c7ee43, type: 3}
+    - target: {fileID: 4220475146329657928, guid: 4855f4c81d54b8647b7db7f687c7ee43,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4220475146329657928, guid: 4855f4c81d54b8647b7db7f687c7ee43, type: 3}
+    - target: {fileID: 4220475146329657928, guid: 4855f4c81d54b8647b7db7f687c7ee43,
+        type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4220475146329657928, guid: 4855f4c81d54b8647b7db7f687c7ee43, type: 3}
+    - target: {fileID: 4220475146329657928, guid: 4855f4c81d54b8647b7db7f687c7ee43,
+        type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4220475146329657928, guid: 4855f4c81d54b8647b7db7f687c7ee43, type: 3}
+    - target: {fileID: 4220475146329657928, guid: 4855f4c81d54b8647b7db7f687c7ee43,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4220475146329657928, guid: 4855f4c81d54b8647b7db7f687c7ee43, type: 3}
+    - target: {fileID: 4220475146329657928, guid: 4855f4c81d54b8647b7db7f687c7ee43,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -125
       objectReference: {fileID: 0}
-    - target: {fileID: 4220475146329657928, guid: 4855f4c81d54b8647b7db7f687c7ee43, type: 3}
+    - target: {fileID: 4220475146329657928, guid: 4855f4c81d54b8647b7db7f687c7ee43,
+        type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4220475146329657928, guid: 4855f4c81d54b8647b7db7f687c7ee43, type: 3}
+    - target: {fileID: 4220475146329657928, guid: 4855f4c81d54b8647b7db7f687c7ee43,
+        type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4220475146329657928, guid: 4855f4c81d54b8647b7db7f687c7ee43, type: 3}
+    - target: {fileID: 4220475146329657928, guid: 4855f4c81d54b8647b7db7f687c7ee43,
+        type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4220475146329657931, guid: 4855f4c81d54b8647b7db7f687c7ee43, type: 3}
+    - target: {fileID: 4220475146329657931, guid: 4855f4c81d54b8647b7db7f687c7ee43,
+        type: 3}
       propertyPath: m_Name
       value: QuickSettings
       objectReference: {fileID: 0}
-    - target: {fileID: 4220475146329657931, guid: 4855f4c81d54b8647b7db7f687c7ee43, type: 3}
+    - target: {fileID: 4220475146329657931, guid: 4855f4c81d54b8647b7db7f687c7ee43,
+        type: 3}
       propertyPath: m_IsActive
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5734763326058268183, guid: 4855f4c81d54b8647b7db7f687c7ee43, type: 3}
+    - target: {fileID: 5734763326058268183, guid: 4855f4c81d54b8647b7db7f687c7ee43,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5734763326058268183, guid: 4855f4c81d54b8647b7db7f687c7ee43, type: 3}
+    - target: {fileID: 5734763326058268183, guid: 4855f4c81d54b8647b7db7f687c7ee43,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5734763326058268183, guid: 4855f4c81d54b8647b7db7f687c7ee43, type: 3}
+    - target: {fileID: 5734763326058268183, guid: 4855f4c81d54b8647b7db7f687c7ee43,
+        type: 3}
       propertyPath: m_SizeDelta.x
       value: 750
       objectReference: {fileID: 0}
-    - target: {fileID: 5734763326058268183, guid: 4855f4c81d54b8647b7db7f687c7ee43, type: 3}
+    - target: {fileID: 5734763326058268183, guid: 4855f4c81d54b8647b7db7f687c7ee43,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 375
       objectReference: {fileID: 0}
-    - target: {fileID: 5734763326058268183, guid: 4855f4c81d54b8647b7db7f687c7ee43, type: 3}
+    - target: {fileID: 5734763326058268183, guid: 4855f4c81d54b8647b7db7f687c7ee43,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -29
       objectReference: {fileID: 0}
-    - target: {fileID: 8095661284169053984, guid: 4855f4c81d54b8647b7db7f687c7ee43, type: 3}
+    - target: {fileID: 8095661284169053984, guid: 4855f4c81d54b8647b7db7f687c7ee43,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8095661284169053984, guid: 4855f4c81d54b8647b7db7f687c7ee43, type: 3}
+    - target: {fileID: 8095661284169053984, guid: 4855f4c81d54b8647b7db7f687c7ee43,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8095661284169053984, guid: 4855f4c81d54b8647b7db7f687c7ee43, type: 3}
+    - target: {fileID: 8095661284169053984, guid: 4855f4c81d54b8647b7db7f687c7ee43,
+        type: 3}
       propertyPath: m_SizeDelta.x
       value: 750
       objectReference: {fileID: 0}
-    - target: {fileID: 8095661284169053984, guid: 4855f4c81d54b8647b7db7f687c7ee43, type: 3}
+    - target: {fileID: 8095661284169053984, guid: 4855f4c81d54b8647b7db7f687c7ee43,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 375
       objectReference: {fileID: 0}
-    - target: {fileID: 8095661284169053984, guid: 4855f4c81d54b8647b7db7f687c7ee43, type: 3}
+    - target: {fileID: 8095661284169053984, guid: 4855f4c81d54b8647b7db7f687c7ee43,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -92
       objectReference: {fileID: 0}
@@ -2357,7 +2611,8 @@ PrefabInstance:
   m_SourcePrefab: {fileID: 100100000, guid: 4855f4c81d54b8647b7db7f687c7ee43, type: 3}
 --- !u!224 &387423407 stripped
 RectTransform:
-  m_CorrespondingSourceObject: {fileID: 4220475146329657928, guid: 4855f4c81d54b8647b7db7f687c7ee43, type: 3}
+  m_CorrespondingSourceObject: {fileID: 4220475146329657928, guid: 4855f4c81d54b8647b7db7f687c7ee43,
+    type: 3}
   m_PrefabInstance: {fileID: 387423406}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &396166999
@@ -2368,571 +2623,713 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 397042284}
     m_Modifications:
-    - target: {fileID: 923944859560468810, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 923944859560468810, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 923944859560468810, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 923944859560468810, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 923944859560468810, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 923944859560468810, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 50
       objectReference: {fileID: 0}
-    - target: {fileID: 923944859560468810, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 923944859560468810, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -145
       objectReference: {fileID: 0}
-    - target: {fileID: 1015521776706112280, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 1015521776706112280, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1015521776706112280, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 1015521776706112280, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1015521776706112280, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 1015521776706112280, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 50
       objectReference: {fileID: 0}
-    - target: {fileID: 1015521776706112280, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 1015521776706112280, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -145
       objectReference: {fileID: 0}
-    - target: {fileID: 1804228161284093612, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 1804228161284093612, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1804228161284093612, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 1804228161284093612, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1804228161284093612, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 1804228161284093612, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 50
       objectReference: {fileID: 0}
-    - target: {fileID: 1804228161284093612, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 1804228161284093612, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -80
       objectReference: {fileID: 0}
-    - target: {fileID: 1863211756566059682, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 1863211756566059682, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1863211756566059682, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 1863211756566059682, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1863211756566059682, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 1863211756566059682, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_SizeDelta.y
       value: 160
       objectReference: {fileID: 0}
-    - target: {fileID: 1863211756566059682, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 1863211756566059682, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 250
       objectReference: {fileID: 0}
-    - target: {fileID: 1863211756566059682, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 1863211756566059682, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -50
       objectReference: {fileID: 0}
-    - target: {fileID: 2003185583018712318, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 2003185583018712318, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2003185583018712318, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 2003185583018712318, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2003185583018712318, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 2003185583018712318, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 50
       objectReference: {fileID: 0}
-    - target: {fileID: 2003185583018712318, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 2003185583018712318, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -80
       objectReference: {fileID: 0}
-    - target: {fileID: 2032747772109177108, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 2032747772109177108, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2032747772109177108, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 2032747772109177108, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2032747772109177108, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 2032747772109177108, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 50
       objectReference: {fileID: 0}
-    - target: {fileID: 2032747772109177108, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 2032747772109177108, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -15
       objectReference: {fileID: 0}
-    - target: {fileID: 2229453393495288646, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 2229453393495288646, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2229453393495288646, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 2229453393495288646, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2229453393495288646, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 2229453393495288646, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 50
       objectReference: {fileID: 0}
-    - target: {fileID: 2229453393495288646, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 2229453393495288646, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -15
       objectReference: {fileID: 0}
-    - target: {fileID: 2530718889766638275, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 2530718889766638275, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2530718889766638275, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 2530718889766638275, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2530718889766638275, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 2530718889766638275, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_SizeDelta.y
       value: 160
       objectReference: {fileID: 0}
-    - target: {fileID: 2530718889766638275, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 2530718889766638275, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 50
       objectReference: {fileID: 0}
-    - target: {fileID: 2530718889766638275, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 2530718889766638275, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -50
       objectReference: {fileID: 0}
-    - target: {fileID: 2570460951685009712, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 2570460951685009712, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2570460951685009712, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 2570460951685009712, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2570460951685009712, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 2570460951685009712, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 50
       objectReference: {fileID: 0}
-    - target: {fileID: 2570460951685009712, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 2570460951685009712, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -15
       objectReference: {fileID: 0}
-    - target: {fileID: 2618112443279854810, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 2618112443279854810, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2618112443279854810, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 2618112443279854810, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2618112443279854810, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 2618112443279854810, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 50
       objectReference: {fileID: 0}
-    - target: {fileID: 2618112443279854810, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 2618112443279854810, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -80
       objectReference: {fileID: 0}
-    - target: {fileID: 2989169099748620477, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 2989169099748620477, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2989169099748620477, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 2989169099748620477, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2989169099748620477, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 2989169099748620477, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 50
       objectReference: {fileID: 0}
-    - target: {fileID: 2989169099748620477, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 2989169099748620477, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -80
       objectReference: {fileID: 0}
-    - target: {fileID: 3351472579802850647, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 3351472579802850647, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3351472579802850647, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 3351472579802850647, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3351472579802850647, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 3351472579802850647, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 50
       objectReference: {fileID: 0}
-    - target: {fileID: 3351472579802850647, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 3351472579802850647, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -15
       objectReference: {fileID: 0}
-    - target: {fileID: 3412701907868381659, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 3412701907868381659, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3412701907868381659, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 3412701907868381659, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3412701907868381659, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 3412701907868381659, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 50
       objectReference: {fileID: 0}
-    - target: {fileID: 3412701907868381659, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 3412701907868381659, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -145
       objectReference: {fileID: 0}
-    - target: {fileID: 3696148239668228462, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 3696148239668228462, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3696148239668228462, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 3696148239668228462, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3696148239668228462, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 3696148239668228462, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 50
       objectReference: {fileID: 0}
-    - target: {fileID: 3696148239668228462, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 3696148239668228462, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -145
       objectReference: {fileID: 0}
-    - target: {fileID: 4053914855838518383, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 4053914855838518383, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4053914855838518383, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 4053914855838518383, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4053914855838518383, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 4053914855838518383, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 50
       objectReference: {fileID: 0}
-    - target: {fileID: 4053914855838518383, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 4053914855838518383, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -80
       objectReference: {fileID: 0}
-    - target: {fileID: 4496163825672963337, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 4496163825672963337, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4496163825672963337, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 4496163825672963337, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4496163825672963337, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 4496163825672963337, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 50
       objectReference: {fileID: 0}
-    - target: {fileID: 4496163825672963337, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 4496163825672963337, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -145
       objectReference: {fileID: 0}
-    - target: {fileID: 4550537150001708835, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 4550537150001708835, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_Name
       value: FiveFretViewer
       objectReference: {fileID: 0}
-    - target: {fileID: 4550537150001708835, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 4550537150001708835, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_IsActive
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4592297151973052805, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 4592297151973052805, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4592297151973052805, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 4592297151973052805, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4592297151973052805, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 4592297151973052805, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 50
       objectReference: {fileID: 0}
-    - target: {fileID: 4592297151973052805, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 4592297151973052805, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -15
       objectReference: {fileID: 0}
-    - target: {fileID: 4773576581307856199, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 4773576581307856199, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_Pivot.x
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 4773576581307856199, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 4773576581307856199, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 4773576581307856199, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 4773576581307856199, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_RootOrder
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4773576581307856199, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 4773576581307856199, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchorMax.x
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 4773576581307856199, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 4773576581307856199, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4773576581307856199, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 4773576581307856199, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchorMin.x
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 4773576581307856199, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 4773576581307856199, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4773576581307856199, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 4773576581307856199, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_SizeDelta.x
       value: 700
       objectReference: {fileID: 0}
-    - target: {fileID: 4773576581307856199, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 4773576581307856199, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_SizeDelta.y
       value: 100
       objectReference: {fileID: 0}
-    - target: {fileID: 4773576581307856199, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 4773576581307856199, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4773576581307856199, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 4773576581307856199, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4773576581307856199, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 4773576581307856199, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4773576581307856199, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 4773576581307856199, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4773576581307856199, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 4773576581307856199, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4773576581307856199, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 4773576581307856199, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4773576581307856199, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 4773576581307856199, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 4773576581307856199, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 4773576581307856199, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4773576581307856199, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 4773576581307856199, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -207
       objectReference: {fileID: 0}
-    - target: {fileID: 4773576581307856199, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 4773576581307856199, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4773576581307856199, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 4773576581307856199, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4773576581307856199, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 4773576581307856199, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4809495223790543464, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 4809495223790543464, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4809495223790543464, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 4809495223790543464, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4809495223790543464, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 4809495223790543464, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_SizeDelta.y
       value: 160
       objectReference: {fileID: 0}
-    - target: {fileID: 4809495223790543464, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 4809495223790543464, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 150
       objectReference: {fileID: 0}
-    - target: {fileID: 4809495223790543464, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 4809495223790543464, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -50
       objectReference: {fileID: 0}
-    - target: {fileID: 5249931034455656470, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 5249931034455656470, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5249931034455656470, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 5249931034455656470, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5249931034455656470, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 5249931034455656470, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 50
       objectReference: {fileID: 0}
-    - target: {fileID: 5249931034455656470, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 5249931034455656470, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -80
       objectReference: {fileID: 0}
-    - target: {fileID: 5702396662984218108, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 5702396662984218108, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5702396662984218108, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 5702396662984218108, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5702396662984218108, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 5702396662984218108, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 50
       objectReference: {fileID: 0}
-    - target: {fileID: 5702396662984218108, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 5702396662984218108, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -15
       objectReference: {fileID: 0}
-    - target: {fileID: 5733096055400551951, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 5733096055400551951, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5733096055400551951, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 5733096055400551951, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5733096055400551951, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 5733096055400551951, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_SizeDelta.y
       value: 160
       objectReference: {fileID: 0}
-    - target: {fileID: 5733096055400551951, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 5733096055400551951, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 650
       objectReference: {fileID: 0}
-    - target: {fileID: 5733096055400551951, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 5733096055400551951, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -50
       objectReference: {fileID: 0}
-    - target: {fileID: 6018793775768344250, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 6018793775768344250, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6018793775768344250, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 6018793775768344250, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6018793775768344250, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 6018793775768344250, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_SizeDelta.y
       value: 160
       objectReference: {fileID: 0}
-    - target: {fileID: 6018793775768344250, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 6018793775768344250, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 350
       objectReference: {fileID: 0}
-    - target: {fileID: 6018793775768344250, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 6018793775768344250, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -50
       objectReference: {fileID: 0}
-    - target: {fileID: 6901128905896408482, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 6901128905896408482, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6901128905896408482, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 6901128905896408482, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6901128905896408482, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 6901128905896408482, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 50
       objectReference: {fileID: 0}
-    - target: {fileID: 6901128905896408482, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 6901128905896408482, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -145
       objectReference: {fileID: 0}
-    - target: {fileID: 7277854903345118659, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 7277854903345118659, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7277854903345118659, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 7277854903345118659, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7277854903345118659, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 7277854903345118659, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 50
       objectReference: {fileID: 0}
-    - target: {fileID: 7277854903345118659, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 7277854903345118659, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -145
       objectReference: {fileID: 0}
-    - target: {fileID: 8073218781510207019, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 8073218781510207019, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8073218781510207019, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 8073218781510207019, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8073218781510207019, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 8073218781510207019, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_SizeDelta.y
       value: 160
       objectReference: {fileID: 0}
-    - target: {fileID: 8073218781510207019, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 8073218781510207019, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 450
       objectReference: {fileID: 0}
-    - target: {fileID: 8073218781510207019, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 8073218781510207019, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -50
       objectReference: {fileID: 0}
-    - target: {fileID: 8223043098546897015, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 8223043098546897015, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8223043098546897015, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 8223043098546897015, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8223043098546897015, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 8223043098546897015, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 50
       objectReference: {fileID: 0}
-    - target: {fileID: 8223043098546897015, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 8223043098546897015, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -80
       objectReference: {fileID: 0}
-    - target: {fileID: 8272141569167338617, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 8272141569167338617, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8272141569167338617, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 8272141569167338617, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8272141569167338617, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 8272141569167338617, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_SizeDelta.y
       value: 160
       objectReference: {fileID: 0}
-    - target: {fileID: 8272141569167338617, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 8272141569167338617, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 550
       objectReference: {fileID: 0}
-    - target: {fileID: 8272141569167338617, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 8272141569167338617, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -50
       objectReference: {fileID: 0}
-    - target: {fileID: 8495871208499633565, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 8495871208499633565, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8495871208499633565, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 8495871208499633565, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8495871208499633565, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 8495871208499633565, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 50
       objectReference: {fileID: 0}
-    - target: {fileID: 8495871208499633565, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+    - target: {fileID: 8495871208499633565, guid: 72eef77c01b66604696836c2b02cb1e1,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -15
       objectReference: {fileID: 0}
@@ -2993,8 +3390,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: b8c498d3c7f26fe4b8c41ba7170e9c73, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   _topPaddingForVocals: 140
 --- !u!1001 &412813829
 PrefabInstance:
@@ -3004,67 +3401,83 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 1517088745}
     m_Modifications:
-    - target: {fileID: 3967995507941194808, guid: 249f3206655c65946a0f15b17834fca4, type: 3}
+    - target: {fileID: 3967995507941194808, guid: 249f3206655c65946a0f15b17834fca4,
+        type: 3}
       propertyPath: m_RootOrder
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3967995507941194808, guid: 249f3206655c65946a0f15b17834fca4, type: 3}
+    - target: {fileID: 3967995507941194808, guid: 249f3206655c65946a0f15b17834fca4,
+        type: 3}
       propertyPath: m_LocalScale.x
       value: 1.5
       objectReference: {fileID: 0}
-    - target: {fileID: 3967995507941194808, guid: 249f3206655c65946a0f15b17834fca4, type: 3}
+    - target: {fileID: 3967995507941194808, guid: 249f3206655c65946a0f15b17834fca4,
+        type: 3}
       propertyPath: m_LocalScale.y
       value: 1.5
       objectReference: {fileID: 0}
-    - target: {fileID: 3967995507941194808, guid: 249f3206655c65946a0f15b17834fca4, type: 3}
+    - target: {fileID: 3967995507941194808, guid: 249f3206655c65946a0f15b17834fca4,
+        type: 3}
       propertyPath: m_LocalScale.z
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3967995507941194808, guid: 249f3206655c65946a0f15b17834fca4, type: 3}
+    - target: {fileID: 3967995507941194808, guid: 249f3206655c65946a0f15b17834fca4,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3967995507941194808, guid: 249f3206655c65946a0f15b17834fca4, type: 3}
+    - target: {fileID: 3967995507941194808, guid: 249f3206655c65946a0f15b17834fca4,
+        type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3967995507941194808, guid: 249f3206655c65946a0f15b17834fca4, type: 3}
+    - target: {fileID: 3967995507941194808, guid: 249f3206655c65946a0f15b17834fca4,
+        type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3967995507941194808, guid: 249f3206655c65946a0f15b17834fca4, type: 3}
+    - target: {fileID: 3967995507941194808, guid: 249f3206655c65946a0f15b17834fca4,
+        type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3967995507941194808, guid: 249f3206655c65946a0f15b17834fca4, type: 3}
+    - target: {fileID: 3967995507941194808, guid: 249f3206655c65946a0f15b17834fca4,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 3967995507941194808, guid: 249f3206655c65946a0f15b17834fca4, type: 3}
+    - target: {fileID: 3967995507941194808, guid: 249f3206655c65946a0f15b17834fca4,
+        type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 3967995507941194808, guid: 249f3206655c65946a0f15b17834fca4, type: 3}
+    - target: {fileID: 3967995507941194808, guid: 249f3206655c65946a0f15b17834fca4,
+        type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 3967995507941194808, guid: 249f3206655c65946a0f15b17834fca4, type: 3}
+    - target: {fileID: 3967995507941194808, guid: 249f3206655c65946a0f15b17834fca4,
+        type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3967995507941194808, guid: 249f3206655c65946a0f15b17834fca4, type: 3}
+    - target: {fileID: 3967995507941194808, guid: 249f3206655c65946a0f15b17834fca4,
+        type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3967995507941194808, guid: 249f3206655c65946a0f15b17834fca4, type: 3}
+    - target: {fileID: 3967995507941194808, guid: 249f3206655c65946a0f15b17834fca4,
+        type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3967995507941194808, guid: 249f3206655c65946a0f15b17834fca4, type: 3}
+    - target: {fileID: 3967995507941194808, guid: 249f3206655c65946a0f15b17834fca4,
+        type: 3}
       propertyPath: m_ConstrainProportionsScale
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4618290287218134900, guid: 249f3206655c65946a0f15b17834fca4, type: 3}
+    - target: {fileID: 4618290287218134900, guid: 249f3206655c65946a0f15b17834fca4,
+        type: 3}
       propertyPath: m_Name
       value: CountdownDisplay
       objectReference: {fileID: 0}
@@ -3075,23 +3488,26 @@ PrefabInstance:
   m_SourcePrefab: {fileID: 100100000, guid: 249f3206655c65946a0f15b17834fca4, type: 3}
 --- !u!114 &412813830 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 4549246668167681472, guid: 249f3206655c65946a0f15b17834fca4, type: 3}
+  m_CorrespondingSourceObject: {fileID: 4549246668167681472, guid: 249f3206655c65946a0f15b17834fca4,
+    type: 3}
   m_PrefabInstance: {fileID: 412813829}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: e01a15edf7c559e49a771df09251d09b, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!4 &412813831 stripped
 Transform:
-  m_CorrespondingSourceObject: {fileID: 3967995507941194808, guid: 249f3206655c65946a0f15b17834fca4, type: 3}
+  m_CorrespondingSourceObject: {fileID: 3967995507941194808, guid: 249f3206655c65946a0f15b17834fca4,
+    type: 3}
   m_PrefabInstance: {fileID: 412813829}
   m_PrefabAsset: {fileID: 0}
 --- !u!1 &417575064 stripped
 GameObject:
-  m_CorrespondingSourceObject: {fileID: 1682100933276730678, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+  m_CorrespondingSourceObject: {fileID: 1682100933276730678, guid: 039fee0ec42345d4f88c0625255415d4,
+    type: 3}
   m_PrefabInstance: {fileID: 329669831}
   m_PrefabAsset: {fileID: 0}
 --- !u!1 &417693871
@@ -3141,8 +3557,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -3151,10 +3567,11 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text:
+  m_text: 
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 04973a14f12bf384f8093a8b70f63fcb, type: 2}
-  m_sharedMaterial: {fileID: -7155836927947826254, guid: 04973a14f12bf384f8093a8b70f63fcb, type: 2}
+  m_sharedMaterial: {fileID: -7155836927947826254, guid: 04973a14f12bf384f8093a8b70f63fcb,
+    type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -3277,8 +3694,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 1344c3c82d62a2a41a3576d8abb8e3ea, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 0
@@ -3287,7 +3704,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Texture: {fileID: 1219814984}
+  m_Texture: {fileID: 384353436}
   m_UVRect:
     serializedVersion: 2
     x: 0
@@ -3310,95 +3727,118 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 1323155441}
     m_Modifications:
-    - target: {fileID: 3138315878222825538, guid: 52629a15f11ae49448efe5f7f4af230c, type: 3}
+    - target: {fileID: 3138315878222825538, guid: 52629a15f11ae49448efe5f7f4af230c,
+        type: 3}
       propertyPath: m_Pivot.x
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 3138315878222825538, guid: 52629a15f11ae49448efe5f7f4af230c, type: 3}
+    - target: {fileID: 3138315878222825538, guid: 52629a15f11ae49448efe5f7f4af230c,
+        type: 3}
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 3138315878222825538, guid: 52629a15f11ae49448efe5f7f4af230c, type: 3}
+    - target: {fileID: 3138315878222825538, guid: 52629a15f11ae49448efe5f7f4af230c,
+        type: 3}
       propertyPath: m_RootOrder
       value: 4
       objectReference: {fileID: 0}
-    - target: {fileID: 3138315878222825538, guid: 52629a15f11ae49448efe5f7f4af230c, type: 3}
+    - target: {fileID: 3138315878222825538, guid: 52629a15f11ae49448efe5f7f4af230c,
+        type: 3}
       propertyPath: m_AnchorMax.x
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3138315878222825538, guid: 52629a15f11ae49448efe5f7f4af230c, type: 3}
+    - target: {fileID: 3138315878222825538, guid: 52629a15f11ae49448efe5f7f4af230c,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3138315878222825538, guid: 52629a15f11ae49448efe5f7f4af230c, type: 3}
+    - target: {fileID: 3138315878222825538, guid: 52629a15f11ae49448efe5f7f4af230c,
+        type: 3}
       propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3138315878222825538, guid: 52629a15f11ae49448efe5f7f4af230c, type: 3}
+    - target: {fileID: 3138315878222825538, guid: 52629a15f11ae49448efe5f7f4af230c,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3138315878222825538, guid: 52629a15f11ae49448efe5f7f4af230c, type: 3}
+    - target: {fileID: 3138315878222825538, guid: 52629a15f11ae49448efe5f7f4af230c,
+        type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3138315878222825538, guid: 52629a15f11ae49448efe5f7f4af230c, type: 3}
+    - target: {fileID: 3138315878222825538, guid: 52629a15f11ae49448efe5f7f4af230c,
+        type: 3}
       propertyPath: m_SizeDelta.y
       value: -250
       objectReference: {fileID: 0}
-    - target: {fileID: 3138315878222825538, guid: 52629a15f11ae49448efe5f7f4af230c, type: 3}
+    - target: {fileID: 3138315878222825538, guid: 52629a15f11ae49448efe5f7f4af230c,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3138315878222825538, guid: 52629a15f11ae49448efe5f7f4af230c, type: 3}
+    - target: {fileID: 3138315878222825538, guid: 52629a15f11ae49448efe5f7f4af230c,
+        type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3138315878222825538, guid: 52629a15f11ae49448efe5f7f4af230c, type: 3}
+    - target: {fileID: 3138315878222825538, guid: 52629a15f11ae49448efe5f7f4af230c,
+        type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3138315878222825538, guid: 52629a15f11ae49448efe5f7f4af230c, type: 3}
+    - target: {fileID: 3138315878222825538, guid: 52629a15f11ae49448efe5f7f4af230c,
+        type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3138315878222825538, guid: 52629a15f11ae49448efe5f7f4af230c, type: 3}
+    - target: {fileID: 3138315878222825538, guid: 52629a15f11ae49448efe5f7f4af230c,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 3138315878222825538, guid: 52629a15f11ae49448efe5f7f4af230c, type: 3}
+    - target: {fileID: 3138315878222825538, guid: 52629a15f11ae49448efe5f7f4af230c,
+        type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 3138315878222825538, guid: 52629a15f11ae49448efe5f7f4af230c, type: 3}
+    - target: {fileID: 3138315878222825538, guid: 52629a15f11ae49448efe5f7f4af230c,
+        type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 3138315878222825538, guid: 52629a15f11ae49448efe5f7f4af230c, type: 3}
+    - target: {fileID: 3138315878222825538, guid: 52629a15f11ae49448efe5f7f4af230c,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3138315878222825538, guid: 52629a15f11ae49448efe5f7f4af230c, type: 3}
+    - target: {fileID: 3138315878222825538, guid: 52629a15f11ae49448efe5f7f4af230c,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -125
       objectReference: {fileID: 0}
-    - target: {fileID: 3138315878222825538, guid: 52629a15f11ae49448efe5f7f4af230c, type: 3}
+    - target: {fileID: 3138315878222825538, guid: 52629a15f11ae49448efe5f7f4af230c,
+        type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3138315878222825538, guid: 52629a15f11ae49448efe5f7f4af230c, type: 3}
+    - target: {fileID: 3138315878222825538, guid: 52629a15f11ae49448efe5f7f4af230c,
+        type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3138315878222825538, guid: 52629a15f11ae49448efe5f7f4af230c, type: 3}
+    - target: {fileID: 3138315878222825538, guid: 52629a15f11ae49448efe5f7f4af230c,
+        type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 3138315878222825539, guid: 52629a15f11ae49448efe5f7f4af230c, type: 3}
+    - target: {fileID: 3138315878222825539, guid: 52629a15f11ae49448efe5f7f4af230c,
+        type: 3}
       propertyPath: m_Name
       value: SelectSections
       objectReference: {fileID: 0}
-    - target: {fileID: 3138315878222825539, guid: 52629a15f11ae49448efe5f7f4af230c, type: 3}
+    - target: {fileID: 3138315878222825539, guid: 52629a15f11ae49448efe5f7f4af230c,
+        type: 3}
       propertyPath: m_IsActive
       value: 0
       objectReference: {fileID: 0}
@@ -3409,7 +3849,8 @@ PrefabInstance:
   m_SourcePrefab: {fileID: 100100000, guid: 52629a15f11ae49448efe5f7f4af230c, type: 3}
 --- !u!224 &459816309 stripped
 RectTransform:
-  m_CorrespondingSourceObject: {fileID: 3138315878222825538, guid: 52629a15f11ae49448efe5f7f4af230c, type: 3}
+  m_CorrespondingSourceObject: {fileID: 3138315878222825538, guid: 52629a15f11ae49448efe5f7f4af230c,
+    type: 3}
   m_PrefabInstance: {fileID: 459816308}
   m_PrefabAsset: {fileID: 0}
 --- !u!1 &477816501
@@ -3459,8 +3900,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -3472,7 +3913,8 @@ MonoBehaviour:
   m_text: 0%
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 04973a14f12bf384f8093a8b70f63fcb, type: 2}
-  m_sharedMaterial: {fileID: -7155836927947826254, guid: 04973a14f12bf384f8093a8b70f63fcb, type: 2}
+  m_sharedMaterial: {fileID: -7155836927947826254, guid: 04973a14f12bf384f8093a8b70f63fcb,
+    type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -3597,8 +4039,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_IgnoreReversedGraphics: 1
   m_BlockingObjects: 0
   m_BlockingMask:
@@ -3637,15 +4079,16 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 26c69184c4c94e07a1c1a5403823ba9a, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   _draggableElementName: scoreDisplay
   _horizontal: 1
   _vertical: 1
   _onEditModeChanged:
     m_PersistentCalls:
       m_Calls: []
-  _draggingDisplayPrefab: {fileID: 5730308542642054521, guid: 2a82983eb1a960843bd5603736f9b042, type: 3}
+  _draggingDisplayPrefab: {fileID: 5730308542642054521, guid: 2a82983eb1a960843bd5603736f9b042,
+    type: 3}
 --- !u!1 &523103389
 GameObject:
   m_ObjectHideFlags: 0
@@ -3693,8 +4136,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -3706,7 +4149,8 @@ MonoBehaviour:
   m_text: Speed
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 21db4751dd6d460499117f8c2d3de781, type: 2}
-  m_sharedMaterial: {fileID: 1134014722335189955, guid: 21db4751dd6d460499117f8c2d3de781, type: 2}
+  m_sharedMaterial: {fileID: 1134014722335189955, guid: 21db4751dd6d460499117f8c2d3de781,
+    type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -3830,8 +4274,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 59f8146938fff824cb5fd77236b75775, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Padding:
     m_Left: 0
     m_Right: 0
@@ -3895,8 +4339,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_IgnoreLayout: 1
   m_MinWidth: -1
   m_MinHeight: -1
@@ -3960,8 +4404,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -3973,7 +4417,8 @@ MonoBehaviour:
   m_text: Album
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: d9dd031fb1c2f2f4fabb34137edfa885, type: 2}
-  m_sharedMaterial: {fileID: 1536850694454096710, guid: d9dd031fb1c2f2f4fabb34137edfa885, type: 2}
+  m_sharedMaterial: {fileID: 1536850694454096710, guid: d9dd031fb1c2f2f4fabb34137edfa885,
+    type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -4097,8 +4542,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 0, g: 0, b: 0, a: 0.8}
   m_RaycastTarget: 0
@@ -4172,8 +4617,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -4185,7 +4630,8 @@ MonoBehaviour:
   m_text: Song Name
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: d9dd031fb1c2f2f4fabb34137edfa885, type: 2}
-  m_sharedMaterial: {fileID: 1536850694454096710, guid: d9dd031fb1c2f2f4fabb34137edfa885, type: 2}
+  m_sharedMaterial: {fileID: 1536850694454096710, guid: d9dd031fb1c2f2f4fabb34137edfa885,
+    type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -4308,8 +4754,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -4321,7 +4767,8 @@ MonoBehaviour:
   m_text: Best
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 21db4751dd6d460499117f8c2d3de781, type: 2}
-  m_sharedMaterial: {fileID: 1134014722335189955, guid: 21db4751dd6d460499117f8c2d3de781, type: 2}
+  m_sharedMaterial: {fileID: 1134014722335189955, guid: 21db4751dd6d460499117f8c2d3de781,
+    type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -4445,8 +4892,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 59f8146938fff824cb5fd77236b75775, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Padding:
     m_Left: 0
     m_Right: 0
@@ -4463,7 +4910,8 @@ MonoBehaviour:
   m_ReverseArrangement: 0
 --- !u!224 &793838894 stripped
 RectTransform:
-  m_CorrespondingSourceObject: {fileID: 4773576581307856199, guid: 72eef77c01b66604696836c2b02cb1e1, type: 3}
+  m_CorrespondingSourceObject: {fileID: 4773576581307856199, guid: 72eef77c01b66604696836c2b02cb1e1,
+    type: 3}
   m_PrefabInstance: {fileID: 396166999}
   m_PrefabAsset: {fileID: 0}
 --- !u!1 &820110413
@@ -4496,12 +4944,11 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 93166677}
-  - {fileID: 131105197}
   m_Father: {fileID: 1316571461}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: -240}
   m_SizeDelta: {x: -760, y: 200}
   m_Pivot: {x: 0.5, y: 0}
 --- !u!114 &820110415
@@ -4514,14 +4961,14 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 59f8146938fff824cb5fd77236b75775, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Padding:
     m_Left: 0
     m_Right: 0
     m_Top: 0
     m_Bottom: 0
-  m_ChildAlignment: 4
+  m_ChildAlignment: 1
   m_Spacing: 0
   m_ChildForceExpandWidth: 1
   m_ChildForceExpandHeight: 1
@@ -4578,8 +5025,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 59f8146938fff824cb5fd77236b75775, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Padding:
     m_Left: 0
     m_Right: 0
@@ -4654,43 +5101,6 @@ Canvas:
   m_SortingLayerID: 0
   m_SortingOrder: 0
   m_TargetDisplay: 0
---- !u!84 &846372168
-RenderTexture:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name:
-  m_ImageContentsHash:
-    serializedVersion: 2
-    Hash: 00000000000000000000000000000000
-  m_IsAlphaChannelOptional: 0
-  serializedVersion: 6
-  m_Width: 1920
-  m_Height: 1080
-  m_AntiAliasing: 1
-  m_MipCount: -1
-  m_DepthStencilFormat: 0
-  m_ColorFormat: 48
-  m_MipMap: 0
-  m_GenerateMips: 1
-  m_SRGB: 0
-  m_UseDynamicScale: 0
-  m_UseDynamicScaleExplicit: 0
-  m_BindMS: 0
-  m_EnableCompatibleFormat: 1
-  m_EnableRandomWrite: 0
-  m_TextureSettings:
-    serializedVersion: 2
-    m_FilterMode: 1
-    m_Aniso: 1
-    m_MipBias: 0
-    m_WrapU: 1
-    m_WrapV: 1
-    m_WrapW: 1
-  m_Dimension: 2
-  m_VolumeDepth: 1
-  m_ShadowSamplingMode: 2
 --- !u!1 &879254556
 GameObject:
   m_ObjectHideFlags: 0
@@ -4738,8 +5148,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 1344c3c82d62a2a41a3576d8abb8e3ea, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 0
@@ -4771,187 +5181,233 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 1212139298}
     m_Modifications:
-    - target: {fileID: 2006855537152082164, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
+    - target: {fileID: 2006855537152082164, guid: f8c143f8514898b4fb85fbadc18550c0,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2006855537152082164, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
+    - target: {fileID: 2006855537152082164, guid: f8c143f8514898b4fb85fbadc18550c0,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2006855537152082164, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
+    - target: {fileID: 2006855537152082164, guid: f8c143f8514898b4fb85fbadc18550c0,
+        type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2006855537152082164, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
+    - target: {fileID: 2006855537152082164, guid: f8c143f8514898b4fb85fbadc18550c0,
+        type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2006855537152082164, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
+    - target: {fileID: 2006855537152082164, guid: f8c143f8514898b4fb85fbadc18550c0,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2006855537152082164, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
+    - target: {fileID: 2006855537152082164, guid: f8c143f8514898b4fb85fbadc18550c0,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2933889975780695480, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
+    - target: {fileID: 2933889975780695480, guid: f8c143f8514898b4fb85fbadc18550c0,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2933889975780695480, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
+    - target: {fileID: 2933889975780695480, guid: f8c143f8514898b4fb85fbadc18550c0,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2933889975780695480, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
+    - target: {fileID: 2933889975780695480, guid: f8c143f8514898b4fb85fbadc18550c0,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 2933889975780695480, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
+    - target: {fileID: 2933889975780695480, guid: f8c143f8514898b4fb85fbadc18550c0,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5322898957872382039, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
+    - target: {fileID: 5322898957872382039, guid: f8c143f8514898b4fb85fbadc18550c0,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6915276943068997200, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
+    - target: {fileID: 6915276943068997200, guid: f8c143f8514898b4fb85fbadc18550c0,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6915276943068997200, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
+    - target: {fileID: 6915276943068997200, guid: f8c143f8514898b4fb85fbadc18550c0,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6915276943068997200, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
+    - target: {fileID: 6915276943068997200, guid: f8c143f8514898b4fb85fbadc18550c0,
+        type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6915276943068997200, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
+    - target: {fileID: 6915276943068997200, guid: f8c143f8514898b4fb85fbadc18550c0,
+        type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6915276943068997200, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
+    - target: {fileID: 6915276943068997200, guid: f8c143f8514898b4fb85fbadc18550c0,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 6915276943068997200, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
+    - target: {fileID: 6915276943068997200, guid: f8c143f8514898b4fb85fbadc18550c0,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7226651616191308852, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
+    - target: {fileID: 7226651616191308852, guid: f8c143f8514898b4fb85fbadc18550c0,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7226651616191308852, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
+    - target: {fileID: 7226651616191308852, guid: f8c143f8514898b4fb85fbadc18550c0,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7226651616191308852, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
+    - target: {fileID: 7226651616191308852, guid: f8c143f8514898b4fb85fbadc18550c0,
+        type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7226651616191308852, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
+    - target: {fileID: 7226651616191308852, guid: f8c143f8514898b4fb85fbadc18550c0,
+        type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7226651616191308852, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
+    - target: {fileID: 7226651616191308852, guid: f8c143f8514898b4fb85fbadc18550c0,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7226651616191308852, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
+    - target: {fileID: 7226651616191308852, guid: f8c143f8514898b4fb85fbadc18550c0,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7369758456864847373, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
+    - target: {fileID: 7369758456864847373, guid: f8c143f8514898b4fb85fbadc18550c0,
+        type: 3}
       propertyPath: m_Name
       value: ReplayViewer
       objectReference: {fileID: 0}
-    - target: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
+    - target: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0,
+        type: 3}
       propertyPath: m_Pivot.x
       value: 0.49999997
       objectReference: {fileID: 0}
-    - target: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
+    - target: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0,
+        type: 3}
       propertyPath: m_Pivot.y
       value: 0.49999997
       objectReference: {fileID: 0}
-    - target: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
+    - target: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0,
+        type: 3}
       propertyPath: m_RootOrder
       value: 7
       objectReference: {fileID: 0}
-    - target: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
+    - target: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0,
+        type: 3}
       propertyPath: m_AnchorMax.x
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
+    - target: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
+    - target: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0,
+        type: 3}
       propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
+    - target: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
+    - target: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0,
+        type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
+    - target: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0,
+        type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
+    - target: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
+    - target: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0,
+        type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
+    - target: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0,
+        type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
+    - target: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0,
+        type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
+    - target: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
+    - target: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0,
+        type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
+    - target: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0,
+        type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
+    - target: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
+    - target: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
+    - target: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0,
+        type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
+    - target: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0,
+        type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
+    - target: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0,
+        type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8431678723656029144, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
+    - target: {fileID: 8431678723656029144, guid: f8c143f8514898b4fb85fbadc18550c0,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
@@ -4962,20 +5418,22 @@ PrefabInstance:
   m_SourcePrefab: {fileID: 100100000, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
 --- !u!224 &922548497 stripped
 RectTransform:
-  m_CorrespondingSourceObject: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
+  m_CorrespondingSourceObject: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0,
+    type: 3}
   m_PrefabInstance: {fileID: 922548496}
   m_PrefabAsset: {fileID: 0}
 --- !u!114 &922548498 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 5703792185782102541, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
+  m_CorrespondingSourceObject: {fileID: 5703792185782102541, guid: f8c143f8514898b4fb85fbadc18550c0,
+    type: 3}
   m_PrefabInstance: {fileID: 922548496}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 0b8f1c89e02545aaa55cf9a7e097e9dd, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &943800968
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -4984,99 +5442,123 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 1323155441}
     m_Modifications:
-    - target: {fileID: 4293127954770772634, guid: baa7a80387dc41d469efe3686d4a6375, type: 3}
+    - target: {fileID: 4293127954770772634, guid: baa7a80387dc41d469efe3686d4a6375,
+        type: 3}
       propertyPath: <Menu>k__BackingField
       value: 8
       objectReference: {fileID: 0}
-    - target: {fileID: 5981333258937755041, guid: baa7a80387dc41d469efe3686d4a6375, type: 3}
+    - target: {fileID: 5981333258937755041, guid: baa7a80387dc41d469efe3686d4a6375,
+        type: 3}
       propertyPath: m_Pivot.x
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 5981333258937755041, guid: baa7a80387dc41d469efe3686d4a6375, type: 3}
+    - target: {fileID: 5981333258937755041, guid: baa7a80387dc41d469efe3686d4a6375,
+        type: 3}
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 5981333258937755041, guid: baa7a80387dc41d469efe3686d4a6375, type: 3}
+    - target: {fileID: 5981333258937755041, guid: baa7a80387dc41d469efe3686d4a6375,
+        type: 3}
       propertyPath: m_RootOrder
       value: 8
       objectReference: {fileID: 0}
-    - target: {fileID: 5981333258937755041, guid: baa7a80387dc41d469efe3686d4a6375, type: 3}
+    - target: {fileID: 5981333258937755041, guid: baa7a80387dc41d469efe3686d4a6375,
+        type: 3}
       propertyPath: m_AnchorMax.x
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5981333258937755041, guid: baa7a80387dc41d469efe3686d4a6375, type: 3}
+    - target: {fileID: 5981333258937755041, guid: baa7a80387dc41d469efe3686d4a6375,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5981333258937755041, guid: baa7a80387dc41d469efe3686d4a6375, type: 3}
+    - target: {fileID: 5981333258937755041, guid: baa7a80387dc41d469efe3686d4a6375,
+        type: 3}
       propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5981333258937755041, guid: baa7a80387dc41d469efe3686d4a6375, type: 3}
+    - target: {fileID: 5981333258937755041, guid: baa7a80387dc41d469efe3686d4a6375,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5981333258937755041, guid: baa7a80387dc41d469efe3686d4a6375, type: 3}
+    - target: {fileID: 5981333258937755041, guid: baa7a80387dc41d469efe3686d4a6375,
+        type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5981333258937755041, guid: baa7a80387dc41d469efe3686d4a6375, type: 3}
+    - target: {fileID: 5981333258937755041, guid: baa7a80387dc41d469efe3686d4a6375,
+        type: 3}
       propertyPath: m_SizeDelta.y
       value: -250
       objectReference: {fileID: 0}
-    - target: {fileID: 5981333258937755041, guid: baa7a80387dc41d469efe3686d4a6375, type: 3}
+    - target: {fileID: 5981333258937755041, guid: baa7a80387dc41d469efe3686d4a6375,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5981333258937755041, guid: baa7a80387dc41d469efe3686d4a6375, type: 3}
+    - target: {fileID: 5981333258937755041, guid: baa7a80387dc41d469efe3686d4a6375,
+        type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5981333258937755041, guid: baa7a80387dc41d469efe3686d4a6375, type: 3}
+    - target: {fileID: 5981333258937755041, guid: baa7a80387dc41d469efe3686d4a6375,
+        type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5981333258937755041, guid: baa7a80387dc41d469efe3686d4a6375, type: 3}
+    - target: {fileID: 5981333258937755041, guid: baa7a80387dc41d469efe3686d4a6375,
+        type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5981333258937755041, guid: baa7a80387dc41d469efe3686d4a6375, type: 3}
+    - target: {fileID: 5981333258937755041, guid: baa7a80387dc41d469efe3686d4a6375,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5981333258937755041, guid: baa7a80387dc41d469efe3686d4a6375, type: 3}
+    - target: {fileID: 5981333258937755041, guid: baa7a80387dc41d469efe3686d4a6375,
+        type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5981333258937755041, guid: baa7a80387dc41d469efe3686d4a6375, type: 3}
+    - target: {fileID: 5981333258937755041, guid: baa7a80387dc41d469efe3686d4a6375,
+        type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5981333258937755041, guid: baa7a80387dc41d469efe3686d4a6375, type: 3}
+    - target: {fileID: 5981333258937755041, guid: baa7a80387dc41d469efe3686d4a6375,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5981333258937755041, guid: baa7a80387dc41d469efe3686d4a6375, type: 3}
+    - target: {fileID: 5981333258937755041, guid: baa7a80387dc41d469efe3686d4a6375,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -125
       objectReference: {fileID: 0}
-    - target: {fileID: 5981333258937755041, guid: baa7a80387dc41d469efe3686d4a6375, type: 3}
+    - target: {fileID: 5981333258937755041, guid: baa7a80387dc41d469efe3686d4a6375,
+        type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5981333258937755041, guid: baa7a80387dc41d469efe3686d4a6375, type: 3}
+    - target: {fileID: 5981333258937755041, guid: baa7a80387dc41d469efe3686d4a6375,
+        type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5981333258937755041, guid: baa7a80387dc41d469efe3686d4a6375, type: 3}
+    - target: {fileID: 5981333258937755041, guid: baa7a80387dc41d469efe3686d4a6375,
+        type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5981333258937755042, guid: baa7a80387dc41d469efe3686d4a6375, type: 3}
+    - target: {fileID: 5981333258937755042, guid: baa7a80387dc41d469efe3686d4a6375,
+        type: 3}
       propertyPath: m_Name
       value: FailPause
       objectReference: {fileID: 0}
-    - target: {fileID: 5981333258937755042, guid: baa7a80387dc41d469efe3686d4a6375, type: 3}
+    - target: {fileID: 5981333258937755042, guid: baa7a80387dc41d469efe3686d4a6375,
+        type: 3}
       propertyPath: m_IsActive
       value: 0
       objectReference: {fileID: 0}
@@ -5087,7 +5569,8 @@ PrefabInstance:
   m_SourcePrefab: {fileID: 100100000, guid: baa7a80387dc41d469efe3686d4a6375, type: 3}
 --- !u!224 &943800969 stripped
 RectTransform:
-  m_CorrespondingSourceObject: {fileID: 5981333258937755041, guid: baa7a80387dc41d469efe3686d4a6375, type: 3}
+  m_CorrespondingSourceObject: {fileID: 5981333258937755041, guid: baa7a80387dc41d469efe3686d4a6375,
+    type: 3}
   m_PrefabInstance: {fileID: 943800968}
   m_PrefabAsset: {fileID: 0}
 --- !u!1 &970019644
@@ -5140,8 +5623,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 59f8146938fff824cb5fd77236b75775, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Padding:
     m_Left: 0
     m_Right: 0
@@ -5203,8 +5686,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 0, g: 0, b: 0, a: 0}
   m_RaycastTarget: 1
@@ -5239,275 +5722,343 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 1323155441}
     m_Modifications:
-    - target: {fileID: 132419825530296480, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
+    - target: {fileID: 132419825530296480, guid: e3d517531b8487141a8a955f24e85a1c,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 132419825530296480, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
+    - target: {fileID: 132419825530296480, guid: e3d517531b8487141a8a955f24e85a1c,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 132419825530296480, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
+    - target: {fileID: 132419825530296480, guid: e3d517531b8487141a8a955f24e85a1c,
+        type: 3}
       propertyPath: m_SizeDelta.x
       value: 750
       objectReference: {fileID: 0}
-    - target: {fileID: 132419825530296480, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
+    - target: {fileID: 132419825530296480, guid: e3d517531b8487141a8a955f24e85a1c,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 375
       objectReference: {fileID: 0}
-    - target: {fileID: 132419825530296480, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
+    - target: {fileID: 132419825530296480, guid: e3d517531b8487141a8a955f24e85a1c,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -470
       objectReference: {fileID: 0}
-    - target: {fileID: 628753446950880641, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
+    - target: {fileID: 628753446950880641, guid: e3d517531b8487141a8a955f24e85a1c,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 628753446950880641, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
+    - target: {fileID: 628753446950880641, guid: e3d517531b8487141a8a955f24e85a1c,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 628753446950880641, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
+    - target: {fileID: 628753446950880641, guid: e3d517531b8487141a8a955f24e85a1c,
+        type: 3}
       propertyPath: m_SizeDelta.x
       value: 750
       objectReference: {fileID: 0}
-    - target: {fileID: 628753446950880641, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
+    - target: {fileID: 628753446950880641, guid: e3d517531b8487141a8a955f24e85a1c,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 375
       objectReference: {fileID: 0}
-    - target: {fileID: 628753446950880641, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
+    - target: {fileID: 628753446950880641, guid: e3d517531b8487141a8a955f24e85a1c,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -29
       objectReference: {fileID: 0}
-    - target: {fileID: 1144209813281861628, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
+    - target: {fileID: 1144209813281861628, guid: e3d517531b8487141a8a955f24e85a1c,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1144209813281861628, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
+    - target: {fileID: 1144209813281861628, guid: e3d517531b8487141a8a955f24e85a1c,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 1144209813281861628, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
+    - target: {fileID: 1144209813281861628, guid: e3d517531b8487141a8a955f24e85a1c,
+        type: 3}
       propertyPath: m_SizeDelta.x
       value: 750
       objectReference: {fileID: 0}
-    - target: {fileID: 1144209813281861628, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
+    - target: {fileID: 1144209813281861628, guid: e3d517531b8487141a8a955f24e85a1c,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 375
       objectReference: {fileID: 0}
-    - target: {fileID: 1144209813281861628, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
+    - target: {fileID: 1144209813281861628, guid: e3d517531b8487141a8a955f24e85a1c,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -155
       objectReference: {fileID: 0}
-    - target: {fileID: 2872069603678488960, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
+    - target: {fileID: 2872069603678488960, guid: e3d517531b8487141a8a955f24e85a1c,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2872069603678488960, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
+    - target: {fileID: 2872069603678488960, guid: e3d517531b8487141a8a955f24e85a1c,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 2872069603678488960, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
+    - target: {fileID: 2872069603678488960, guid: e3d517531b8487141a8a955f24e85a1c,
+        type: 3}
       propertyPath: m_SizeDelta.x
       value: 750
       objectReference: {fileID: 0}
-    - target: {fileID: 2872069603678488960, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
+    - target: {fileID: 2872069603678488960, guid: e3d517531b8487141a8a955f24e85a1c,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 375
       objectReference: {fileID: 0}
-    - target: {fileID: 2872069603678488960, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
+    - target: {fileID: 2872069603678488960, guid: e3d517531b8487141a8a955f24e85a1c,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -92
       objectReference: {fileID: 0}
-    - target: {fileID: 3317591240376291203, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
+    - target: {fileID: 3317591240376291203, guid: e3d517531b8487141a8a955f24e85a1c,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3317591240376291203, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
+    - target: {fileID: 3317591240376291203, guid: e3d517531b8487141a8a955f24e85a1c,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3317591240376291203, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
+    - target: {fileID: 3317591240376291203, guid: e3d517531b8487141a8a955f24e85a1c,
+        type: 3}
       propertyPath: m_SizeDelta.x
       value: 750
       objectReference: {fileID: 0}
-    - target: {fileID: 3317591240376291203, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
+    - target: {fileID: 3317591240376291203, guid: e3d517531b8487141a8a955f24e85a1c,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 375
       objectReference: {fileID: 0}
-    - target: {fileID: 3317591240376291203, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
+    - target: {fileID: 3317591240376291203, guid: e3d517531b8487141a8a955f24e85a1c,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -281
       objectReference: {fileID: 0}
-    - target: {fileID: 6355455761800452810, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
+    - target: {fileID: 6355455761800452810, guid: e3d517531b8487141a8a955f24e85a1c,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6355455761800452810, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
+    - target: {fileID: 6355455761800452810, guid: e3d517531b8487141a8a955f24e85a1c,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6355455761800452810, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
+    - target: {fileID: 6355455761800452810, guid: e3d517531b8487141a8a955f24e85a1c,
+        type: 3}
       propertyPath: m_SizeDelta.x
       value: 750
       objectReference: {fileID: 0}
-    - target: {fileID: 6355455761800452810, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
+    - target: {fileID: 6355455761800452810, guid: e3d517531b8487141a8a955f24e85a1c,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 375
       objectReference: {fileID: 0}
-    - target: {fileID: 6355455761800452810, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
+    - target: {fileID: 6355455761800452810, guid: e3d517531b8487141a8a955f24e85a1c,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -407
       objectReference: {fileID: 0}
-    - target: {fileID: 6864359232142243101, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
+    - target: {fileID: 6864359232142243101, guid: e3d517531b8487141a8a955f24e85a1c,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6864359232142243101, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
+    - target: {fileID: 6864359232142243101, guid: e3d517531b8487141a8a955f24e85a1c,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 6864359232142243101, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
+    - target: {fileID: 6864359232142243101, guid: e3d517531b8487141a8a955f24e85a1c,
+        type: 3}
       propertyPath: m_SizeDelta.x
       value: 750
       objectReference: {fileID: 0}
-    - target: {fileID: 6864359232142243101, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
+    - target: {fileID: 6864359232142243101, guid: e3d517531b8487141a8a955f24e85a1c,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 375
       objectReference: {fileID: 0}
-    - target: {fileID: 6864359232142243101, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
+    - target: {fileID: 6864359232142243101, guid: e3d517531b8487141a8a955f24e85a1c,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -344
       objectReference: {fileID: 0}
-    - target: {fileID: 7476284975017015384, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
+    - target: {fileID: 7476284975017015384, guid: e3d517531b8487141a8a955f24e85a1c,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7476284975017015384, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
+    - target: {fileID: 7476284975017015384, guid: e3d517531b8487141a8a955f24e85a1c,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7476284975017015384, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
+    - target: {fileID: 7476284975017015384, guid: e3d517531b8487141a8a955f24e85a1c,
+        type: 3}
       propertyPath: m_SizeDelta.x
       value: 750
       objectReference: {fileID: 0}
-    - target: {fileID: 7476284975017015384, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
+    - target: {fileID: 7476284975017015384, guid: e3d517531b8487141a8a955f24e85a1c,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 375
       objectReference: {fileID: 0}
-    - target: {fileID: 7476284975017015384, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
+    - target: {fileID: 7476284975017015384, guid: e3d517531b8487141a8a955f24e85a1c,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -218
       objectReference: {fileID: 0}
-    - target: {fileID: 8520012361836660394, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
+    - target: {fileID: 8520012361836660394, guid: e3d517531b8487141a8a955f24e85a1c,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8520012361836660394, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
+    - target: {fileID: 8520012361836660394, guid: e3d517531b8487141a8a955f24e85a1c,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8520012361836660394, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
+    - target: {fileID: 8520012361836660394, guid: e3d517531b8487141a8a955f24e85a1c,
+        type: 3}
       propertyPath: m_SizeDelta.x
       value: 750
       objectReference: {fileID: 0}
-    - target: {fileID: 8520012361836660394, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
+    - target: {fileID: 8520012361836660394, guid: e3d517531b8487141a8a955f24e85a1c,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 375
       objectReference: {fileID: 0}
-    - target: {fileID: 8520012361836660394, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
+    - target: {fileID: 8520012361836660394, guid: e3d517531b8487141a8a955f24e85a1c,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -533
       objectReference: {fileID: 0}
-    - target: {fileID: 8687143271907180245, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
+    - target: {fileID: 8687143271907180245, guid: e3d517531b8487141a8a955f24e85a1c,
+        type: 3}
       propertyPath: m_Name
       value: PracticePause
       objectReference: {fileID: 0}
-    - target: {fileID: 8687143271907180245, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
+    - target: {fileID: 8687143271907180245, guid: e3d517531b8487141a8a955f24e85a1c,
+        type: 3}
       propertyPath: m_IsActive
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8687143271907180246, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
+    - target: {fileID: 8687143271907180246, guid: e3d517531b8487141a8a955f24e85a1c,
+        type: 3}
       propertyPath: m_Pivot.x
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 8687143271907180246, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
+    - target: {fileID: 8687143271907180246, guid: e3d517531b8487141a8a955f24e85a1c,
+        type: 3}
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 8687143271907180246, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
+    - target: {fileID: 8687143271907180246, guid: e3d517531b8487141a8a955f24e85a1c,
+        type: 3}
       propertyPath: m_RootOrder
       value: 3
       objectReference: {fileID: 0}
-    - target: {fileID: 8687143271907180246, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
+    - target: {fileID: 8687143271907180246, guid: e3d517531b8487141a8a955f24e85a1c,
+        type: 3}
       propertyPath: m_AnchorMax.x
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8687143271907180246, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
+    - target: {fileID: 8687143271907180246, guid: e3d517531b8487141a8a955f24e85a1c,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8687143271907180246, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
+    - target: {fileID: 8687143271907180246, guid: e3d517531b8487141a8a955f24e85a1c,
+        type: 3}
       propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8687143271907180246, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
+    - target: {fileID: 8687143271907180246, guid: e3d517531b8487141a8a955f24e85a1c,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8687143271907180246, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
+    - target: {fileID: 8687143271907180246, guid: e3d517531b8487141a8a955f24e85a1c,
+        type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8687143271907180246, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
+    - target: {fileID: 8687143271907180246, guid: e3d517531b8487141a8a955f24e85a1c,
+        type: 3}
       propertyPath: m_SizeDelta.y
       value: -250
       objectReference: {fileID: 0}
-    - target: {fileID: 8687143271907180246, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
+    - target: {fileID: 8687143271907180246, guid: e3d517531b8487141a8a955f24e85a1c,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8687143271907180246, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
+    - target: {fileID: 8687143271907180246, guid: e3d517531b8487141a8a955f24e85a1c,
+        type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8687143271907180246, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
+    - target: {fileID: 8687143271907180246, guid: e3d517531b8487141a8a955f24e85a1c,
+        type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8687143271907180246, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
+    - target: {fileID: 8687143271907180246, guid: e3d517531b8487141a8a955f24e85a1c,
+        type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8687143271907180246, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
+    - target: {fileID: 8687143271907180246, guid: e3d517531b8487141a8a955f24e85a1c,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8687143271907180246, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
+    - target: {fileID: 8687143271907180246, guid: e3d517531b8487141a8a955f24e85a1c,
+        type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8687143271907180246, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
+    - target: {fileID: 8687143271907180246, guid: e3d517531b8487141a8a955f24e85a1c,
+        type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8687143271907180246, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
+    - target: {fileID: 8687143271907180246, guid: e3d517531b8487141a8a955f24e85a1c,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8687143271907180246, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
+    - target: {fileID: 8687143271907180246, guid: e3d517531b8487141a8a955f24e85a1c,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -125
       objectReference: {fileID: 0}
-    - target: {fileID: 8687143271907180246, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
+    - target: {fileID: 8687143271907180246, guid: e3d517531b8487141a8a955f24e85a1c,
+        type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8687143271907180246, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
+    - target: {fileID: 8687143271907180246, guid: e3d517531b8487141a8a955f24e85a1c,
+        type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8687143271907180246, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
+    - target: {fileID: 8687143271907180246, guid: e3d517531b8487141a8a955f24e85a1c,
+        type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
@@ -5518,7 +6069,8 @@ PrefabInstance:
   m_SourcePrefab: {fileID: 100100000, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
 --- !u!224 &1041685787 stripped
 RectTransform:
-  m_CorrespondingSourceObject: {fileID: 8687143271907180246, guid: e3d517531b8487141a8a955f24e85a1c, type: 3}
+  m_CorrespondingSourceObject: {fileID: 8687143271907180246, guid: e3d517531b8487141a8a955f24e85a1c,
+    type: 3}
   m_PrefabInstance: {fileID: 1041685786}
   m_PrefabAsset: {fileID: 0}
 --- !u!1 &1047079480
@@ -5572,8 +6124,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: cc4da8b0e2bf53c4d88672deccceb379, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   _normalBackground: {fileID: 214379078}
   _transparentBackground: {fileID: 658438231}
   _lyricText: {fileID: 1651499655}
@@ -5588,15 +6140,16 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 26c69184c4c94e07a1c1a5403823ba9a, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   _draggableElementName: lyricBar
   _horizontal: 0
   _vertical: 1
   _onEditModeChanged:
     m_PersistentCalls:
       m_Calls: []
-  _draggingDisplayPrefab: {fileID: 8670888432685319550, guid: d9f80531f3f74e94083d15499b97d33c, type: 3}
+  _draggingDisplayPrefab: {fileID: 8670888432685319550, guid: d9f80531f3f74e94083d15499b97d33c,
+    type: 3}
 --- !u!1 &1061222912
 GameObject:
   m_ObjectHideFlags: 0
@@ -5644,8 +6197,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -5657,7 +6210,8 @@ MonoBehaviour:
   m_text: Accuracy
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 21db4751dd6d460499117f8c2d3de781, type: 2}
-  m_sharedMaterial: {fileID: 1134014722335189955, guid: 21db4751dd6d460499117f8c2d3de781, type: 2}
+  m_sharedMaterial: {fileID: 1134014722335189955, guid: 21db4751dd6d460499117f8c2d3de781,
+    type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -5780,8 +6334,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -5793,7 +6347,8 @@ MonoBehaviour:
   m_text: 0%
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 04973a14f12bf384f8093a8b70f63fcb, type: 2}
-  m_sharedMaterial: {fileID: -7155836927947826254, guid: 04973a14f12bf384f8093a8b70f63fcb, type: 2}
+  m_sharedMaterial: {fileID: -7155836927947826254, guid: 04973a14f12bf384f8093a8b70f63fcb,
+    type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -5971,7 +6526,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 250, y: 28}
+  m_SizeDelta: {x: 250, y: 41.664}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &1212139297
 GameObject:
@@ -6030,8 +6585,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_IgnoreReversedGraphics: 1
   m_BlockingObjects: 0
   m_BlockingMask:
@@ -6047,8 +6602,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_UiScaleMode: 1
   m_ReferencePixelsPerUnit: 100
   m_ScaleFactor: 1
@@ -6093,56 +6648,20 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 8a3fa9892ec94f35bb93485c9fff8343, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
---- !u!84 &1219814984
-RenderTexture:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name:
-  m_ImageContentsHash:
-    serializedVersion: 2
-    Hash: 00000000000000000000000000000000
-  m_IsAlphaChannelOptional: 0
-  serializedVersion: 6
-  m_Width: 258
-  m_Height: 2678
-  m_AntiAliasing: 1
-  m_MipCount: -1
-  m_DepthStencilFormat: 0
-  m_ColorFormat: 48
-  m_MipMap: 0
-  m_GenerateMips: 1
-  m_SRGB: 0
-  m_UseDynamicScale: 0
-  m_UseDynamicScaleExplicit: 0
-  m_BindMS: 0
-  m_EnableCompatibleFormat: 1
-  m_EnableRandomWrite: 0
-  m_TextureSettings:
-    serializedVersion: 2
-    m_FilterMode: 1
-    m_Aniso: 1
-    m_MipBias: 0
-    m_WrapU: 1
-    m_WrapV: 1
-    m_WrapW: 1
-  m_Dimension: 2
-  m_VolumeDepth: 1
-  m_ShadowSamplingMode: 2
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &1312797156 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 5801866611232935394, guid: f09d7030713b2e34dbc210e5e014add2, type: 3}
+  m_CorrespondingSourceObject: {fileID: 5801866611232935394, guid: f09d7030713b2e34dbc210e5e014add2,
+    type: 3}
   m_PrefabInstance: {fileID: 5801866609987599366}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: ac0dfb757e714fe78df8cb113995c2cb, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1316571460
 GameObject:
   m_ObjectHideFlags: 0
@@ -6192,8 +6711,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: e23899b37ed7428c95c5729c80329c75, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   _speedPercentText: {fileID: 203730482}
   _sectionHeaderText: {fileID: 216564560}
   _sectionText: {fileID: 417693873}
@@ -6255,8 +6774,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9a5c23225dc861948b6ec713e8c7050e, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   _albumText: {fileID: 653890501}
   _songText: {fileID: 672646200}
   _artistText: {fileID: 1886693832}
@@ -6310,8 +6829,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 1344c3c82d62a2a41a3576d8abb8e3ea, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -6382,10 +6901,12 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: d91557b093c94541a16865d7aea2083f, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
-  _trackViewPrefab: {fileID: 504031665406120138, guid: 06628de4f7ccad849a699ee59bdd2f37, type: 3}
-  _vocalHudPrefab: {fileID: 3517124488286897926, guid: 6447755fd93bf6b4dbcb391c82737397, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _trackViewPrefab: {fileID: 504031665406120138, guid: 06628de4f7ccad849a699ee59bdd2f37,
+    type: 3}
+  _vocalHudPrefab: {fileID: 3517124488286897926, guid: 6447755fd93bf6b4dbcb391c82737397,
+    type: 3}
   _highwayCameraRendering: {fileID: 1516249583}
   _vocalImage: {fileID: 626807278}
   _vocalHudParent: {fileID: 1338572397}
@@ -6435,8 +6956,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 30649d3a9faa99c48a7b1166b86bf2a0, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Padding:
     m_Left: 0
     m_Right: 0
@@ -6501,8 +7022,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 0, g: 0, b: 0, a: 0.8}
   m_RaycastTarget: 1
@@ -6537,211 +7058,263 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 1323155441}
     m_Modifications:
-    - target: {fileID: 154592444964813920, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
+    - target: {fileID: 154592444964813920, guid: 7efe71303a450f348a4c71ec8eea331f,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 154592444964813920, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
+    - target: {fileID: 154592444964813920, guid: 7efe71303a450f348a4c71ec8eea331f,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 154592444964813920, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
+    - target: {fileID: 154592444964813920, guid: 7efe71303a450f348a4c71ec8eea331f,
+        type: 3}
       propertyPath: m_SizeDelta.x
       value: 750
       objectReference: {fileID: 0}
-    - target: {fileID: 154592444964813920, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
+    - target: {fileID: 154592444964813920, guid: 7efe71303a450f348a4c71ec8eea331f,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 375
       objectReference: {fileID: 0}
-    - target: {fileID: 154592444964813920, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
+    - target: {fileID: 154592444964813920, guid: 7efe71303a450f348a4c71ec8eea331f,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -155
       objectReference: {fileID: 0}
-    - target: {fileID: 3255133668864834793, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
+    - target: {fileID: 3255133668864834793, guid: 7efe71303a450f348a4c71ec8eea331f,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3255133668864834793, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
+    - target: {fileID: 3255133668864834793, guid: 7efe71303a450f348a4c71ec8eea331f,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 3255133668864834793, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
+    - target: {fileID: 3255133668864834793, guid: 7efe71303a450f348a4c71ec8eea331f,
+        type: 3}
       propertyPath: m_SizeDelta.x
       value: 750
       objectReference: {fileID: 0}
-    - target: {fileID: 3255133668864834793, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
+    - target: {fileID: 3255133668864834793, guid: 7efe71303a450f348a4c71ec8eea331f,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 375
       objectReference: {fileID: 0}
-    - target: {fileID: 3255133668864834793, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
+    - target: {fileID: 3255133668864834793, guid: 7efe71303a450f348a4c71ec8eea331f,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -29
       objectReference: {fileID: 0}
-    - target: {fileID: 5730081093640278258, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
+    - target: {fileID: 5730081093640278258, guid: 7efe71303a450f348a4c71ec8eea331f,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5730081093640278258, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
+    - target: {fileID: 5730081093640278258, guid: 7efe71303a450f348a4c71ec8eea331f,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5730081093640278258, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
+    - target: {fileID: 5730081093640278258, guid: 7efe71303a450f348a4c71ec8eea331f,
+        type: 3}
       propertyPath: m_SizeDelta.x
       value: 750
       objectReference: {fileID: 0}
-    - target: {fileID: 5730081093640278258, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
+    - target: {fileID: 5730081093640278258, guid: 7efe71303a450f348a4c71ec8eea331f,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 375
       objectReference: {fileID: 0}
-    - target: {fileID: 5730081093640278258, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
+    - target: {fileID: 5730081093640278258, guid: 7efe71303a450f348a4c71ec8eea331f,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -218
       objectReference: {fileID: 0}
-    - target: {fileID: 5764441561947984321, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
+    - target: {fileID: 5764441561947984321, guid: 7efe71303a450f348a4c71ec8eea331f,
+        type: 3}
       propertyPath: m_Pivot.x
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 5764441561947984321, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
+    - target: {fileID: 5764441561947984321, guid: 7efe71303a450f348a4c71ec8eea331f,
+        type: 3}
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 5764441561947984321, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
+    - target: {fileID: 5764441561947984321, guid: 7efe71303a450f348a4c71ec8eea331f,
+        type: 3}
       propertyPath: m_RootOrder
       value: 5
       objectReference: {fileID: 0}
-    - target: {fileID: 5764441561947984321, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
+    - target: {fileID: 5764441561947984321, guid: 7efe71303a450f348a4c71ec8eea331f,
+        type: 3}
       propertyPath: m_AnchorMax.x
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5764441561947984321, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
+    - target: {fileID: 5764441561947984321, guid: 7efe71303a450f348a4c71ec8eea331f,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5764441561947984321, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
+    - target: {fileID: 5764441561947984321, guid: 7efe71303a450f348a4c71ec8eea331f,
+        type: 3}
       propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5764441561947984321, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
+    - target: {fileID: 5764441561947984321, guid: 7efe71303a450f348a4c71ec8eea331f,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5764441561947984321, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
+    - target: {fileID: 5764441561947984321, guid: 7efe71303a450f348a4c71ec8eea331f,
+        type: 3}
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5764441561947984321, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
+    - target: {fileID: 5764441561947984321, guid: 7efe71303a450f348a4c71ec8eea331f,
+        type: 3}
       propertyPath: m_SizeDelta.y
       value: -250
       objectReference: {fileID: 0}
-    - target: {fileID: 5764441561947984321, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
+    - target: {fileID: 5764441561947984321, guid: 7efe71303a450f348a4c71ec8eea331f,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5764441561947984321, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
+    - target: {fileID: 5764441561947984321, guid: 7efe71303a450f348a4c71ec8eea331f,
+        type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5764441561947984321, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
+    - target: {fileID: 5764441561947984321, guid: 7efe71303a450f348a4c71ec8eea331f,
+        type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5764441561947984321, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
+    - target: {fileID: 5764441561947984321, guid: 7efe71303a450f348a4c71ec8eea331f,
+        type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5764441561947984321, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
+    - target: {fileID: 5764441561947984321, guid: 7efe71303a450f348a4c71ec8eea331f,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5764441561947984321, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
+    - target: {fileID: 5764441561947984321, guid: 7efe71303a450f348a4c71ec8eea331f,
+        type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5764441561947984321, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
+    - target: {fileID: 5764441561947984321, guid: 7efe71303a450f348a4c71ec8eea331f,
+        type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5764441561947984321, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
+    - target: {fileID: 5764441561947984321, guid: 7efe71303a450f348a4c71ec8eea331f,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5764441561947984321, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
+    - target: {fileID: 5764441561947984321, guid: 7efe71303a450f348a4c71ec8eea331f,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -125
       objectReference: {fileID: 0}
-    - target: {fileID: 5764441561947984321, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
+    - target: {fileID: 5764441561947984321, guid: 7efe71303a450f348a4c71ec8eea331f,
+        type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5764441561947984321, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
+    - target: {fileID: 5764441561947984321, guid: 7efe71303a450f348a4c71ec8eea331f,
+        type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5764441561947984321, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
+    - target: {fileID: 5764441561947984321, guid: 7efe71303a450f348a4c71ec8eea331f,
+        type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5764441561947984322, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
+    - target: {fileID: 5764441561947984322, guid: 7efe71303a450f348a4c71ec8eea331f,
+        type: 3}
       propertyPath: m_Name
       value: ReplayPause
       objectReference: {fileID: 0}
-    - target: {fileID: 5764441561947984322, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
+    - target: {fileID: 5764441561947984322, guid: 7efe71303a450f348a4c71ec8eea331f,
+        type: 3}
       propertyPath: m_IsActive
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7580215650778954327, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
+    - target: {fileID: 7580215650778954327, guid: 7efe71303a450f348a4c71ec8eea331f,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7580215650778954327, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
+    - target: {fileID: 7580215650778954327, guid: 7efe71303a450f348a4c71ec8eea331f,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7580215650778954327, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
+    - target: {fileID: 7580215650778954327, guid: 7efe71303a450f348a4c71ec8eea331f,
+        type: 3}
       propertyPath: m_SizeDelta.x
       value: 750
       objectReference: {fileID: 0}
-    - target: {fileID: 7580215650778954327, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
+    - target: {fileID: 7580215650778954327, guid: 7efe71303a450f348a4c71ec8eea331f,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 375
       objectReference: {fileID: 0}
-    - target: {fileID: 7580215650778954327, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
+    - target: {fileID: 7580215650778954327, guid: 7efe71303a450f348a4c71ec8eea331f,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -281
       objectReference: {fileID: 0}
-    - target: {fileID: 7929139973946126061, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
+    - target: {fileID: 7929139973946126061, guid: 7efe71303a450f348a4c71ec8eea331f,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7929139973946126061, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
+    - target: {fileID: 7929139973946126061, guid: 7efe71303a450f348a4c71ec8eea331f,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7929139973946126061, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
+    - target: {fileID: 7929139973946126061, guid: 7efe71303a450f348a4c71ec8eea331f,
+        type: 3}
       propertyPath: m_SizeDelta.x
       value: 750
       objectReference: {fileID: 0}
-    - target: {fileID: 7929139973946126061, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
+    - target: {fileID: 7929139973946126061, guid: 7efe71303a450f348a4c71ec8eea331f,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -373
       objectReference: {fileID: 0}
-    - target: {fileID: 8153367324949550618, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
+    - target: {fileID: 8153367324949550618, guid: 7efe71303a450f348a4c71ec8eea331f,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8153367324949550618, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
+    - target: {fileID: 8153367324949550618, guid: 7efe71303a450f348a4c71ec8eea331f,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8153367324949550618, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
+    - target: {fileID: 8153367324949550618, guid: 7efe71303a450f348a4c71ec8eea331f,
+        type: 3}
       propertyPath: m_SizeDelta.x
       value: 750
       objectReference: {fileID: 0}
-    - target: {fileID: 8153367324949550618, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
+    - target: {fileID: 8153367324949550618, guid: 7efe71303a450f348a4c71ec8eea331f,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 375
       objectReference: {fileID: 0}
-    - target: {fileID: 8153367324949550618, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
+    - target: {fileID: 8153367324949550618, guid: 7efe71303a450f348a4c71ec8eea331f,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: -92
       objectReference: {fileID: 0}
@@ -6752,7 +7325,8 @@ PrefabInstance:
   m_SourcePrefab: {fileID: 100100000, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
 --- !u!224 &1405426188 stripped
 RectTransform:
-  m_CorrespondingSourceObject: {fileID: 5764441561947984321, guid: 7efe71303a450f348a4c71ec8eea331f, type: 3}
+  m_CorrespondingSourceObject: {fileID: 5764441561947984321, guid: 7efe71303a450f348a4c71ec8eea331f,
+    type: 3}
   m_PrefabInstance: {fileID: 1405426187}
   m_PrefabAsset: {fileID: 0}
 --- !u!1 &1494490346
@@ -6803,8 +7377,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -6816,7 +7390,8 @@ MonoBehaviour:
   m_text: Song Source
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: d9dd031fb1c2f2f4fabb34137edfa885, type: 2}
-  m_sharedMaterial: {fileID: 1536850694454096710, guid: d9dd031fb1c2f2f4fabb34137edfa885, type: 2}
+  m_sharedMaterial: {fileID: 1536850694454096710, guid: d9dd031fb1c2f2f4fabb34137edfa885,
+    type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -6921,8 +7496,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 19b73f8c1d10b1f5ca0912eeefcc50b6, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   _highwaysOutput: {fileID: 428528605}
 --- !u!114 &1516249584
 MonoBehaviour:
@@ -6934,8 +7509,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: a79441f348de89743a2939f4d699eac1, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_RenderShadows: 0
   m_RequiresDepthTextureOption: 2
   m_RequiresOpaqueTextureOption: 2
@@ -7009,7 +7584,7 @@ Camera:
     serializedVersion: 2
     m_Bits: 503
   m_RenderingPath: -1
-  m_TargetTexture: {fileID: 1219814984}
+  m_TargetTexture: {fileID: 384353436}
   m_TargetDisplay: 0
   m_TargetEye: 3
   m_HDR: 1
@@ -7117,8 +7692,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -7193,8 +7768,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 30649d3a9faa99c48a7b1166b86bf2a0, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Padding:
     m_Left: 0
     m_Right: 0
@@ -7256,8 +7831,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -7269,7 +7844,8 @@ MonoBehaviour:
   m_text: This is where the lyrics are displayed
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: d9dd031fb1c2f2f4fabb34137edfa885, type: 2}
-  m_sharedMaterial: {fileID: 1536850694454096710, guid: d9dd031fb1c2f2f4fabb34137edfa885, type: 2}
+  m_sharedMaterial: {fileID: 1536850694454096710, guid: d9dd031fb1c2f2f4fabb34137edfa885,
+    type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -7392,8 +7968,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -7405,7 +7981,8 @@ MonoBehaviour:
   m_text: Notes
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 21db4751dd6d460499117f8c2d3de781, type: 2}
-  m_sharedMaterial: {fileID: 1134014722335189955, guid: 21db4751dd6d460499117f8c2d3de781, type: 2}
+  m_sharedMaterial: {fileID: 1134014722335189955, guid: 21db4751dd6d460499117f8c2d3de781,
+    type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -7512,6 +8089,7 @@ RectTransform:
   m_Children:
   - {fileID: 550613178}
   - {fileID: 189938502}
+  - {fileID: 131105197}
   m_Father: {fileID: 1316571461}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -7529,15 +8107,15 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 59f8146938fff824cb5fd77236b75775, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Padding:
     m_Left: 0
     m_Right: 0
     m_Top: 0
     m_Bottom: 0
   m_ChildAlignment: 4
-  m_Spacing: 0
+  m_Spacing: 40
   m_ChildForceExpandWidth: 1
   m_ChildForceExpandHeight: 1
   m_ChildControlWidth: 0
@@ -7573,8 +8151,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 474bcb49853aa07438625e644c072ee6, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_UsePipelineSettings: 1
   m_AdditionalLightsShadowResolutionTier: 2
   m_CustomShadowLayers: 0
@@ -7699,8 +8277,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 172515602e62fb746b5d573b38a5fe58, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_IsGlobal: 1
   priority: 0
   blendDistance: 0
@@ -7768,8 +8346,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 1344c3c82d62a2a41a3576d8abb8e3ea, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -7801,91 +8379,113 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 397042284}
     m_Modifications:
-    - target: {fileID: 8712046426310438026, guid: d0b16d99b827a28449b37e491eb7cd45, type: 3}
+    - target: {fileID: 8712046426310438026, guid: d0b16d99b827a28449b37e491eb7cd45,
+        type: 3}
       propertyPath: m_Name
       value: FailMeter
       objectReference: {fileID: 0}
-    - target: {fileID: 8712046426310438027, guid: d0b16d99b827a28449b37e491eb7cd45, type: 3}
+    - target: {fileID: 8712046426310438027, guid: d0b16d99b827a28449b37e491eb7cd45,
+        type: 3}
       propertyPath: m_Pivot.x
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 8712046426310438027, guid: d0b16d99b827a28449b37e491eb7cd45, type: 3}
+    - target: {fileID: 8712046426310438027, guid: d0b16d99b827a28449b37e491eb7cd45,
+        type: 3}
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 8712046426310438027, guid: d0b16d99b827a28449b37e491eb7cd45, type: 3}
+    - target: {fileID: 8712046426310438027, guid: d0b16d99b827a28449b37e491eb7cd45,
+        type: 3}
       propertyPath: m_RootOrder
       value: 4
       objectReference: {fileID: 0}
-    - target: {fileID: 8712046426310438027, guid: d0b16d99b827a28449b37e491eb7cd45, type: 3}
+    - target: {fileID: 8712046426310438027, guid: d0b16d99b827a28449b37e491eb7cd45,
+        type: 3}
       propertyPath: m_AnchorMax.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8712046426310438027, guid: d0b16d99b827a28449b37e491eb7cd45, type: 3}
+    - target: {fileID: 8712046426310438027, guid: d0b16d99b827a28449b37e491eb7cd45,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 8712046426310438027, guid: d0b16d99b827a28449b37e491eb7cd45, type: 3}
+    - target: {fileID: 8712046426310438027, guid: d0b16d99b827a28449b37e491eb7cd45,
+        type: 3}
       propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8712046426310438027, guid: d0b16d99b827a28449b37e491eb7cd45, type: 3}
+    - target: {fileID: 8712046426310438027, guid: d0b16d99b827a28449b37e491eb7cd45,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 8712046426310438027, guid: d0b16d99b827a28449b37e491eb7cd45, type: 3}
+    - target: {fileID: 8712046426310438027, guid: d0b16d99b827a28449b37e491eb7cd45,
+        type: 3}
       propertyPath: m_SizeDelta.x
       value: 24
       objectReference: {fileID: 0}
-    - target: {fileID: 8712046426310438027, guid: d0b16d99b827a28449b37e491eb7cd45, type: 3}
+    - target: {fileID: 8712046426310438027, guid: d0b16d99b827a28449b37e491eb7cd45,
+        type: 3}
       propertyPath: m_SizeDelta.y
       value: 385
       objectReference: {fileID: 0}
-    - target: {fileID: 8712046426310438027, guid: d0b16d99b827a28449b37e491eb7cd45, type: 3}
+    - target: {fileID: 8712046426310438027, guid: d0b16d99b827a28449b37e491eb7cd45,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8712046426310438027, guid: d0b16d99b827a28449b37e491eb7cd45, type: 3}
+    - target: {fileID: 8712046426310438027, guid: d0b16d99b827a28449b37e491eb7cd45,
+        type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8712046426310438027, guid: d0b16d99b827a28449b37e491eb7cd45, type: 3}
+    - target: {fileID: 8712046426310438027, guid: d0b16d99b827a28449b37e491eb7cd45,
+        type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8712046426310438027, guid: d0b16d99b827a28449b37e491eb7cd45, type: 3}
+    - target: {fileID: 8712046426310438027, guid: d0b16d99b827a28449b37e491eb7cd45,
+        type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8712046426310438027, guid: d0b16d99b827a28449b37e491eb7cd45, type: 3}
+    - target: {fileID: 8712046426310438027, guid: d0b16d99b827a28449b37e491eb7cd45,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8712046426310438027, guid: d0b16d99b827a28449b37e491eb7cd45, type: 3}
+    - target: {fileID: 8712046426310438027, guid: d0b16d99b827a28449b37e491eb7cd45,
+        type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8712046426310438027, guid: d0b16d99b827a28449b37e491eb7cd45, type: 3}
+    - target: {fileID: 8712046426310438027, guid: d0b16d99b827a28449b37e491eb7cd45,
+        type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8712046426310438027, guid: d0b16d99b827a28449b37e491eb7cd45, type: 3}
+    - target: {fileID: 8712046426310438027, guid: d0b16d99b827a28449b37e491eb7cd45,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 40
       objectReference: {fileID: 0}
-    - target: {fileID: 8712046426310438027, guid: d0b16d99b827a28449b37e491eb7cd45, type: 3}
+    - target: {fileID: 8712046426310438027, guid: d0b16d99b827a28449b37e491eb7cd45,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8712046426310438027, guid: d0b16d99b827a28449b37e491eb7cd45, type: 3}
+    - target: {fileID: 8712046426310438027, guid: d0b16d99b827a28449b37e491eb7cd45,
+        type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8712046426310438027, guid: d0b16d99b827a28449b37e491eb7cd45, type: 3}
+    - target: {fileID: 8712046426310438027, guid: d0b16d99b827a28449b37e491eb7cd45,
+        type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8712046426310438027, guid: d0b16d99b827a28449b37e491eb7cd45, type: 3}
+    - target: {fileID: 8712046426310438027, guid: d0b16d99b827a28449b37e491eb7cd45,
+        type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
@@ -7941,8 +8541,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -8016,8 +8616,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -8029,7 +8629,8 @@ MonoBehaviour:
   m_text: Change Speed
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 21db4751dd6d460499117f8c2d3de781, type: 2}
-  m_sharedMaterial: {fileID: 1134014722335189955, guid: 21db4751dd6d460499117f8c2d3de781, type: 2}
+  m_sharedMaterial: {fileID: 1134014722335189955, guid: 21db4751dd6d460499117f8c2d3de781,
+    type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -8152,8 +8753,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -8287,8 +8888,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -8300,7 +8901,8 @@ MonoBehaviour:
   m_text: Song Artist
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: d9dd031fb1c2f2f4fabb34137edfa885, type: 2}
-  m_sharedMaterial: {fileID: 1536850694454096710, guid: d9dd031fb1c2f2f4fabb34137edfa885, type: 2}
+  m_sharedMaterial: {fileID: 1536850694454096710, guid: d9dd031fb1c2f2f4fabb34137edfa885,
+    type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -8411,7 +9013,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 250, y: 28}
+  m_SizeDelta: {x: 250, y: 46.205}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &1888549646
 CanvasRenderer:
@@ -8468,8 +9070,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -8481,7 +9083,8 @@ MonoBehaviour:
   m_text: This is where the next lyrics are displayed
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: d9dd031fb1c2f2f4fabb34137edfa885, type: 2}
-  m_sharedMaterial: {fileID: 1536850694454096710, guid: d9dd031fb1c2f2f4fabb34137edfa885, type: 2}
+  m_sharedMaterial: {fileID: 1536850694454096710, guid: d9dd031fb1c2f2f4fabb34137edfa885,
+    type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -8563,7 +9166,7 @@ RenderTexture:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_Name:
+  m_Name: 
   m_ImageContentsHash:
     serializedVersion: 2
     Hash: 00000000000000000000000000000000
@@ -8642,8 +9245,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 59f8146938fff824cb5fd77236b75775, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Padding:
     m_Left: 0
     m_Right: 0
@@ -8761,8 +9364,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: a79441f348de89743a2939f4d699eac1, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_RenderShadows: 0
   m_RequiresDepthTextureOption: 0
   m_RequiresOpaqueTextureOption: 0
@@ -8842,8 +9445,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 0.050980393}
   m_RaycastTarget: 1
@@ -8918,8 +9521,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -8993,8 +9596,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 1
@@ -9006,7 +9609,8 @@ MonoBehaviour:
   m_text: Restart Section
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 21db4751dd6d460499117f8c2d3de781, type: 2}
-  m_sharedMaterial: {fileID: 1134014722335189955, guid: 21db4751dd6d460499117f8c2d3de781, type: 2}
+  m_sharedMaterial: {fileID: 1134014722335189955, guid: 21db4751dd6d460499117f8c2d3de781,
+    type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -9090,55 +9694,68 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
-    - target: {fileID: 5801866611232935394, guid: f09d7030713b2e34dbc210e5e014add2, type: 3}
+    - target: {fileID: 5801866611232935394, guid: f09d7030713b2e34dbc210e5e014add2,
+        type: 3}
       propertyPath: _countdownDisplay
-      value:
+      value: 
       objectReference: {fileID: 412813830}
-    - target: {fileID: 5801866611232935397, guid: f09d7030713b2e34dbc210e5e014add2, type: 3}
+    - target: {fileID: 5801866611232935397, guid: f09d7030713b2e34dbc210e5e014add2,
+        type: 3}
       propertyPath: m_RootOrder
       value: 7
       objectReference: {fileID: 0}
-    - target: {fileID: 5801866611232935397, guid: f09d7030713b2e34dbc210e5e014add2, type: 3}
+    - target: {fileID: 5801866611232935397, guid: f09d7030713b2e34dbc210e5e014add2,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5801866611232935397, guid: f09d7030713b2e34dbc210e5e014add2, type: 3}
+    - target: {fileID: 5801866611232935397, guid: f09d7030713b2e34dbc210e5e014add2,
+        type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5801866611232935397, guid: f09d7030713b2e34dbc210e5e014add2, type: 3}
+    - target: {fileID: 5801866611232935397, guid: f09d7030713b2e34dbc210e5e014add2,
+        type: 3}
       propertyPath: m_LocalPosition.z
       value: -20
       objectReference: {fileID: 0}
-    - target: {fileID: 5801866611232935397, guid: f09d7030713b2e34dbc210e5e014add2, type: 3}
+    - target: {fileID: 5801866611232935397, guid: f09d7030713b2e34dbc210e5e014add2,
+        type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 5801866611232935397, guid: f09d7030713b2e34dbc210e5e014add2, type: 3}
+    - target: {fileID: 5801866611232935397, guid: f09d7030713b2e34dbc210e5e014add2,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 5801866611232935397, guid: f09d7030713b2e34dbc210e5e014add2, type: 3}
+    - target: {fileID: 5801866611232935397, guid: f09d7030713b2e34dbc210e5e014add2,
+        type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 5801866611232935397, guid: f09d7030713b2e34dbc210e5e014add2, type: 3}
+    - target: {fileID: 5801866611232935397, guid: f09d7030713b2e34dbc210e5e014add2,
+        type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 5801866611232935397, guid: f09d7030713b2e34dbc210e5e014add2, type: 3}
+    - target: {fileID: 5801866611232935397, guid: f09d7030713b2e34dbc210e5e014add2,
+        type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5801866611232935397, guid: f09d7030713b2e34dbc210e5e014add2, type: 3}
+    - target: {fileID: 5801866611232935397, guid: f09d7030713b2e34dbc210e5e014add2,
+        type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5801866611232935397, guid: f09d7030713b2e34dbc210e5e014add2, type: 3}
+    - target: {fileID: 5801866611232935397, guid: f09d7030713b2e34dbc210e5e014add2,
+        type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5801866611232935399, guid: f09d7030713b2e34dbc210e5e014add2, type: 3}
+    - target: {fileID: 5801866611232935399, guid: f09d7030713b2e34dbc210e5e014add2,
+        type: 3}
       propertyPath: m_Name
       value: VocalTrack
       objectReference: {fileID: 0}

--- a/Assets/Script/Gameplay/HUD/MainHUDPaddingAdjuster.cs
+++ b/Assets/Script/Gameplay/HUD/MainHUDPaddingAdjuster.cs
@@ -8,7 +8,7 @@ namespace YARG.Gameplay.HUD
     public class MainHUDPaddingAdjuster : GameplayBehaviour
     {
         [SerializeField]
-        private float _topPaddingForVocals = 128f;
+        private float _topPaddingForVocals = 200f;
 
         protected override void OnChartLoaded(SongChart chart)
         {

--- a/Assets/Script/Gameplay/HUD/TrackView.cs
+++ b/Assets/Script/Gameplay/HUD/TrackView.cs
@@ -47,15 +47,16 @@ namespace YARG.Gameplay.HUD
             _scaleContainer.localScale = _scaleContainer.localScale.WithX(newScale).WithY(newScale);
 
             //Set center element position
-            Vector2 position = _highwayRenderer.GetTrackPositionScreenSpace(highwayIndex, 0.5f, CENTER_ELEMENT_DEPTH);
-            _centerElementContainer.transform.position = position;
+            var centerPosition = _highwayRenderer.GetTrackPositionScreenSpace(highwayIndex, 0.5f, CENTER_ELEMENT_DEPTH);
+            _centerElementContainer.transform.position = centerPosition;
 
-            if (_topDraggable != null && _topDraggable.HasCustomPosition == false)
+            if (_topDraggable != null && !_topDraggable.HasCustomPosition)
             {
-                // Place top elements at 100% depth plus n screen independent units up to avoid highway overlap
+                // Place top elements at 100% depth of the track, plus some extra amount above the track.
+                // Since y=0 is the top of the screen, we subtract the extra offset.
                 var extraOffset = TOP_ELEMENT_EXTRA_OFFSET * Screen.height / 1000f;
-                Vector2 position2 = _highwayRenderer.GetTrackPositionScreenSpace(highwayIndex, 0.5f, 1.0f).AddY(extraOffset);
-                _topElementContainer.position = position2;
+                var topPosition = _highwayRenderer.GetTrackPositionScreenSpace(highwayIndex, 0.5f, 1.0f).AddY(-extraOffset);
+                _topElementContainer.position = topPosition;
             }
         }
 

--- a/Assets/Script/Gameplay/HUD/TrackView.cs
+++ b/Assets/Script/Gameplay/HUD/TrackView.cs
@@ -53,9 +53,8 @@ namespace YARG.Gameplay.HUD
             if (_topDraggable != null && !_topDraggable.HasCustomPosition)
             {
                 // Place top elements at 100% depth of the track, plus some extra amount above the track.
-                // Since y=0 is the top of the screen, we subtract the extra offset.
                 var extraOffset = TOP_ELEMENT_EXTRA_OFFSET * Screen.height / 1000f;
-                var topPosition = _highwayRenderer.GetTrackPositionScreenSpace(highwayIndex, 0.5f, 1.0f).AddY(-extraOffset);
+                var topPosition = _highwayRenderer.GetTrackPositionScreenSpace(highwayIndex, 0.5f, 1.0f).AddY(extraOffset);
                 _topElementContainer.position = topPosition;
             }
         }

--- a/Assets/Script/Gameplay/Visuals/HighwayCameraRendering.cs
+++ b/Assets/Script/Gameplay/Visuals/HighwayCameraRendering.cs
@@ -21,7 +21,7 @@ namespace YARG.Gameplay.Visuals
         //For multiple lanes, cap the lane width to a percentage of the screen width, 1.0f = 100% of screen width
         private const float MAX_LANE_SCREEN_WIDTH_PERCENT  = 0.45f;
 
-        //For all lanes, cap the lane height to a percentage of the screen height, 1.0f = 100% of screen height
+        //For multiple lanes, cap the lane height to a percentage of the screen height, 1.0f = 100% of screen height
         private const float MAX_LANE_SCREEN_HEIGHT_PERCENT = 0.55f;
 
         //In single player, allow more height
@@ -47,6 +47,7 @@ namespace YARG.Gameplay.Visuals
         private ScriptableRenderPass       _fadeCalcPass;
         private bool                       _allowTextureRecreation = true;
         private bool                       _needsInitialization    = true;
+        private bool                       _needsCameraReset;
 
         private readonly float[]           _curveFactors       = new float[MAX_MATRICES];
         private readonly float[]           _zeroFadePositions  = new float[MAX_MATRICES];
@@ -244,7 +245,7 @@ namespace YARG.Gameplay.Visuals
             _highwayPositions.Add(position);
             UpdateCurveFactor(curveFactor, index);
             UpdateFadeParams(index, zeroFadePosition, fadeSize);
-            ResetCameras();
+            _needsCameraReset = true;
         }
 
         public void UpdateCurveFactor(float curveFactor, int index)
@@ -336,9 +337,10 @@ namespace YARG.Gameplay.Visuals
                 return;
             }
 
-            if (ScreenSizeDetector.HasScreenSizeChanged)
+            if (ScreenSizeDetector.HasScreenSizeChanged || _needsCameraReset)
             {
                 ResetCameras();
+                _needsCameraReset = false;
             }
 
             RecalculateFadeParams();
@@ -504,9 +506,9 @@ namespace YARG.Gameplay.Visuals
         /// <summary>
         /// Calculates the screen space position of any normalized coordinate on the track, from the strikeline.
         /// </summary>
-        /// <param name="trackIndex">The index of the highway to get the position for. 0 is left most highway</param>
+        /// <param name="trackIndex">The index of the highway to get the position for. 0 is leftmost highway</param>
         /// <param name="x">The normalized position across the track width (0.0 is leftmost track edge. 1.0 is rightmost track edge)</param>
-        /// <param name="y">The normalized position up the track (0.0 = strikeline, 1.0 is zero fade position)</param>
+        /// <param name="y">The normalized position up the track (0.0 is the strikeline, 1.0 is zero fade position)</param>
         public Vector2 GetTrackPositionScreenSpace(int trackIndex, float x, float y)
         {
             if (trackIndex < 0 || trackIndex >= _cameras.Count)


### PR DESCRIPTION
Discord issue: https://discord.com/channels/1086048856678084609/1459274675304534037/1459274675304534037

This PR fixes three things:

1. There was a highway camera renderer bug which was causing lanes to be taller than they should be.  This caused the solo box to overlap the highway.  The fix is to wait for `OnCameraPreRender` to reset the cameras when a new track is added

2. Solo box was overlapping the practice mode UI even with the above issue fixed.  So we moved the "restart section" to the left

3. With vocals in practice mode, the ui overlapped the vocals highway.  Fix is to push everything down enough

Fixed screenshots (with a silly tall preset):

<img width="2382" height="1348" alt="CleanShot 2026-01-26 at 22 13 29@2x" src="https://github.com/user-attachments/assets/fbe59fcd-5af7-4826-a190-4860db48374b" />

<img width="2376" height="1344" alt="CleanShot 2026-01-26 at 22 14 11@2x" src="https://github.com/user-attachments/assets/c7450427-b9a7-4d4f-a065-3c1d9f156915" />

<img width="2380" height="1338" alt="CleanShot 2026-01-26 at 22 23 41@2x" src="https://github.com/user-attachments/assets/c79c4a63-3a59-4b74-b990-2847869c97ce" />
