### PR TITLE
Use pro drums icon when part is available

### DIFF
--- a/Assets/Script/Menu/MusicLibrary/Sidebar.cs
+++ b/Assets/Script/Menu/MusicLibrary/Sidebar.cs
@@ -182,6 +182,10 @@ namespace YARG.Menu.MusicLibrary
             {
                 _difficultyRings[2].SetInfo("ghDrums", Instrument.FiveLaneDrums, entry[Instrument.FiveLaneDrums]);
             }
+            else if (entry.HasInstrument(Instrument.ProDrums))
+            {
+                _difficultyRings[2].SetInfo("realDrums", Instrument.ProDrums, entry[Instrument.ProDrums]);
+            }
             else
             {
                 _difficultyRings[2].SetInfo("drums", Instrument.FourLaneDrums, entry[Instrument.FourLaneDrums]);


### PR DESCRIPTION
This will show the pro drums icon in place of the standard drums icon if pro drums is available. This does unfortunately make pro drums the only pro icon to not be in the second row, but I feel like that's preferable to not showing it at all.