### PR TITLE
Reset valid score flag when loading song

### DIFF
--- a/Assets/Script/Gameplay/GameManager.Loading.cs
+++ b/Assets/Script/Gameplay/GameManager.Loading.cs
@@ -380,6 +380,8 @@ namespace YARG.Gameplay
                 int vocalIndex = -1;
                 foreach (var player in YargPlayers)
                 {
+                    player.IsScoreValid = true;
+
                     if (!player.IsReplay)
                     {
                         // Reset microphone (resets channel buffers)


### PR DESCRIPTION
YargPlayer outlives the song, so we need to reset / assume the score is valid at the start of each song.

This fixes two bugs:
1. Disabling no fail right at the end of the song to cheese the song would disable score saving until game restart
2. Enabling / Disabling auto calibration would disable score saving until game restart