### PR TITLE
Fix discord sdk console error on macos

### DIFF
--- a/Assets/Plugins/DiscordGameSDK/Plugins/aarch64/discord_game_sdk.dylib.meta
+++ b/Assets/Plugins/DiscordGameSDK/Plugins/aarch64/discord_game_sdk.dylib.meta
@@ -19,13 +19,13 @@ PluginImporter:
   - first:
       Editor: Editor
     second:
-      enabled: 1
+      enabled: 0
       settings:
         DefaultValueInitialized: true
   - first:
       Standalone: OSXUniversal
     second:
-      enabled: 1
+      enabled: 0
       settings:
         CPU: AnyCPU
   userData: 

--- a/Assets/Plugins/DiscordGameSDK/Plugins/x86_64/discord_game_sdk.dylib.meta
+++ b/Assets/Plugins/DiscordGameSDK/Plugins/x86_64/discord_game_sdk.dylib.meta
@@ -14,7 +14,7 @@ PluginImporter:
   - first:
       Any: 
     second:
-      enabled: 1
+      enabled: 0
       settings: {}
   - first:
       Editor: Editor
@@ -26,13 +26,13 @@ PluginImporter:
   - first:
       Standalone: Linux64
     second:
-      enabled: 1
+      enabled: 0
       settings:
         CPU: x86_64
   - first:
       Standalone: OSXUniversal
     second:
-      enabled: 1
+      enabled: 0
       settings:
         CPU: x86_64
   - first:
@@ -44,7 +44,7 @@ PluginImporter:
   - first:
       Standalone: Win64
     second:
-      enabled: 1
+      enabled: 0
       settings:
         CPU: x86_64
   userData: 


### PR DESCRIPTION
We have both a .bundle and a .dylib which conflict for the discord sdk

Both discord_game_sdk.bundle and discord_game_sdk.dylib had the same internal plugin name, and Unity can only load one in the Editor.

Fix is to deactivate the dylib and keep the bundle

