### PR TITLE
Allow adjusting the start and end practice positions using the arrow keys and mouse scroll wheel

### DIFF
--- a/Assets/Script/Gameplay/HUD/Pause/GenericPause.cs
+++ b/Assets/Script/Gameplay/HUD/Pause/GenericPause.cs
@@ -27,7 +27,7 @@ namespace YARG.Gameplay.HUD
             }, false));
         }
 
-        private void OnDisable()
+        protected virtual void OnDisable()
         {
             Navigator.Instance.PopScheme();
         }

--- a/Assets/Script/Gameplay/HUD/Pause/PracticePause.cs
+++ b/Assets/Script/Gameplay/HUD/Pause/PracticePause.cs
@@ -1,6 +1,8 @@
 using System;
 using TMPro;
 using UnityEngine;
+using YARG.Core.Input;
+using YARG.Menu.Navigation;
 
 namespace YARG.Gameplay.HUD
 {
@@ -12,11 +14,46 @@ namespace YARG.Gameplay.HUD
         [SerializeField]
         private TextMeshProUGUI _bPositionText;
 
+        private NavigatableBehaviour _aPositionNav;
+        private NavigatableBehaviour _bPositionNav;
+
         protected override void OnEnable()
         {
-            base.OnEnable();
+            // Cache navigatable references for the A/B position buttons
+            _aPositionNav ??= _aPositionText.GetComponentInParent<NavigatableBehaviour>();
+            _bPositionNav ??= _bPositionText.GetComponentInParent<NavigatableBehaviour>();
+
+            // Push scheme with Left/Right for position adjustment (replaces base.OnEnable scheme)
+            Navigator.Instance.PushScheme(new NavigationScheme(new()
+            {
+                NavigationScheme.Entry.NavigateSelect,
+                new NavigationScheme.Entry(MenuAction.Red, "Menu.Common.Back", Back),
+                NavigationScheme.Entry.NavigateUp,
+                NavigationScheme.Entry.NavigateDown,
+                new NavigationScheme.Entry(MenuAction.Left, "Menu.Common.Decrease", () => AdjustSelectedPosition(-1.0)),
+                new NavigationScheme.Entry(MenuAction.Right, "Menu.Common.Increase", () => AdjustSelectedPosition(1.0)),
+            }, false));
 
             UpdatePositionText();
+        }
+
+        private void AdjustSelectedPosition(double deltaSeconds)
+        {
+            var selected = NavigationGroup.CurrentNavigationGroup?.SelectedBehaviour;
+            if (selected == null) return;
+
+            if (selected == _aPositionNav)
+            {
+                double newTime = Math.Max(0, GameManager.PracticeManager.TimeStart + deltaSeconds);
+                GameManager.PracticeManager.SetAPosition(newTime);
+                UpdatePositionText();
+            }
+            else if (selected == _bPositionNav)
+            {
+                double newTime = Math.Max(0, GameManager.PracticeManager.TimeEnd + deltaSeconds);
+                GameManager.PracticeManager.SetBPosition(newTime);
+                UpdatePositionText();
+            }
         }
 
         public void SetAPosition()

--- a/Assets/Script/Gameplay/HUD/Pause/PracticePause.cs
+++ b/Assets/Script/Gameplay/HUD/Pause/PracticePause.cs
@@ -25,8 +25,14 @@ namespace YARG.Gameplay.HUD
         protected override void OnEnable()
         {
             // Cache navigatable references for the A/B position buttons
-            _aPositionNav ??= _aPositionText.GetComponentInParent<NavigatableBehaviour>();
-            _bPositionNav ??= _bPositionText.GetComponentInParent<NavigatableBehaviour>();
+            if (_aPositionNav == null)
+            {
+                _aPositionNav = _aPositionText.GetComponentInParent<NavigatableBehaviour>();
+            }
+            if (_bPositionNav == null)
+            {
+                _bPositionNav = _bPositionText.GetComponentInParent<NavigatableBehaviour>();
+            }
 
             // Push scheme with Left/Right for position adjustment (replaces base.OnEnable scheme)
             Navigator.Instance.PushScheme(new NavigationScheme(new()
@@ -66,8 +72,17 @@ namespace YARG.Gameplay.HUD
 
         private void AdjustSelectedPosition(double deltaSeconds)
         {
-            var selected = NavigationGroup.CurrentNavigationGroup?.SelectedBehaviour;
-            if (selected == null) return;
+            var group = NavigationGroup.CurrentNavigationGroup;
+            if (group == null)
+            {
+                return;
+            }
+
+            var selected = group.SelectedBehaviour;
+            if (selected == null)
+            {
+                return;
+            }
 
             if (selected == _aPositionNav)
             {

--- a/Assets/Script/Gameplay/HUD/Pause/PracticePause.cs
+++ b/Assets/Script/Gameplay/HUD/Pause/PracticePause.cs
@@ -34,18 +34,32 @@ namespace YARG.Gameplay.HUD
                 _bPositionNav = _bPositionText.GetComponentInParent<NavigatableBehaviour>();
             }
 
-            // Push scheme with Left/Right for position adjustment (replaces base.OnEnable scheme)
-            Navigator.Instance.PushScheme(new NavigationScheme(new()
-            {
-                NavigationScheme.Entry.NavigateSelect,
-                new NavigationScheme.Entry(MenuAction.Red, "Menu.Common.Back", Back),
-                NavigationScheme.Entry.NavigateUp,
-                NavigationScheme.Entry.NavigateDown,
-                new NavigationScheme.Entry(MenuAction.Left, "Menu.Common.Decrease", () => AdjustSelectedPosition(-1.0)),
-                new NavigationScheme.Entry(MenuAction.Right, "Menu.Common.Increase", () => AdjustSelectedPosition(1.0)),
-            }, false));
+            // Use base scheme for standard navigation (Select, Back, Up, Down)
+            base.OnEnable();
+
+            // Handle Left/Right via NavigationEvent so they don't appear in the help bar
+            Navigator.Instance.NavigationEvent += OnNavigationEvent;
 
             UpdatePositionText();
+        }
+
+        protected override void OnDisable()
+        {
+            Navigator.Instance.NavigationEvent -= OnNavigationEvent;
+            base.OnDisable();
+        }
+
+        private void OnNavigationEvent(NavigationContext ctx)
+        {
+            switch (ctx.Action)
+            {
+                case MenuAction.Left:
+                    AdjustSelectedPosition(-1.0);
+                    break;
+                case MenuAction.Right:
+                    AdjustSelectedPosition(1.0);
+                    break;
+            }
         }
 
         private void Update()
@@ -86,12 +100,14 @@ namespace YARG.Gameplay.HUD
 
             if (selected == _aPositionNav)
             {
-                double newTime = Math.Max(0, GameManager.PracticeManager.TimeStart + deltaSeconds);
+                double newTime = Math.Min(GameManager.SongLength,
+                    Math.Max(0, GameManager.PracticeManager.TimeStart + deltaSeconds));
                 GameManager.PracticeManager.SetAPosition(newTime);
             }
             else if (selected == _bPositionNav)
             {
-                double newTime = Math.Max(0, GameManager.PracticeManager.TimeEnd + deltaSeconds);
+                double newTime = Math.Min(GameManager.SongLength,
+                    Math.Max(0, GameManager.PracticeManager.TimeEnd + deltaSeconds));
                 GameManager.PracticeManager.SetBPosition(newTime);
             }
             else

--- a/Assets/Script/Gameplay/HUD/Pause/PracticePause.cs
+++ b/Assets/Script/Gameplay/HUD/Pause/PracticePause.cs
@@ -1,6 +1,7 @@
 using System;
 using TMPro;
 using UnityEngine;
+using UnityEngine.InputSystem;
 using YARG.Core.Input;
 using YARG.Menu.Navigation;
 
@@ -14,8 +15,12 @@ namespace YARG.Gameplay.HUD
         [SerializeField]
         private TextMeshProUGUI _bPositionText;
 
+        private const float SCROLL_TIME = 1f / 60f;
+        private const double SCROLL_ADJUST_SECONDS = 5.0;
+
         private NavigatableBehaviour _aPositionNav;
         private NavigatableBehaviour _bPositionNav;
+        private float _scrollTimer;
 
         protected override void OnEnable()
         {
@@ -35,6 +40,28 @@ namespace YARG.Gameplay.HUD
             }, false));
 
             UpdatePositionText();
+        }
+
+        private void Update()
+        {
+            if (_scrollTimer > 0f)
+            {
+                _scrollTimer -= Time.unscaledDeltaTime;
+                return;
+            }
+
+            var delta = Mouse.current.scroll.ReadValue().y * Time.unscaledDeltaTime;
+
+            if (delta > 0f)
+            {
+                AdjustSelectedPosition(SCROLL_ADJUST_SECONDS);
+                _scrollTimer = SCROLL_TIME;
+            }
+            else if (delta < 0f)
+            {
+                AdjustSelectedPosition(-SCROLL_ADJUST_SECONDS);
+                _scrollTimer = SCROLL_TIME;
+            }
         }
 
         private void AdjustSelectedPosition(double deltaSeconds)

--- a/Assets/Script/Gameplay/HUD/Pause/PracticePause.cs
+++ b/Assets/Script/Gameplay/HUD/Pause/PracticePause.cs
@@ -73,14 +73,18 @@ namespace YARG.Gameplay.HUD
             {
                 double newTime = Math.Max(0, GameManager.PracticeManager.TimeStart + deltaSeconds);
                 GameManager.PracticeManager.SetAPosition(newTime);
-                UpdatePositionText();
             }
             else if (selected == _bPositionNav)
             {
                 double newTime = Math.Max(0, GameManager.PracticeManager.TimeEnd + deltaSeconds);
                 GameManager.PracticeManager.SetBPosition(newTime);
-                UpdatePositionText();
             }
+            else
+            {
+                return;
+            }
+
+            UpdatePositionText();
         }
 
         public void SetAPosition()

--- a/Assets/Script/Gameplay/PracticeManager.cs
+++ b/Assets/Script/Gameplay/PracticeManager.cs
@@ -63,8 +63,10 @@ namespace YARG.Gameplay
                 return;
             }
 
+            // Reset when A/B positions were adjusted (e.g. from the pause menu) so that
+            // stats are cleared and the song seeks to the updated start position on resume.
             double endPoint = TimeEnd + (SECTION_RESTART_DELAY * GameManager.SongSpeed);
-            if (GameManager.SongTime >= endPoint)
+            if (HasUpdatedAbPositions || GameManager.SongTime >= endPoint)
             {
                 ResetPractice();
             }


### PR DESCRIPTION
The start and end practice positions can now be adjusted 1 second by navigating to the appropriate menu item and pressing buttons bound to Menu.Decrease and Menu.Increase.  Menu.Decrease and Menu.Increase were previously ignored in this context.

Likewise, the positions can now be adjusted 5 seconds by navigating to the appropriate menu item and scrolling forwards or backwards with the mouse scroll wheel.  The code in PracticeSectionMenu.cs was used as a model for these changes.

This code change also fixes a minor bug.  Previously setting the start or end position to the current strike line did not reset the HUD statistics.  Now it does.