### PR TITLE
Small UI Tweaks, Round 1

### DIFF
--- a/Assets/Script/Helpers/Extensions/ImageExtensions.cs
+++ b/Assets/Script/Helpers/Extensions/ImageExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using Cysharp.Threading.Tasks;
@@ -62,14 +63,34 @@ namespace YARG.Helpers.Extensions
             return texture;
         }
 
-        private static SongEntry _current = null;
+        private sealed class AlbumCoverRequestState
+        {
+            public int RequestId;
+            public SongEntry SongEntry;
+        }
+
+        private static readonly Dictionary<int, AlbumCoverRequestState> _currentByImage = new();
         public static async void LoadAlbumCover(this RawImage rawImage, SongEntry songEntry, CancellationToken cancellationToken, float alpha = 1)
         {
-            _current = songEntry;
+            if (rawImage == null)
+            {
+                return;
+            }
+
+            var instanceId = rawImage.GetInstanceID();
+            if (!_currentByImage.TryGetValue(instanceId, out var state))
+            {
+                state = new AlbumCoverRequestState();
+                _currentByImage[instanceId] = state;
+            }
+
+            state.RequestId++;
+            state.SongEntry = songEntry;
+            var requestId = state.RequestId;
             using var image = await UniTask.RunOnThreadPool(songEntry.LoadAlbumData);
             // Everything that happens after this conditional should only happen *once*
             // There's no reason to create and destroy texture objects if they're just gonna be overriden
-            if (_current != songEntry)
+            if (!_currentByImage.TryGetValue(instanceId, out state) || state.RequestId != requestId || state.SongEntry != songEntry)
             {
                 return;
             }
@@ -79,7 +100,12 @@ namespace YARG.Helpers.Extensions
                 // Dispose of the old texture (prevent memory leaks)
                 UnityEngine.Object.Destroy(rawImage.texture);
 
-                if (image != null && !cancellationToken.IsCancellationRequested)
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    return;
+                }
+
+                if (image != null)
                 {
                     rawImage.texture = image.LoadTexture(false);
                     rawImage.uvRect = new Rect(0f, 0f, 1f, -1f);

--- a/Assets/Script/Helpers/Extensions/ImageExtensions.cs
+++ b/Assets/Script/Helpers/Extensions/ImageExtensions.cs
@@ -15,6 +15,22 @@ namespace YARG.Helpers.Extensions
 {
     public static class ImageExtensions
     {
+        private sealed class AlbumCoverRequestTracker : MonoBehaviour
+        {
+            private RawImage _rawImage;
+
+            public void Initialize(RawImage rawImage)
+            {
+                _rawImage = rawImage;
+            }
+
+            private void OnDestroy()
+            {
+                if (_rawImage != null)
+                    ClearRequest(_rawImage);
+            }
+        }
+
         public static Texture2D LoadTexture(this YARGImage image, bool mips)
         {
             var gfxFormat = image.Format switch
@@ -70,12 +86,23 @@ namespace YARG.Helpers.Extensions
         }
 
         private static readonly Dictionary<int, AlbumCoverRequestState> _currentByImage = new();
+
+        private static void ClearRequest(RawImage rawImage)
+        {
+            if (rawImage == null) return;
+
+            _currentByImage.Remove(rawImage.GetInstanceID());
+        }
+
         public static async void LoadAlbumCover(this RawImage rawImage, SongEntry songEntry, CancellationToken cancellationToken, float alpha = 1)
         {
-            if (rawImage == null)
-            {
-                return;
-            }
+            if (rawImage == null) return;
+
+            var tracker = rawImage.GetComponent<AlbumCoverRequestTracker>();
+            if (tracker == null)
+                tracker = rawImage.gameObject.AddComponent<AlbumCoverRequestTracker>();
+            
+            tracker.Initialize(rawImage);
 
             var instanceId = rawImage.GetInstanceID();
             if (!_currentByImage.TryGetValue(instanceId, out var state))
@@ -100,10 +127,7 @@ namespace YARG.Helpers.Extensions
                 // Dispose of the old texture (prevent memory leaks)
                 UnityEngine.Object.Destroy(rawImage.texture);
 
-                if (cancellationToken.IsCancellationRequested)
-                {
-                    return;
-                }
+                if (cancellationToken.IsCancellationRequested) return;
 
                 if (image != null)
                 {

--- a/Assets/Script/Menu/Common/ListMenu/ListMenu.cs
+++ b/Assets/Script/Menu/Common/ListMenu/ListMenu.cs
@@ -163,6 +163,18 @@ namespace YARG.Menu.ListMenu
 
         private void UpdateScrollbar()
         {
+            // Avoid hard crash when loading an empty list
+            if (_scrollbar == null)
+            {
+                return;
+            }
+
+            if (_viewList == null || _viewList.Count == 0)
+            {
+                _scrollbar.SetValueWithoutNotify(0f);
+                return;
+            }
+
             _scrollbar.SetValueWithoutNotify((float) SelectedIndex / _viewList.Count);
         }
 
@@ -170,6 +182,7 @@ namespace YARG.Menu.ListMenu
         {
             _viewList = CreateViewList();
             RefreshViewsObjects();
+            UpdateScrollbar();
         }
 
         protected abstract List<TViewType> CreateViewList();

--- a/Assets/Script/Menu/Common/ListMenu/ListMenu.cs
+++ b/Assets/Script/Menu/Common/ListMenu/ListMenu.cs
@@ -164,10 +164,7 @@ namespace YARG.Menu.ListMenu
         private void UpdateScrollbar()
         {
             // Avoid hard crash when loading an empty list
-            if (_scrollbar == null)
-            {
-                return;
-            }
+            if (_scrollbar == null) return;
 
             if (_viewList == null || _viewList.Count == 0)
             {

--- a/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
+++ b/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
@@ -711,7 +711,7 @@ namespace YARG.Menu.MusicLibrary
             // keep selection stable when the search text changes
             if (!PlaylistMode && searchChanged)
             {
-                // jump to top when tightening search
+                // jump to top when tightening search (adding characters)
                 if (searchExpanded)
                 {
                     _currentSong = null;
@@ -734,7 +734,7 @@ namespace YARG.Menu.MusicLibrary
                         OnSelectedIndexChanged();
                     }
                 }
-                // jump to most recent song when widening search
+                // jump to most recent song when widening search (removing characters)
                 else if (previousSelectedSong != null)
                 {
                     if (!SetIndexTo(i => i is SongViewType view && view.SongEntry == previousSelectedSong, _primaryHeaderIndex))

--- a/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
+++ b/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
@@ -708,8 +708,10 @@ namespace YARG.Menu.MusicLibrary
                 EnsureValidSelectionAfterFilter();
             }
 
+            // keep selection stable when the search text changes
             if (!PlaylistMode && searchChanged)
             {
+                // jump to top when tightening search
                 if (searchExpanded)
                 {
                     _currentSong = null;
@@ -732,6 +734,7 @@ namespace YARG.Menu.MusicLibrary
                         OnSelectedIndexChanged();
                     }
                 }
+                // jump to most recent song when widening search
                 else if (previousSelectedSong != null)
                 {
                     if (!SetIndexTo(i => i is SongViewType view && view.SongEntry == previousSelectedSong, _primaryHeaderIndex))

--- a/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
+++ b/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
@@ -477,8 +477,9 @@ namespace YARG.Menu.MusicLibrary
                         list.Add(new CategoryViewType(key, _recommendedSongs.Length, _recommendedSongs,
                             () =>
                             {
-                                SetRecommendedSongs();
-                                RefreshAndReselect();
+                                bool selectTopOfList = CurrentSelection is SongViewType songView &&
+                                    _recommendedSongs.Contains(songView.SongEntry);
+                                RefreshAndReselect(selectTopOfList);
                             }
                         ));
 
@@ -977,11 +978,21 @@ namespace YARG.Menu.MusicLibrary
             } while (CurrentSelection is not SongViewType);
         }
 
-        public void RefreshAndReselect()
+        public void RefreshAndReselect(bool selectTopOfList = false)
         {
             int index = SelectedIndex;
             var previousSong = _currentSong;
             Refresh();
+
+            if (selectTopOfList)
+            {
+                if (SetIndexToFirstRecommendedSong()) return;
+
+                if (SetIndexTo(i => i is SongViewType)) return;
+
+                SelectedIndex = 0;
+                return;
+            }
 
             if (previousSong != null &&
                 SetIndexTo(i => i is SongViewType view && view.SongEntry.SortBasedLocation == previousSong.SortBasedLocation, _primaryHeaderIndex))
@@ -995,6 +1006,15 @@ namespace YARG.Menu.MusicLibrary
             }
 
             SelectedIndex = index;
+        }
+
+        private bool SetIndexToFirstRecommendedSong()
+        {
+            if (_recommendedSongs == null || _recommendedSongs.Length == 0)
+                return false;
+
+            var recommendedSet = new HashSet<SongEntry>(_recommendedSongs);
+            return SetIndexTo(i => i is SongViewType view && recommendedSet.Contains(view.SongEntry));
         }
 
         public void RefreshSidebar()

--- a/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
+++ b/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
@@ -231,6 +231,9 @@ namespace YARG.Menu.MusicLibrary
 
             PlayerContainer.PlayerAdded += OnPlayerAdded;
             PlayerContainer.PlayerRemoved += OnPlayerRemoved;
+
+            // Ensure the sidebar is rendered correctly on first entry
+            _sidebar.UpdateSidebar(true);
         }
 
         private void SetRefreshIfNeeded()
@@ -616,6 +619,9 @@ namespace YARG.Menu.MusicLibrary
                 return;
             }
 
+            string previousSearch = _currentSearch;
+            SongEntry previousSelectedSong = (CurrentSelection as SongViewType)?.SongEntry;
+            int previousSelectedIndex = SelectedIndex;
             if (!PlaylistMode)
             {
                 _sortedSongs = _searchField.Search(SettingsManager.Settings.LibrarySort);
@@ -644,7 +650,13 @@ namespace YARG.Menu.MusicLibrary
                 _searchField.gameObject.SetActive(false);
             }
 
-            if (_reloadState != MusicLibraryReloadState.Partial)
+            string currentSearch = _searchField.FullSearchQuery;
+            bool searchChanged = !PlaylistMode &&
+                !string.Equals(previousSearch, currentSearch, StringComparison.Ordinal);
+            bool searchExpanded = !PlaylistMode && currentSearch.Length > previousSearch.Length;
+            _currentSearch = currentSearch;
+
+            if (_reloadState != MusicLibraryReloadState.Partial && !searchChanged)
             {
                 int newPositionStartIndex = 0;
                 if (_recommendedSongs != null)
@@ -693,6 +705,39 @@ namespace YARG.Menu.MusicLibrary
             if (shouldApplyFilters)
             {
                 EnsureValidSelectionAfterFilter();
+            }
+
+            if (!PlaylistMode && searchChanged)
+            {
+                if (searchExpanded)
+                {
+                    _currentSong = null;
+                    int targetIndex = 0;
+                    for (int i = _primaryHeaderIndex; i < ViewList.Count; i++)
+                    {
+                        if (ViewList[i] is SongViewType)
+                        {
+                            targetIndex = i;
+                            break;
+                        }
+                    }
+
+                    if (SelectedIndex != targetIndex)
+                    {
+                        SelectedIndex = targetIndex;
+                    }
+                    else
+                    {
+                        OnSelectedIndexChanged();
+                    }
+                }
+                else if (previousSelectedSong != null)
+                {
+                    if (!SetIndexTo(i => i is SongViewType view && view.SongEntry == previousSelectedSong, _primaryHeaderIndex))
+                    {
+                        SelectedIndex = Mathf.Clamp(previousSelectedIndex, 0, ViewList.Count - 1);
+                    }
+                }
             }
         }
 

--- a/Assets/Script/Menu/MusicLibrary/Sidebar.cs
+++ b/Assets/Script/Menu/MusicLibrary/Sidebar.cs
@@ -294,7 +294,7 @@ namespace YARG.Menu.MusicLibrary
         private static void SetWrappedText(GameObject container, TextMeshProUGUI label, string text, ref float baseFontSize)
         {
             const int maxCharsBeforeShrink = 36; // number of characters before we shrink the text
-            const int maxCharsBeforeWrap = 48;   // number of characters before we wrap the text
+            const int maxCharsBeforeWrap = 45;   // number of characters before we wrap the text
             const float shrinkFactor = 0.8f;     // percentage to shrink the font by after shrink threshold
 
             if (string.IsNullOrEmpty(text))

--- a/Assets/Script/Menu/MusicLibrary/Sidebar.cs
+++ b/Assets/Script/Menu/MusicLibrary/Sidebar.cs
@@ -8,6 +8,7 @@ using UnityEngine.UI;
 using YARG.Core;
 using YARG.Core.Input;
 using YARG.Core.Song;
+using YARG.Core.Utility;
 using YARG.Helpers.Extensions;
 using YARG.Menu.Navigation;
 using YARG.Menu.Persistent;
@@ -102,6 +103,8 @@ namespace YARG.Menu.MusicLibrary
         private readonly Color _filledFavoritesHeart = new Color(255 / 255f, 89 / 255f, 119 / 255f);
 
         private float _albumBaseFontSize;
+        private float _charterBaseFontSize;
+        private float _sourceBaseFontSize;
 
         public void Initialize(MusicLibraryMenu musicLibraryMenu, SongSearchingField songSearchingField)
         {
@@ -138,7 +141,7 @@ namespace YARG.Menu.MusicLibrary
                 _filledFavoritesHeart : _unfilledFavoritesHeart;
         }
 
-        public void UpdateSidebar()
+        public void UpdateSidebar(bool force = false)
         {
             if (_musicLibraryMenu.ViewList.Count <= 0)
             {
@@ -146,7 +149,7 @@ namespace YARG.Menu.MusicLibrary
             }
 
             var viewType = _musicLibraryMenu.CurrentSelection;
-            if (_currentView != null && _currentView == viewType)
+            if (!force && _currentView != null && _currentView == viewType)
                 return;
 
             _currentView = viewType;
@@ -231,10 +234,9 @@ namespace YARG.Menu.MusicLibrary
         {
             var songEntry = songViewType.SongEntry;
 
-            _albumTitleContainer.SetActive(true);
-            SetAlbumNameFont(songEntry.Album);
-            SetText(_sourceContainer, _source, SongSources.SourceToGameName(songEntry.Source));
-            SetText(_charterContainer, _charter, songEntry.Charter);
+            SetWrappedText(_albumTitleContainer, _album, songEntry.Album, ref _albumBaseFontSize);
+            SetWrappedText(_sourceContainer, _source, SongSources.SourceToGameName(songEntry.Source), ref _sourceBaseFontSize);
+            SetWrappedText(_charterContainer, _charter, songEntry.Charter, ref _charterBaseFontSize);
 
             _genreContainer.SetActive(true); // Empty genres are rendered as "Unknown Genre", so this should always be active
             _genre.text = CurrentCulture.TextInfo.ToTitleCase(songEntry.Genre) + (songEntry.Subgenre == string.Empty ? "" : ",");
@@ -288,27 +290,42 @@ namespace YARG.Menu.MusicLibrary
             _albumCoverSmall.LoadAlbumCover(songEntry, _cancellationToken.Token);
         }
 
-        // Wrap and shrink album name if it's too long to fit in the sidebar
-        private void SetAlbumNameFont(string albumText)
+        // Wrap and shrink long sidebar fields (album/source/charter) if they are too long to fit
+        private static void SetWrappedText(GameObject container, TextMeshProUGUI label, string text, ref float baseFontSize)
         {
-            const int maxCharsBeforeShrink = 40; // number of characters before we shrink the text
-            const int maxCharsBeforeWrap = 50;   // number of characters before we wrap the text
+            const int maxCharsBeforeShrink = 36; // number of characters before we shrink the text
+            const int maxCharsBeforeWrap = 48;   // number of characters before we wrap the text
             const float shrinkFactor = 0.8f;     // percentage to shrink the font by after shrink threshold
 
-            if (_albumBaseFontSize <= 0f)
-                _albumBaseFontSize = _album.fontSize > 0f ? _album.fontSize : 20f;
+            if (string.IsNullOrEmpty(text))
+            {
+                container.SetActive(false);
+                label.text = string.Empty;
+                return;
+            }
 
-            var displayText = albumText ?? string.Empty;
+            container.SetActive(true);
 
-            _album.enableAutoSizing = false;
-            _album.textWrappingMode = TextWrappingModes.Normal;
-            _album.overflowMode = TextOverflowModes.Overflow;
-            _album.fontSize = _albumBaseFontSize;
+            if (baseFontSize <= 0f)
+            {
+                if (label.enableAutoSizing && label.fontSizeMax > 0f)
+                    baseFontSize = label.fontSizeMax;
+                else
+                    baseFontSize = label.fontSize > 0f ? label.fontSize : 20f;
+            }
 
-            if (displayText.Length > maxCharsBeforeShrink)
-                _album.fontSize = _albumBaseFontSize * shrinkFactor;
+            var measureText = RichTextUtils.StripRichTextTags(text);
+            var displayText = text;
 
-            if (displayText.Length > maxCharsBeforeWrap && !displayText.Contains('\n'))
+            label.enableAutoSizing = false;
+            label.textWrappingMode = TextWrappingModes.Normal;
+            label.overflowMode = TextOverflowModes.Overflow;
+            label.fontSize = baseFontSize;
+
+            if (measureText.Length > maxCharsBeforeShrink)
+                label.fontSize = baseFontSize * shrinkFactor;
+
+            if (measureText.Length > maxCharsBeforeWrap && !displayText.Contains('\n'))
             {
                 var wrapIndex = displayText.LastIndexOf(' ', maxCharsBeforeWrap);
                 if (wrapIndex <= 0 || wrapIndex >= displayText.Length - 1)
@@ -317,7 +334,7 @@ namespace YARG.Menu.MusicLibrary
                 displayText = displayText[..wrapIndex].TrimEnd() + "\n" + displayText[wrapIndex..].TrimStart();
             }
 
-            _album.text = displayText;
+            label.text = displayText;
         }
 
         private void UpdateDifficulties(SongEntry entry)

--- a/Assets/Script/Menu/MusicLibrary/Sidebar.cs
+++ b/Assets/Script/Menu/MusicLibrary/Sidebar.cs
@@ -286,7 +286,6 @@ namespace YARG.Menu.MusicLibrary
 
             _cancellationToken = new();
             _albumCover.LoadAlbumCover(songEntry, _cancellationToken.Token, 0.025f);
-            _cancellationToken = new();
             _albumCoverSmall.LoadAlbumCover(songEntry, _cancellationToken.Token);
         }
 

--- a/Assets/Script/Menu/MusicLibrary/Sidebar.cs
+++ b/Assets/Script/Menu/MusicLibrary/Sidebar.cs
@@ -148,11 +148,11 @@ namespace YARG.Menu.MusicLibrary
                 return;
             }
 
-            var viewType = _musicLibraryMenu.CurrentSelection;
-            if (!force && _currentView != null && _currentView == viewType)
+            var selected = _musicLibraryMenu.CurrentSelection;
+            if (!force && _currentView != null && _currentView == selected)
                 return;
 
-            _currentView = viewType;
+            _currentView = selected;
 
             // Cancel album art
             if (_cancellationToken != null)
@@ -162,7 +162,7 @@ namespace YARG.Menu.MusicLibrary
                 _cancellationToken = null;
             }
 
-            switch (viewType)
+            switch (selected)
             {
                 case SongViewType songViewType:
                     ShowSongInfo(songViewType);
@@ -296,14 +296,13 @@ namespace YARG.Menu.MusicLibrary
             const int maxCharsBeforeWrap = 45;   // number of characters before we wrap the text
             const float shrinkFactor = 0.8f;     // percentage to shrink the font by after shrink threshold
 
+            container.SetActive(true);
+            
             if (string.IsNullOrEmpty(text))
             {
-                container.SetActive(false);
                 label.text = string.Empty;
                 return;
             }
-
-            container.SetActive(true);
 
             if (baseFontSize <= 0f)
             {

--- a/Assets/Script/Menu/MusicLibrary/SongSearchingField.cs
+++ b/Assets/Script/Menu/MusicLibrary/SongSearchingField.cs
@@ -48,6 +48,7 @@ namespace YARG.Menu.MusicLibrary
         public bool IsSearching => !string.IsNullOrEmpty(_fullSearchQuery);
         public bool IsCurrentSearchInField => _searchQueries[_currentSearchFilter] == _searchField.text;
         public bool IsUnspecified => _searchContext.IsUnspecified();
+        public string FullSearchQuery => _fullSearchQuery;
 
         public event Action<bool> OnSearchQueryUpdated;
 


### PR DESCRIPTION
- Show scrollbar thumb on first load and proper default "empty" `Sidebar` content
- When typing in search, force `MusicLibraryMenu` to first song position when adding text, or last song position when removing text.  **In other words: 1)** When adding more text to the search bar, make sure we stay at the top (first result), which is the most likely match.  **2)** When removing text (backspace/delete) from the search bar, stay on the last song position we were on.  This will be useful when sorting by artist, searching for a song, remove the search bar text, and having all that artists songs in the area.
- Update `Sidebar` and preview when doing actions that move scroll position automatically (e.g. Searching, Re-scanning Songs)
- Shrink/Wrap Charter and Source with same logic for Album.  Considered Unity RichText so <color="#ff0000"> and what not get discarded when deciding when to shrink/wrap, but will still show up in the display.  Also, made length criteria slightly less to accommodate text with lots of capital "W" and not many lowercase "l".
- Fixed a race condition in album art loading and reuse the same cancellation token for both sidebar album covers.  This fixes an occasional issue when coming from `FilterMenu` to `MusicLibraryMenu` where `Sidebar` would only have the smaller foreground album art or the larger background album art, but not both.