### PR TITLE
Add missing imports

### DIFF
--- a/Assets/Script/Audio/Bass/BassAudioManager.cs
+++ b/Assets/Script/Audio/Bass/BassAudioManager.cs
@@ -7,6 +7,7 @@ using ManagedBass.Mix;
 using UnityEngine;
 using YARG.Core.Audio;
 using YARG.Core.Logging;
+using YARG.Menu.Persistent;
 using YARG.Settings;
 
 #if UNITY_EDITOR

--- a/Assets/Script/Helpers/FileExplorerHelper.cs
+++ b/Assets/Script/Helpers/FileExplorerHelper.cs
@@ -3,6 +3,7 @@ using SimpleFileBrowser;
 using YARG.Core.Logging;
 
 using System.Diagnostics;
+using System.IO;
 using UnityEngine;
 using Object = UnityEngine.Object;
 


### PR DESCRIPTION
Without these the build fails with:

```
Assets/Script/Audio/Bass/BassAudioManager.cs(161,21): error CS0103: The name 'ToastManager' does not exist in the current context
Assets/Script/Helpers/FileExplorerHelper.cs(150,39): error CS0103: The name 'Path' does not exist in the current context
```