### PR TITLE
Implement auto video calibration

### DIFF
--- a/Assets/Script/Gameplay/GameManager.Loading.cs
+++ b/Assets/Script/Gameplay/GameManager.Loading.cs
@@ -247,9 +247,7 @@ namespace YARG.Gameplay
 
                 SettingsManager.Settings.NoFailMode.OnChange += OnNoFailModeChanged;
                 SettingsManager.Settings.AutoCalibrateAudio.Value = false;
-                SettingsManager.Settings.AutoCalibrateAudio.OnChange += OnAutoCalibrationChanged;
                 SettingsManager.Settings.AutoCalibrateVideo.Value = false;
-                SettingsManager.Settings.AutoCalibrateVideo.OnChange += OnAutoCalibrationVideoChanged;
             }
 
             // Log constant values

--- a/Assets/Script/Gameplay/GameManager.Loading.cs
+++ b/Assets/Script/Gameplay/GameManager.Loading.cs
@@ -248,6 +248,8 @@ namespace YARG.Gameplay
                 SettingsManager.Settings.NoFailMode.OnChange += OnNoFailModeChanged;
                 SettingsManager.Settings.AutoCalibrateAudio.Value = false;
                 SettingsManager.Settings.AutoCalibrateAudio.OnChange += OnAutoCalibrationChanged;
+                SettingsManager.Settings.AutoCalibrateVideo.Value = false;
+                SettingsManager.Settings.AutoCalibrateVideo.OnChange += OnAutoCalibrationVideoChanged;
             }
 
             // Log constant values

--- a/Assets/Script/Gameplay/GameManager.Loading.cs
+++ b/Assets/Script/Gameplay/GameManager.Loading.cs
@@ -246,8 +246,8 @@ namespace YARG.Gameplay
                 EngineManager.InitializeHappiness();
 
                 SettingsManager.Settings.NoFailMode.OnChange += OnNoFailModeChanged;
-                SettingsManager.Settings.AutoCalibration.Value = false;
-                SettingsManager.Settings.AutoCalibration.OnChange += OnAutoCalibrationChanged;
+                SettingsManager.Settings.AutoCalibrateAudio.Value = false;
+                SettingsManager.Settings.AutoCalibrateAudio.OnChange += OnAutoCalibrationChanged;
             }
 
             // Log constant values

--- a/Assets/Script/Gameplay/GameManager.cs
+++ b/Assets/Script/Gameplay/GameManager.cs
@@ -168,7 +168,7 @@ namespace YARG.Gameplay
         private double _pauseTime;
         private double _rewindLimit = double.MinValue;
         private bool   _resumeInProgress;
-        private bool   _autoCalibrationVideoOnPause;
+        private bool   _autoCalibrateVideoOnPause;
         private double _preFadeOutVolume = DEFAULT_VOLUME;
 
         public bool PlayingAShow => GlobalVariables.State.PlayingAShow;
@@ -415,7 +415,7 @@ namespace YARG.Gameplay
                 _rewindLimit = rewindTime;
             }
 
-            _autoCalibrationVideoOnPause = SettingsManager.Settings.AutoCalibrateVideo.Value;
+            _autoCalibrateVideoOnPause = SettingsManager.Settings.AutoCalibrateVideo.Value;
 
             // Pause any audio samples that are currently playing
             GlobalAudioHandler.PauseAllSfx();
@@ -447,7 +447,7 @@ namespace YARG.Gameplay
 
             // If AutoCalibrateVideo changed while paused, fade the mixer accordingly
             bool autoCalibrateVideoEnabled = SettingsManager.Settings.AutoCalibrateVideo.Value;
-            bool didChangeWhilePaused = autoCalibrateVideoEnabled != _autoCalibrationVideoOnPause;
+            bool didChangeWhilePaused = autoCalibrateVideoEnabled != _autoCalibrateVideoOnPause;
             if (didChangeWhilePaused)
             {
                 if (autoCalibrateVideoEnabled)

--- a/Assets/Script/Gameplay/GameManager.cs
+++ b/Assets/Script/Gameplay/GameManager.cs
@@ -168,6 +168,8 @@ namespace YARG.Gameplay
         private double _pauseTime;
         private double _rewindLimit = double.MinValue;
         private bool   _resumeInProgress;
+        private bool   _autoCalibrationVideoOnPause;
+        private double _preFadeOutVolume = DEFAULT_VOLUME;
 
         public bool PlayingAShow => GlobalVariables.State.PlayingAShow;
         public int  ShowIndex = 0;
@@ -227,6 +229,7 @@ namespace YARG.Gameplay
             // Unsubscribe from other events
             SettingsManager.Settings.NoFailMode.OnChange -= OnNoFailModeChanged;
             SettingsManager.Settings.AutoCalibrateAudio.OnChange -= OnAutoCalibrationChanged;
+            SettingsManager.Settings.AutoCalibrateVideo.OnChange -= OnAutoCalibrationVideoChanged;
             EngineManager.OnSongFailed -= OnSongFailed;
 
             //Restore stem volumes to their original state
@@ -414,6 +417,8 @@ namespace YARG.Gameplay
                 _rewindLimit = rewindTime;
             }
 
+            _autoCalibrationVideoOnPause = SettingsManager.Settings.AutoCalibrateVideo.Value;
+
             // Pause any audio samples that are currently playing
             GlobalAudioHandler.PauseAllSfx();
 
@@ -441,6 +446,22 @@ namespace YARG.Gameplay
 
             _resumeInProgress = true;
             Rewinding = true;
+
+            // If AutoCalibrateVideo changed while paused, fade the mixer accordingly
+            bool autoCalibrateVideoEnabled = SettingsManager.Settings.AutoCalibrateVideo.Value;
+            bool didChangeWhilePaused = autoCalibrateVideoEnabled != _autoCalibrationVideoOnPause;
+            if (didChangeWhilePaused)
+            {
+                if (autoCalibrateVideoEnabled)
+                {
+                    _preFadeOutVolume = _mixer.GetVolume();
+                    _mixer.FadeOut(SONG_START_DELAY);
+                }
+                else
+                {
+                    _mixer.FadeIn(_preFadeOutVolume, SONG_START_DELAY);
+                }
+            }
 
             // try block is here so we can ensure that _resumeInProgress always gets reset
             try
@@ -863,6 +884,16 @@ namespace YARG.Gameplay
             if (enabled)
             {
                 InvalidateScores("Menu.Toast.AutoCalibrationScore");
+                SettingsManager.Settings.AutoCalibrateVideo.Value = false;
+            }
+        }
+
+        private void OnAutoCalibrationVideoChanged(bool enabled)
+        {
+            if (enabled)
+            {
+                InvalidateScores("Menu.Toast.AutoCalibrationScore");
+                SettingsManager.Settings.AutoCalibrateAudio.Value = false;
             }
         }
 

--- a/Assets/Script/Gameplay/GameManager.cs
+++ b/Assets/Script/Gameplay/GameManager.cs
@@ -228,8 +228,6 @@ namespace YARG.Gameplay
 
             // Unsubscribe from other events
             SettingsManager.Settings.NoFailMode.OnChange -= OnNoFailModeChanged;
-            SettingsManager.Settings.AutoCalibrateAudio.OnChange -= OnAutoCalibrationChanged;
-            SettingsManager.Settings.AutoCalibrateVideo.OnChange -= OnAutoCalibrationVideoChanged;
             EngineManager.OnSongFailed -= OnSongFailed;
 
             //Restore stem volumes to their original state
@@ -879,24 +877,6 @@ namespace YARG.Gameplay
             }
         }
 
-        private void OnAutoCalibrationChanged(bool enabled)
-        {
-            if (enabled)
-            {
-                InvalidateScores("Menu.Toast.AutoCalibrationScore");
-                SettingsManager.Settings.AutoCalibrateVideo.Value = false;
-            }
-        }
-
-        private void OnAutoCalibrationVideoChanged(bool enabled)
-        {
-            if (enabled)
-            {
-                InvalidateScores("Menu.Toast.AutoCalibrationScore");
-                SettingsManager.Settings.AutoCalibrateAudio.Value = false;
-            }
-        }
-
         // If we go from no fail to fail, we need to reinitialize the happiness state so we avoid
         // the possibility of an instant fail. Yes, this is cheeseable since toggling no fail resets happiness.
         private void OnNoFailModeChanged(bool noFail)
@@ -911,7 +891,7 @@ namespace YARG.Gameplay
             }
         }
 
-        private void InvalidateScores(string toastKey)
+        internal void InvalidateScores(string toastKey)
         {
             bool invalidated = false;
 

--- a/Assets/Script/Gameplay/GameManager.cs
+++ b/Assets/Script/Gameplay/GameManager.cs
@@ -226,7 +226,7 @@ namespace YARG.Gameplay
 
             // Unsubscribe from other events
             SettingsManager.Settings.NoFailMode.OnChange -= OnNoFailModeChanged;
-            SettingsManager.Settings.AutoCalibration.OnChange -= OnAutoCalibrationChanged;
+            SettingsManager.Settings.AutoCalibrateAudio.OnChange -= OnAutoCalibrationChanged;
             EngineManager.OnSongFailed -= OnSongFailed;
 
             //Restore stem volumes to their original state

--- a/Assets/Script/Gameplay/HUD/Pause/QuickSettings.Settings.cs
+++ b/Assets/Script/Gameplay/HUD/Pause/QuickSettings.Settings.cs
@@ -25,7 +25,8 @@ namespace YARG.Gameplay.HUD
         {
             nameof(SettingsManager.Settings.AudioCalibration),
             nameof(SettingsManager.Settings.VideoCalibration),
-            nameof(SettingsManager.Settings.AutoCalibrateAudio)
+            nameof(SettingsManager.Settings.AutoCalibrateAudio),
+            nameof(SettingsManager.Settings.AutoCalibrateVideo)
         };
     }
 }

--- a/Assets/Script/Gameplay/HUD/Pause/QuickSettings.Settings.cs
+++ b/Assets/Script/Gameplay/HUD/Pause/QuickSettings.Settings.cs
@@ -25,7 +25,7 @@ namespace YARG.Gameplay.HUD
         {
             nameof(SettingsManager.Settings.AudioCalibration),
             nameof(SettingsManager.Settings.VideoCalibration),
-            nameof(SettingsManager.Settings.AutoCalibration)
+            nameof(SettingsManager.Settings.AutoCalibrateAudio)
         };
     }
 }

--- a/Assets/Script/Gameplay/HUD/Pause/QuickSettings.cs
+++ b/Assets/Script/Gameplay/HUD/Pause/QuickSettings.cs
@@ -96,7 +96,7 @@ namespace YARG.Gameplay.HUD
             var allowAutoCalibration = activeHumanPlayers == 1;
             if (!allowAutoCalibration || GlobalVariables.State.IsReplay)
             {
-                settings.Remove(nameof(SettingsManager.Settings.AutoCalibration));
+                settings.Remove(nameof(SettingsManager.Settings.AutoCalibrateAudio));
             }
             OpenSubSettings(settings);
         }

--- a/Assets/Script/Gameplay/HUD/Pause/QuickSettings.cs
+++ b/Assets/Script/Gameplay/HUD/Pause/QuickSettings.cs
@@ -97,6 +97,7 @@ namespace YARG.Gameplay.HUD
             if (!allowAutoCalibration || GlobalVariables.State.IsReplay)
             {
                 settings.Remove(nameof(SettingsManager.Settings.AutoCalibrateAudio));
+                settings.Remove(nameof(SettingsManager.Settings.AutoCalibrateVideo));
             }
             OpenSubSettings(settings);
         }

--- a/Assets/Script/Gameplay/HUD/Pause/Settings/TogglePauseSetting.cs
+++ b/Assets/Script/Gameplay/HUD/Pause/Settings/TogglePauseSetting.cs
@@ -20,6 +20,12 @@ namespace YARG.Gameplay.HUD
 
             _toggle.onValueChanged.AddListener(SetValue);
             _toggle.SetIsOnWithoutNotify(setting.Value);
+            Setting.OnChange += OnSettingChanged;
+        }
+
+        private void OnSettingChanged(bool value)
+        {
+            _toggle.SetIsOnWithoutNotify(value);
         }
 
         protected override NavigationScheme GetNavigationScheme()
@@ -55,6 +61,8 @@ namespace YARG.Gameplay.HUD
             {
                 _toggle.onValueChanged.RemoveListener(SetValue);
             }
+
+            Setting.OnChange -= OnSettingChanged;
 
             base.OnDestroy();
         }

--- a/Assets/Script/Gameplay/Player/TrackPlayer.cs
+++ b/Assets/Script/Gameplay/Player/TrackPlayer.cs
@@ -182,7 +182,7 @@ namespace YARG.Gameplay.Player
 
         private AutoCalibrator _autoCalibrator;
 
-        private bool IsAutoCalibrating => SettingsManager.Settings.AutoCalibration.Value;
+        private bool IsAutoCalibrating => SettingsManager.Settings.AutoCalibrateAudio.Value;
 
         public override void Initialize(int index, YargPlayer player, SongChart chart, TrackView trackView,
             StemMixer mixer, int? currentHighScore)

--- a/Assets/Script/Gameplay/Player/TrackPlayer.cs
+++ b/Assets/Script/Gameplay/Player/TrackPlayer.cs
@@ -181,9 +181,7 @@ namespace YARG.Gameplay.Player
         protected SongChart Chart;
 
         private AutoCalibrator _autoCalibrator;
-
-        private bool IsAutoCalibrating => SettingsManager.Settings.AutoCalibrateAudio.Value;
-
+        
         public override void Initialize(int index, YargPlayer player, SongChart chart, TrackView trackView,
             StemMixer mixer, int? currentHighScore)
         {

--- a/Assets/Script/Gameplay/Player/TrackPlayer.cs
+++ b/Assets/Script/Gameplay/Player/TrackPlayer.cs
@@ -261,6 +261,8 @@ namespace YARG.Gameplay.Player
             GameManager.BeatEventHandler.Audio.Unsubscribe(MetronomeTock);
             GameManager.BeatEventHandler.Visual.Unsubscribe(SunburstEffects.PulseSunburst);
 
+            _autoCalibrator?.Dispose();
+
             base.FinishDestruction();
         }
 
@@ -893,7 +895,7 @@ namespace YARG.Gameplay.Player
 
         protected virtual void OnNoteHit(int index, TNote note)
         {
-            if (IsAutoCalibrating && !Player.Profile.IsBot)
+            if (!Player.Profile.IsBot)
             {
                 _autoCalibrator.RecordAccuracy(note.Time);
             }

--- a/Assets/Script/Gameplay/Player/TrackPlayer.cs
+++ b/Assets/Script/Gameplay/Player/TrackPlayer.cs
@@ -181,7 +181,7 @@ namespace YARG.Gameplay.Player
         protected SongChart Chart;
 
         private AutoCalibrator _autoCalibrator;
-        
+
         public override void Initialize(int index, YargPlayer player, SongChart chart, TrackView trackView,
             StemMixer mixer, int? currentHighScore)
         {

--- a/Assets/Script/Helpers/AutoCalibrator.cs
+++ b/Assets/Script/Helpers/AutoCalibrator.cs
@@ -18,6 +18,9 @@ namespace YARG.Helpers
         // Fraction of the measured error to apply as correction (0-1).
         private const double DAMPING = 0.5;
 
+        // Median error (ms) below which calibration is considered stable.
+        private const double STABLE_THRESHOLD_MS = 5.0;
+
         private readonly List<double> _accuracyList = new();
         private readonly GameManager _gameManager;
 
@@ -92,7 +95,7 @@ namespace YARG.Helpers
             double median = CalculateMedian(filtered);
             int adjustment = (int) Math.Round(median * DAMPING);
 
-            if (adjustment == 0)
+            if (Math.Abs(median) <= STABLE_THRESHOLD_MS)
             {
                 NotifyCalibrationStable();
             }

--- a/Assets/Script/Helpers/AutoCalibrator.cs
+++ b/Assets/Script/Helpers/AutoCalibrator.cs
@@ -6,10 +6,11 @@ using YARG.Settings;
 
 using YARG.Gameplay;
 using YARG.Menu.Persistent;
+using YARG.Settings.Types;
 
 namespace YARG.Helpers
 {
-    public class AutoCalibrator
+    public class AutoCalibrator : IDisposable
     {
         // Number of notes to collect before each adjustment
         private const int SAMPLE_SIZE = 20;
@@ -22,14 +23,62 @@ namespace YARG.Helpers
 
         private int _calibration;
 
+        private bool IsCalibratingAudio => CalibrationMode == CalibrationType.AUDIO;
+        private bool IsCalibratingVideo => CalibrationMode == CalibrationType.VIDEO;
+        private IntSetting AudioCalibrationSetting => SettingsManager.Settings.AudioCalibration;
+        private IntSetting VideoCalibrationSetting => SettingsManager.Settings.VideoCalibration;
+        private ToggleSetting AutoAudioSetting => SettingsManager.Settings.AutoCalibrateAudio;
+        private ToggleSetting AutoVideoSetting => SettingsManager.Settings.AutoCalibrateVideo;
+
+        private enum CalibrationType
+        {
+            DISABLED,
+            AUDIO,
+            VIDEO
+        }
+
+        private CalibrationType CalibrationMode =>
+            AutoAudioSetting.Value   ? CalibrationType.AUDIO
+            : AutoVideoSetting.Value ? CalibrationType.VIDEO
+                                       : CalibrationType.DISABLED;
+
         public AutoCalibrator(GameManager gameManager)
         {
             _gameManager = gameManager;
-            _calibration = SettingsManager.Settings.AudioCalibration.Value;
+            AutoAudioSetting.OnChange += AutoCalibrateModeChanged;
+            AutoVideoSetting.OnChange += AutoCalibrateModeChanged;
+        }
+
+        private void AutoCalibrateModeChanged(bool enabled)
+        {
+            Reset();
+        }
+
+        public void Dispose()
+        {
+            AutoAudioSetting.OnChange -= AutoCalibrateModeChanged;
+            AutoVideoSetting.OnChange -= AutoCalibrateModeChanged;
+        }
+
+        private void Reset()
+        {
+            _accuracyList.Clear();
+            if (IsCalibratingAudio)
+            {
+                _calibration = AudioCalibrationSetting.Value;
+            }
+            else if (IsCalibratingVideo)
+            {
+                _calibration = VideoCalibrationSetting.Value;
+            }
         }
 
         public void RecordAccuracy(double noteTime)
         {
+            if (CalibrationMode == CalibrationType.DISABLED)
+            {
+                return;
+            }
 
             double accuracy = (_gameManager.InputTime - noteTime) * 1000;
             _accuracyList.Add(accuracy);
@@ -59,18 +108,26 @@ namespace YARG.Helpers
         private void ApplyAdjustment(int adjustment)
         {
             _calibration += adjustment;
-            SettingsManager.Settings.AudioCalibration.Value = _calibration;
+            if (CalibrationMode == CalibrationType.AUDIO)
+            {
+                AudioCalibrationSetting.Value = _calibration;
+            } else if (CalibrationMode == CalibrationType.VIDEO)
+            {
+                VideoCalibrationSetting.Value = _calibration;
+            }
             _gameManager.UpdateCalibration();
         }
 
         private void NotifyCalibrationUpdated()
         {
-            ToastManager.ToastMessage($"Calibration updated: {_calibration} ms");
+            var type = IsCalibratingAudio ? "Audio" : "Video";
+            ToastManager.ToastMessage($"{type} calibration updated: {_calibration} ms");
         }
 
         private void NotifyCalibrationStable()
         {
-            ToastManager.ToastSuccess($"Auto calibration stable ({_calibration} ms)");
+            var type = IsCalibratingAudio ? "Audio" : "Video";
+            ToastManager.ToastSuccess($"{type} calibration stable ({_calibration} ms)");
         }
 
         // Removes hits near the edges of the hit window.  We find the "middle 50%" of the data (Q1 to Q3),

--- a/Assets/Script/Helpers/AutoCalibrator.cs
+++ b/Assets/Script/Helpers/AutoCalibrator.cs
@@ -48,19 +48,36 @@ namespace YARG.Helpers
         public AutoCalibrator(GameManager gameManager)
         {
             _gameManager = gameManager;
-            AutoAudioSetting.OnChange += AutoCalibrateModeChanged;
-            AutoVideoSetting.OnChange += AutoCalibrateModeChanged;
+            AutoAudioSetting.OnChange += OnAutoCalibrateAudioChanged;
+            AutoVideoSetting.OnChange += OnAutoCalibrateVideoChanged;
         }
 
-        private void AutoCalibrateModeChanged(bool enabled)
+        private void OnAutoCalibrateAudioChanged(bool enabled)
         {
+            if (enabled)
+            {
+                _gameManager.InvalidateScores("Menu.Toast.AutoCalibrationScore");
+                AutoVideoSetting.Value = false;
+            }
+
+            Reset();
+        }
+
+        private void OnAutoCalibrateVideoChanged(bool enabled)
+        {
+            if (enabled)
+            {
+                _gameManager.InvalidateScores("Menu.Toast.AutoCalibrationScore");
+                AutoAudioSetting.Value = false;
+            }
+
             Reset();
         }
 
         public void Dispose()
         {
-            AutoAudioSetting.OnChange -= AutoCalibrateModeChanged;
-            AutoVideoSetting.OnChange -= AutoCalibrateModeChanged;
+            AutoAudioSetting.OnChange -= OnAutoCalibrateAudioChanged;
+            AutoVideoSetting.OnChange -= OnAutoCalibrateVideoChanged;
         }
 
         private void Reset()

--- a/Assets/Script/Playback/SongRunner.cs
+++ b/Assets/Script/Playback/SongRunner.cs
@@ -603,7 +603,9 @@ namespace YARG.Playback
             int videoCalibrationMs = SettingsManager.Settings.VideoCalibration.Value;
             int audioCalibrationMs = SettingsManager.Settings.AudioCalibration.Value;
             if (SettingsManager.Settings.AccountForHardwareLatency.Value)
+            {
                 audioCalibrationMs += GlobalAudioHandler.PlaybackLatency;
+            }
 
             AudioCalibration = audioCalibrationMs / 1000.0;
             VideoCalibration = videoCalibrationMs / 1000.0;

--- a/Assets/Script/Settings/SettingsManager.Settings.cs
+++ b/Assets/Script/Settings/SettingsManager.Settings.cs
@@ -92,6 +92,7 @@ namespace YARG.Settings
             public IntSetting AudioCalibration { get; } = new(0);
             public IntSetting VideoCalibration { get; } = new(0);
             public ToggleSetting AutoCalibrateAudio { get; } = new(false);
+            public ToggleSetting AutoCalibrateVideo { get; } = new(false);
 
             public ToggleSetting AccountForHardwareLatency { get; } = new(true);
 

--- a/Assets/Script/Settings/SettingsManager.Settings.cs
+++ b/Assets/Script/Settings/SettingsManager.Settings.cs
@@ -91,7 +91,7 @@ namespace YARG.Settings
 
             public IntSetting AudioCalibration { get; } = new(0);
             public IntSetting VideoCalibration { get; } = new(0);
-            public ToggleSetting AutoCalibration { get; } = new(false);
+            public ToggleSetting AutoCalibrateAudio { get; } = new(false);
 
             public ToggleSetting AccountForHardwareLatency { get; } = new(true);
 

--- a/Assets/StreamingAssets/lang/en-US.json
+++ b/Assets/StreamingAssets/lang/en-US.json
@@ -1317,8 +1317,8 @@
                 "Description": "Automatically adjusts calibration during gameplay based on your input timing."
             },
             "AutoCalibrateVideo": {
-                "Name": "Auto Video Calibration",
-                "PauseName": "Auto Video Calibration",
+                "Name": "Auto Calibrate Video",
+                "PauseName": "Auto Calibrate Video",
                 "Description": "Placeholder setting. Currently has no effect."
             },
             "VocalMonitoring": {

--- a/Assets/StreamingAssets/lang/en-US.json
+++ b/Assets/StreamingAssets/lang/en-US.json
@@ -1316,6 +1316,11 @@
                 "PauseName": "Auto Calibrate Audio",
                 "Description": "Automatically adjusts calibration during gameplay based on your input timing."
             },
+            "AutoCalibrateVideo": {
+                "Name": "Auto Video Calibration",
+                "PauseName": "Auto Video Calibration",
+                "Description": "Placeholder setting. Currently has no effect."
+            },
             "VocalMonitoring": {
                 "Name": "Vocal Monitoring Volume",
                 "PauseName": "Monitoring",

--- a/Assets/StreamingAssets/lang/en-US.json
+++ b/Assets/StreamingAssets/lang/en-US.json
@@ -1311,9 +1311,9 @@
                 "PauseName": "Video Calibration (ms)",
                 "Description": "Video calibration in milliseconds. Use the calibrator to automatically calibrate. This accounts for delays between the game's processing and the actual frame being displayed."
             },
-            "AutoCalibration": {
-                "Name": "Auto Calibration",
-                "PauseName": "Auto Calibration",
+            "AutoCalibrateAudio": {
+                "Name": "Auto Calibrate Audio",
+                "PauseName": "Auto Calibrate Audio",
                 "Description": "Automatically adjusts calibration during gameplay based on your input timing."
             },
             "VocalMonitoring": {


### PR DESCRIPTION
This works similarly to audio calibration except it fades out the audio when auto video calibration is active.

Users cannot calibrate both audio and video calibration at the same time and the UI will prevent it

Video:


https://github.com/user-attachments/assets/6c40d202-65e0-4240-ba9a-6641748a5f74



