### PR TITLE
Use visual calibration for vocals visuals

### DIFF
--- a/Assets/Script/Gameplay/Visuals/VocalElements/VocalScrollingLyricSyllableElement.cs
+++ b/Assets/Script/Gameplay/Visuals/VocalElements/VocalScrollingLyricSyllableElement.cs
@@ -59,11 +59,11 @@ namespace YARG.Gameplay.Visuals
 
         protected override void UpdateElement()
         {
-            if (GameManager.SongTime < _lyricRef.Time)
+            if (GameManager.VisualTime < _lyricRef.Time)
             {
                 _lyricText.color = _isStarpower ? Color.yellow : Color.white;
             }
-            else if (GameManager.SongTime > _lyricRef.Time && GameManager.SongTime < _lyricRef.Time + _lyricLength)
+            else if (GameManager.VisualTime > _lyricRef.Time && GameManager.VisualTime < _lyricRef.Time + _lyricLength)
             {
                 _lyricText.color = new Color(0.0549f, 0.6431f, 0.9765f);
             }

--- a/Assets/Script/Gameplay/Visuals/VocalElements/VocalStaticLyricPhraseElement.cs
+++ b/Assets/Script/Gameplay/Visuals/VocalElements/VocalStaticLyricPhraseElement.cs
@@ -210,11 +210,11 @@ namespace YARG.Gameplay.Visuals
 
             foreach (var syllable in _syllables)
             {
-                if (GameManager.SongTime < syllable.Time)
+                if (GameManager.VisualTime < syllable.Time)
                 {
                     BuilderAppendWithColorTag(syllable.Text, syllable.IsStarpower ? FUTURE_STAR_POWER_LYRIC_COLOR_TAG : FUTURE_LYRIC_COLOR_TAG);
                 }
-                else if (syllable.Time <= GameManager.SongTime && GameManager.SongTime < syllable.TimeEnd)
+                else if (syllable.Time <= GameManager.VisualTime && GameManager.VisualTime < syllable.TimeEnd)
                 {
                     BuilderAppendWithColorTag(syllable.Text, PRESENT_LYRIC_COLOR_TAG);
                 }


### PR DESCRIPTION
This changes vocals visuals to be tied to visual time, which includes visual calibration

Summary of the discussion here: https://discord.com/channels/1086048856678084609/1467942566237569024

Lyrics/vocal visual events (like static lyrics turning blue) were synced to audio time instead of visual time. This caused lyrics to appear off-beat in the case where there is a large gap between visual and audio latency (tv / speakers device latency).

The fix is to change lyrics visual events to use visual time (`VisualTime = InputTime + (VideoCalibration * SongSpeed)`) instead of audio time. This is the technically correct approach since these are visual elements that should respect visual calibration settings.

  Key points from discussion:
  - Audio events (like clapping SFX, metronome) should still use audio/song time
  - Visual events (like lyrics highlighting) should use visual time
  - The issue becomes more noticeable with higher display latency and low audio latency (e.g., 50ms visual lag TV)
  - There is one caveat: users who have set audio calibration but not visual calibration may not see improvement (or could see slightly worse sync) until they also calibrate video.  This could be a problem given that we don't have an easy way to dial in visual calibration.
  - For users with properly configured visual calibration, this fix ensures lyrics appear on-beat
  - This does not change vocals or harmony gameplay mechanics
