### PR TITLE
Implement font scaling accessibility setting

### DIFF
--- a/Assets/Scenes/PersistentScene.unity
+++ b/Assets/Scenes/PersistentScene.unity
@@ -3103,6 +3103,7 @@ Canvas:
   m_SortingBucketNormalizedSize: 0
   m_VertexColorAlwaysGammaSpace: 0
   m_AdditionalShaderChannelsFlag: 0
+  m_UpdateRectTransformForStandalone: 0
   m_SortingLayerID: 0
   m_SortingOrder: 102
   m_TargetDisplay: 0
@@ -4181,6 +4182,7 @@ GameObject:
   - component: {fileID: 1694016461}
   - component: {fileID: 1694016460}
   - component: {fileID: 1694016464}
+  - component: {fileID: 1694016465}
   m_Layer: 5
   m_Name: Persistent Canvas
   m_TagString: Untagged
@@ -4287,6 +4289,20 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fe60bde778204d1ab2aad2f2f2c4c49d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &1694016465
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1694016459}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9fc8e810ea88d44f1b1d6151eb0cc3a2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::YARG.Menu.Persistent.MenuFontScaler
+  _maximumMinFontSize: 22.9
+  _fontSizeScale: 0
 --- !u!1 &1710005230
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/PersistentScene.unity
+++ b/Assets/Scenes/PersistentScene.unity
@@ -4296,13 +4296,12 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1694016459}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9fc8e810ea88d44f1b1d6151eb0cc3a2, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::YARG.Menu.Persistent.MenuFontScaler
-  _maximumMinFontSize: 22.9
-  _fontSizeScale: 0
+  _fontScaleNormalized: 0
 --- !u!1 &1710005230
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Script/Helpers/ScreenHelper.cs
+++ b/Assets/Script/Helpers/ScreenHelper.cs
@@ -58,12 +58,12 @@ namespace YARG.Helpers
         /// </summary>
         public static Resolution GetScreenResolution()
         {
-            var screenInfo = Screen.mainWindowDisplayInfo;
+            var screenInfo = Screen.currentResolution;
             return new Resolution()
             {
                 width = screenInfo.width,
                 height = screenInfo.height,
-                refreshRateRatio = screenInfo.refreshRate,
+                refreshRateRatio = screenInfo.refreshRateRatio,
             };
         }
 

--- a/Assets/Script/Menu/Persistent/MenuFontScaler.cs
+++ b/Assets/Script/Menu/Persistent/MenuFontScaler.cs
@@ -4,6 +4,7 @@ using TMPro;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 using YARG.Core.Logging;
+using YARG.Settings;
 
 namespace YARG.Menu.Persistent
 {
@@ -49,6 +50,11 @@ namespace YARG.Menu.Persistent
 
         private void Start()
         {
+            if (SettingsManager.Settings != null)
+            {
+                _fontScaleNormalized = Mathf.Clamp01(SettingsManager.Settings.FontScaling.Value / 100f);
+            }
+
             DoScaling();
         }
 
@@ -160,6 +166,13 @@ namespace YARG.Menu.Persistent
                 text.fontSize = scaledSize;
                 text.ForceMeshUpdate();
             }
+        }
+
+        public void SetFontScalePercent(float percent)
+        {
+            _fontScaleNormalized = Mathf.Clamp01(percent / 100f);
+            ScaleTexts();
+            enabled = _fontScaleNormalized > 0f;
         }
 
         private void OnValidate()

--- a/Assets/Script/Menu/Persistent/MenuFontScaler.cs
+++ b/Assets/Script/Menu/Persistent/MenuFontScaler.cs
@@ -1,120 +1,170 @@
-using System;
 using System.Collections.Generic;
+using System.Linq;
 using TMPro;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 using YARG.Core.Logging;
 
 namespace YARG.Menu.Persistent
 {
-    public class MenuFontScaler : MonoBehaviour
+    public class MenuFontScaler : MonoSingleton<MenuFontScaler>
     {
-        [SerializeField]
-        private float _minimumFontSize = 14f;
+        private const float DEFAULT_MAX_FONT_SIZE = 22f;
 
-        private TMP_Text[] _allTexts;
-
-        private struct Baseline
+        private static readonly Dictionary<string, float> MaxFontSizeByContainerName = new()
         {
-            public float FontSize;
-            public float FontSizeMin;
-            public float FontSizeMax;
+            { "Persistent Canvas", 22.9f },
+            { "MusicLibraryMenu", 36f },
+            { "ProfileList", 23.5f },
+            { "Songs", 36f },
+            { "Content", 20.4f },
+        };
+
+        private static readonly float AbsoluteMaxFontSize = Mathf.Max(
+            DEFAULT_MAX_FONT_SIZE,
+            MaxFontSizeByContainerName.Values.Max()
+        );
+
+        [SerializeField][Range(0f, 1f)]
+        private float _fontScaleNormalized;
+
+        private readonly Dictionary<TMP_Text, TextFontInfo> _fontInfoByText = new();
+        private readonly Dictionary<Transform, int> _childCountByTransform = new();
+
+        private struct TextFontInfo
+        {
+            public float BaseFontSize;
+            public float MaxFontSize;
         }
 
-        private readonly Dictionary<int, Baseline> _baselines = new();
+        protected override void SingletonAwake()
+        {
+            SceneManager.sceneLoaded += OnSceneLoaded;
+        }
+
+        protected override void SingletonDestroy()
+        {
+            SceneManager.sceneLoaded -= OnSceneLoaded;
+        }
+
         private void Start()
         {
-            _allTexts = GetAllTextObjects();
-            CacheBaselines();
-            ScaleText();
-
-            YargLogger.LogDebug(">>Found " + _allTexts.Length + " text objects for scaling.");
-
-            // PrintAllTextSizes();
+            DoScaling();
         }
 
-        private void PrintAllTextSizes()
+        private void OnSceneLoaded(Scene scene, LoadSceneMode mode)
         {
-            foreach (var text in _allTexts)
-            {
-                int id = text.GetInstanceID();
-                var baseline = _baselines[id];
+            DoScaling();
+        }
 
-                if (text.enableAutoSizing)
-                {
-                    YargLogger.LogFormatDebug("  {0}: auto [{1}-{2}] -> [{3}-{4}]",
-                        text.name, baseline.FontSizeMin, baseline.FontSizeMax,
-                        text.fontSizeMin, text.fontSizeMax);
-                }
-                else
-                {
-                    YargLogger.LogFormatDebug("  {0}: {1} -> {2}",
-                        text.name, baseline.FontSize, text.fontSize);
-                }
+        private void Update()
+        {
+            if (DidAnyTransformChildrenChange())
+            {
+                DoScaling();
             }
         }
 
-        private void ScaleText()
+        private bool DidAnyTransformChildrenChange()
         {
-            foreach (var text in _allTexts)
+            foreach ((var transform, int count) in _childCountByTransform)
             {
-                int id = text.GetInstanceID();
-                var baseline = _baselines[id];
+                var didChildrenChange = transform == null || transform.childCount != count;
+                if (!didChildrenChange)
+                {
+                    continue;
+                }
 
-                if (text.enableAutoSizing)
-                {
-                    float newMin = Mathf.Max(baseline.FontSizeMin, _minimumFontSize);
-                    float newMax = Mathf.Max(baseline.FontSizeMax, _minimumFontSize);
-                    if (newMin != baseline.FontSizeMin || newMax != baseline.FontSizeMax)
-                    {
-                        text.fontSizeMin = newMin;
-                        text.fontSizeMax = newMax;
-                        YargLogger.LogFormatDebug("Scaled {0}: auto [{1}-{2}] -> [{3}-{4}]",
-                            text.name, baseline.FontSizeMin, baseline.FontSizeMax,
-                            newMin, newMax);
-                    }
-                }
-                else
-                {
-                    float newSize = Mathf.Max(baseline.FontSize, _minimumFontSize);
-                    if (newSize != baseline.FontSize)
-                    {
-                        text.fontSize = newSize;
-                        YargLogger.LogFormatDebug("Scaled {0}: {1} -> {2}",
-                            text.name, baseline.FontSize, newSize);
-                    }
-                }
+                return true;
             }
+
+            return false;
         }
 
-        private void CacheBaselines()
+        private void DoScaling()
         {
-            foreach (var text in _allTexts)
+            BuildTextToFontInfo();
+            ScaleTexts();
+
+            YargLogger.LogFormatDebug("MenuFontScaler: found {0} texts across all containers.", _fontInfoByText.Count);
+        }
+
+        private void BuildTextToFontInfo()
+        {
+            var previous = new Dictionary<TMP_Text, TextFontInfo>(_fontInfoByText);
+            _fontInfoByText.Clear();
+            _childCountByTransform.Clear();
+
+            //Set up baseline and max font size using defaults
+            foreach (var text in FindAllTexts())
             {
-                int id = text.GetInstanceID();
-                _baselines[id] = new Baseline
+                float baselineFontSize = previous.TryGetValue(text, out var previousInfo)
+                    ? previousInfo.BaseFontSize
+                    : text.fontSize;
+
+                _fontInfoByText[text] = new TextFontInfo
                 {
-                    FontSize = text.fontSize,
-                    FontSizeMin = text.fontSizeMin,
-                    FontSizeMax = text.fontSizeMax,
+                    BaseFontSize = baselineFontSize,
+                    MaxFontSize = DEFAULT_MAX_FONT_SIZE,
                 };
             }
+
+            // Override with any custom max font sizes for containers, and store child counts to detect changes later
+            foreach (var transform in FindAllTransforms())
+            {
+                if (!MaxFontSizeByContainerName.TryGetValue(transform.name, out float maxFontSize))
+                {
+                    continue;
+                }
+
+                _childCountByTransform[transform] = transform.childCount;
+
+                var transformTexts = transform.GetComponentsInChildren<TMP_Text>(true);
+                foreach (var text in transformTexts)
+                {
+                    if (!_fontInfoByText.TryGetValue(text, out var scaleInfo))
+                    {
+                        continue;
+                    }
+
+                    scaleInfo.MaxFontSize = maxFontSize;
+                    _fontInfoByText[text] = scaleInfo;
+                }
+            }
         }
 
-        private TMP_Text[] GetAllTextObjects()
+        private Transform[] FindAllTransforms()
         {
-            YargLogger.LogDebug(">>GETTING all text objects");
-            return GetComponentsInChildren<TMP_Text>(true);
+            return FindObjectsByType<Transform>(FindObjectsInactive.Include, FindObjectsSortMode.None);
         }
 
-        // Re-apply scaling when values are changed in the inspector
+        private TMP_Text[] FindAllTexts()
+        {
+            return FindObjectsByType<TMP_Text>(FindObjectsInactive.Include, FindObjectsSortMode.None);
+        }
+
+        private void ScaleTexts()
+        {
+            foreach ((var text, TextFontInfo scaleInfo) in _fontInfoByText)
+            {
+                if (text == null)
+                {
+                    continue;
+                }
+
+                float scaledSize = _fontScaleNormalized * AbsoluteMaxFontSize;
+                scaledSize = Mathf.Min(scaledSize, scaleInfo.MaxFontSize);
+                scaledSize = Mathf.Max(scaledSize, scaleInfo.BaseFontSize);
+
+                text.enableAutoSizing = false;
+                text.fontSize = scaledSize;
+                text.ForceMeshUpdate();
+            }
+        }
+
         private void OnValidate()
         {
-            if (_allTexts == null || _allTexts.Length == 0)
-            {
-                return;
-            }
-
-            ScaleText();
+            ScaleTexts();
         }
     }
 }

--- a/Assets/Script/Menu/Persistent/MenuFontScaler.cs
+++ b/Assets/Script/Menu/Persistent/MenuFontScaler.cs
@@ -1,0 +1,120 @@
+using System;
+using System.Collections.Generic;
+using TMPro;
+using UnityEngine;
+using YARG.Core.Logging;
+
+namespace YARG.Menu.Persistent
+{
+    public class MenuFontScaler : MonoBehaviour
+    {
+        [SerializeField]
+        private float _minimumFontSize = 14f;
+
+        private TMP_Text[] _allTexts;
+
+        private struct Baseline
+        {
+            public float FontSize;
+            public float FontSizeMin;
+            public float FontSizeMax;
+        }
+
+        private readonly Dictionary<int, Baseline> _baselines = new();
+        private void Start()
+        {
+            _allTexts = GetAllTextObjects();
+            CacheBaselines();
+            ScaleText();
+
+            YargLogger.LogDebug(">>Found " + _allTexts.Length + " text objects for scaling.");
+
+            // PrintAllTextSizes();
+        }
+
+        private void PrintAllTextSizes()
+        {
+            foreach (var text in _allTexts)
+            {
+                int id = text.GetInstanceID();
+                var baseline = _baselines[id];
+
+                if (text.enableAutoSizing)
+                {
+                    YargLogger.LogFormatDebug("  {0}: auto [{1}-{2}] -> [{3}-{4}]",
+                        text.name, baseline.FontSizeMin, baseline.FontSizeMax,
+                        text.fontSizeMin, text.fontSizeMax);
+                }
+                else
+                {
+                    YargLogger.LogFormatDebug("  {0}: {1} -> {2}",
+                        text.name, baseline.FontSize, text.fontSize);
+                }
+            }
+        }
+
+        private void ScaleText()
+        {
+            foreach (var text in _allTexts)
+            {
+                int id = text.GetInstanceID();
+                var baseline = _baselines[id];
+
+                if (text.enableAutoSizing)
+                {
+                    float newMin = Mathf.Max(baseline.FontSizeMin, _minimumFontSize);
+                    float newMax = Mathf.Max(baseline.FontSizeMax, _minimumFontSize);
+                    if (newMin != baseline.FontSizeMin || newMax != baseline.FontSizeMax)
+                    {
+                        text.fontSizeMin = newMin;
+                        text.fontSizeMax = newMax;
+                        YargLogger.LogFormatDebug("Scaled {0}: auto [{1}-{2}] -> [{3}-{4}]",
+                            text.name, baseline.FontSizeMin, baseline.FontSizeMax,
+                            newMin, newMax);
+                    }
+                }
+                else
+                {
+                    float newSize = Mathf.Max(baseline.FontSize, _minimumFontSize);
+                    if (newSize != baseline.FontSize)
+                    {
+                        text.fontSize = newSize;
+                        YargLogger.LogFormatDebug("Scaled {0}: {1} -> {2}",
+                            text.name, baseline.FontSize, newSize);
+                    }
+                }
+            }
+        }
+
+        private void CacheBaselines()
+        {
+            foreach (var text in _allTexts)
+            {
+                int id = text.GetInstanceID();
+                _baselines[id] = new Baseline
+                {
+                    FontSize = text.fontSize,
+                    FontSizeMin = text.fontSizeMin,
+                    FontSizeMax = text.fontSizeMax,
+                };
+            }
+        }
+
+        private TMP_Text[] GetAllTextObjects()
+        {
+            YargLogger.LogDebug(">>GETTING all text objects");
+            return GetComponentsInChildren<TMP_Text>(true);
+        }
+
+        // Re-apply scaling when values are changed in the inspector
+        private void OnValidate()
+        {
+            if (_allTexts == null || _allTexts.Length == 0)
+            {
+                return;
+            }
+
+            ScaleText();
+        }
+    }
+}

--- a/Assets/Script/Menu/Persistent/MenuFontScaler.cs
+++ b/Assets/Script/Menu/Persistent/MenuFontScaler.cs
@@ -30,10 +30,12 @@ namespace YARG.Menu.Persistent
         );
 
         [SerializeField][Range(0f, 1f)]
-        private float _fontScaleNormalized;
+        private float _fontScaleFactor;
 
         private readonly Dictionary<TMP_Text, TextFontInfo> _fontInfoByText = new();
         private readonly Dictionary<Transform, int> _childCountByTransform = new();
+
+        private float FontScaleSetting => SettingsManager.Settings.FontScaling.Value;
 
         private struct TextFontInfo
         {
@@ -55,7 +57,7 @@ namespace YARG.Menu.Persistent
         {
             if (SettingsManager.Settings != null)
             {
-                _fontScaleNormalized = Mathf.Clamp01(SettingsManager.Settings.FontScaling.Value / 100f);
+                _fontScaleFactor = Mathf.Clamp01(FontScaleSetting / 100f);
             }
 
             DoScaling();
@@ -159,9 +161,8 @@ namespace YARG.Menu.Persistent
                     continue;
                 }
 
-                float scaledSize = _fontScaleNormalized * AbsoluteMaxFontSize;
-                scaledSize = Mathf.Min(scaledSize, scaleInfo.MaxFontSize);
-                scaledSize = Mathf.Max(scaledSize, scaleInfo.BaseFontSize);
+                float scaledSize = _fontScaleFactor * AbsoluteMaxFontSize;
+                scaledSize = Mathf.Clamp(scaledSize, scaleInfo.BaseFontSize, scaleInfo.MaxFontSize);
 
                 text.enableAutoSizing = false;
                 text.fontSize = scaledSize;
@@ -171,9 +172,9 @@ namespace YARG.Menu.Persistent
 
         public void SetFontScalePercent(float percent)
         {
-            _fontScaleNormalized = Mathf.Clamp01(percent / 100f);
+            _fontScaleFactor = Mathf.Clamp01(percent / 100f);
             ScaleTexts();
-            enabled = _fontScaleNormalized > 0f;
+            enabled = _fontScaleFactor > 0f;
         }
 
         private void OnValidate()

--- a/Assets/Script/Menu/Persistent/MenuFontScaler.cs
+++ b/Assets/Script/Menu/Persistent/MenuFontScaler.cs
@@ -10,8 +10,11 @@ namespace YARG.Menu.Persistent
 {
     public class MenuFontScaler : MonoSingleton<MenuFontScaler>
     {
+        // For most elements, this is used as the "font size floor" when scaling is set to 100%
         private const float DEFAULT_MAX_FONT_SIZE = 22f;
 
+        // This overrides the "font size floor" per section, to be used when scaling is set to 100%.
+        //  This allows us to have some sections that scale more than others without breaking the layout
         private static readonly Dictionary<string, float> MaxFontSizeByContainerName = new()
         {
             { "Persistent Canvas", 22.9f },
@@ -91,8 +94,6 @@ namespace YARG.Menu.Persistent
         {
             BuildTextToFontInfo();
             ScaleTexts();
-
-            YargLogger.LogFormatDebug("MenuFontScaler: found {0} texts across all containers.", _fontInfoByText.Count);
         }
 
         private void BuildTextToFontInfo()

--- a/Assets/Script/Menu/Persistent/MenuFontScaler.cs.meta
+++ b/Assets/Script/Menu/Persistent/MenuFontScaler.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9fc8e810ea88d44f1b1d6151eb0cc3a2

--- a/Assets/Script/Settings/SettingsManager.Settings.cs
+++ b/Assets/Script/Settings/SettingsManager.Settings.cs
@@ -537,6 +537,7 @@ namespace YARG.Settings
                 BandComboType.Strict
             };
             public ToggleSetting SaveScoresWithBots { get; } = new(false);
+            public SliderSetting FontScaling { get; } = new(0f, 0f, 100f, FontScalingCallback);
 
             public OutputDeviceSetting OutputDevice { get; } = new("Default", OutputDeviceCallback);
             public OutputChannelDefaultSetting OutputChannelDefault { get; } = new(1, OutputChannelDefaultCallback);
@@ -632,6 +633,12 @@ namespace YARG.Settings
                 }
                 DataStreamController.Instance.HandleEnabledChanged(value);
             }
+
+            private static void FontScalingCallback(float value)
+            {
+                MenuFontScaler.Instance.SetFontScalePercent(value);
+            }
+
             private static void RB3EEnabledCallback(bool value)
             {
                 RB3EHardware.Instance.HandleEnabledChanged(value);

--- a/Assets/Script/Settings/SettingsManager.cs
+++ b/Assets/Script/Settings/SettingsManager.cs
@@ -234,6 +234,8 @@ namespace YARG.Settings
                 nameof(Settings.DataStreamEnable),
                 nameof(Settings.EnableNormalization),
                 nameof(Settings.SaveScoresWithBots),
+                new HeaderMetadata("Accessibility"),
+                nameof(Settings.FontScaling),
                 new HeaderMetadata("OutputConfiguration"),
                 nameof(Settings.OutputDevice),
                 nameof(Settings.OutputChannelDefault),

--- a/Assets/StreamingAssets/lang/en-US.json
+++ b/Assets/StreamingAssets/lang/en-US.json
@@ -764,7 +764,8 @@
             "Experimental": "Experimental",
             "HUD": "HUD",
             "Gameplay": "Gameplay",
-            "OutputConfiguration": "Output Configuration"
+            "OutputConfiguration": "Output Configuration",
+            "Accessibility": "Accessibility"
         },
         "Button": {
             "CopyCurrentSongJsonFilePath": "Copy Current Song Json File Path",
@@ -930,6 +931,10 @@
             "FpsStats": {
                 "Name": "Show FPS Counter",
                 "Description": "Shows the framerate counter on the Status Bar."
+            },
+            "FontScaling": {
+                "Name": "Font Scaling",
+                "Description": "Scales the minimum font size to be more visible"
             },
             "FullscreenMode": {
                 "Name": "Fullscreen Mode",


### PR DESCRIPTION
This PR adds a slider in experimental settings that allows us to raise the minimum font across the app.

DIfferent sections can have a different minimum font size.

We can easily add minimum font sizes for individual transforms on the app, to ensure that we can increase the size large enough to be useful, but not enough to break the layouts.  

These values can be determined by starting with a ceiling of 100 and then scaling in the unity editor to see at what point the UI starts to break.

The component can be found on the persistent scene canvas in the editor.

When scaling is set to 0, the component becomes inactive.  This makes it an "opt-in" feature.

Example video:

https://github.com/user-attachments/assets/1b038f74-68cd-4479-8a1a-23f29266413c


