### PR TITLE
Fix return to recommended song

### DIFF
--- a/Assets/Script/Menu/MusicLibrary/ViewTypes/SongViewType.cs
+++ b/Assets/Script/Menu/MusicLibrary/ViewTypes/SongViewType.cs
@@ -154,6 +154,7 @@ namespace YARG.Menu.MusicLibrary
 
             // Reset library's main index so we don't return to the index set by play a show
             MusicLibraryMenu.ResetMainLibraryIndex();
+            MusicLibraryMenu.SetReload(MusicLibraryReloadState.Partial);
 
             GlobalVariables.State.CurrentSong = SongEntry;
             // This just makes stuff in DifficultySelectMenu easier


### PR DESCRIPTION
Previously, if you selected a song from the recommended songs list, went to the pre-game menu (difficulty selection etc.), and then returned back to music library the song position was lost.