### PR TITLE
Fix issues with replay viewer

### DIFF
--- a/Assets/Prefabs/Gameplay/HUD/ReplayViewer.prefab
+++ b/Assets/Prefabs/Gameplay/HUD/ReplayViewer.prefab
@@ -34,7 +34,6 @@ RectTransform:
   m_Children:
   - {fileID: 8122009540001113090}
   m_Father: {fileID: 7369758458041123574}
-  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 1}
   m_AnchorMax: {x: 1, y: 1}
@@ -186,7 +185,6 @@ RectTransform:
   m_Children:
   - {fileID: 2933889975780695480}
   m_Father: {fileID: 2006855537152082164}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 0}
@@ -252,7 +250,6 @@ RectTransform:
   m_Children:
   - {fileID: 6299547331283667970}
   m_Father: {fileID: 182650594059561298}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 0.5}
   m_AnchorMax: {x: 1, y: 0.5}
@@ -386,7 +383,6 @@ RectTransform:
   m_Children:
   - {fileID: 1156395086982228201}
   m_Father: {fileID: 182650594059561298}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0.5}
   m_AnchorMax: {x: 0, y: 0.5}
@@ -518,7 +514,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 8642466853652824189}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 180}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -595,7 +590,6 @@ RectTransform:
   - {fileID: 7478673088016294437}
   - {fileID: 962586939960239826}
   m_Father: {fileID: 7369758458041123574}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -653,7 +647,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 3649841699488849902}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -693,8 +686,7 @@ MonoBehaviour:
 '
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 19b7115073766a24aa48ceca884dcbf5, type: 2}
-  m_sharedMaterial: {fileID: 4249517445589659644, guid: 19b7115073766a24aa48ceca884dcbf5,
-    type: 2}
+  m_sharedMaterial: {fileID: 4249517445589659644, guid: 19b7115073766a24aa48ceca884dcbf5, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -729,20 +721,23 @@ MonoBehaviour:
   m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
+  m_TextWrappingMode: 1
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}
   parentLinkedComponent: {fileID: 0}
   m_enableKerning: 1
+  m_ActiveFontFeatures: 6e72656b
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0
@@ -792,7 +787,6 @@ RectTransform:
   - {fileID: 182650594059561298}
   - {fileID: 9189071023315886846}
   m_Father: {fileID: 7369758458041123574}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -851,7 +845,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2933889975780695480}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -983,7 +976,6 @@ RectTransform:
   m_Children:
   - {fileID: 248279859240249411}
   m_Father: {fileID: 7369758458041123574}
-  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -1041,7 +1033,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 6915276943068997200}
-  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -1079,8 +1070,7 @@ MonoBehaviour:
   m_text: ' / 0:00:00.000'
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 65a8a6500dc773741bd815e54cd7c1ec, type: 2}
-  m_sharedMaterial: {fileID: -8996134669666270778, guid: 65a8a6500dc773741bd815e54cd7c1ec,
-    type: 2}
+  m_sharedMaterial: {fileID: -8996134669666270778, guid: 65a8a6500dc773741bd815e54cd7c1ec, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -1099,7 +1089,7 @@ MonoBehaviour:
   m_spriteAsset: {fileID: 0}
   m_tintAllSprites: 0
   m_StyleSheet: {fileID: 0}
-  m_TextStyleHashCode: -1905602860
+  m_TextStyleHashCode: -1183493901
   m_overrideHtmlColors: 0
   m_faceColor:
     serializedVersion: 2
@@ -1115,20 +1105,23 @@ MonoBehaviour:
   m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 0
+  m_TextWrappingMode: 0
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}
   parentLinkedComponent: {fileID: 0}
   m_enableKerning: 1
+  m_ActiveFontFeatures: 6e72656b
   m_enableExtraPadding: 1
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0
@@ -1177,7 +1170,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 7862273872121982748}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -1215,8 +1207,7 @@ MonoBehaviour:
   m_text: +
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 19b7115073766a24aa48ceca884dcbf5, type: 2}
-  m_sharedMaterial: {fileID: 4249517445589659644, guid: 19b7115073766a24aa48ceca884dcbf5,
-    type: 2}
+  m_sharedMaterial: {fileID: 4249517445589659644, guid: 19b7115073766a24aa48ceca884dcbf5, type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -1251,20 +1242,23 @@ MonoBehaviour:
   m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
+  m_TextWrappingMode: 1
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}
   parentLinkedComponent: {fileID: 0}
   m_enableKerning: 1
+  m_ActiveFontFeatures: 6e72656b
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0
@@ -1313,7 +1307,6 @@ RectTransform:
   m_Children:
   - {fileID: 7369758458041123574}
   m_Father: {fileID: 0}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -1334,6 +1327,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _container: {fileID: 7369758458041123574}
   _showHudButtonArrow: {fileID: 8122009540001113090}
+  _showHudButton: {fileID: 8642466853652824189}
   _playButton: {fileID: 8754751340897396004}
   _pauseButton: {fileID: 5276235996489484041}
   _timeInput: {fileID: 5485872602135839116}
@@ -1377,7 +1371,6 @@ RectTransform:
   - {fileID: 7226651616191308852}
   - {fileID: 8642466853652824189}
   m_Father: {fileID: 7369758456864847374}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 0}
@@ -1479,7 +1472,6 @@ RectTransform:
   - {fileID: 2963002935905172222}
   - {fileID: 2229915905071058482}
   m_Father: {fileID: 9189071023315886846}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -1518,7 +1510,6 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2933889975780695480}
-  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -1624,195 +1615,165 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
+    serializedVersion: 3
     m_TransformParent: {fileID: 7226651616191308852}
     m_Modifications:
-    - target: {fileID: 385803019352111189, guid: abd40d758b3e1a74486df5d631e4a775,
-        type: 3}
+    - target: {fileID: 385803019352111189, guid: abd40d758b3e1a74486df5d631e4a775, type: 3}
       propertyPath: m_Pivot.x
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 385803019352111189, guid: abd40d758b3e1a74486df5d631e4a775,
-        type: 3}
+    - target: {fileID: 385803019352111189, guid: abd40d758b3e1a74486df5d631e4a775, type: 3}
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 385803019352111189, guid: abd40d758b3e1a74486df5d631e4a775,
-        type: 3}
+    - target: {fileID: 385803019352111189, guid: abd40d758b3e1a74486df5d631e4a775, type: 3}
       propertyPath: m_RootOrder
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 385803019352111189, guid: abd40d758b3e1a74486df5d631e4a775,
-        type: 3}
+    - target: {fileID: 385803019352111189, guid: abd40d758b3e1a74486df5d631e4a775, type: 3}
       propertyPath: m_AnchorMax.x
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 385803019352111189, guid: abd40d758b3e1a74486df5d631e4a775,
-        type: 3}
+    - target: {fileID: 385803019352111189, guid: abd40d758b3e1a74486df5d631e4a775, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 385803019352111189, guid: abd40d758b3e1a74486df5d631e4a775,
-        type: 3}
+    - target: {fileID: 385803019352111189, guid: abd40d758b3e1a74486df5d631e4a775, type: 3}
       propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 385803019352111189, guid: abd40d758b3e1a74486df5d631e4a775,
-        type: 3}
+    - target: {fileID: 385803019352111189, guid: abd40d758b3e1a74486df5d631e4a775, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 385803019352111189, guid: abd40d758b3e1a74486df5d631e4a775,
-        type: 3}
+    - target: {fileID: 385803019352111189, guid: abd40d758b3e1a74486df5d631e4a775, type: 3}
       propertyPath: m_SizeDelta.x
       value: -10
       objectReference: {fileID: 0}
-    - target: {fileID: 385803019352111189, guid: abd40d758b3e1a74486df5d631e4a775,
-        type: 3}
+    - target: {fileID: 385803019352111189, guid: abd40d758b3e1a74486df5d631e4a775, type: 3}
       propertyPath: m_SizeDelta.y
       value: 10
       objectReference: {fileID: 0}
-    - target: {fileID: 385803019352111189, guid: abd40d758b3e1a74486df5d631e4a775,
-        type: 3}
+    - target: {fileID: 385803019352111189, guid: abd40d758b3e1a74486df5d631e4a775, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 385803019352111189, guid: abd40d758b3e1a74486df5d631e4a775,
-        type: 3}
+    - target: {fileID: 385803019352111189, guid: abd40d758b3e1a74486df5d631e4a775, type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 385803019352111189, guid: abd40d758b3e1a74486df5d631e4a775,
-        type: 3}
+    - target: {fileID: 385803019352111189, guid: abd40d758b3e1a74486df5d631e4a775, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 385803019352111189, guid: abd40d758b3e1a74486df5d631e4a775,
-        type: 3}
+    - target: {fileID: 385803019352111189, guid: abd40d758b3e1a74486df5d631e4a775, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 385803019352111189, guid: abd40d758b3e1a74486df5d631e4a775,
-        type: 3}
+    - target: {fileID: 385803019352111189, guid: abd40d758b3e1a74486df5d631e4a775, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 385803019352111189, guid: abd40d758b3e1a74486df5d631e4a775,
-        type: 3}
+    - target: {fileID: 385803019352111189, guid: abd40d758b3e1a74486df5d631e4a775, type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 385803019352111189, guid: abd40d758b3e1a74486df5d631e4a775,
-        type: 3}
+    - target: {fileID: 385803019352111189, guid: abd40d758b3e1a74486df5d631e4a775, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 385803019352111189, guid: abd40d758b3e1a74486df5d631e4a775,
-        type: 3}
+    - target: {fileID: 385803019352111189, guid: abd40d758b3e1a74486df5d631e4a775, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 385803019352111189, guid: abd40d758b3e1a74486df5d631e4a775,
-        type: 3}
+    - target: {fileID: 385803019352111189, guid: abd40d758b3e1a74486df5d631e4a775, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 385803019352111189, guid: abd40d758b3e1a74486df5d631e4a775,
-        type: 3}
+    - target: {fileID: 385803019352111189, guid: abd40d758b3e1a74486df5d631e4a775, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 385803019352111189, guid: abd40d758b3e1a74486df5d631e4a775,
-        type: 3}
+    - target: {fileID: 385803019352111189, guid: abd40d758b3e1a74486df5d631e4a775, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 385803019352111189, guid: abd40d758b3e1a74486df5d631e4a775,
-        type: 3}
+    - target: {fileID: 385803019352111189, guid: abd40d758b3e1a74486df5d631e4a775, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 901111967453049492, guid: abd40d758b3e1a74486df5d631e4a775,
-        type: 3}
+    - target: {fileID: 901111967453049492, guid: abd40d758b3e1a74486df5d631e4a775, type: 3}
       propertyPath: m_Name
       value: Slider
       objectReference: {fileID: 0}
-    - target: {fileID: 5761802240589336641, guid: abd40d758b3e1a74486df5d631e4a775,
-        type: 3}
+    - target: {fileID: 5761802240589336641, guid: abd40d758b3e1a74486df5d631e4a775, type: 3}
       propertyPath: m_AnchorMax.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5761802240589336641, guid: abd40d758b3e1a74486df5d631e4a775,
-        type: 3}
+    - target: {fileID: 5761802240589336641, guid: abd40d758b3e1a74486df5d631e4a775, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8298977265691902926, guid: abd40d758b3e1a74486df5d631e4a775,
-        type: 3}
+    - target: {fileID: 8298977265691902926, guid: abd40d758b3e1a74486df5d631e4a775, type: 3}
       propertyPath: m_AnchorMax.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8298977265691902926, guid: abd40d758b3e1a74486df5d631e4a775,
-        type: 3}
+    - target: {fileID: 8298977265691902926, guid: abd40d758b3e1a74486df5d631e4a775, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8298977265691902926, guid: abd40d758b3e1a74486df5d631e4a775,
-        type: 3}
+    - target: {fileID: 8298977265691902926, guid: abd40d758b3e1a74486df5d631e4a775, type: 3}
       propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8696487122370294474, guid: abd40d758b3e1a74486df5d631e4a775,
-        type: 3}
+    - target: {fileID: 8696487122370294474, guid: abd40d758b3e1a74486df5d631e4a775, type: 3}
       propertyPath: m_Value
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8696487122370294474, guid: abd40d758b3e1a74486df5d631e4a775,
-        type: 3}
+    - target: {fileID: 8696487122370294474, guid: abd40d758b3e1a74486df5d631e4a775, type: 3}
       propertyPath: m_OnValueChanged.m_PersistentCalls.m_Calls.Array.size
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8696487122370294474, guid: abd40d758b3e1a74486df5d631e4a775,
-        type: 3}
+    - target: {fileID: 8696487122370294474, guid: abd40d758b3e1a74486df5d631e4a775, type: 3}
       propertyPath: m_OnValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8696487122370294474, guid: abd40d758b3e1a74486df5d631e4a775,
-        type: 3}
+    - target: {fileID: 8696487122370294474, guid: abd40d758b3e1a74486df5d631e4a775, type: 3}
       propertyPath: m_OnValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 
       objectReference: {fileID: 5703792185782102541}
-    - target: {fileID: 8696487122370294474, guid: abd40d758b3e1a74486df5d631e4a775,
-        type: 3}
+    - target: {fileID: 8696487122370294474, guid: abd40d758b3e1a74486df5d631e4a775, type: 3}
       propertyPath: m_OnValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
       value: 2
       objectReference: {fileID: 0}
-    - target: {fileID: 8696487122370294474, guid: abd40d758b3e1a74486df5d631e4a775,
-        type: 3}
+    - target: {fileID: 8696487122370294474, guid: abd40d758b3e1a74486df5d631e4a775, type: 3}
       propertyPath: m_OnValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
       value: OnTimelineSliderChanged
       objectReference: {fileID: 0}
-    - target: {fileID: 8696487122370294474, guid: abd40d758b3e1a74486df5d631e4a775,
-        type: 3}
+    - target: {fileID: 8696487122370294474, guid: abd40d758b3e1a74486df5d631e4a775, type: 3}
       propertyPath: m_OnValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
       value: YARG.Gameplay.HUD.ReplayController, Assembly-CSharp
       objectReference: {fileID: 0}
-    - target: {fileID: 8696487122370294474, guid: abd40d758b3e1a74486df5d631e4a775,
-        type: 3}
+    - target: {fileID: 8696487122370294474, guid: abd40d758b3e1a74486df5d631e4a775, type: 3}
       propertyPath: m_OnValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
       value: UnityEngine.Object, UnityEngine
       objectReference: {fileID: 0}
     m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 901111967453049492, guid: abd40d758b3e1a74486df5d631e4a775, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 7397922087469340408}
   m_SourcePrefab: {fileID: 100100000, guid: abd40d758b3e1a74486df5d631e4a775, type: 3}
 --- !u!224 &248279859240249411 stripped
 RectTransform:
-  m_CorrespondingSourceObject: {fileID: 385803019352111189, guid: abd40d758b3e1a74486df5d631e4a775,
-    type: 3}
+  m_CorrespondingSourceObject: {fileID: 385803019352111189, guid: abd40d758b3e1a74486df5d631e4a775, type: 3}
   m_PrefabInstance: {fileID: 443803550190358550}
   m_PrefabAsset: {fileID: 0}
 --- !u!1 &768374413946200706 stripped
 GameObject:
-  m_CorrespondingSourceObject: {fileID: 901111967453049492, guid: abd40d758b3e1a74486df5d631e4a775,
-    type: 3}
+  m_CorrespondingSourceObject: {fileID: 901111967453049492, guid: abd40d758b3e1a74486df5d631e4a775, type: 3}
   m_PrefabInstance: {fileID: 443803550190358550}
   m_PrefabAsset: {fileID: 0}
 --- !u!114 &7397922087469340408
@@ -1862,8 +1823,7 @@ MonoBehaviour:
           m_CallState: 2
 --- !u!114 &9122203824592036572 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 8696487122370294474, guid: abd40d758b3e1a74486df5d631e4a775,
-    type: 3}
+  m_CorrespondingSourceObject: {fileID: 8696487122370294474, guid: abd40d758b3e1a74486df5d631e4a775, type: 3}
   m_PrefabInstance: {fileID: 443803550190358550}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 768374413946200706}
@@ -1877,235 +1837,201 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
+    serializedVersion: 3
     m_TransformParent: {fileID: 6915276943068997200}
     m_Modifications:
-    - target: {fileID: 1988200050303033511, guid: 8f25b12de267d7544aa2ff7993247fcd,
-        type: 3}
+    - target: {fileID: 1988200050303033511, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
       propertyPath: m_Name
       value: Time Input
       objectReference: {fileID: 0}
-    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd,
-        type: 3}
+    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
       propertyPath: m_Text
       value: "0:00:00.000\u200B"
       objectReference: {fileID: 0}
-    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd,
-        type: 3}
+    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
       propertyPath: m_RegexValue
       value: '[\d,.:]'
       objectReference: {fileID: 0}
-    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd,
-        type: 3}
+    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
       propertyPath: m_ContentType
       value: 9
       objectReference: {fileID: 0}
-    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd,
-        type: 3}
+    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
       propertyPath: m_Placeholder
       value: 
       objectReference: {fileID: 0}
-    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd,
-        type: 3}
+    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
       propertyPath: m_OnFocusSelectAll
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd,
-        type: 3}
+    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
       propertyPath: m_CharacterValidation
       value: 6
       objectReference: {fileID: 0}
-    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd,
-        type: 3}
+    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
       propertyPath: m_OnEndEdit.m_PersistentCalls.m_Calls.Array.size
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd,
-        type: 3}
+    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
       propertyPath: m_OnEndEdit.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd,
-        type: 3}
+    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
       propertyPath: m_OnEndEdit.m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 
       objectReference: {fileID: 5703792185782102541}
-    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd,
-        type: 3}
+    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
       propertyPath: m_OnEndEdit.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
       value: 2
       objectReference: {fileID: 0}
-    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd,
-        type: 3}
+    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
       propertyPath: m_OnEndEdit.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
       value: OnTimeInputEndEdit
       objectReference: {fileID: 0}
-    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd,
-        type: 3}
+    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
       propertyPath: m_OnEndEdit.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
       value: YARG.Gameplay.HUD.ReplayController, Assembly-CSharp
       objectReference: {fileID: 0}
-    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd,
-        type: 3}
+    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
       propertyPath: m_OnEndEdit.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
       value: UnityEngine.Object, UnityEngine
       objectReference: {fileID: 0}
-    - target: {fileID: 6274164203294727049, guid: 8f25b12de267d7544aa2ff7993247fcd,
-        type: 3}
+    - target: {fileID: 6274164203294727049, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
       propertyPath: m_SizeDelta.x
       value: -20
       objectReference: {fileID: 0}
-    - target: {fileID: 6274164203294727049, guid: 8f25b12de267d7544aa2ff7993247fcd,
-        type: 3}
+    - target: {fileID: 6274164203294727049, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7421987709479303017, guid: 8f25b12de267d7544aa2ff7993247fcd,
-        type: 3}
+    - target: {fileID: 7421987709479303017, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
       propertyPath: m_text
       value: "0:00:00.000\u200B\u200B"
       objectReference: {fileID: 0}
-    - target: {fileID: 7421987709479303017, guid: 8f25b12de267d7544aa2ff7993247fcd,
-        type: 3}
+    - target: {fileID: 7421987709479303017, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
       propertyPath: m_fontColor.g
       value: 0.8509804
       objectReference: {fileID: 0}
-    - target: {fileID: 7421987709479303017, guid: 8f25b12de267d7544aa2ff7993247fcd,
-        type: 3}
+    - target: {fileID: 7421987709479303017, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
       propertyPath: m_fontColor.r
       value: 0.18039216
       objectReference: {fileID: 0}
-    - target: {fileID: 7421987709479303017, guid: 8f25b12de267d7544aa2ff7993247fcd,
-        type: 3}
+    - target: {fileID: 7421987709479303017, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
       propertyPath: m_fontColor32.rgba
       value: 4294957358
       objectReference: {fileID: 0}
-    - target: {fileID: 7421987709479303017, guid: 8f25b12de267d7544aa2ff7993247fcd,
-        type: 3}
+    - target: {fileID: 7421987709479303017, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
       propertyPath: m_TextStyleHashCode
-      value: -1905602860
+      value: -1183493901
       objectReference: {fileID: 0}
-    - target: {fileID: 7421987709479303017, guid: 8f25b12de267d7544aa2ff7993247fcd,
-        type: 3}
+    - target: {fileID: 7421987709479303017, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
       propertyPath: m_HorizontalAlignment
       value: 2
       objectReference: {fileID: 0}
-    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd,
-        type: 3}
+    - target: {fileID: 7421987709479303017, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
+      value: 1801810542
+      objectReference: {fileID: 0}
+    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
       propertyPath: m_Pivot.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd,
-        type: 3}
+    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd,
-        type: 3}
+    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
       propertyPath: m_RootOrder
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd,
-        type: 3}
+    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
       propertyPath: m_AnchorMax.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd,
-        type: 3}
+    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd,
-        type: 3}
+    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
       propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd,
-        type: 3}
+    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd,
-        type: 3}
+    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
       propertyPath: m_SizeDelta.x
       value: 200
       objectReference: {fileID: 0}
-    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd,
-        type: 3}
+    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
       propertyPath: m_SizeDelta.y
       value: 64
       objectReference: {fileID: 0}
-    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd,
-        type: 3}
+    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd,
-        type: 3}
+    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd,
-        type: 3}
+    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd,
-        type: 3}
+    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd,
-        type: 3}
+    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd,
-        type: 3}
+    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd,
-        type: 3}
+    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd,
-        type: 3}
+    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd,
-        type: 3}
+    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd,
-        type: 3}
+    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd,
-        type: 3}
+    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd,
-        type: 3}
+    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8371195817729540105, guid: 8f25b12de267d7544aa2ff7993247fcd,
-        type: 3}
+    - target: {fileID: 8371195817729540105, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
       propertyPath: m_IsActive
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents:
     - {fileID: 3605409488639070977, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 450096836518303239, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 5200000206662208388}
   m_SourcePrefab: {fileID: 100100000, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
 --- !u!1 &835204727217706609 stripped
 GameObject:
-  m_CorrespondingSourceObject: {fileID: 450096836518303239, guid: 8f25b12de267d7544aa2ff7993247fcd,
-    type: 3}
+  m_CorrespondingSourceObject: {fileID: 450096836518303239, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
   m_PrefabInstance: {fileID: 984088153209602166}
   m_PrefabAsset: {fileID: 0}
 --- !u!114 &5200000206662208388
@@ -2139,8 +2065,7 @@ MonoBehaviour:
           m_CallState: 2
 --- !u!114 &5485872602135839116 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd,
-    type: 3}
+  m_CorrespondingSourceObject: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
   m_PrefabInstance: {fileID: 984088153209602166}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 835204727217706609}
@@ -2151,8 +2076,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
 --- !u!224 &7478673088016294437 stripped
 RectTransform:
-  m_CorrespondingSourceObject: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd,
-    type: 3}
+  m_CorrespondingSourceObject: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
   m_PrefabInstance: {fileID: 984088153209602166}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &7559675453870017281
@@ -2160,236 +2084,205 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
+    serializedVersion: 3
     m_TransformParent: {fileID: 2006855537152082164}
     m_Modifications:
-    - target: {fileID: 1988200050303033511, guid: 8f25b12de267d7544aa2ff7993247fcd,
-        type: 3}
+    - target: {fileID: 1988200050303033511, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
       propertyPath: m_Name
       value: Speed Input
       objectReference: {fileID: 0}
-    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd,
-        type: 3}
+    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
       propertyPath: m_Text
       value: 100%
       objectReference: {fileID: 0}
-    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd,
-        type: 3}
+    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
       propertyPath: m_RegexValue
       value: '[\d,.%]'
       objectReference: {fileID: 0}
-    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd,
-        type: 3}
+    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
       propertyPath: m_ContentType
       value: 9
       objectReference: {fileID: 0}
-    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd,
-        type: 3}
+    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
       propertyPath: m_Placeholder
       value: 
       objectReference: {fileID: 0}
-    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd,
-        type: 3}
+    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
       propertyPath: m_CharacterValidation
       value: 6
       objectReference: {fileID: 0}
-    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd,
-        type: 3}
+    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
       propertyPath: m_OnEndEdit.m_PersistentCalls.m_Calls.Array.size
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd,
-        type: 3}
+    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
       propertyPath: m_OnEndEdit.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd,
-        type: 3}
+    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
       propertyPath: m_OnEndEdit.m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 
       objectReference: {fileID: 5703792185782102541}
-    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd,
-        type: 3}
+    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
       propertyPath: m_OnEndEdit.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
       value: 2
       objectReference: {fileID: 0}
-    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd,
-        type: 3}
+    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
       propertyPath: m_OnEndEdit.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
       value: OnSpeedInputEndEdit
       objectReference: {fileID: 0}
-    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd,
-        type: 3}
+    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
       propertyPath: m_OnEndEdit.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
       value: YARG.Gameplay.HUD.ReplayController, Assembly-CSharp
       objectReference: {fileID: 0}
-    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd,
-        type: 3}
+    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
       propertyPath: m_OnEndEdit.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
       value: UnityEngine.Object, UnityEngine
       objectReference: {fileID: 0}
-    - target: {fileID: 6274164203294727049, guid: 8f25b12de267d7544aa2ff7993247fcd,
-        type: 3}
+    - target: {fileID: 6274164203294727049, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
       propertyPath: m_SizeDelta.x
       value: -20
       objectReference: {fileID: 0}
-    - target: {fileID: 6274164203294727049, guid: 8f25b12de267d7544aa2ff7993247fcd,
-        type: 3}
+    - target: {fileID: 6274164203294727049, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7421987709479303017, guid: 8f25b12de267d7544aa2ff7993247fcd,
-        type: 3}
+    - target: {fileID: 7421987709479303017, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
       propertyPath: m_text
       value: "100%\u200B"
       objectReference: {fileID: 0}
-    - target: {fileID: 7421987709479303017, guid: 8f25b12de267d7544aa2ff7993247fcd,
-        type: 3}
+    - target: {fileID: 7421987709479303017, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
       propertyPath: m_fontColor.g
       value: 0.8509804
       objectReference: {fileID: 0}
-    - target: {fileID: 7421987709479303017, guid: 8f25b12de267d7544aa2ff7993247fcd,
-        type: 3}
+    - target: {fileID: 7421987709479303017, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
       propertyPath: m_fontColor.r
       value: 0.18039216
       objectReference: {fileID: 0}
-    - target: {fileID: 7421987709479303017, guid: 8f25b12de267d7544aa2ff7993247fcd,
-        type: 3}
+    - target: {fileID: 7421987709479303017, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
       propertyPath: m_fontColor32.rgba
       value: 4294957358
       objectReference: {fileID: 0}
-    - target: {fileID: 7421987709479303017, guid: 8f25b12de267d7544aa2ff7993247fcd,
-        type: 3}
+    - target: {fileID: 7421987709479303017, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
       propertyPath: m_TextStyleHashCode
       value: -1183493901
       objectReference: {fileID: 0}
-    - target: {fileID: 7421987709479303017, guid: 8f25b12de267d7544aa2ff7993247fcd,
-        type: 3}
+    - target: {fileID: 7421987709479303017, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
       propertyPath: m_HorizontalAlignment
       value: 2
       objectReference: {fileID: 0}
-    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd,
-        type: 3}
+    - target: {fileID: 7421987709479303017, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
+      value: 1801810542
+      objectReference: {fileID: 0}
+    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
       propertyPath: m_Pivot.x
       value: 1.0000002
       objectReference: {fileID: 0}
-    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd,
-        type: 3}
+    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd,
-        type: 3}
+    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
       propertyPath: m_RootOrder
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd,
-        type: 3}
+    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
       propertyPath: m_AnchorMax.x
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd,
-        type: 3}
+    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd,
-        type: 3}
+    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
       propertyPath: m_AnchorMin.x
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd,
-        type: 3}
+    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
       propertyPath: m_AnchorMin.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd,
-        type: 3}
+    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
       propertyPath: m_SizeDelta.x
       value: 150
       objectReference: {fileID: 0}
-    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd,
-        type: 3}
+    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
       propertyPath: m_SizeDelta.y
       value: 64
       objectReference: {fileID: 0}
-    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd,
-        type: 3}
+    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd,
-        type: 3}
+    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd,
-        type: 3}
+    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd,
-        type: 3}
+    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd,
-        type: 3}
+    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd,
-        type: 3}
+    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd,
-        type: 3}
+    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd,
-        type: 3}
+    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd,
-        type: 3}
+    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd,
-        type: 3}
+    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd,
-        type: 3}
+    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd,
-        type: 3}
+    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8371195817729540105, guid: 8f25b12de267d7544aa2ff7993247fcd,
-        type: 3}
+    - target: {fileID: 8371195817729540105, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
       propertyPath: m_IsActive
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents:
     - {fileID: 3605409488639070977, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    m_RemovedGameObjects: []
+    m_AddedGameObjects:
+    - targetCorrespondingSourceObject: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 7862273872121982748}
+    - targetCorrespondingSourceObject: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 3649841699488849902}
+    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
 --- !u!224 &182650594059561298 stripped
 RectTransform:
-  m_CorrespondingSourceObject: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd,
-    type: 3}
+  m_CorrespondingSourceObject: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
   m_PrefabInstance: {fileID: 7559675453870017281}
   m_PrefabAsset: {fileID: 0}
 --- !u!114 &2981609604511288059 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd,
-    type: 3}
+  m_CorrespondingSourceObject: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
   m_PrefabInstance: {fileID: 7559675453870017281}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}

--- a/Assets/Prefabs/Gameplay/HUD/ReplayViewer.prefab
+++ b/Assets/Prefabs/Gameplay/HUD/ReplayViewer.prefab
@@ -34,6 +34,7 @@ RectTransform:
   m_Children:
   - {fileID: 8122009540001113090}
   m_Father: {fileID: 7369758458041123574}
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 1}
   m_AnchorMax: {x: 1, y: 1}
@@ -185,6 +186,7 @@ RectTransform:
   m_Children:
   - {fileID: 2933889975780695480}
   m_Father: {fileID: 2006855537152082164}
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 0}
@@ -250,6 +252,7 @@ RectTransform:
   m_Children:
   - {fileID: 6299547331283667970}
   m_Father: {fileID: 182650594059561298}
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 0.5}
   m_AnchorMax: {x: 1, y: 0.5}
@@ -383,6 +386,7 @@ RectTransform:
   m_Children:
   - {fileID: 1156395086982228201}
   m_Father: {fileID: 182650594059561298}
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0.5}
   m_AnchorMax: {x: 0, y: 0.5}
@@ -514,6 +518,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 8642466853652824189}
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 180}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -590,6 +595,7 @@ RectTransform:
   - {fileID: 7478673088016294437}
   - {fileID: 962586939960239826}
   m_Father: {fileID: 7369758458041123574}
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -647,6 +653,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 3649841699488849902}
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -686,7 +693,8 @@ MonoBehaviour:
 '
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 19b7115073766a24aa48ceca884dcbf5, type: 2}
-  m_sharedMaterial: {fileID: 4249517445589659644, guid: 19b7115073766a24aa48ceca884dcbf5, type: 2}
+  m_sharedMaterial: {fileID: 4249517445589659644, guid: 19b7115073766a24aa48ceca884dcbf5,
+    type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -721,23 +729,20 @@ MonoBehaviour:
   m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
-  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_TextWrappingMode: 1
+  m_enableWordWrapping: 1
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}
   parentLinkedComponent: {fileID: 0}
   m_enableKerning: 1
-  m_ActiveFontFeatures: 6e72656b
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
-  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0
@@ -787,6 +792,7 @@ RectTransform:
   - {fileID: 182650594059561298}
   - {fileID: 9189071023315886846}
   m_Father: {fileID: 7369758458041123574}
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -845,6 +851,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2933889975780695480}
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -976,6 +983,7 @@ RectTransform:
   m_Children:
   - {fileID: 248279859240249411}
   m_Father: {fileID: 7369758458041123574}
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -1033,6 +1041,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 6915276943068997200}
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -1070,7 +1079,8 @@ MonoBehaviour:
   m_text: ' / 0:00:00.000'
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 65a8a6500dc773741bd815e54cd7c1ec, type: 2}
-  m_sharedMaterial: {fileID: -8996134669666270778, guid: 65a8a6500dc773741bd815e54cd7c1ec, type: 2}
+  m_sharedMaterial: {fileID: -8996134669666270778, guid: 65a8a6500dc773741bd815e54cd7c1ec,
+    type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -1089,7 +1099,7 @@ MonoBehaviour:
   m_spriteAsset: {fileID: 0}
   m_tintAllSprites: 0
   m_StyleSheet: {fileID: 0}
-  m_TextStyleHashCode: -1183493901
+  m_TextStyleHashCode: -1905602860
   m_overrideHtmlColors: 0
   m_faceColor:
     serializedVersion: 2
@@ -1105,23 +1115,20 @@ MonoBehaviour:
   m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
-  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_TextWrappingMode: 0
+  m_enableWordWrapping: 0
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}
   parentLinkedComponent: {fileID: 0}
   m_enableKerning: 1
-  m_ActiveFontFeatures: 6e72656b
   m_enableExtraPadding: 1
   checkPaddingRequired: 0
   m_isRichText: 1
-  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0
@@ -1170,6 +1177,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 7862273872121982748}
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -1207,7 +1215,8 @@ MonoBehaviour:
   m_text: +
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 19b7115073766a24aa48ceca884dcbf5, type: 2}
-  m_sharedMaterial: {fileID: 4249517445589659644, guid: 19b7115073766a24aa48ceca884dcbf5, type: 2}
+  m_sharedMaterial: {fileID: 4249517445589659644, guid: 19b7115073766a24aa48ceca884dcbf5,
+    type: 2}
   m_fontSharedMaterials: []
   m_fontMaterial: {fileID: 0}
   m_fontMaterials: []
@@ -1242,23 +1251,20 @@ MonoBehaviour:
   m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
-  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_TextWrappingMode: 1
+  m_enableWordWrapping: 1
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}
   parentLinkedComponent: {fileID: 0}
   m_enableKerning: 1
-  m_ActiveFontFeatures: 6e72656b
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
-  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0
@@ -1307,6 +1313,7 @@ RectTransform:
   m_Children:
   - {fileID: 7369758458041123574}
   m_Father: {fileID: 0}
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -1327,7 +1334,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _container: {fileID: 7369758458041123574}
   _showHudButtonArrow: {fileID: 8122009540001113090}
-  _showHudButton: {fileID: 8642466853652824189}
   _playButton: {fileID: 8754751340897396004}
   _pauseButton: {fileID: 5276235996489484041}
   _timeInput: {fileID: 5485872602135839116}
@@ -1371,6 +1377,7 @@ RectTransform:
   - {fileID: 7226651616191308852}
   - {fileID: 8642466853652824189}
   m_Father: {fileID: 7369758456864847374}
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 0}
@@ -1472,6 +1479,7 @@ RectTransform:
   - {fileID: 2963002935905172222}
   - {fileID: 2229915905071058482}
   m_Father: {fileID: 9189071023315886846}
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -1510,6 +1518,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2933889975780695480}
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
@@ -1615,165 +1624,195 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 7226651616191308852}
     m_Modifications:
-    - target: {fileID: 385803019352111189, guid: abd40d758b3e1a74486df5d631e4a775, type: 3}
+    - target: {fileID: 385803019352111189, guid: abd40d758b3e1a74486df5d631e4a775,
+        type: 3}
       propertyPath: m_Pivot.x
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 385803019352111189, guid: abd40d758b3e1a74486df5d631e4a775, type: 3}
+    - target: {fileID: 385803019352111189, guid: abd40d758b3e1a74486df5d631e4a775,
+        type: 3}
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 385803019352111189, guid: abd40d758b3e1a74486df5d631e4a775, type: 3}
+    - target: {fileID: 385803019352111189, guid: abd40d758b3e1a74486df5d631e4a775,
+        type: 3}
       propertyPath: m_RootOrder
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 385803019352111189, guid: abd40d758b3e1a74486df5d631e4a775, type: 3}
+    - target: {fileID: 385803019352111189, guid: abd40d758b3e1a74486df5d631e4a775,
+        type: 3}
       propertyPath: m_AnchorMax.x
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 385803019352111189, guid: abd40d758b3e1a74486df5d631e4a775, type: 3}
+    - target: {fileID: 385803019352111189, guid: abd40d758b3e1a74486df5d631e4a775,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 385803019352111189, guid: abd40d758b3e1a74486df5d631e4a775, type: 3}
+    - target: {fileID: 385803019352111189, guid: abd40d758b3e1a74486df5d631e4a775,
+        type: 3}
       propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 385803019352111189, guid: abd40d758b3e1a74486df5d631e4a775, type: 3}
+    - target: {fileID: 385803019352111189, guid: abd40d758b3e1a74486df5d631e4a775,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 385803019352111189, guid: abd40d758b3e1a74486df5d631e4a775, type: 3}
+    - target: {fileID: 385803019352111189, guid: abd40d758b3e1a74486df5d631e4a775,
+        type: 3}
       propertyPath: m_SizeDelta.x
       value: -10
       objectReference: {fileID: 0}
-    - target: {fileID: 385803019352111189, guid: abd40d758b3e1a74486df5d631e4a775, type: 3}
+    - target: {fileID: 385803019352111189, guid: abd40d758b3e1a74486df5d631e4a775,
+        type: 3}
       propertyPath: m_SizeDelta.y
       value: 10
       objectReference: {fileID: 0}
-    - target: {fileID: 385803019352111189, guid: abd40d758b3e1a74486df5d631e4a775, type: 3}
+    - target: {fileID: 385803019352111189, guid: abd40d758b3e1a74486df5d631e4a775,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 385803019352111189, guid: abd40d758b3e1a74486df5d631e4a775, type: 3}
+    - target: {fileID: 385803019352111189, guid: abd40d758b3e1a74486df5d631e4a775,
+        type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 385803019352111189, guid: abd40d758b3e1a74486df5d631e4a775, type: 3}
+    - target: {fileID: 385803019352111189, guid: abd40d758b3e1a74486df5d631e4a775,
+        type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 385803019352111189, guid: abd40d758b3e1a74486df5d631e4a775, type: 3}
+    - target: {fileID: 385803019352111189, guid: abd40d758b3e1a74486df5d631e4a775,
+        type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 385803019352111189, guid: abd40d758b3e1a74486df5d631e4a775, type: 3}
+    - target: {fileID: 385803019352111189, guid: abd40d758b3e1a74486df5d631e4a775,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 385803019352111189, guid: abd40d758b3e1a74486df5d631e4a775, type: 3}
+    - target: {fileID: 385803019352111189, guid: abd40d758b3e1a74486df5d631e4a775,
+        type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 385803019352111189, guid: abd40d758b3e1a74486df5d631e4a775, type: 3}
+    - target: {fileID: 385803019352111189, guid: abd40d758b3e1a74486df5d631e4a775,
+        type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 385803019352111189, guid: abd40d758b3e1a74486df5d631e4a775, type: 3}
+    - target: {fileID: 385803019352111189, guid: abd40d758b3e1a74486df5d631e4a775,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 385803019352111189, guid: abd40d758b3e1a74486df5d631e4a775, type: 3}
+    - target: {fileID: 385803019352111189, guid: abd40d758b3e1a74486df5d631e4a775,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 385803019352111189, guid: abd40d758b3e1a74486df5d631e4a775, type: 3}
+    - target: {fileID: 385803019352111189, guid: abd40d758b3e1a74486df5d631e4a775,
+        type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 385803019352111189, guid: abd40d758b3e1a74486df5d631e4a775, type: 3}
+    - target: {fileID: 385803019352111189, guid: abd40d758b3e1a74486df5d631e4a775,
+        type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 385803019352111189, guid: abd40d758b3e1a74486df5d631e4a775, type: 3}
+    - target: {fileID: 385803019352111189, guid: abd40d758b3e1a74486df5d631e4a775,
+        type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 901111967453049492, guid: abd40d758b3e1a74486df5d631e4a775, type: 3}
+    - target: {fileID: 901111967453049492, guid: abd40d758b3e1a74486df5d631e4a775,
+        type: 3}
       propertyPath: m_Name
       value: Slider
       objectReference: {fileID: 0}
-    - target: {fileID: 5761802240589336641, guid: abd40d758b3e1a74486df5d631e4a775, type: 3}
+    - target: {fileID: 5761802240589336641, guid: abd40d758b3e1a74486df5d631e4a775,
+        type: 3}
       propertyPath: m_AnchorMax.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 5761802240589336641, guid: abd40d758b3e1a74486df5d631e4a775, type: 3}
+    - target: {fileID: 5761802240589336641, guid: abd40d758b3e1a74486df5d631e4a775,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8298977265691902926, guid: abd40d758b3e1a74486df5d631e4a775, type: 3}
+    - target: {fileID: 8298977265691902926, guid: abd40d758b3e1a74486df5d631e4a775,
+        type: 3}
       propertyPath: m_AnchorMax.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8298977265691902926, guid: abd40d758b3e1a74486df5d631e4a775, type: 3}
+    - target: {fileID: 8298977265691902926, guid: abd40d758b3e1a74486df5d631e4a775,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8298977265691902926, guid: abd40d758b3e1a74486df5d631e4a775, type: 3}
+    - target: {fileID: 8298977265691902926, guid: abd40d758b3e1a74486df5d631e4a775,
+        type: 3}
       propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8696487122370294474, guid: abd40d758b3e1a74486df5d631e4a775, type: 3}
+    - target: {fileID: 8696487122370294474, guid: abd40d758b3e1a74486df5d631e4a775,
+        type: 3}
       propertyPath: m_Value
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8696487122370294474, guid: abd40d758b3e1a74486df5d631e4a775, type: 3}
+    - target: {fileID: 8696487122370294474, guid: abd40d758b3e1a74486df5d631e4a775,
+        type: 3}
       propertyPath: m_OnValueChanged.m_PersistentCalls.m_Calls.Array.size
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8696487122370294474, guid: abd40d758b3e1a74486df5d631e4a775, type: 3}
+    - target: {fileID: 8696487122370294474, guid: abd40d758b3e1a74486df5d631e4a775,
+        type: 3}
       propertyPath: m_OnValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 8696487122370294474, guid: abd40d758b3e1a74486df5d631e4a775, type: 3}
+    - target: {fileID: 8696487122370294474, guid: abd40d758b3e1a74486df5d631e4a775,
+        type: 3}
       propertyPath: m_OnValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 
       objectReference: {fileID: 5703792185782102541}
-    - target: {fileID: 8696487122370294474, guid: abd40d758b3e1a74486df5d631e4a775, type: 3}
+    - target: {fileID: 8696487122370294474, guid: abd40d758b3e1a74486df5d631e4a775,
+        type: 3}
       propertyPath: m_OnValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
       value: 2
       objectReference: {fileID: 0}
-    - target: {fileID: 8696487122370294474, guid: abd40d758b3e1a74486df5d631e4a775, type: 3}
+    - target: {fileID: 8696487122370294474, guid: abd40d758b3e1a74486df5d631e4a775,
+        type: 3}
       propertyPath: m_OnValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
       value: OnTimelineSliderChanged
       objectReference: {fileID: 0}
-    - target: {fileID: 8696487122370294474, guid: abd40d758b3e1a74486df5d631e4a775, type: 3}
+    - target: {fileID: 8696487122370294474, guid: abd40d758b3e1a74486df5d631e4a775,
+        type: 3}
       propertyPath: m_OnValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
       value: YARG.Gameplay.HUD.ReplayController, Assembly-CSharp
       objectReference: {fileID: 0}
-    - target: {fileID: 8696487122370294474, guid: abd40d758b3e1a74486df5d631e4a775, type: 3}
+    - target: {fileID: 8696487122370294474, guid: abd40d758b3e1a74486df5d631e4a775,
+        type: 3}
       propertyPath: m_OnValueChanged.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
       value: UnityEngine.Object, UnityEngine
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 901111967453049492, guid: abd40d758b3e1a74486df5d631e4a775, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 7397922087469340408}
   m_SourcePrefab: {fileID: 100100000, guid: abd40d758b3e1a74486df5d631e4a775, type: 3}
 --- !u!224 &248279859240249411 stripped
 RectTransform:
-  m_CorrespondingSourceObject: {fileID: 385803019352111189, guid: abd40d758b3e1a74486df5d631e4a775, type: 3}
+  m_CorrespondingSourceObject: {fileID: 385803019352111189, guid: abd40d758b3e1a74486df5d631e4a775,
+    type: 3}
   m_PrefabInstance: {fileID: 443803550190358550}
   m_PrefabAsset: {fileID: 0}
 --- !u!1 &768374413946200706 stripped
 GameObject:
-  m_CorrespondingSourceObject: {fileID: 901111967453049492, guid: abd40d758b3e1a74486df5d631e4a775, type: 3}
+  m_CorrespondingSourceObject: {fileID: 901111967453049492, guid: abd40d758b3e1a74486df5d631e4a775,
+    type: 3}
   m_PrefabInstance: {fileID: 443803550190358550}
   m_PrefabAsset: {fileID: 0}
 --- !u!114 &7397922087469340408
@@ -1823,7 +1862,8 @@ MonoBehaviour:
           m_CallState: 2
 --- !u!114 &9122203824592036572 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 8696487122370294474, guid: abd40d758b3e1a74486df5d631e4a775, type: 3}
+  m_CorrespondingSourceObject: {fileID: 8696487122370294474, guid: abd40d758b3e1a74486df5d631e4a775,
+    type: 3}
   m_PrefabInstance: {fileID: 443803550190358550}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 768374413946200706}
@@ -1837,201 +1877,235 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 6915276943068997200}
     m_Modifications:
-    - target: {fileID: 1988200050303033511, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    - target: {fileID: 1988200050303033511, guid: 8f25b12de267d7544aa2ff7993247fcd,
+        type: 3}
       propertyPath: m_Name
       value: Time Input
       objectReference: {fileID: 0}
-    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd,
+        type: 3}
       propertyPath: m_Text
       value: "0:00:00.000\u200B"
       objectReference: {fileID: 0}
-    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd,
+        type: 3}
       propertyPath: m_RegexValue
       value: '[\d,.:]'
       objectReference: {fileID: 0}
-    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd,
+        type: 3}
       propertyPath: m_ContentType
       value: 9
       objectReference: {fileID: 0}
-    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd,
+        type: 3}
       propertyPath: m_Placeholder
       value: 
       objectReference: {fileID: 0}
-    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd,
+        type: 3}
       propertyPath: m_OnFocusSelectAll
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd,
+        type: 3}
       propertyPath: m_CharacterValidation
       value: 6
       objectReference: {fileID: 0}
-    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd,
+        type: 3}
       propertyPath: m_OnEndEdit.m_PersistentCalls.m_Calls.Array.size
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd,
+        type: 3}
       propertyPath: m_OnEndEdit.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd,
+        type: 3}
       propertyPath: m_OnEndEdit.m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 
       objectReference: {fileID: 5703792185782102541}
-    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd,
+        type: 3}
       propertyPath: m_OnEndEdit.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
       value: 2
       objectReference: {fileID: 0}
-    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd,
+        type: 3}
       propertyPath: m_OnEndEdit.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
       value: OnTimeInputEndEdit
       objectReference: {fileID: 0}
-    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd,
+        type: 3}
       propertyPath: m_OnEndEdit.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
       value: YARG.Gameplay.HUD.ReplayController, Assembly-CSharp
       objectReference: {fileID: 0}
-    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd,
+        type: 3}
       propertyPath: m_OnEndEdit.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
       value: UnityEngine.Object, UnityEngine
       objectReference: {fileID: 0}
-    - target: {fileID: 6274164203294727049, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    - target: {fileID: 6274164203294727049, guid: 8f25b12de267d7544aa2ff7993247fcd,
+        type: 3}
       propertyPath: m_SizeDelta.x
       value: -20
       objectReference: {fileID: 0}
-    - target: {fileID: 6274164203294727049, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    - target: {fileID: 6274164203294727049, guid: 8f25b12de267d7544aa2ff7993247fcd,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7421987709479303017, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    - target: {fileID: 7421987709479303017, guid: 8f25b12de267d7544aa2ff7993247fcd,
+        type: 3}
       propertyPath: m_text
       value: "0:00:00.000\u200B\u200B"
       objectReference: {fileID: 0}
-    - target: {fileID: 7421987709479303017, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    - target: {fileID: 7421987709479303017, guid: 8f25b12de267d7544aa2ff7993247fcd,
+        type: 3}
       propertyPath: m_fontColor.g
       value: 0.8509804
       objectReference: {fileID: 0}
-    - target: {fileID: 7421987709479303017, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    - target: {fileID: 7421987709479303017, guid: 8f25b12de267d7544aa2ff7993247fcd,
+        type: 3}
       propertyPath: m_fontColor.r
       value: 0.18039216
       objectReference: {fileID: 0}
-    - target: {fileID: 7421987709479303017, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    - target: {fileID: 7421987709479303017, guid: 8f25b12de267d7544aa2ff7993247fcd,
+        type: 3}
       propertyPath: m_fontColor32.rgba
       value: 4294957358
       objectReference: {fileID: 0}
-    - target: {fileID: 7421987709479303017, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    - target: {fileID: 7421987709479303017, guid: 8f25b12de267d7544aa2ff7993247fcd,
+        type: 3}
       propertyPath: m_TextStyleHashCode
-      value: -1183493901
+      value: -1905602860
       objectReference: {fileID: 0}
-    - target: {fileID: 7421987709479303017, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    - target: {fileID: 7421987709479303017, guid: 8f25b12de267d7544aa2ff7993247fcd,
+        type: 3}
       propertyPath: m_HorizontalAlignment
       value: 2
       objectReference: {fileID: 0}
-    - target: {fileID: 7421987709479303017, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
-      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
-      value: 1801810542
-      objectReference: {fileID: 0}
-    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd,
+        type: 3}
       propertyPath: m_Pivot.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd,
+        type: 3}
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd,
+        type: 3}
       propertyPath: m_RootOrder
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd,
+        type: 3}
       propertyPath: m_AnchorMax.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd,
+        type: 3}
       propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd,
+        type: 3}
       propertyPath: m_SizeDelta.x
       value: 200
       objectReference: {fileID: 0}
-    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd,
+        type: 3}
       propertyPath: m_SizeDelta.y
       value: 64
       objectReference: {fileID: 0}
-    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd,
+        type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd,
+        type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd,
+        type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd,
+        type: 3}
       propertyPath: m_LocalRotation.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd,
+        type: 3}
       propertyPath: m_LocalRotation.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd,
+        type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd,
+        type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd,
+        type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8371195817729540105, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    - target: {fileID: 8371195817729540105, guid: 8f25b12de267d7544aa2ff7993247fcd,
+        type: 3}
       propertyPath: m_IsActive
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents:
     - {fileID: 3605409488639070977, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 450096836518303239, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 5200000206662208388}
   m_SourcePrefab: {fileID: 100100000, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
 --- !u!1 &835204727217706609 stripped
 GameObject:
-  m_CorrespondingSourceObject: {fileID: 450096836518303239, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+  m_CorrespondingSourceObject: {fileID: 450096836518303239, guid: 8f25b12de267d7544aa2ff7993247fcd,
+    type: 3}
   m_PrefabInstance: {fileID: 984088153209602166}
   m_PrefabAsset: {fileID: 0}
 --- !u!114 &5200000206662208388
@@ -2065,7 +2139,8 @@ MonoBehaviour:
           m_CallState: 2
 --- !u!114 &5485872602135839116 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+  m_CorrespondingSourceObject: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd,
+    type: 3}
   m_PrefabInstance: {fileID: 984088153209602166}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 835204727217706609}
@@ -2076,7 +2151,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
 --- !u!224 &7478673088016294437 stripped
 RectTransform:
-  m_CorrespondingSourceObject: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+  m_CorrespondingSourceObject: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd,
+    type: 3}
   m_PrefabInstance: {fileID: 984088153209602166}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &7559675453870017281
@@ -2084,205 +2160,236 @@ PrefabInstance:
   m_ObjectHideFlags: 0
   serializedVersion: 2
   m_Modification:
-    serializedVersion: 3
     m_TransformParent: {fileID: 2006855537152082164}
     m_Modifications:
-    - target: {fileID: 1988200050303033511, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    - target: {fileID: 1988200050303033511, guid: 8f25b12de267d7544aa2ff7993247fcd,
+        type: 3}
       propertyPath: m_Name
       value: Speed Input
       objectReference: {fileID: 0}
-    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd,
+        type: 3}
       propertyPath: m_Text
       value: 100%
       objectReference: {fileID: 0}
-    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd,
+        type: 3}
       propertyPath: m_RegexValue
       value: '[\d,.%]'
       objectReference: {fileID: 0}
-    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd,
+        type: 3}
       propertyPath: m_ContentType
       value: 9
       objectReference: {fileID: 0}
-    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd,
+        type: 3}
       propertyPath: m_Placeholder
       value: 
       objectReference: {fileID: 0}
-    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd,
+        type: 3}
       propertyPath: m_CharacterValidation
       value: 6
       objectReference: {fileID: 0}
-    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd,
+        type: 3}
       propertyPath: m_OnEndEdit.m_PersistentCalls.m_Calls.Array.size
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd,
+        type: 3}
       propertyPath: m_OnEndEdit.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd,
+        type: 3}
       propertyPath: m_OnEndEdit.m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 
       objectReference: {fileID: 5703792185782102541}
-    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd,
+        type: 3}
       propertyPath: m_OnEndEdit.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
       value: 2
       objectReference: {fileID: 0}
-    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd,
+        type: 3}
       propertyPath: m_OnEndEdit.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
       value: OnSpeedInputEndEdit
       objectReference: {fileID: 0}
-    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd,
+        type: 3}
       propertyPath: m_OnEndEdit.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
       value: YARG.Gameplay.HUD.ReplayController, Assembly-CSharp
       objectReference: {fileID: 0}
-    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    - target: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd,
+        type: 3}
       propertyPath: m_OnEndEdit.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
       value: UnityEngine.Object, UnityEngine
       objectReference: {fileID: 0}
-    - target: {fileID: 6274164203294727049, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    - target: {fileID: 6274164203294727049, guid: 8f25b12de267d7544aa2ff7993247fcd,
+        type: 3}
       propertyPath: m_SizeDelta.x
       value: -20
       objectReference: {fileID: 0}
-    - target: {fileID: 6274164203294727049, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    - target: {fileID: 6274164203294727049, guid: 8f25b12de267d7544aa2ff7993247fcd,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7421987709479303017, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    - target: {fileID: 7421987709479303017, guid: 8f25b12de267d7544aa2ff7993247fcd,
+        type: 3}
       propertyPath: m_text
       value: "100%\u200B"
       objectReference: {fileID: 0}
-    - target: {fileID: 7421987709479303017, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    - target: {fileID: 7421987709479303017, guid: 8f25b12de267d7544aa2ff7993247fcd,
+        type: 3}
       propertyPath: m_fontColor.g
       value: 0.8509804
       objectReference: {fileID: 0}
-    - target: {fileID: 7421987709479303017, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    - target: {fileID: 7421987709479303017, guid: 8f25b12de267d7544aa2ff7993247fcd,
+        type: 3}
       propertyPath: m_fontColor.r
       value: 0.18039216
       objectReference: {fileID: 0}
-    - target: {fileID: 7421987709479303017, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    - target: {fileID: 7421987709479303017, guid: 8f25b12de267d7544aa2ff7993247fcd,
+        type: 3}
       propertyPath: m_fontColor32.rgba
       value: 4294957358
       objectReference: {fileID: 0}
-    - target: {fileID: 7421987709479303017, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    - target: {fileID: 7421987709479303017, guid: 8f25b12de267d7544aa2ff7993247fcd,
+        type: 3}
       propertyPath: m_TextStyleHashCode
       value: -1183493901
       objectReference: {fileID: 0}
-    - target: {fileID: 7421987709479303017, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    - target: {fileID: 7421987709479303017, guid: 8f25b12de267d7544aa2ff7993247fcd,
+        type: 3}
       propertyPath: m_HorizontalAlignment
       value: 2
       objectReference: {fileID: 0}
-    - target: {fileID: 7421987709479303017, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
-      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
-      value: 1801810542
-      objectReference: {fileID: 0}
-    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd,
+        type: 3}
       propertyPath: m_Pivot.x
       value: 1.0000002
       objectReference: {fileID: 0}
-    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd,
+        type: 3}
       propertyPath: m_Pivot.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd,
+        type: 3}
       propertyPath: m_RootOrder
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd,
+        type: 3}
       propertyPath: m_AnchorMax.x
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd,
+        type: 3}
       propertyPath: m_AnchorMin.x
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd,
+        type: 3}
       propertyPath: m_AnchorMin.y
       value: 0.5
       objectReference: {fileID: 0}
-    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd,
+        type: 3}
       propertyPath: m_SizeDelta.x
       value: 150
       objectReference: {fileID: 0}
-    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd,
+        type: 3}
       propertyPath: m_SizeDelta.y
       value: 64
       objectReference: {fileID: 0}
-    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd,
+        type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd,
+        type: 3}
       propertyPath: m_LocalPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd,
+        type: 3}
       propertyPath: m_LocalPosition.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd,
+        type: 3}
       propertyPath: m_LocalRotation.w
       value: 1
       objectReference: {fileID: 0}
-    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd,
+        type: 3}
       propertyPath: m_LocalRotation.x
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd,
+        type: 3}
       propertyPath: m_LocalRotation.y
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd,
+        type: 3}
       propertyPath: m_LocalRotation.z
       value: -0
       objectReference: {fileID: 0}
-    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd,
+        type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd,
+        type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd,
+        type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd,
+        type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    - target: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd,
+        type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
-    - target: {fileID: 8371195817729540105, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+    - target: {fileID: 8371195817729540105, guid: 8f25b12de267d7544aa2ff7993247fcd,
+        type: 3}
       propertyPath: m_IsActive
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents:
     - {fileID: 3605409488639070977, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
-    m_RemovedGameObjects: []
-    m_AddedGameObjects:
-    - targetCorrespondingSourceObject: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 7862273872121982748}
-    - targetCorrespondingSourceObject: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 3649841699488849902}
-    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
 --- !u!224 &182650594059561298 stripped
 RectTransform:
-  m_CorrespondingSourceObject: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+  m_CorrespondingSourceObject: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd,
+    type: 3}
   m_PrefabInstance: {fileID: 7559675453870017281}
   m_PrefabAsset: {fileID: 0}
 --- !u!114 &2981609604511288059 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
+  m_CorrespondingSourceObject: {fileID: 4722467204755374586, guid: 8f25b12de267d7544aa2ff7993247fcd,
+    type: 3}
   m_PrefabInstance: {fileID: 7559675453870017281}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}

--- a/Assets/Scenes/Gameplay.unity
+++ b/Assets/Scenes/Gameplay.unity
@@ -360,6 +360,7 @@ MonoBehaviour:
   m_VerticalAlignment: 256
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -541,6 +542,7 @@ MonoBehaviour:
   m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -952,6 +954,7 @@ MonoBehaviour:
   m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -1163,6 +1166,7 @@ MonoBehaviour:
   m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -1527,6 +1531,10 @@ PrefabInstance:
       propertyPath: m_AnchorMin.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 1682100931862694993, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
+      value: 1801810542
+      objectReference: {fileID: 0}
     - target: {fileID: 1682100932150968561, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -1759,6 +1767,10 @@ PrefabInstance:
       propertyPath: m_SizeDelta.x
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 5887468963209947489, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
+      value: 1801810542
+      objectReference: {fileID: 0}
     - target: {fileID: 6081917654220247207, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: 157.1503
@@ -1774,6 +1786,10 @@ PrefabInstance:
     - target: {fileID: 6275240589393950520, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       propertyPath: m_AnchoredPosition.x
       value: -157.1503
+      objectReference: {fileID: 0}
+    - target: {fileID: 6897601373631971078, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
+      value: 1801810542
       objectReference: {fileID: 0}
     - target: {fileID: 7328250424041952305, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       propertyPath: m_AnchoredPosition.x
@@ -1798,6 +1814,10 @@ PrefabInstance:
     - target: {fileID: 8915388482217552038, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       propertyPath: m_text
       value: <mspace=0.538em>99x
+      objectReference: {fileID: 0}
+    - target: {fileID: 8915388482217552038, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
+      value: 1801810542
       objectReference: {fileID: 0}
     - target: {fileID: 9151995171417952487, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       propertyPath: m_AnchoredPosition.x
@@ -3004,6 +3024,10 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 1517088745}
     m_Modifications:
+    - target: {fileID: 2412034789861198308, guid: 249f3206655c65946a0f15b17834fca4, type: 3}
+      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
+      value: 1801810542
+      objectReference: {fileID: 0}
     - target: {fileID: 3967995507941194808, guid: 249f3206655c65946a0f15b17834fca4, type: 3}
       propertyPath: m_RootOrder
       value: 0
@@ -3189,6 +3213,7 @@ MonoBehaviour:
   m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -3287,7 +3312,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Texture: {fileID: 1963028385}
+  m_Texture: {fileID: 2035860077}
   m_UVRect:
     serializedVersion: 2
     x: 0
@@ -3507,6 +3532,7 @@ MonoBehaviour:
   m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -3741,6 +3767,7 @@ MonoBehaviour:
   m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -4008,6 +4035,7 @@ MonoBehaviour:
   m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -4220,6 +4248,7 @@ MonoBehaviour:
   m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -4356,6 +4385,7 @@ MonoBehaviour:
   m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -4733,6 +4763,18 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 1212139298}
     m_Modifications:
+    - target: {fileID: 1146569326023523432, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
+      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
+      value: 1801810542
+      objectReference: {fileID: 0}
+    - target: {fileID: 1896662541191257382, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
+      propertyPath: m_TextStyleHashCode
+      value: -1183493901
+      objectReference: {fileID: 0}
+    - target: {fileID: 1896662541191257382, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
+      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
+      value: 1801810542
+      objectReference: {fileID: 0}
     - target: {fileID: 2006855537152082164, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -4757,6 +4799,10 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 2842466915050512126, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
+      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
+      value: 1801810542
+      objectReference: {fileID: 0}
     - target: {fileID: 2933889975780695480, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -4773,10 +4819,18 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 4585064127559478306, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
+      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
+      value: 1801810542
+      objectReference: {fileID: 0}
     - target: {fileID: 5322898957872382039, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 5703792185782102541, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
+      propertyPath: _showHudButton
+      value: 
+      objectReference: {fileID: 1346104900}
     - target: {fileID: 6915276943068997200, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -4912,6 +4966,14 @@ PrefabInstance:
     - target: {fileID: 7369758456864847374, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7685424141149583135, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
+      propertyPath: m_TextStyleHashCode
+      value: -1183493901
+      objectReference: {fileID: 0}
+    - target: {fileID: 7685424141149583135, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
+      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
+      value: 1801810542
       objectReference: {fileID: 0}
     - target: {fileID: 8431678723656029144, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
       propertyPath: m_AnchorMax.y
@@ -5654,6 +5716,7 @@ MonoBehaviour:
   m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -5790,6 +5853,7 @@ MonoBehaviour:
   m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -6376,6 +6440,11 @@ MonoBehaviour:
   m_ChildScaleWidth: 0
   m_ChildScaleHeight: 0
   m_ReverseArrangement: 0
+--- !u!224 &1346104900 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 8642466853652824189, guid: f8c143f8514898b4fb85fbadc18550c0, type: 3}
+  m_PrefabInstance: {fileID: 922548496}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1403276640
 GameObject:
   m_ObjectHideFlags: 0
@@ -6776,6 +6845,7 @@ MonoBehaviour:
   m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -6934,7 +7004,7 @@ Camera:
     serializedVersion: 2
     m_Bits: 503
   m_RenderingPath: -1
-  m_TargetTexture: {fileID: 1963028385}
+  m_TargetTexture: {fileID: 2035860077}
   m_TargetDisplay: 0
   m_TargetEye: 3
   m_HDR: 1
@@ -7229,6 +7299,7 @@ MonoBehaviour:
   m_VerticalAlignment: 256
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -7365,6 +7436,7 @@ MonoBehaviour:
   m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -7526,14 +7598,14 @@ Light:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1731387086}
   m_Enabled: 1
-  serializedVersion: 11
+  serializedVersion: 12
   m_Type: 1
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_Intensity: 2
   m_Range: 10
   m_SpotAngle: 30
   m_InnerSpotAngle: 21.80208
-  m_CookieSize: 10
+  m_CookieSize2D: {x: 10, y: 10}
   m_Shadows:
     m_Type: 2
     m_Resolution: -1
@@ -7990,6 +8062,7 @@ MonoBehaviour:
   m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -8261,6 +8334,7 @@ MonoBehaviour:
   m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -8442,6 +8516,7 @@ MonoBehaviour:
   m_VerticalAlignment: 256
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0
@@ -8584,7 +8659,7 @@ MonoBehaviour:
   m_ChildScaleWidth: 0
   m_ChildScaleHeight: 0
   m_ReverseArrangement: 0
---- !u!84 &1963028385
+--- !u!84 &2035860077
 RenderTexture:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -8596,11 +8671,11 @@ RenderTexture:
     Hash: 00000000000000000000000000000000
   m_IsAlphaChannelOptional: 0
   serializedVersion: 6
-  m_Width: 2451
+  m_Width: 2089
   m_Height: 1304
   m_AntiAliasing: 1
   m_MipCount: -1
-  m_DepthStencilFormat: 0
+  m_DepthStencilFormat: 94
   m_ColorFormat: 48
   m_MipMap: 0
   m_GenerateMips: 1
@@ -9004,6 +9079,7 @@ MonoBehaviour:
   m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
+  m_characterHorizontalScale: 1
   m_wordSpacing: 0
   m_lineSpacing: 0
   m_lineSpacingMax: 0

--- a/Assets/Script/Audio/Bass/BassStemMixer.cs
+++ b/Assets/Script/Audio/Bass/BassStemMixer.cs
@@ -225,7 +225,7 @@ namespace YARG.Audio.BASS
 
         protected override void SetPosition_Internal(double position)
         {
-            var wasPlaying = !IsPlaying;
+            var wasPlaying = IsPlaying;
             Pause_Internal();
 
             var channels = BassMix.MixerGetChannels(_mixerHandle);

--- a/Assets/Script/Gameplay/HUD/Pause/QuickSettings.cs
+++ b/Assets/Script/Gameplay/HUD/Pause/QuickSettings.cs
@@ -94,7 +94,7 @@ namespace YARG.Gameplay.HUD
             var settings = new List<string>(_calibrationSettings);
             var activeHumanPlayers = PlayerContainer.Players.Count(p => !p.SittingOut && !p.Profile.IsBot);
             var allowAutoCalibration = activeHumanPlayers == 1;
-            if (!allowAutoCalibration)
+            if (!allowAutoCalibration || GlobalVariables.State.IsReplay)
             {
                 settings.Remove(nameof(SettingsManager.Settings.AutoCalibration));
             }

--- a/Assets/Script/Gameplay/HUD/ReplayViewer/ReplayController.cs
+++ b/Assets/Script/Gameplay/HUD/ReplayViewer/ReplayController.cs
@@ -48,14 +48,8 @@ namespace YARG.Gameplay.HUD
 
         private bool _sliderPauseState;
 
-        private bool _previousHighwayAnimationSetting;
-
         protected override void GameplayAwake()
         {
-            // Disable highway animations during replay viewing as it causes too many issues
-            _previousHighwayAnimationSetting = SettingsManager.Settings.EnableHighwayAnimation.Value;
-            SettingsManager.Settings.EnableHighwayAnimation.Value = false;
-
             if (GameManager.ReplayInfo == null)
             {
                 Destroy(gameObject);
@@ -72,9 +66,6 @@ namespace YARG.Gameplay.HUD
 
         protected override void GameplayDestroy()
         {
-            // Restore highway animations setting when exiting replay viewer
-            SettingsManager.Settings.EnableHighwayAnimation.Value = _previousHighwayAnimationSetting;
-
             Navigator.Instance.NavigationEvent -= OnNavigationEvent;
         }
 

--- a/Assets/Script/Gameplay/HUD/ReplayViewer/ReplayController.cs
+++ b/Assets/Script/Gameplay/HUD/ReplayViewer/ReplayController.cs
@@ -8,6 +8,7 @@ using YARG.Core.Input;
 using YARG.Core.Logging;
 using YARG.Core.Replays;
 using YARG.Menu.Navigation;
+using YARG.Settings;
 
 namespace YARG.Gameplay.HUD
 {
@@ -47,8 +48,14 @@ namespace YARG.Gameplay.HUD
 
         private bool _sliderPauseState;
 
+        private bool _previousHighwayAnimationSetting;
+
         protected override void GameplayAwake()
         {
+            // Disable highway animations during replay viewing as it causes too many issues
+            _previousHighwayAnimationSetting = SettingsManager.Settings.EnableHighwayAnimation.Value;
+            SettingsManager.Settings.EnableHighwayAnimation.Value = false;
+
             if (GameManager.ReplayInfo == null)
             {
                 Destroy(gameObject);
@@ -56,9 +63,8 @@ namespace YARG.Gameplay.HUD
             }
 
             // Get the hidden position based on the container, accounting for show button arrow height
-            YargLogger.LogDebug($"Size delta: {_container.sizeDelta}, Show button arrow size delta: {_showHudButtonArrow.sizeDelta}");
             _hudHiddenY = -_container.sizeDelta.y + _showHudButton.sizeDelta.y;
-            _container.position = _container.position.WithY(_hudHiddenY);
+            _container.position = _container.position.WithY(-_container.sizeDelta.y);
 
             // Listen for menu inputs
             Navigator.Instance.NavigationEvent += OnNavigationEvent;
@@ -66,6 +72,9 @@ namespace YARG.Gameplay.HUD
 
         protected override void GameplayDestroy()
         {
+            // Restore highway animations setting when exiting replay viewer
+            SettingsManager.Settings.EnableHighwayAnimation.Value = _previousHighwayAnimationSetting;
+
             Navigator.Instance.NavigationEvent -= OnNavigationEvent;
         }
 

--- a/Assets/Script/Gameplay/HUD/ReplayViewer/ReplayController.cs
+++ b/Assets/Script/Gameplay/HUD/ReplayViewer/ReplayController.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Globalization;
 using DG.Tweening;
 using TMPro;
@@ -19,6 +19,8 @@ namespace YARG.Gameplay.HUD
         private RectTransform _container;
         [SerializeField]
         private RectTransform _showHudButtonArrow;
+        [SerializeField]
+        private RectTransform _showHudButton;
 
         [Space]
         [SerializeField]
@@ -53,8 +55,9 @@ namespace YARG.Gameplay.HUD
                 return;
             }
 
-            // Get the hidden position based on the container, and then move to that position
-            _hudHiddenY = -_container.sizeDelta.y;
+            // Get the hidden position based on the container, accounting for show button arrow height
+            YargLogger.LogDebug($"Size delta: {_container.sizeDelta}, Show button arrow size delta: {_showHudButtonArrow.sizeDelta}");
+            _hudHiddenY = -_container.sizeDelta.y + _showHudButton.sizeDelta.y;
             _container.position = _container.position.WithY(_hudHiddenY);
 
             // Listen for menu inputs

--- a/Assets/Script/Gameplay/HUD/ReplayViewer/ReplayController.cs
+++ b/Assets/Script/Gameplay/HUD/ReplayViewer/ReplayController.cs
@@ -95,6 +95,12 @@ namespace YARG.Gameplay.HUD
             {
                 UpdateTimeControls();
             }
+
+            if (_timelineSlider.value >= 1.0f)
+            {
+                //End of song, pause
+                SetPaused(true);
+            }
         }
 
         private void UpdateTimeControls()

--- a/Assets/Script/Gameplay/HUD/TrackView.cs
+++ b/Assets/Script/Gameplay/HUD/TrackView.cs
@@ -33,6 +33,8 @@ namespace YARG.Gameplay.HUD
 
         private DraggableHudElement _topDraggable;
 
+        private Vector3 _hiddenPosition = new Vector3(-10000f, -10000f, 0f);
+
         public void Initialize(HighwayCameraRendering highwayRenderer)
         {
             _highwayRenderer = highwayRenderer;
@@ -46,15 +48,18 @@ namespace YARG.Gameplay.HUD
             var newScale = Math.Max(0.5f, 1.1f - (0.1f * highwayCount));
             _scaleContainer.localScale = _scaleContainer.localScale.WithX(newScale).WithY(newScale);
 
-            //Set center element position
-            var centerPosition = _highwayRenderer.GetTrackPositionScreenSpace(highwayIndex, 0.5f, CENTER_ELEMENT_DEPTH);
+            var centerPosition =
+                _highwayRenderer.GetTrackPositionScreenSpace(highwayIndex, 0.5f, CENTER_ELEMENT_DEPTH)
+                ?? _hiddenPosition;
             _centerElementContainer.transform.position = centerPosition;
 
             if (_topDraggable != null && !_topDraggable.HasCustomPosition)
             {
                 // Place top elements at 100% depth of the track, plus some extra amount above the track.
                 var extraOffset = TOP_ELEMENT_EXTRA_OFFSET * Screen.height / 1000f;
-                var topPosition = _highwayRenderer.GetTrackPositionScreenSpace(highwayIndex, 0.5f, 1.0f).AddY(extraOffset);
+                var topPosition =
+                    _highwayRenderer.GetTrackPositionScreenSpace(highwayIndex, 0.5f, 1.0f)?.AddY(extraOffset)
+                    ?? _hiddenPosition;
                 _topElementContainer.position = topPosition;
             }
         }

--- a/Assets/Script/Gameplay/Visuals/CameraPositioner.cs
+++ b/Assets/Script/Gameplay/Visuals/CameraPositioner.cs
@@ -106,7 +106,9 @@ namespace YARG.Gameplay.Visuals
             _globalAnimDelay = Mathf.Clamp((float) latestStart, 0f, MAX_ANIM_DELAY);
 
             // Animate the highway raise
-            if (!_gameManager.IsPractice && SettingsManager.Settings.EnableHighwayAnimation.Value)
+            if (!_gameManager.IsPractice
+                && !GlobalVariables.State.IsReplay
+                && SettingsManager.Settings.EnableHighwayAnimation.Value)
             {
                 if (_highwayRaised)
                 {

--- a/Assets/Script/Gameplay/Visuals/HighwayCameraRendering.cs
+++ b/Assets/Script/Gameplay/Visuals/HighwayCameraRendering.cs
@@ -528,7 +528,7 @@ namespace YARG.Gameplay.Visuals
         /// <param name="trackIndex">The index of the highway to get the position for. 0 is leftmost highway</param>
         /// <param name="x">The normalized position across the track width (0.0 is leftmost track edge. 1.0 is rightmost track edge)</param>
         /// <param name="y">The normalized position up the track (0.0 is the strikeline, 1.0 is zero fade position)</param>
-        public Vector2 GetTrackPositionScreenSpace(int trackIndex, float x, float y)
+        public Vector2? GetTrackPositionScreenSpace(int trackIndex, float x, float y)
         {
             if (trackIndex < 0 || trackIndex >= _cameras.Count)
             {
@@ -548,12 +548,18 @@ namespace YARG.Gameplay.Visuals
             float xOffset = Mathf.LerpUnclamped(-trackWidth / 2f, trackWidth / 2f, x);
 
             // Calculate screen space from world position
-            Vector3 worldPositionAtPercent = new Vector3(
+            var worldPositionAtPercent = new Vector3(
                 trackPosition.x + xOffset,
                 trackPosition.y,
                 zPositionAtPercent
             );
-            Vector2 viewportPosition = WorldToViewport(worldPositionAtPercent, trackIndex);
+
+            var viewportPosition = WorldToViewport(worldPositionAtPercent, trackIndex);
+            if (float.IsNaN(viewportPosition.x) || float.IsNaN(viewportPosition.y))
+            {
+                return null;
+            }
+
             float screenX = viewportPosition.x * Screen.width;
             float screenY = (1.0f - viewportPosition.y) * Screen.height;
 

--- a/Assets/Script/Menu/History/ViewTypes/ViewType.cs
+++ b/Assets/Script/Menu/History/ViewTypes/ViewType.cs
@@ -65,8 +65,7 @@ namespace YARG.Menu.History
             GlobalVariables.State.CurrentSong = song;
             GlobalVariables.State.CurrentReplay = replay;
 
-            // TODO: Store selected song speed in replays
-            // GlobalVariables.State.SongSpeed = replay.
+            GlobalVariables.State.SongSpeed = replay.SongSpeed;
 
             GlobalVariables.Instance.LoadScene(SceneIndex.Gameplay);
         }


### PR DESCRIPTION
This fixes a bunch of issues with the replay viewer.  There's still probably more things I haven't discovered but its a start

1. Fix hud arrow going off screen when closed
2. Set song speed on replay viewer so strikeline animations show up on time
3. Don't allow auto calibration during replay
4. Disable highway animations on replay, too many seeking issues
5. Fix error when hud elements have an invalid position
6. Pause replay viewer when it reaches end of track