### PR TITLE
Shrink Album Name without Wrap

### DIFF
--- a/Assets/Script/Menu/MusicLibrary/Sidebar.cs
+++ b/Assets/Script/Menu/MusicLibrary/Sidebar.cs
@@ -273,13 +273,12 @@ namespace YARG.Menu.MusicLibrary
         // Wrap and shrink album name if it's too long to fit in the sidebar
         private void SetAlbumNameFont(string albumText)
         {
-            const int maxCharsBeforeWrap = 50; // number of characters before we wrap the text
-            const float shrinkFactor = 0.8f;   // percentage to shrink the font by when wrapping
+            const int maxCharsBeforeShrink = 40; // number of characters before we shrink the text
+            const int maxCharsBeforeWrap = 50;   // number of characters before we wrap the text
+            const float shrinkFactor = 0.8f;     // percentage to shrink the font by after shrink threshold
 
             if (_albumBaseFontSize <= 0f)
-            {
                 _albumBaseFontSize = _album.fontSize > 0f ? _album.fontSize : 20f;
-            }
 
             var displayText = albumText ?? string.Empty;
 
@@ -288,27 +287,20 @@ namespace YARG.Menu.MusicLibrary
             _album.overflowMode = TextOverflowModes.Overflow;
             _album.fontSize = _albumBaseFontSize;
 
-            if (displayText.Length <= maxCharsBeforeWrap)
-            {
-                _album.text = displayText;
-                return;
-            }
+            if (displayText.Length > maxCharsBeforeShrink)
+                _album.fontSize = _albumBaseFontSize * shrinkFactor;
 
-            if (!displayText.Contains('\n'))
+            if (displayText.Length > maxCharsBeforeWrap && !displayText.Contains('\n'))
             {
                 var wrapIndex = displayText.LastIndexOf(' ', maxCharsBeforeWrap);
-                if (wrapIndex <= 0)
-                {
+                if (wrapIndex <= 0 || wrapIndex >= displayText.Length - 1)
                     wrapIndex = maxCharsBeforeWrap;
-                }
 
                 displayText = displayText[..wrapIndex].TrimEnd() + "\n" + displayText[wrapIndex..].TrimStart();
             }
 
             _album.text = displayText;
-            _album.fontSize = _albumBaseFontSize * shrinkFactor;
         }
-
 
         private void UpdateDifficulties(SongEntry entry)
         {


### PR DESCRIPTION
Album names were still too long to fit in area after 40 characters, but not long enough that they needed to be shrunk and wrapped.  Shrink album names after 40 characters.  Wrap album names after 50 characters.

This resolves: https://github.com/YARC-Official/YARG/issues/1319

Test Results:
40 characters - upper limit for no shrink, no wrap
<img width="667" height="377" alt="image" src="https://github.com/user-attachments/assets/01a2d1a6-22ee-4667-adc0-8dce1c1b95fc" />

41 characters - lower limit for yes shrink, no wrap
<img width="667" height="377" alt="image" src="https://github.com/user-attachments/assets/8fa955f4-3e35-43b1-82ae-be3bb80a980d" />

50 characters - upper limit for yes shrink, no wrap
<img width="667" height="377" alt="image" src="https://github.com/user-attachments/assets/82e15049-8142-46f6-b742-bc1e32b3f912" />

51 characters - lower limit for yes shrink, yes wrap
<img width="667" height="377" alt="image" src="https://github.com/user-attachments/assets/00ba4f3f-7f82-4022-ad16-461d9287d61e" />

