### PR TITLE
Support custom characters

### DIFF
--- a/Assets/Editor/BundleBackgroundInspector.cs
+++ b/Assets/Editor/BundleBackgroundInspector.cs
@@ -11,10 +11,14 @@ namespace Editor
     public class BundleBackgroundInspector : UnityEditor.Editor
     {
         private SerializedProperty _mainCameraProperty;
+        private SerializedProperty _replaceableVocalistProperty;
+
+        private Button _characterExportButton;
 
         private void OnEnable()
         {
             _mainCameraProperty = serializedObject.FindProperty("mainCamera");
+            _replaceableVocalistProperty = serializedObject.FindProperty("_replaceableVocalist");
         }
 
         public override VisualElement CreateInspectorGUI()
@@ -34,6 +38,7 @@ namespace Editor
             });
 
             myInspector.Add(new PropertyField(_mainCameraProperty));
+            myInspector.Add(new PropertyField(_replaceableVocalistProperty));
 
             myInspector.Add(new Label("\n\n<b><size=1.25em>Actions</size></b>\n"));
 
@@ -48,7 +53,29 @@ namespace Editor
             exportButton.Add(new Label("Export Background"));
             myInspector.Add(exportButton);
 
+            _characterExportButton = new Button(() =>
+            {
+                if (target is BundleBackgroundManager manager)
+                {
+                    manager.ExportCharacter();
+                }
+            });
+
+            if (_replaceableVocalistProperty.objectReferenceValue == null)
+            {
+                _characterExportButton.SetEnabled(false);
+            }
+
+            _characterExportButton.Add(new Label("Export Character"));
+            myInspector.Add(_characterExportButton);
+            myInspector.TrackPropertyValue(_replaceableVocalistProperty, OnCharacterChanged);
+
             return myInspector;
+        }
+
+        private void OnCharacterChanged(SerializedProperty property)
+        {
+            _characterExportButton.SetEnabled(_replaceableVocalistProperty.objectReferenceValue != null);
         }
     }
 }

--- a/Assets/Editor/VenueOverride.cs
+++ b/Assets/Editor/VenueOverride.cs
@@ -1,0 +1,133 @@
+﻿using UnityEditor;
+using UnityEditor.SceneManagement;
+using UnityEngine.SceneManagement;
+using YARG.Venue;
+
+namespace YARG.Editor
+{
+    public class VenueOverrideMenu
+    {
+        private const string MENU_ROOT = "YARG/Venue/";
+
+        [MenuItem(MENU_ROOT + "Select Venue Scene", priority = 10)]
+        private static void UseSelectedScene()
+        {
+            var scene = Selection.activeObject as SceneAsset;
+            if (scene == null)
+            {
+                EditorUtility.DisplayDialog("Error", "No scene selected\nSelect a scene to use as the venue!", "OK");
+                return;
+            }
+
+            var path = AssetDatabase.GetAssetPath(scene);
+            if (string.IsNullOrEmpty(path))
+            {
+                EditorUtility.DisplayDialog("Venue Error", "Could not find venue scene path", "OK");
+                return;
+            }
+
+            if (!IsSceneValid(path))
+            {
+                EditorUtility.DisplayDialog("Venue Error", "Selected scene does not contain a BundleBackgroundManager", "OK");
+                return;
+            }
+
+            var guid = AssetDatabase.AssetPathToGUID(path);
+
+            var settings = VenueOverrideSettings.instance;
+            settings.SceneGuid = guid;
+            settings.Enabled = true;
+            settings.SaveSettings();
+
+            VenueEditorHelper.SetScenePath(path, true);
+        }
+
+        [MenuItem(MENU_ROOT + "Enable Editor Venue", priority = 1)]
+        private static void ToggleEnabled()
+        {
+            var settings = VenueOverrideSettings.instance;
+            settings.Enabled = !settings.Enabled;
+            settings.SaveSettings();
+
+            VenueEditorHelper.SetSceneEnabled(settings.Enabled);
+        }
+
+        [MenuItem(MENU_ROOT + "Enable Editor Venue", true)]
+        private static bool ValidateToggleEnabled()
+        {
+            UnityEditor.Menu.SetChecked(MENU_ROOT + "Enable Editor Venue", VenueOverrideSettings.instance.Enabled);
+            return true;
+        }
+
+        private static bool IsSceneValid(string scenePath)
+        {
+            var previousScene = SceneManager.GetActiveScene();
+
+            // If the selected scene is already loaded, we can just check if it contains the venue manager
+            if (previousScene.IsValid() && previousScene.isLoaded && previousScene.path == scenePath)
+            {
+                foreach (var root in previousScene.GetRootGameObjects())
+                {
+                    if (root.GetComponentInChildren<BundleBackgroundManager>() != null)
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+
+            var scene = EditorSceneManager.OpenScene(scenePath, OpenSceneMode.Additive);
+
+            try
+            {
+                foreach (var root in scene.GetRootGameObjects())
+                {
+                    if (root.GetComponentInChildren<BundleBackgroundManager>() != null)
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+            finally
+            {
+                EditorSceneManager.CloseScene(scene, true);
+                if (previousScene.IsValid())
+                {
+                    SceneManager.SetActiveScene(previousScene);
+                }
+            }
+        }
+    }
+
+    internal sealed class VenueOverrideSettings : ScriptableSingleton<VenueOverrideSettings>
+    {
+        public bool   Enabled;
+        public string SceneGuid;
+
+        public void SaveSettings()
+        {
+            Save(true);
+        }
+    }
+
+    internal static class VenueOverride
+    {
+        public static bool Enabled => VenueOverrideSettings.instance.Enabled;
+        public static string SceneGuid => VenueOverrideSettings.instance.SceneGuid;
+
+        public static bool TryGetVenuePath(out string path)
+        {
+            if (!Enabled || string.IsNullOrEmpty(SceneGuid))
+            {
+                path = null;
+                return false;
+            }
+
+            path = AssetDatabase.GUIDToAssetPath(SceneGuid);
+            return !string.IsNullOrEmpty(path);
+        }
+    }
+}

--- a/Assets/Editor/VenueOverride.cs.meta
+++ b/Assets/Editor/VenueOverride.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: cecba49e01e643bdac2c3b8288ee93b1
+timeCreated: 1771206168

--- a/Assets/Script/Gameplay/BackgroundManager.cs
+++ b/Assets/Script/Gameplay/BackgroundManager.cs
@@ -11,15 +11,25 @@ using YARG.Core.Venue;
 using YARG.Helpers.Extensions;
 using YARG.Settings;
 using YARG.Venue;
+using YARG.Venue.Characters;
+using YARG.Core.Logging;
+
+#if UNITY_EDITOR
+using UnityEditor.SceneManagement;
+using UnityEngine.SceneManagement;
+#endif
+
 #if UNITY_EDITOR_OSX || UNITY_STANDALONE_OSX
 using System.Collections.Generic;
-using YARG.Core.Logging;
 #endif
 
 namespace YARG.Gameplay
 {
     public class BackgroundManager : GameplayBehaviour, IDisposable
     {
+        // e.g. DefaultController.Vocals.controller
+        private const string DEFAULT_ANIMATION_CONTROLLER_PATH = "DefaultAnimations/DefaultController.{0}.controller";
+
         private string VIDEO_PATH;
 
         [SerializeField]
@@ -47,12 +57,97 @@ namespace YARG.Gameplay
         // End time cannot be negative; a negative value means it is not set.
         private double _videoEndTime;
 
+        private AssetBundle _characterBundle;
+
+#if UNITY_EDITOR
+        private bool        _usingEditorVenue;
+        private string      _editorVenuePath;
+        private Scene       _editorVenueScene;
+#endif
         // "The Unity message 'Start' has an incorrect signature."
         [SuppressMessage("Type Safety", "UNT0006", Justification = "UniTaskVoid is a compatible return type.")]
         private async UniTaskVoid Start()
         {
             // We don't need to update unless we're using a video
             enabled = false;
+
+#if UNITY_EDITOR
+            if (VenueEditorHelper.IsSceneEnabled())
+            {
+                if (VenueEditorHelper.TryGetScenePath(out _editorVenuePath))
+                {
+                    var loadedScene = SceneManager.GetSceneByName(_editorVenuePath);
+                    if (loadedScene.IsValid() && loadedScene.isLoaded)
+                    {
+                        _editorVenueScene = loadedScene;
+                    }
+                    else
+                    {
+                        var op = EditorSceneManager.LoadSceneAsyncInPlayMode(
+                            _editorVenuePath, new LoadSceneParameters(LoadSceneMode.Additive));
+
+                        await op;
+                        _editorVenueScene = SceneManager.GetSceneByPath(_editorVenuePath);
+                    }
+                }
+
+                if (!_editorVenueScene.IsValid() || !_editorVenueScene.isLoaded)
+                {
+                    YargLogger.LogFormatError("Failed to load editor venue scene {0}", _editorVenuePath);
+                    return;
+                }
+
+                BundleBackgroundManager editorBg = null;
+                foreach (var go in _editorVenueScene.GetRootGameObjects())
+                {
+                    editorBg = go.GetComponent<BundleBackgroundManager>();
+
+                    if (editorBg != null)
+                    {
+                        break;
+                    }
+                }
+
+                if (editorBg == null)
+                {
+                    YargLogger.LogFormatError("Scene {0} missing BundleBackgroundManager", _editorVenuePath);
+                    return;
+                }
+
+                _usingEditorVenue = true;
+
+                _venueOutput.gameObject.SetActive(true);
+
+                var editorRenderers = editorBg.GetComponentsInChildren<Renderer>(true);
+
+                // Song specific textures
+                var tm = GetComponent<TextureManager>();
+                var songBg = GameManager.Song.LoadBackground();
+
+                foreach (var renderer in editorRenderers)
+                {
+                    var materials = renderer.materials;
+
+                    for (int i = 0; i < materials.Length; i++)
+                    {
+                        tm.ProcessMaterial(materials[i], songBg?.Type);
+                    }
+
+                    renderer.materials = materials;
+                }
+
+                editorBg.SetupVenueCamera(editorBg.gameObject);
+                editorBg.LimitVenueLights(editorBg.gameObject);
+
+                if (_videoPlayer != null && _videoPlayer.targetCamera != null)
+                {
+                    Destroy(_videoPlayer.targetCamera.gameObject);
+                }
+
+                _type = BackgroundType.Yarground;
+                return;
+            }
+#endif
 
             using var result = VenueLoader.GetVenue(GameManager.Song, out _source);
             if (result == null)
@@ -77,52 +172,10 @@ namespace YARG.Gameplay
                     var bg = (GameObject) await bundle.LoadAssetAsync<GameObject>(
                         BundleBackgroundManager.BACKGROUND_PREFAB_PATH.ToLowerInvariant());
                     var renderers = bg.GetComponentsInChildren<Renderer>(true);
-#if UNITY_EDITOR_OSX || UNITY_STANDALONE_OSX
-                    var metalShaders = new Dictionary<string, Shader>();
 
-                    var shaderBundleData = (TextAsset)await bundle.LoadAssetAsync<TextAsset>(
-                        "Assets/" + BundleBackgroundManager.BACKGROUND_SHADER_BUNDLE_NAME
-                    );
+                    // Load Metal shaders, if necessary
+                    shaderBundle = await LoadMetalShaders(bundle, bg);
 
-                    if (shaderBundleData != null && shaderBundleData.bytes.Length > 0)
-                    {
-                        YargLogger.LogInfo("Loading Metal shader bundle");
-                        shaderBundle = await AssetBundle.LoadFromMemoryAsync(shaderBundleData.bytes);
-                        var allAssets = shaderBundle.LoadAllAssets<Shader>();
-                        foreach (var shader in allAssets)
-                        {
-                            metalShaders.Add(shader.name, shader);
-                        }
-                    }
-                    else
-                    {
-                        YargLogger.LogInfo("Did not find Metal shader bundle");
-                    }
-
-                    // Yarground comes with shaders for dx11/dx12/glcore/vulkan
-                    // Metal shaders used on OSX come in this separate bundle
-                    // Update our renderers to use them
-
-                    foreach (var renderer in renderers)
-                    {
-                        foreach (var material in renderer.sharedMaterials)
-                        {
-                            var shaderName = material.shader.name;
-                            if (metalShaders.TryGetValue(shaderName, out var shader))
-                            {
-                                YargLogger.LogFormatDebug("Found bundled shader {0}", shaderName);
-                                // We found shader from Yarground
-                                material.shader = shader;
-                            }
-                            else
-                            {
-                                YargLogger.LogFormatDebug("Did not find bundled shader {0}", shaderName);
-                                // Fallback to try to find among builtin shaders
-                                material.shader = Shader.Find(shaderName);
-                            }
-                        }
-                    }
-#endif
                     // Hookup song-specific textures
                     var textureManager = GetComponent<TextureManager>();
                     // Load SongBackground here to determine if textures need to be replaced
@@ -148,6 +201,15 @@ namespace YARG.Gameplay
                     if (textureManager.VideoTexFound())
                     {
                         SetUpVideoTexture(songBackground);
+                    }
+
+                    LoadCustomCharacter(bgInstance);
+
+                    // Initialize CharacterManager, if it exists
+                    var characterManager = bgInstance.GetComponentInChildren<CharacterManager>();
+                    if (characterManager != null)
+                    {
+                        characterManager.Initialize();
                     }
 
                     break;
@@ -385,6 +447,137 @@ namespace YARG.Gameplay
             // The venue is dealt with in the GameManager via Time.timeScale
         }
 
+        private void LoadCustomCharacter(GameObject venueRoot)
+        {
+            string characterPath = SettingsManager.Settings.CustomVocalsCharacter.Value;
+
+            if (string.IsNullOrEmpty(characterPath))
+            {
+                return;
+            }
+
+            var bundle = AssetBundle.LoadFromFile(characterPath);
+
+            if (bundle == null)
+            {
+                return;
+            }
+
+            _characterBundle = bundle;
+
+            var character = bundle.LoadAsset<GameObject>(BundleBackgroundManager.CHARACTER_PREFAB_PATH.ToLowerInvariant());
+            if (character == null)
+            {
+                YargLogger.LogFormatError("Failed to load character from {0}", characterPath);
+                return;
+            }
+
+            // Check for an existing animation controller and use default if none is found
+            // TODO: Do this somewhere else where we can check song genre so we can have different default animations for
+            //  different genres. (Rock vs Dance vs Latin vs whatever)
+            var animator = character.GetComponent<Animator>();
+            if (animator != null)
+            {
+                var controller = animator.runtimeAnimatorController;
+                if (controller == null)
+                {
+                    var charType = character.GetComponent<VenueCharacter>().Type;
+                    var path = string.Format(DEFAULT_ANIMATION_CONTROLLER_PATH, charType.ToString());
+                    var newController = Resources.Load<RuntimeAnimatorController>(path);
+                    if (newController != null)
+                    {
+                        animator.runtimeAnimatorController = newController;
+                    }
+                    else
+                    {
+                        YargLogger.LogFormatError("Failed to load default animation controller for {0}", charType);
+                    }
+                }
+            }
+
+            var newType = character.GetComponent<VenueCharacter>().Type;
+            // Find a character of the same type in venueRoot
+            GameObject existingCharacter = null;
+
+            var characters = venueRoot.GetComponentsInChildren<VenueCharacter>();
+            foreach (var c in characters)
+            {
+                if (c.Type == newType)
+                {
+                    existingCharacter = c.gameObject;
+                    break;
+                }
+            }
+
+            if (existingCharacter == null)
+            {
+                YargLogger.LogFormatError("Failed to find character of type {0} in venue root", newType);
+                return;
+            }
+
+            // Replace existingCharacter with the new character
+            var existingParent = existingCharacter.transform.parent;
+
+            Destroy(existingCharacter);
+            Instantiate(character, existingParent);
+        }
+
+        private async UniTask<AssetBundle> LoadMetalShaders(AssetBundle bundle, GameObject bg)
+        {
+#if UNITY_EDITOR_OSX || UNITY_STANDALONE_OSX
+            AssetBundle shaderBundle = null;
+            var renderers = bg.GetComponentsInChildren<Renderer>(true);
+            var metalShaders = new Dictionary<string, Shader>();
+
+            var shaderBundleData = (TextAsset)await bundle.LoadAssetAsync<TextAsset>(
+                "Assets/" + BundleBackgroundManager.BACKGROUND_SHADER_BUNDLE_NAME
+            );
+
+            if (shaderBundleData != null && shaderBundleData.bytes.Length > 0)
+            {
+                YargLogger.LogInfo("Loading Metal shader bundle");
+                shaderBundle = await AssetBundle.LoadFromMemoryAsync(shaderBundleData.bytes);
+                var allAssets = shaderBundle.LoadAllAssets<Shader>();
+                foreach (var shader in allAssets)
+                {
+                    metalShaders.Add(shader.name, shader);
+                }
+            }
+            else
+            {
+                YargLogger.LogInfo("Did not find Metal shader bundle");
+            }
+
+            // Yarground comes with shaders for dx11/dx12/glcore/vulkan
+            // Metal shaders used on OSX come in this separate bundle
+            // Update our renderers to use them
+
+            foreach (var renderer in renderers)
+            {
+                foreach (var material in renderer.sharedMaterials)
+                {
+                    var shaderName = material.shader.name;
+                    if (metalShaders.TryGetValue(shaderName, out var shader))
+                    {
+                        YargLogger.LogFormatDebug("Found bundled shader {0}", shaderName);
+                        // We found shader from Yarground
+                        material.shader = shader;
+                    }
+                    else
+                    {
+                        YargLogger.LogFormatDebug("Did not find bundled shader {0}", shaderName);
+                        // Fallback to try to find among builtin shaders
+                        material.shader = Shader.Find(shaderName);
+                    }
+                }
+            }
+
+            return shaderBundle;
+#endif
+            // Fallback if we're not running on OSX
+            return null;
+        }
+
         public void Dispose()
         {
             if (VIDEO_PATH != null)
@@ -392,6 +585,18 @@ namespace YARG.Gameplay
                 File.Delete(VIDEO_PATH);
                 VIDEO_PATH = null;
             }
+
+            if (_characterBundle != null)
+            {
+                _characterBundle.Unload(true);
+                _characterBundle = null;
+            }
+#if UNITY_EDITOR
+            if (_usingEditorVenue)
+            {
+                SceneManager.UnloadSceneAsync(_editorVenueScene);
+            }
+#endif
         }
 
         ~BackgroundManager()

--- a/Assets/Script/Gameplay/BackgroundManager.cs
+++ b/Assets/Script/Gameplay/BackgroundManager.cs
@@ -27,8 +27,8 @@ namespace YARG.Gameplay
 {
     public class BackgroundManager : GameplayBehaviour, IDisposable
     {
-        // e.g. DefaultController.Vocals.controller
-        private const string DEFAULT_ANIMATION_CONTROLLER_PATH = "DefaultAnimations/DefaultController.{0}.controller";
+        // e.g. DefaultController.Vocals.Rock.controller
+        private const string DEFAULT_ANIMATION_CONTROLLER_PATH = "DefaultAnimations/DefaultController.{0}.{1}.controller";
 
         private string VIDEO_PATH;
 
@@ -473,16 +473,15 @@ namespace YARG.Gameplay
             }
 
             // Check for an existing animation controller and use default if none is found
-            // TODO: Do this somewhere else where we can check song genre so we can have different default animations for
-            //  different genres. (Rock vs Dance vs Latin vs whatever)
             var animator = character.GetComponent<Animator>();
             if (animator != null)
             {
                 var controller = animator.runtimeAnimatorController;
                 if (controller == null)
                 {
+                    var genre = GetDefaultGenre(GameManager.Song.Genre);
                     var charType = character.GetComponent<VenueCharacter>().Type;
-                    var path = string.Format(DEFAULT_ANIMATION_CONTROLLER_PATH, charType.ToString());
+                    var path = string.Format(DEFAULT_ANIMATION_CONTROLLER_PATH, charType.ToString(), genre);
                     var newController = Resources.Load<RuntimeAnimatorController>(path);
                     if (newController != null)
                     {
@@ -576,6 +575,12 @@ namespace YARG.Gameplay
 #endif
             // Fallback if we're not running on OSX
             return null;
+        }
+
+        // TODO: Move this to Genrelizer or sth and implement
+        public static string GetDefaultGenre(string realGenre)
+        {
+            return "Generic";
         }
 
         public void Dispose()

--- a/Assets/Script/Gameplay/BackgroundManager.cs
+++ b/Assets/Script/Gameplay/BackgroundManager.cs
@@ -1,8 +1,12 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
+using Cinemachine;
 using Cysharp.Threading.Tasks;
+using UniHumanoid;
 using UnityEngine;
+using UnityEngine.Animations;
 using UnityEngine.UI;
 using UnityEngine.Video;
 using YARG.Core.IO;
@@ -517,8 +521,19 @@ namespace YARG.Gameplay
             // Replace existingCharacter with the new character
             var existingParent = existingCharacter.transform.parent;
 
+            var newCharacter = Instantiate(character, existingParent);
+            ReplaceReferences(venueRoot, existingCharacter, newCharacter);
+            existingCharacter.SetActive(false);
             Destroy(existingCharacter);
-            Instantiate(character, existingParent);
+
+            // Lastly, make sure the new character and all its children are in the Venue layer
+            var layerIndex = LayerMask.NameToLayer("Venue");
+            character.gameObject.layer = layerIndex;
+            var children = character.GetComponentsInChildren<Transform>();
+            foreach (var child in children)
+            {
+                child.gameObject.layer = layerIndex;
+            }
         }
 
         private async UniTask<AssetBundle> LoadMetalShaders(AssetBundle bundle, GameObject bg)
@@ -575,6 +590,100 @@ namespace YARG.Gameplay
 #endif
             // Fallback if we're not running on OSX
             return null;
+        }
+
+        // It would be better if we could replace all references, but I'm not sure how to do that, so I'm fixing up the ones I know how to do
+        public void ReplaceReferences(GameObject venueRoot, GameObject oldObject, GameObject newObject)
+        {
+            Transform hips = null;
+            Transform head = null;
+            var humanoid = newObject.GetComponent<Humanoid>();
+            if (humanoid != null)
+            {
+                hips = humanoid.Hips;
+                head = humanoid.Head;
+            }
+
+            // Find references to oldObject.transform anywhere in venueRoot..for now we'll just deal with Cinemachine and Lights having lookat/follow properties
+            var lookAts = venueRoot.GetComponentsInChildren<LookAtConstraint>(true);
+            var sources = new List<ConstraintSource>();
+            foreach (var lookat in lookAts)
+            {
+                sources.Clear();
+                lookat.GetSources(sources);
+
+                for (int i = 0; i < sources.Count; i++)
+                {
+                    var s = sources[i];
+                    if (s.sourceTransform != null && s.sourceTransform.IsChildOf(oldObject.transform))
+                    {
+                        if (head != null && (s.sourceTransform.gameObject.name.Contains("Head") ||
+                            s.sourceTransform.gameObject.name.Contains("Face")))
+                        {
+                            s.sourceTransform = head;
+                        }
+                        else if (hips != null && s.sourceTransform.gameObject.name.Contains("Hips"))
+                        {
+                            s.sourceTransform = hips;
+                        }
+                        else
+                        {
+                            s.sourceTransform = newObject.transform;
+                        }
+
+                        sources[i] = s;
+                    }
+                }
+
+                lookat.SetSources(sources);
+            }
+
+            var cinemachines = venueRoot.GetComponentsInChildren<CinemachineVirtualCamera>(true);
+            foreach (var cinemachine in cinemachines)
+            {
+                // If we can easily determine face/hips, we use the corresponding transform on the VRM character, otherwise we default to hips if set, otherwise newObject.transform
+                // We also use a heuristic based on the camera name so as to make certain existing venues not look stupid on the Vocals Closeup cam
+                var follow = cinemachine.Follow;
+                if (follow != null && follow.IsChildOf(oldObject.transform))
+                {
+                    if (head != null &&
+                        (follow.gameObject.name.Contains("Face") ||
+                         follow.gameObject.name.Contains("Head") ||
+                         cinemachine.gameObject.name == "Vocals Closeup" ||
+                         cinemachine.gameObject.name.EndsWith("Closeup Head")))
+                    {
+                        cinemachine.Follow = head;
+                    }
+                    else if (hips != null)
+                    {
+                        cinemachine.Follow = hips;
+                    }
+                    else
+                    {
+                        cinemachine.Follow = newObject.transform;
+                    }
+                }
+
+                var lookAt = cinemachine.LookAt;
+                if (lookAt != null && lookAt.IsChildOf(oldObject.transform))
+                {
+                    if (head != null && (lookAt.gameObject.name.Contains("Face") ||
+                        lookAt.gameObject.name.Contains("Head") ||
+                        cinemachine.gameObject.name == "Vocals Closeup" ||
+                        cinemachine.gameObject.name.EndsWith("Closeup Head")))
+                    {
+                        cinemachine.LookAt = head;
+                    }
+                    else if (hips != null)
+                    {
+                        cinemachine.LookAt = hips;
+                    }
+                    else
+                    {
+                        cinemachine.LookAt = newObject.transform;
+                    }
+                }
+            }
         }
 
         // TODO: Move this to Genrelizer or sth and implement

--- a/Assets/Script/Gameplay/GameManager.Loading.cs
+++ b/Assets/Script/Gameplay/GameManager.Loading.cs
@@ -290,6 +290,7 @@ namespace YARG.Gameplay
                 if (Chart != null)
                 {
                     GenerateVenueTrack();
+                    GenerateLipsyncTrack();
                 }
                 else
                 {
@@ -311,7 +312,7 @@ namespace YARG.Gameplay
             {
                     SongChart.LoadVenueFromMilo(Chart, Song);
 
-                    YargLogger.LogFormatWarning("Loaded {0} lighting events from milo", Chart.VenueTrack.Lighting.Count);
+                    YargLogger.LogFormatDebug("Loaded {0} lighting events from milo", Chart.VenueTrack.Lighting.Count);
             }
 
             if (File.Exists(VenueAutoGenerationPreset.DefaultPath))
@@ -327,6 +328,13 @@ namespace YARG.Gameplay
                     Chart = preset.GenerateLightingEvents(Chart);
                 }
             }
+        }
+
+        private void GenerateLipsyncTrack()
+        {
+            SongChart.LoadLipsyncFromMilo(Chart, Song);
+
+            YargLogger.LogFormatDebug("Loaded {0} lipsync events from milo", Chart.LipsyncEvents.Count);
         }
 
         private void FinalizeChart()

--- a/Assets/Script/Settings/SettingsManager.Settings.cs
+++ b/Assets/Script/Settings/SettingsManager.Settings.cs
@@ -21,6 +21,7 @@ using YARG.Scores;
 using YARG.Settings.Types;
 using YARG.Song;
 using YARG.Venue;
+using YARG.Venue.Characters;
 
 namespace YARG.Settings
 {
@@ -546,6 +547,7 @@ namespace YARG.Settings
             public OutputChannelSetting OutputChannelMetronome { get; } = new(-1, OutputChannelMetronomeCallback);
 
             public ToggleSetting EnableNormalization { get; } = new(false);
+            public CustomCharacterSetting CustomVocalsCharacter { get; } = new(string.Empty, VenueCharacter.CharacterType.Vocals);
             #endregion
 
             #region Helpers

--- a/Assets/Script/Settings/SettingsManager.cs
+++ b/Assets/Script/Settings/SettingsManager.cs
@@ -231,6 +231,7 @@ namespace YARG.Settings
             {
                 new HeaderMetadata("Other"),
                 nameof(Settings.BandComboTypeSetting),
+                nameof(Settings.CustomVocalsCharacter),
                 nameof(Settings.DataStreamEnable),
                 nameof(Settings.EnableNormalization),
                 nameof(Settings.SaveScoresWithBots),

--- a/Assets/Script/Settings/Types/CustomCharacterSetting.cs
+++ b/Assets/Script/Settings/Types/CustomCharacterSetting.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using UnityEngine;
+using UniVRM10;
+using YARG.Settings.Customization;
+using YARG.Venue;
+using YARG.Venue.Characters;
+
+namespace YARG.Settings.Types
+{
+    public class CustomCharacterSetting : DropdownSetting<string>
+    {
+        private VenueCharacter.CharacterType _characterType;
+        private Dictionary<string, string>   _fileToName = new();
+
+        public CustomCharacterSetting(string value, VenueCharacter.CharacterType characterType, Action<string> onChange = null) :
+            base(value, onChange, localizable: false)
+        {
+            _characterType = characterType;
+        }
+
+        public override void UpdateValues()
+        {
+            _fileToName.Clear();
+            _possibleValues.Clear();
+            _possibleValues.Add(string.Empty);
+
+            var folder = Path.Combine(CustomContentManager.CustomizationDirectory, "characters");
+            string[] files = Directory.Exists(folder) ? Directory.GetFiles(folder, "*.yargchar") : Array.Empty<string>();
+
+            // Load the AssetBundles and pull the character names from the VrmInstance (and use the filename as a fallback for the display name)
+            foreach (var file in files)
+            {
+                var bundle = AssetBundle.LoadFromFile(file);
+                if (bundle == null)
+                {
+                    continue;
+                }
+
+                var character = bundle.LoadAsset<GameObject>(BundleBackgroundManager.CHARACTER_PREFAB_PATH.ToLowerInvariant());
+                if (character == null)
+                {
+                    bundle.Unload(true);
+                    continue;
+                }
+
+                var vrmInstance = character.GetComponent<Vrm10Instance>();
+                if (vrmInstance == null)
+                {
+                    bundle.Unload(true);
+                    continue;
+                }
+
+                string name;
+
+                if (!string.IsNullOrEmpty(vrmInstance.Vrm.Meta.Name))
+                {
+                    name = vrmInstance.Vrm.Meta.Name;
+                }
+                else
+                {
+                    name = Path.GetFileNameWithoutExtension(file);
+                }
+
+                var venueCharacter = character.GetComponent<VenueCharacter>();
+                if (venueCharacter != null && venueCharacter.Type != _characterType)
+                {
+                    _possibleValues.Add(file);
+                    _fileToName[file] = name;
+                }
+
+                bundle.Unload(true);
+            }
+        }
+
+        public override string ValueToString(string value)
+        {
+            return _fileToName.GetValueOrDefault(value, "None");
+        }
+    }
+}

--- a/Assets/Script/Settings/Types/CustomCharacterSetting.cs.meta
+++ b/Assets/Script/Settings/Types/CustomCharacterSetting.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 1d9202bf07b646fbbe63cc9e898533b1
+timeCreated: 1771335301

--- a/Assets/Script/Venue/Characters/VRMCharacter.cs
+++ b/Assets/Script/Venue/Characters/VRMCharacter.cs
@@ -1,0 +1,217 @@
+﻿using System;
+using System.Collections.Generic;
+using DG.Tweening;
+using UnityEngine;
+using UniVRM10;
+using YARG.Core.Chart;
+using LipsyncType = YARG.Core.Chart.LipsyncEvent.LipsyncType;
+using YARG.Gameplay;
+
+namespace YARG.Venue.Characters
+{
+    public class VRMCharacter : VenueCharacter
+    {
+        private Vrm10RuntimeExpression _expression;
+        private List<LipsyncEvent>     _lipsyncEvents;
+
+        private ExpressionKey _browAggressive;
+        private ExpressionKey _browDown;
+        private ExpressionKey _browOpenmouthed;
+        private ExpressionKey _squint;
+
+        private readonly Dictionary<string, ExpressionKey> _customExpressions = new();
+
+        private int _lipsyncIndex;
+
+        [Header("Lipsync Settings")]
+        [SerializeField]
+        [Tooltip("The expression key to activate for basic lipsync.")]
+        private ExpressionKeyKind _expressionKey = ExpressionKeyKind.Ou;
+        [SerializeField]
+        [Tooltip("Set to true if you have the full set of RB expressions implemented.\n\nOtherwise, lipsync will only use the selected VRM default expression key.")]
+        private bool _useFullLipsync;
+
+        private ExpressionKey _lipsyncKey;
+
+        public override void Initialize(CharacterManager characterManager)
+        {
+            _lipsyncKey = GetExpressionKey(_expressionKey);
+            _characterManager = characterManager;
+            VrmInstance = GetComponent<Vrm10Instance>();
+            _expression = VrmInstance.Runtime.Expression;
+            _lipsyncEvents = _characterManager.LipsyncEvents;
+
+            var clips = VrmInstance.Vrm.Expression.CustomClips;
+
+            foreach (var clip in clips)
+            {
+                _customExpressions[clip.name] = VrmInstance.Vrm.Expression.CreateKey(clip);
+            }
+
+            base.Initialize(characterManager);
+        }
+
+        protected override void Update()
+        {
+            ProcessLipsync(_characterManager.SongTime);
+            base.Update();
+        }
+
+        private void ProcessLipsync(double time)
+        {
+            // We may have initialized too early, so we need to protect against null reference and hope it fixes itself later
+            if (_characterManager.LipsyncEvents == null)
+            {
+                return;
+            }
+
+            while (_lipsyncIndex < _characterManager.LipsyncEvents.Count && _characterManager.LipsyncEvents[_lipsyncIndex].Time <= time)
+            {
+                var lipsyncEvent = _characterManager.LipsyncEvents[_lipsyncIndex];
+
+                SetExpression(lipsyncEvent);
+
+                _lipsyncIndex++;
+            }
+        }
+
+        private void SetExpression(LipsyncEvent lipsyncEvent)
+        {
+            if (VrmInstance != null && TryGetExpressionKey(lipsyncEvent.Type, out var key))
+            {
+                _expression.SetWeight(key, lipsyncEvent.Value);
+                return;
+            }
+
+            // Couldn't find a default expression, so look for customs
+            if (TryGetExpressionKey(lipsyncEvent.Type.ToString(), out key))
+            {
+                _expression.SetWeight(key, lipsyncEvent.Value);
+            }
+        }
+
+        public override void OnNote<T>(Note<T> note)
+        {
+            if (VrmInstance == null)
+            {
+                return;
+            }
+
+            if (note is VocalNote vocalNote)
+            {
+                // Animate in/out of expression for animLength time
+                float animLength = (float) vocalNote.TotalTimeLength * 0.1f;
+                float offDelay = (float) vocalNote.TotalTimeLength * 0.9f;
+
+                var currentWeight = _expression.GetWeight(_lipsyncKey);
+                DOVirtual.Float(currentWeight, 1f, animLength, x => _expression.SetWeight(_lipsyncKey, x))
+                    .SetAutoKill(true);
+                DOVirtual.DelayedCall(offDelay, () => ExpressionOff(_lipsyncKey, animLength));
+            }
+        }
+
+        private void ExpressionOff(ExpressionKey key, float length)
+        {
+            if (length > 0)
+            {
+                DOVirtual.Float(_expression.GetWeight(key), 0f, length, x => _expression.SetWeight(key, x)).SetAutoKill(true);
+                return;
+            }
+
+            _expression.SetWeight(key, 0f);
+        }
+
+        private static bool IsMouthShape(LipsyncType type)
+        {
+            return type switch
+            {
+                LipsyncType.Bump_hi    => true,
+                LipsyncType.Bump_lo    => true,
+                LipsyncType.Cage_hi    => true,
+                LipsyncType.Cage_lo    => true,
+                LipsyncType.Church_hi  => true,
+                LipsyncType.Church_lo  => true,
+                LipsyncType.Earth_hi   => true,
+                LipsyncType.Earth_lo   => true,
+                LipsyncType.Eat_hi     => true,
+                LipsyncType.Eat_lo     => true,
+                LipsyncType.Fave_hi    => true,
+                LipsyncType.Fave_lo    => true,
+                LipsyncType.If_hi      => true,
+                LipsyncType.If_lo      => true,
+                LipsyncType.Neutral_hi => true,
+                LipsyncType.Neutral_lo => true,
+                LipsyncType.New_hi     => true,
+                LipsyncType.New_lo     => true,
+                LipsyncType.Oat_hi     => true,
+                LipsyncType.Oat_lo     => true,
+                LipsyncType.Ox_hi      => true,
+                LipsyncType.Ox_lo      => true,
+                LipsyncType.Roar_hi    => true,
+                LipsyncType.Roar_lo    => true,
+                LipsyncType.Size_hi    => true,
+                LipsyncType.Size_lo    => true,
+                LipsyncType.Though_hi  => true,
+                LipsyncType.Though_lo  => true,
+                LipsyncType.Told_hi    => true,
+                LipsyncType.Told_lo    => true,
+                LipsyncType.Wet_hi     => true,
+                LipsyncType.Wet_lo     => true,
+                _                      => false
+            };
+        }
+
+        public enum ExpressionKeyKind
+        {
+            Aa,
+            Ih,
+            Ou,
+            Ee,
+            Oh,
+        }
+
+        private static ExpressionKey GetExpressionKey(ExpressionKeyKind kind)
+        {
+            return kind switch
+            {
+                ExpressionKeyKind.Aa => ExpressionKey.Aa,
+                ExpressionKeyKind.Ih => ExpressionKey.Ih,
+                ExpressionKeyKind.Ee => ExpressionKey.Ee,
+                ExpressionKeyKind.Ou => ExpressionKey.Ou,
+                ExpressionKeyKind.Oh => ExpressionKey.Oh,
+                _                    => throw new ArgumentException("Invalid expression key kind"),
+            };
+        }
+
+        private bool TryGetExpressionKey(string keyName, out ExpressionKey key)
+        {
+            key = default;
+
+            if (_customExpressions.TryGetValue(keyName, out key))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        private static bool TryGetExpressionKey(LipsyncType type, out ExpressionKey key)
+        {
+            ExpressionKey? possibleKey = type switch
+            {
+                LipsyncType.Blink => ExpressionKey.Blink,
+                _ => null
+            };
+
+            if (possibleKey.HasValue)
+            {
+                key = possibleKey.Value;
+                return true;
+            }
+
+            key = default;
+
+            return false;
+        }
+    }
+}

--- a/Assets/Script/Venue/Characters/VRMCharacter.cs
+++ b/Assets/Script/Venue/Characters/VRMCharacter.cs
@@ -32,12 +32,14 @@ namespace YARG.Venue.Characters
         private bool _useFullLipsync;
 
         private ExpressionKey _lipsyncKey;
+        private bool          _hasVrmInstance;
 
         public override void Initialize(CharacterManager characterManager)
         {
             _lipsyncKey = GetExpressionKey(_expressionKey);
             _characterManager = characterManager;
             VrmInstance = GetComponent<Vrm10Instance>();
+            _hasVrmInstance = VrmInstance != null;
             _expression = VrmInstance.Runtime.Expression;
             _lipsyncEvents = _characterManager.LipsyncEvents;
 
@@ -77,7 +79,12 @@ namespace YARG.Venue.Characters
 
         private void SetExpression(LipsyncEvent lipsyncEvent)
         {
-            if (VrmInstance != null && TryGetExpressionKey(lipsyncEvent.Type, out var key))
+            if (!_hasVrmInstance)
+            {
+                return;
+            }
+
+            if (TryGetExpressionKey(lipsyncEvent.Type, out var key))
             {
                 _expression.SetWeight(key, lipsyncEvent.Value);
                 return;
@@ -92,7 +99,8 @@ namespace YARG.Venue.Characters
 
         public override void OnNote<T>(Note<T> note)
         {
-            if (VrmInstance == null)
+            // If _useFullLipsync is set, we don't use the default expression or the note-based trigger
+            if (!_hasVrmInstance || _useFullLipsync)
             {
                 return;
             }

--- a/Assets/Script/Venue/Characters/VRMCharacter.cs.meta
+++ b/Assets/Script/Venue/Characters/VRMCharacter.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: a2fe58d053b845839d712ed1a52c507b
+timeCreated: 1771054178

--- a/Assets/Script/Venue/Characters/VenueCharacter.cs
+++ b/Assets/Script/Venue/Characters/VenueCharacter.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using DG.Tweening;
 using UnityEngine;
+using UniVRM10;
 using YARG.Core.Chart;
 using YARG.Core.Logging;
 using AnimationTrigger = YARG.Venue.Characters.CharacterManager.AnimationTrigger;
@@ -28,7 +30,7 @@ namespace YARG.Venue.Characters
         }
 
         [SerializeField]
-        private CharacterManager _characterManager;
+        protected CharacterManager _characterManager;
 
         [SerializeField]
         public CharacterType Type;
@@ -108,20 +110,39 @@ namespace YARG.Venue.Characters
         private bool _hasSlap;
         private bool _hasPick;
 
-        private void Awake()
+        private bool _hasAnimationController;
+
+        protected Vrm10Instance VrmInstance;
+
+        public virtual void Initialize(CharacterManager characterManager)
         {
             _animator = GetComponent<Animator>();
             _animatorController = _animator.runtimeAnimatorController;
 
+            _hasAnimationController = _animatorController != null;
+
             _layerStates = LayerStates.ToDictionary();
+
+            if (_layerStates == null || _layerStates.Count == 0)
+            {
+                _layerStates = BuildEditorVenueLayerStates();
+            }
 
             PopulateAnimationData();
             CheckAdvancedAnimations();
 
             // Get the available animations so we don't try to call ones the venue author didn't implement
-            foreach (var animation in _animatorController.animationClips)
+            if (_hasAnimationController)
             {
-                _availableAnimations.Add(animation.name);
+                foreach (var animation in _animatorController.animationClips)
+                {
+                    _availableAnimations.Add(animation.name);
+                }
+            }
+            else
+            {
+                YargLogger.LogWarning("No animation controller found for character type {Type}");
+                _availableAnimations.Clear();
             }
 
             foreach (var state in _strumUpStates)
@@ -129,9 +150,17 @@ namespace YARG.Venue.Characters
                 _strumUpHashes.Add(Animator.StringToHash(state));
             }
 
-            var clip = _animatorController.animationClips[0];
-            _animationLength = clip.length;
-            TimeToFirstHit = _framesToFirstHit / clip.frameRate;
+            if (_hasAnimationController)
+            {
+                var clip = _animatorController.animationClips[0];
+                _animationLength = clip.length;
+                TimeToFirstHit = _framesToFirstHit / clip.frameRate;
+            }
+            else
+            {
+                // Arbitrary default
+                TimeToFirstHit = 0.1f;
+            }
 
             _speedAdjustmentHash = Animator.StringToHash("SpeedAdjustment");
             _unclampedSpeedAdjustmentHash = Animator.StringToHash("UnclampedSpeedAdjustment");
@@ -143,7 +172,6 @@ namespace YARG.Venue.Characters
 
             GetPositionHashes();
             GetIKTargets();
-
         }
 
         private void CheckAdvancedAnimations()
@@ -216,7 +244,7 @@ namespace YARG.Venue.Characters
             _hasAdvancedAnimations = false;
         }
 
-        private void Update()
+        protected virtual void Update()
         {
             if (_delayedTriggerTime > 0)
             {
@@ -434,7 +462,7 @@ namespace YARG.Venue.Characters
 
         }
 
-        public void OnNote<T>(Note<T> note) where T : Note<T>
+        public virtual void OnNote<T>(Note<T> note) where T : Note<T>
         {
 
             if (note is GuitarNote gNote)
@@ -486,9 +514,20 @@ namespace YARG.Venue.Characters
                 SetHandAnimationForNote(gNote);
             }
 
-            if (note is Note<VocalNote>)
+            if (note is Note<VocalNote> vocalNote)
             {
+                if (VrmInstance != null)
+                {
+                    var expression = VrmInstance.Runtime.Expression;
 
+                    expression.SetWeight(ExpressionKey.Oh, 1.0f);
+
+                    DOTween.Sequence().AppendInterval((float) vocalNote.TimeLength).AppendCallback(() =>
+                    {
+                        expression.SetWeight(ExpressionKey.Oh, 0.0f);
+                        expression.SetWeight(ExpressionKey.Happy, 1.0f);
+                    }).SetAutoKill(true);
+                }
             }
 
             if (note is Note<ProKeysNote>)

--- a/Assets/Script/Venue/Characters/VenueCharacter.cs
+++ b/Assets/Script/Venue/Characters/VenueCharacter.cs
@@ -5,6 +5,7 @@ using UnityEngine;
 using UniVRM10;
 using YARG.Core.Chart;
 using YARG.Core.Logging;
+using YARG.Core.Song;
 using AnimationTrigger = YARG.Venue.Characters.CharacterManager.AnimationTrigger;
 using CharacterStateType = YARG.Core.Chart.Events.CharacterState.CharacterStateType;
 using AnimationType = YARG.Core.Chart.AnimationEvent.AnimationType;
@@ -34,6 +35,8 @@ namespace YARG.Venue.Characters
 
         [SerializeField]
         public CharacterType Type;
+        [SerializeField]
+        public VocalGender CharacterGender = VocalGender.Unspecified;
 
         [SerializeField]
         private int _actionsPerAnimationCycle;

--- a/Assets/Script/Venue/VenueEditorHelper.cs
+++ b/Assets/Script/Venue/VenueEditorHelper.cs
@@ -1,0 +1,49 @@
+﻿namespace YARG.Venue
+{
+    public static class VenueEditorHelper
+    {
+        private const string ENABLED_KEY = "YARG_VENUE_SCENE_ENABLED";
+        private const string SCENE_PATH_KEY = "YARG_VENUE_SCENE_PATH";
+
+        public static bool TryGetScenePath(out string scenePath)
+        {
+#if UNITY_EDITOR
+            if (!UnityEditor.EditorPrefs.GetBool(ENABLED_KEY, false))
+            {
+                scenePath = null;
+                return false;
+            }
+
+            scenePath = UnityEditor.EditorPrefs.GetString(SCENE_PATH_KEY, string.Empty);
+            return !string.IsNullOrEmpty(scenePath);
+#else
+            scenePath = null;
+            return false;
+#endif
+        }
+
+#if UNITY_EDITOR
+        public static void SetScenePath(string scenePath, bool enabled = true)
+        {
+            UnityEditor.EditorPrefs.SetString(SCENE_PATH_KEY, scenePath);
+            UnityEditor.EditorPrefs.SetBool(ENABLED_KEY, enabled);
+        }
+
+        public static void ClearScenePath()
+        {
+            UnityEditor.EditorPrefs.DeleteKey(SCENE_PATH_KEY);
+            UnityEditor.EditorPrefs.DeleteKey(ENABLED_KEY);
+        }
+
+        public static void SetSceneEnabled(bool enabled)
+        {
+            UnityEditor.EditorPrefs.SetBool(ENABLED_KEY, enabled);
+        }
+
+        public static bool IsSceneEnabled()
+        {
+            return UnityEditor.EditorPrefs.GetBool(ENABLED_KEY, false);
+        }
+#endif
+    }
+}

--- a/Assets/Script/Venue/VenueEditorHelper.cs.meta
+++ b/Assets/Script/Venue/VenueEditorHelper.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 06c7728021024c4789a8d4b8cb8885b5
+timeCreated: 1771209180

--- a/Assets/StreamingAssets/lang/en-US.json
+++ b/Assets/StreamingAssets/lang/en-US.json
@@ -1442,6 +1442,10 @@
             "EnableNormalization": {
                 "Name": "Normalize Audio",
                 "Description": "If enabled, normalizes audio so that all songs are approximately the same volume.  Increases memory and performance requirements."
+            },
+            "CustomVocalsCharacter": {
+                "Name": "Custom Vocals Character",
+                "Description": "Select a custom vocals character to use in venues that support characters."
             }
         },
         "PresetType": {

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -46,6 +46,8 @@
     "com.unity.render-pipelines.universal": "17.3.0",
     "com.unity.timeline": "1.8.10",
     "com.unity.ugui": "2.0.0",
+    "com.vrmc.gltf": "https://github.com/vrm-c/UniVRM.git?path=/Packages/UniGLTF#v0.131.0",
+    "com.vrmc.vrm": "https://github.com/vrm-c/UniVRM.git?path=/Packages/VRM10#v0.131.0",
     "com.yasirkula.simplefilebrowser": "https://github.com/yasirkula/UnitySimpleFileBrowser.git",
     "in.yarg.core": "file:../YARG.Core/YARG.Core",
     "jp.keijiro.minis": "https://github.com/TheNathannator/Minis.git?path=/Packages/jp.keijiro.minis#yarg",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -174,7 +174,7 @@
     },
     "com.unity.mathematics": {
       "version": "1.3.3",
-      "depth": 2,
+      "depth": 1,
       "source": "registry",
       "dependencies": {},
       "url": "https://packages.unity.com"
@@ -325,6 +325,29 @@
         "com.unity.modules.ui": "1.0.0",
         "com.unity.modules.imgui": "1.0.0"
       }
+    },
+    "com.vrmc.gltf": {
+      "version": "https://github.com/vrm-c/UniVRM.git?path=/Packages/UniGLTF#v0.131.0",
+      "depth": 0,
+      "source": "git",
+      "dependencies": {
+        "com.unity.modules.animation": "1.0.0",
+        "com.unity.modules.imgui": "1.0.0",
+        "com.unity.modules.imageconversion": "1.0.0",
+        "com.unity.test-framework": "1.4.6",
+        "com.unity.mathematics": "1.2.6"
+      },
+      "hash": "3b99078d26b362733ad9bf463f98c83b8a1b4c9f"
+    },
+    "com.vrmc.vrm": {
+      "version": "https://github.com/vrm-c/UniVRM.git?path=/Packages/VRM10#v0.131.0",
+      "depth": 0,
+      "source": "git",
+      "dependencies": {
+        "com.unity.timeline": "1.7.6",
+        "com.vrmc.gltf": "0.131.0"
+      },
+      "hash": "3b99078d26b362733ad9bf463f98c83b8a1b4c9f"
     },
     "com.yasirkula.simplefilebrowser": {
       "version": "https://github.com/yasirkula/UnitySimpleFileBrowser.git",


### PR DESCRIPTION
Adds the ability to create and load custom characters into venues. Works pretty much the same as existing venues, except we create a .yargchar file which is just an AssetBundle with a prefab named `_character` instead of `_background`. 

When `.yargchar` files are found in the `custom/characters` folder, they appear in a dropdown menu in experimental settings so they can be selected by the player. When BackgroundManager loads a `.yarground` it now looks for existing characters of the same type as the user-selected character and replaces it if found. If no character of the same type is found, the custom character loading process stops. This allows the feature to work with existing venues.

UniVRM and UniGLTF are now dependencies so that VRM characters can be used with minimal adaptation.

Lipsync data (which includes facial animations) are read from the milo file in CONs that have them (see [YARG.Core #330](https://github.com/YARC-Official/YARG.Core/pull/330)). RB visemes are activated in VRM characters that have correspondingly named custom expressions. The author of the character can specify that the character requires "basic lipsync", in which case a selected default expression is used instead (defaults to `Ou`), triggered in the same way as proposed in #1113.

Still up for investigation:
* Load VRMs directly, using a default animation controller and set of animations. This is obviously limiting since facial expressions cannot be supported in this way due to the underlying blendshapes in each VRM character being inconsistent and the required expressions not well overlapping with what is required to use an RB-style animation track, but it would allow for some basic functionality for any reasonably proportioned character a player might care to use. This would require some changes to the loader itself, both to allow the use of characters that don't already have a `VenueCharacter` (or `VRMCharacter`) component specifying their type and to create a default `VRMCharacter` component when loading the character.
* Allow the use of custom characters other than vocals. At a minimum, settings would need to be added to allow other character types to be loaded. Given the amount of animation work required to get a somewhat passable looking character, I don't expect people are going to be clamoring to make them.
* Make the character selection per-profile so that different people can specify different characters.
* A graphical character selection screen with a preview of the character. (The MVP for this would probably to load the character into the settings preview area when selected, but we'd ideally have a nice carousel or something that displayed more than one character at a time)
* Support for distribution of characters through the launcher or some in-game interface.

Edited to note: This also includes an editor-only option to load a venue from a scene rather than a compiled AssetBundle. This is to make debugging animation issues easier since you can actually see what the animation controller is doing. Currently, something is leaking memory like a sieve, though, and memory usage grows with every song played.