### PR TITLE
Show note offset histogram (Continued)

### DIFF
--- a/Assets/Prefabs/Menu/ScoreScreen/ScoreCard.prefab
+++ b/Assets/Prefabs/Menu/ScoreScreen/ScoreCard.prefab
@@ -142,7 +142,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: Advanced Statistics
+  m_text: Note Offsets
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 65a8a6500dc773741bd815e54cd7c1ec, type: 2}
   m_sharedMaterial: {fileID: -8996134669666270778, guid: 65a8a6500dc773741bd815e54cd7c1ec, type: 2}
@@ -495,7 +495,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 138}
   m_Pivot: {x: 0, y: 1}
 --- !u!222 &1249978465127411411
 CanvasRenderer:
@@ -826,260 +826,6 @@ MonoBehaviour:
   m_MinHeight: 2
   m_PreferredWidth: -1
   m_PreferredHeight: 2
-  m_FlexibleWidth: -1
-  m_FlexibleHeight: -1
-  m_LayoutPriority: 1
---- !u!1 &771001000000000006
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 771001000000000007}
-  - component: {fileID: 771001000000000008}
-  - component: {fileID: 771001000000000009}
-  - component: {fileID: 771001000000000010}
-  m_Layer: 5
-  m_Name: Seperator
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &771001000000000007
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 771001000000000006}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 936862610138747247}
-  m_RootOrder: 6
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0.5, y: 1}
---- !u!222 &771001000000000008
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 771001000000000006}
-  m_CullTransparentMesh: 1
---- !u!114 &771001000000000009
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 771001000000000006}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 45b978848f334c34b84b3b3e637c8a38, type: 3}
-  m_Type: 0
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
---- !u!114 &771001000000000010
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 771001000000000006}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
-  m_IgnoreLayout: 0
-  m_MinWidth: -1
-  m_MinHeight: 2
-  m_PreferredWidth: -1
-  m_PreferredHeight: 2
-  m_FlexibleWidth: -1
-  m_FlexibleHeight: -1
-  m_LayoutPriority: 1
---- !u!1 &771001000000000001
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 771001000000000002}
-  - component: {fileID: 771001000000000003}
-  - component: {fileID: 771001000000000004}
-  - component: {fileID: 771001000000000005}
-  m_Layer: 5
-  m_Name: Note Offsets Header
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &771001000000000002
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 771001000000000001}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 936862610138747247}
-  m_RootOrder: 7
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!222 &771001000000000003
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 771001000000000001}
-  m_CullTransparentMesh: 1
---- !u!114 &771001000000000004
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 771001000000000001}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_text: Note offsets
-  m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 65a8a6500dc773741bd815e54cd7c1ec, type: 2}
-  m_sharedMaterial: {fileID: -8996134669666270778, guid: 65a8a6500dc773741bd815e54cd7c1ec,
-    type: 2}
-  m_fontSharedMaterials: []
-  m_fontMaterial: {fileID: 0}
-  m_fontMaterials: []
-  m_fontColor32:
-    serializedVersion: 2
-    rgba: 4294967295
-  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
-  m_enableVertexGradient: 0
-  m_colorMode: 3
-  m_fontColorGradient:
-    topLeft: {r: 1, g: 1, b: 1, a: 1}
-    topRight: {r: 1, g: 1, b: 1, a: 1}
-    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
-    bottomRight: {r: 1, g: 1, b: 1, a: 1}
-  m_fontColorGradientPreset: {fileID: 0}
-  m_spriteAsset: {fileID: 0}
-  m_tintAllSprites: 0
-  m_StyleSheet: {fileID: 0}
-  m_TextStyleHashCode: -1183493901
-  m_overrideHtmlColors: 0
-  m_faceColor:
-    serializedVersion: 2
-    rgba: 4294967295
-  m_fontSize: 20
-  m_fontSizeBase: 20
-  m_fontWeight: 400
-  m_enableAutoSizing: 0
-  m_fontSizeMin: 18
-  m_fontSizeMax: 72
-  m_fontStyle: 16
-  m_HorizontalAlignment: 2
-  m_VerticalAlignment: 256
-  m_textAlignment: 65535
-  m_characterSpacing: 0
-  m_wordSpacing: 0
-  m_lineSpacing: 0
-  m_lineSpacingMax: 0
-  m_paragraphSpacing: 0
-  m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
-  m_wordWrappingRatios: 0.4
-  m_overflowMode: 0
-  m_linkedTextComponent: {fileID: 0}
-  parentLinkedComponent: {fileID: 0}
-  m_enableKerning: 1
-  m_enableExtraPadding: 0
-  checkPaddingRequired: 0
-  m_isRichText: 1
-  m_parseCtrlCharacters: 1
-  m_isOrthographic: 1
-  m_isCullingEnabled: 0
-  m_horizontalMapping: 0
-  m_verticalMapping: 0
-  m_uvLineOffset: 0
-  m_geometrySortingOrder: 0
-  m_IsTextObjectScaleStatic: 0
-  m_VertexBufferAutoSizeReduction: 0
-  m_useMaxVisibleDescender: 1
-  m_pageToDisplay: 1
-  m_margin: {x: 0, y: 0, z: 0, w: 0}
-  m_isUsingLegacyAnimationComponent: 0
-  m_isVolumetricText: 0
-  m_hasFontAssetChanged: 0
-  m_baseMaterial: {fileID: 0}
-  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
---- !u!114 &771001000000000005
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 771001000000000001}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
-  m_IgnoreLayout: 0
-  m_MinWidth: -1
-  m_MinHeight: 50
-  m_PreferredWidth: -1
-  m_PreferredHeight: 50
   m_FlexibleWidth: -1
   m_FlexibleHeight: -1
   m_LayoutPriority: 1
@@ -2965,9 +2711,6 @@ RectTransform:
   - {fileID: 8193507001648788098}
   - {fileID: 107103795363976376}
   - {fileID: 7681823618586221643}
-  - {fileID: 771001000000000007}
-  - {fileID: 771001000000000002}
-  - {fileID: 7784946160505734746}
   m_Father: {fileID: 6824594073045700767}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -3440,7 +3183,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4947336598239539785, guid: 7ceadb1ec3f67f64e8ca8ca3a866cd96, type: 3}
       propertyPath: m_text
-      value: Average Offset
+      value: Average
       objectReference: {fileID: 0}
     - target: {fileID: 4947336598239539785, guid: 7ceadb1ec3f67f64e8ca8ca3a866cd96, type: 3}
       propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
@@ -3788,151 +3531,6 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 6356829577256650213, guid: 7ceadb1ec3f67f64e8ca8ca3a866cd96, type: 3}
   m_PrefabInstance: {fileID: 3651486034138356142}
   m_PrefabAsset: {fileID: 0}
---- !u!1001 &3764536066005533631
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 936862610138747247}
-    m_Modifications:
-    - target: {fileID: 4741857710018727948, guid: 7ceadb1ec3f67f64e8ca8ca3a866cd96,
-        type: 3}
-      propertyPath: m_Name
-      value: Average Offset
-      objectReference: {fileID: 0}
-    - target: {fileID: 4782872457405020691, guid: 7ceadb1ec3f67f64e8ca8ca3a866cd96,
-        type: 3}
-      propertyPath: m_Name
-      value: Average Offset Name
-      objectReference: {fileID: 0}
-    - target: {fileID: 4947336598239539785, guid: 7ceadb1ec3f67f64e8ca8ca3a866cd96,
-        type: 3}
-      propertyPath: m_text
-      value: Average
-      objectReference: {fileID: 0}
-    - target: {fileID: 5034480264797334952, guid: 7ceadb1ec3f67f64e8ca8ca3a866cd96,
-        type: 3}
-      propertyPath: m_Name
-      value: Average Offset Value
-      objectReference: {fileID: 0}
-    - target: {fileID: 6356829577256650213, guid: 7ceadb1ec3f67f64e8ca8ca3a866cd96,
-        type: 3}
-      propertyPath: m_Pivot.x
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 6356829577256650213, guid: 7ceadb1ec3f67f64e8ca8ca3a866cd96,
-        type: 3}
-      propertyPath: m_Pivot.y
-      value: 0.5
-      objectReference: {fileID: 0}
-    - target: {fileID: 6356829577256650213, guid: 7ceadb1ec3f67f64e8ca8ca3a866cd96,
-        type: 3}
-      propertyPath: m_RootOrder
-      value: 8
-      objectReference: {fileID: 0}
-    - target: {fileID: 6356829577256650213, guid: 7ceadb1ec3f67f64e8ca8ca3a866cd96,
-        type: 3}
-      propertyPath: m_AnchorMax.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6356829577256650213, guid: 7ceadb1ec3f67f64e8ca8ca3a866cd96,
-        type: 3}
-      propertyPath: m_AnchorMax.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6356829577256650213, guid: 7ceadb1ec3f67f64e8ca8ca3a866cd96,
-        type: 3}
-      propertyPath: m_AnchorMin.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6356829577256650213, guid: 7ceadb1ec3f67f64e8ca8ca3a866cd96,
-        type: 3}
-      propertyPath: m_AnchorMin.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6356829577256650213, guid: 7ceadb1ec3f67f64e8ca8ca3a866cd96,
-        type: 3}
-      propertyPath: m_SizeDelta.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6356829577256650213, guid: 7ceadb1ec3f67f64e8ca8ca3a866cd96,
-        type: 3}
-      propertyPath: m_SizeDelta.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6356829577256650213, guid: 7ceadb1ec3f67f64e8ca8ca3a866cd96,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6356829577256650213, guid: 7ceadb1ec3f67f64e8ca8ca3a866cd96,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6356829577256650213, guid: 7ceadb1ec3f67f64e8ca8ca3a866cd96,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6356829577256650213, guid: 7ceadb1ec3f67f64e8ca8ca3a866cd96,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6356829577256650213, guid: 7ceadb1ec3f67f64e8ca8ca3a866cd96,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6356829577256650213, guid: 7ceadb1ec3f67f64e8ca8ca3a866cd96,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6356829577256650213, guid: 7ceadb1ec3f67f64e8ca8ca3a866cd96,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6356829577256650213, guid: 7ceadb1ec3f67f64e8ca8ca3a866cd96,
-        type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6356829577256650213, guid: 7ceadb1ec3f67f64e8ca8ca3a866cd96,
-        type: 3}
-      propertyPath: m_AnchoredPosition.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6356829577256650213, guid: 7ceadb1ec3f67f64e8ca8ca3a866cd96,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6356829577256650213, guid: 7ceadb1ec3f67f64e8ca8ca3a866cd96,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6356829577256650213, guid: 7ceadb1ec3f67f64e8ca8ca3a866cd96,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7098550245714764604, guid: 7ceadb1ec3f67f64e8ca8ca3a866cd96,
-        type: 3}
-      propertyPath: m_text
-      value: 0 ms
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 7ceadb1ec3f67f64e8ca8ca3a866cd96, type: 3}
---- !u!224 &7784946160505734746 stripped
-RectTransform:
-  m_CorrespondingSourceObject: {fileID: 6356829577256650213, guid: 7ceadb1ec3f67f64e8ca8ca3a866cd96,
-    type: 3}
-  m_PrefabInstance: {fileID: 3764536066005533631}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &6434373414287331677
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -4207,13 +3805,17 @@ PrefabInstance:
       propertyPath: m_Name
       value: Basic
       objectReference: {fileID: 0}
+    - target: {fileID: 3586108267756431076, guid: 81863a63e0d96cf459c263ee0ea6f98e, type: 3}
+      propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 6232041351873830570, guid: 81863a63e0d96cf459c263ee0ea6f98e, type: 3}
       propertyPath: m_Size
-      value: 0.9895832
+      value: 0.94763076
       objectReference: {fileID: 0}
     - target: {fileID: 6232041351873830570, guid: 81863a63e0d96cf459c263ee0ea6f98e, type: 3}
       propertyPath: m_Value
-      value: 1.0000076
+      value: 1.0000014
       objectReference: {fileID: 0}
     - target: {fileID: 8632074353890534202, guid: 81863a63e0d96cf459c263ee0ea6f98e, type: 3}
       propertyPath: m_AnchorMax.x

--- a/Assets/Prefabs/Menu/ScoreScreen/ScoreCard.prefab
+++ b/Assets/Prefabs/Menu/ScoreScreen/ScoreCard.prefab
@@ -829,6 +829,260 @@ MonoBehaviour:
   m_FlexibleWidth: -1
   m_FlexibleHeight: -1
   m_LayoutPriority: 1
+--- !u!1 &771001000000000006
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 771001000000000007}
+  - component: {fileID: 771001000000000008}
+  - component: {fileID: 771001000000000009}
+  - component: {fileID: 771001000000000010}
+  m_Layer: 5
+  m_Name: Seperator
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &771001000000000007
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 771001000000000006}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 936862610138747247}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 1}
+--- !u!222 &771001000000000008
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 771001000000000006}
+  m_CullTransparentMesh: 1
+--- !u!114 &771001000000000009
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 771001000000000006}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 45b978848f334c34b84b3b3e637c8a38, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &771001000000000010
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 771001000000000006}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  m_IgnoreLayout: 0
+  m_MinWidth: -1
+  m_MinHeight: 2
+  m_PreferredWidth: -1
+  m_PreferredHeight: 2
+  m_FlexibleWidth: -1
+  m_FlexibleHeight: -1
+  m_LayoutPriority: 1
+--- !u!1 &771001000000000001
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 771001000000000002}
+  - component: {fileID: 771001000000000003}
+  - component: {fileID: 771001000000000004}
+  - component: {fileID: 771001000000000005}
+  m_Layer: 5
+  m_Name: Note Offsets Header
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &771001000000000002
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 771001000000000001}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 936862610138747247}
+  m_RootOrder: 7
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &771001000000000003
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 771001000000000001}
+  m_CullTransparentMesh: 1
+--- !u!114 &771001000000000004
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 771001000000000001}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Note offsets
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 65a8a6500dc773741bd815e54cd7c1ec, type: 2}
+  m_sharedMaterial: {fileID: -8996134669666270778, guid: 65a8a6500dc773741bd815e54cd7c1ec,
+    type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 20
+  m_fontSizeBase: 20
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 16
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!114 &771001000000000005
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 771001000000000001}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  m_IgnoreLayout: 0
+  m_MinWidth: -1
+  m_MinHeight: 50
+  m_PreferredWidth: -1
+  m_PreferredHeight: 50
+  m_FlexibleWidth: -1
+  m_FlexibleHeight: -1
+  m_LayoutPriority: 1
 --- !u!1 &2885240812740932814
 GameObject:
   m_ObjectHideFlags: 0
@@ -2711,6 +2965,9 @@ RectTransform:
   - {fileID: 8193507001648788098}
   - {fileID: 107103795363976376}
   - {fileID: 7681823618586221643}
+  - {fileID: 771001000000000007}
+  - {fileID: 771001000000000002}
+  - {fileID: 7784946160505734746}
   m_Father: {fileID: 6824594073045700767}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -3530,6 +3787,151 @@ PrefabInstance:
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 6356829577256650213, guid: 7ceadb1ec3f67f64e8ca8ca3a866cd96, type: 3}
   m_PrefabInstance: {fileID: 3651486034138356142}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &3764536066005533631
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 936862610138747247}
+    m_Modifications:
+    - target: {fileID: 4741857710018727948, guid: 7ceadb1ec3f67f64e8ca8ca3a866cd96,
+        type: 3}
+      propertyPath: m_Name
+      value: Average Offset
+      objectReference: {fileID: 0}
+    - target: {fileID: 4782872457405020691, guid: 7ceadb1ec3f67f64e8ca8ca3a866cd96,
+        type: 3}
+      propertyPath: m_Name
+      value: Average Offset Name
+      objectReference: {fileID: 0}
+    - target: {fileID: 4947336598239539785, guid: 7ceadb1ec3f67f64e8ca8ca3a866cd96,
+        type: 3}
+      propertyPath: m_text
+      value: Average
+      objectReference: {fileID: 0}
+    - target: {fileID: 5034480264797334952, guid: 7ceadb1ec3f67f64e8ca8ca3a866cd96,
+        type: 3}
+      propertyPath: m_Name
+      value: Average Offset Value
+      objectReference: {fileID: 0}
+    - target: {fileID: 6356829577256650213, guid: 7ceadb1ec3f67f64e8ca8ca3a866cd96,
+        type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6356829577256650213, guid: 7ceadb1ec3f67f64e8ca8ca3a866cd96,
+        type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 6356829577256650213, guid: 7ceadb1ec3f67f64e8ca8ca3a866cd96,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 8
+      objectReference: {fileID: 0}
+    - target: {fileID: 6356829577256650213, guid: 7ceadb1ec3f67f64e8ca8ca3a866cd96,
+        type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6356829577256650213, guid: 7ceadb1ec3f67f64e8ca8ca3a866cd96,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6356829577256650213, guid: 7ceadb1ec3f67f64e8ca8ca3a866cd96,
+        type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6356829577256650213, guid: 7ceadb1ec3f67f64e8ca8ca3a866cd96,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6356829577256650213, guid: 7ceadb1ec3f67f64e8ca8ca3a866cd96,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6356829577256650213, guid: 7ceadb1ec3f67f64e8ca8ca3a866cd96,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6356829577256650213, guid: 7ceadb1ec3f67f64e8ca8ca3a866cd96,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6356829577256650213, guid: 7ceadb1ec3f67f64e8ca8ca3a866cd96,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6356829577256650213, guid: 7ceadb1ec3f67f64e8ca8ca3a866cd96,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6356829577256650213, guid: 7ceadb1ec3f67f64e8ca8ca3a866cd96,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6356829577256650213, guid: 7ceadb1ec3f67f64e8ca8ca3a866cd96,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6356829577256650213, guid: 7ceadb1ec3f67f64e8ca8ca3a866cd96,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6356829577256650213, guid: 7ceadb1ec3f67f64e8ca8ca3a866cd96,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6356829577256650213, guid: 7ceadb1ec3f67f64e8ca8ca3a866cd96,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6356829577256650213, guid: 7ceadb1ec3f67f64e8ca8ca3a866cd96,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6356829577256650213, guid: 7ceadb1ec3f67f64e8ca8ca3a866cd96,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6356829577256650213, guid: 7ceadb1ec3f67f64e8ca8ca3a866cd96,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6356829577256650213, guid: 7ceadb1ec3f67f64e8ca8ca3a866cd96,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7098550245714764604, guid: 7ceadb1ec3f67f64e8ca8ca3a866cd96,
+        type: 3}
+      propertyPath: m_text
+      value: 0 ms
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7ceadb1ec3f67f64e8ca8ca3a866cd96, type: 3}
+--- !u!224 &7784946160505734746 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 6356829577256650213, guid: 7ceadb1ec3f67f64e8ca8ca3a866cd96,
+    type: 3}
+  m_PrefabInstance: {fileID: 3764536066005533631}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &6434373414287331677
 PrefabInstance:

--- a/Assets/Prefabs/Menu/ScoreScreen/VocalsScoreCard.prefab
+++ b/Assets/Prefabs/Menu/ScoreScreen/VocalsScoreCard.prefab
@@ -32,6 +32,58 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 771001000000000002, guid: 1b5d8949b9f2d7345a0fed53e687c843, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 771001000000000002, guid: 1b5d8949b9f2d7345a0fed53e687c843, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 771001000000000002, guid: 1b5d8949b9f2d7345a0fed53e687c843, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 771001000000000002, guid: 1b5d8949b9f2d7345a0fed53e687c843, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 771001000000000002, guid: 1b5d8949b9f2d7345a0fed53e687c843, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 771001000000000002, guid: 1b5d8949b9f2d7345a0fed53e687c843, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 771001000000000004, guid: 1b5d8949b9f2d7345a0fed53e687c843, type: 3}
+      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
+      value: 1801810542
+      objectReference: {fileID: 0}
+    - target: {fileID: 771001000000000007, guid: 1b5d8949b9f2d7345a0fed53e687c843, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 771001000000000007, guid: 1b5d8949b9f2d7345a0fed53e687c843, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 771001000000000007, guid: 1b5d8949b9f2d7345a0fed53e687c843, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 771001000000000007, guid: 1b5d8949b9f2d7345a0fed53e687c843, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 771001000000000007, guid: 1b5d8949b9f2d7345a0fed53e687c843, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 771001000000000007, guid: 1b5d8949b9f2d7345a0fed53e687c843, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 936862610138747247, guid: 1b5d8949b9f2d7345a0fed53e687c843, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -62,11 +114,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1007692541323341066, guid: 1b5d8949b9f2d7345a0fed53e687c843, type: 3}
       propertyPath: m_Size
-      value: 1
+      value: 0.94999987
       objectReference: {fileID: 0}
     - target: {fileID: 1007692541323341066, guid: 1b5d8949b9f2d7345a0fed53e687c843, type: 3}
       propertyPath: m_Value
-      value: 1
+      value: 1.0000015
       objectReference: {fileID: 0}
     - target: {fileID: 1516494443395727076, guid: 1b5d8949b9f2d7345a0fed53e687c843, type: 3}
       propertyPath: m_AnchorMax.y
@@ -680,6 +732,10 @@ PrefabInstance:
       propertyPath: m_IsActive
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 6250235755591835779, guid: 1b5d8949b9f2d7345a0fed53e687c843, type: 3}
+      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
+      value: 1801810542
+      objectReference: {fileID: 0}
     - target: {fileID: 6824594073045700767, guid: 1b5d8949b9f2d7345a0fed53e687c843, type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
@@ -743,6 +799,10 @@ PrefabInstance:
     - target: {fileID: 7784946160505734746, guid: 1b5d8949b9f2d7345a0fed53e687c843, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8112717922879894006, guid: 1b5d8949b9f2d7345a0fed53e687c843, type: 3}
+      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
+      value: 1801810542
       objectReference: {fileID: 0}
     - target: {fileID: 8193507001648788098, guid: 1b5d8949b9f2d7345a0fed53e687c843, type: 3}
       propertyPath: m_AnchorMax.y

--- a/Assets/Script/Menu/ScoreScreen/ScoreCards/ScoreCard.cs
+++ b/Assets/Script/Menu/ScoreScreen/ScoreCards/ScoreCard.cs
@@ -1,10 +1,9 @@
-﻿using Cysharp.Text;
+﻿using System.Collections.Generic;
 using TMPro;
 using UnityEngine;
 using UnityEngine.AddressableAssets;
 using UnityEngine.UI;
 using YARG.Helpers.Extensions;
-using YARG.Core;
 using YARG.Core.Engine;
 using YARG.Core.Extensions;
 using YARG.Core.Game;
@@ -15,6 +14,14 @@ namespace YARG.Menu.ScoreScreen
 {
     public abstract class ScoreCard<T> : MonoBehaviour, IScoreCard<T> where T : BaseStats
     {
+        private const int OFFSET_HISTOGRAM_BIN_COUNT = 35;
+        private const float OFFSET_HISTOGRAM_ABS_BOUND_MS = 70f;
+        private const float OFFSET_HISTOGRAM_TOTAL_HEIGHT = 154f;
+        private const float OFFSET_HISTOGRAM_GRAPH_HEIGHT = 132f;
+        private const float OFFSET_HISTOGRAM_AXIS_LABEL_HEIGHT = 22f;
+        private const float OFFSET_HISTOGRAM_AXIS_FONT_SIZE = 20f;
+        private const float OFFSET_HISTOGRAM_HORIZONTAL_MARGIN = 54f;
+
         [SerializeField]
         private ModifierIcon _modifierIconPrefab;
 
@@ -73,6 +80,16 @@ namespace YARG.Menu.ScoreScreen
 
 
         private ScoreCardColorizer _colorizer;
+        private GameObject _offsetHistogramObject;
+        private RectTransform _offsetHistogramRootRect;
+        private RectTransform _offsetHistogramContentRect;
+        private RectTransform _offsetHistogramGraphRect;
+        private RectTransform _offsetHistogramBarsRect;
+        private RectTransform _offsetHistogramZeroLineRect;
+        private TextMeshProUGUI _offsetHistogramLeftAxisLabel;
+        private TextMeshProUGUI _offsetHistogramCenterAxisLabel;
+        private TextMeshProUGUI _offsetHistogramRightAxisLabel;
+        private readonly List<RectTransform> _offsetHistogramBarPool = new();
 
         protected bool IsHighScore;
         protected T Stats;
@@ -145,13 +162,9 @@ namespace YARG.Menu.ScoreScreen
             _notesMissed.text = WrapWithColor(Stats.NotesMissed);
             _starpowerPhrases.text = $"{WrapWithColor(Stats.StarPowerPhrasesHit)} / {Stats.TotalStarPowerPhrases}";
             _bandBonusScore.text = WrapWithColor(Stats.BandBonusScore.ToString("N0"));
-
-            //Average offset
-            int offsetMs = Mathf.RoundToInt((float)(Stats.GetAverageOffset() * 1000.0));
-            using var offsetText = ZString.CreateStringBuilder();
-            offsetText.Append(WrapWithColor(offsetMs));
-            offsetText.Append(" ms");
-            _averageOffset.text = offsetText.ToString();
+            _averageOffset.text = WrapWithColor(
+                Mathf.RoundToInt((float) (Stats.GetAverageOffset() * 1000.0)).ToString() + " ms");
+            BuildOffsetHistogram();
 
             // Set background icon
             _instrumentIcon.sprite = Addressables
@@ -172,6 +185,327 @@ namespace YARG.Menu.ScoreScreen
                 var icon = Instantiate(_modifierIconPrefab, _modifierIconContainer);
                 icon.InitializeForModifier(modifier);
             }
+        }
+
+        private void BuildOffsetHistogram()
+        {
+            if (!TryGetHistogramSection(out var sectionContainer, out int insertIndex))
+            {
+                SetOffsetHistogramActive(false);
+                return;
+            }
+
+            var offsetSamples = Stats.GetOffsetSamples();
+            if (offsetSamples.Count == 0)
+            {
+                SetOffsetHistogramActive(false);
+                return;
+            }
+
+            float minOffsetMs = -OFFSET_HISTOGRAM_ABS_BOUND_MS;
+            float maxOffsetMs = OFFSET_HISTOGRAM_ABS_BOUND_MS;
+            int[] bins = BuildHistogramBins(offsetSamples, minOffsetMs, maxOffsetMs, out int maxCount);
+            if (maxCount <= 0)
+            {
+                SetOffsetHistogramActive(false);
+                return;
+            }
+
+            EnsureOffsetHistogramLayout(sectionContainer, insertIndex);
+            SetOffsetHistogramActive(true);
+            var layoutElement = _offsetHistogramObject.GetComponent<LayoutElement>();
+            layoutElement.preferredHeight = OFFSET_HISTOGRAM_TOTAL_HEIGHT;
+            layoutElement.minHeight = OFFSET_HISTOGRAM_TOTAL_HEIGHT;
+
+            _offsetHistogramContentRect.offsetMin = new Vector2(OFFSET_HISTOGRAM_HORIZONTAL_MARGIN, 0f);
+            _offsetHistogramContentRect.offsetMax = new Vector2(-OFFSET_HISTOGRAM_HORIZONTAL_MARGIN, 0f);
+            _offsetHistogramGraphRect.anchoredPosition = new Vector2(0f, OFFSET_HISTOGRAM_AXIS_LABEL_HEIGHT - 2f);
+            _offsetHistogramGraphRect.sizeDelta = new Vector2(0f, OFFSET_HISTOGRAM_GRAPH_HEIGHT);
+
+            float zeroAxisPosition = Mathf.InverseLerp(minOffsetMs, maxOffsetMs, 0f);
+            SetVerticalAxisLinePosition(_offsetHistogramZeroLineRect, zeroAxisPosition, 3f);
+            PopulateHistogramBars(bins, maxCount);
+            SetHistogramAxisLabels(minOffsetMs, maxOffsetMs);
+        }
+
+        private void EnsureOffsetHistogramLayout(Transform sectionContainer, int insertIndex)
+        {
+            if (_offsetHistogramObject == null)
+            {
+                CreateOffsetHistogramLayout();
+            }
+
+            _offsetHistogramRootRect.SetParent(sectionContainer, false);
+            _offsetHistogramRootRect.SetSiblingIndex(insertIndex);
+        }
+
+        private bool TryGetHistogramSection(out Transform sectionContainer, out int insertIndex)
+        {
+            sectionContainer = null;
+            insertIndex = 0;
+
+            if (_statsRect == null || _statsRect.content == null || _averageOffset == null)
+            {
+                return false;
+            }
+
+            var averageOffsetRow = _averageOffset.transform.parent;
+            if (averageOffsetRow == null)
+            {
+                return false;
+            }
+
+            sectionContainer = averageOffsetRow.parent == null ? _statsRect.content : averageOffsetRow.parent;
+            insertIndex = averageOffsetRow.GetSiblingIndex();
+            return true;
+        }
+
+        private void SetHistogramAxisLabels(float minOffsetMs, float maxOffsetMs)
+        {
+            _offsetHistogramLeftAxisLabel.fontSize = OFFSET_HISTOGRAM_AXIS_FONT_SIZE;
+            _offsetHistogramLeftAxisLabel.text = $"{Mathf.RoundToInt(minOffsetMs)} ms";
+            _offsetHistogramCenterAxisLabel.fontSize = OFFSET_HISTOGRAM_AXIS_FONT_SIZE;
+            _offsetHistogramCenterAxisLabel.text = "0";
+            _offsetHistogramRightAxisLabel.fontSize = OFFSET_HISTOGRAM_AXIS_FONT_SIZE;
+            _offsetHistogramRightAxisLabel.text = $"+{Mathf.RoundToInt(maxOffsetMs)} ms";
+        }
+
+        private void CreateOffsetHistogramLayout()
+        {
+            _offsetHistogramObject = new GameObject("Offset Histogram", typeof(RectTransform), typeof(LayoutElement));
+            _offsetHistogramRootRect = (RectTransform) _offsetHistogramObject.transform;
+
+            var contentObject = new GameObject("Content", typeof(RectTransform));
+            _offsetHistogramContentRect = (RectTransform) contentObject.transform;
+            _offsetHistogramContentRect.SetParent(_offsetHistogramRootRect, false);
+            _offsetHistogramContentRect.anchorMin = Vector2.zero;
+            _offsetHistogramContentRect.anchorMax = Vector2.one;
+
+            var graphObject = new GameObject("Graph", typeof(RectTransform));
+            _offsetHistogramGraphRect = (RectTransform) graphObject.transform;
+            _offsetHistogramGraphRect.SetParent(_offsetHistogramContentRect, false);
+            _offsetHistogramGraphRect.anchorMin = new Vector2(0f, 0f);
+            _offsetHistogramGraphRect.anchorMax = new Vector2(1f, 0f);
+            _offsetHistogramGraphRect.pivot = new Vector2(0.5f, 0f);
+
+            CreateHorizontalAxisLine(_offsetHistogramGraphRect, "XAxis", new Color(1f, 1f, 1f, 0.25f), 3f);
+            _offsetHistogramZeroLineRect = CreateVerticalAxisLine(_offsetHistogramGraphRect, "Zero",
+                new Color(1f, 1f, 1f, 0.35f), 3f);
+
+            var barsObject = new GameObject("Bars", typeof(RectTransform));
+            _offsetHistogramBarsRect = (RectTransform) barsObject.transform;
+            _offsetHistogramBarsRect.SetParent(_offsetHistogramGraphRect, false);
+            _offsetHistogramBarsRect.anchorMin = Vector2.zero;
+            _offsetHistogramBarsRect.anchorMax = Vector2.one;
+            _offsetHistogramBarsRect.offsetMin = Vector2.zero;
+            _offsetHistogramBarsRect.offsetMax = Vector2.zero;
+
+            _offsetHistogramLeftAxisLabel = CreateHistogramLabel(_offsetHistogramContentRect, "Axis Left",
+                TextAlignmentOptions.Left);
+            ConfigureAxisLabel(_offsetHistogramLeftAxisLabel);
+
+            _offsetHistogramCenterAxisLabel = CreateHistogramLabel(_offsetHistogramContentRect, "Axis Center",
+                TextAlignmentOptions.Center);
+            ConfigureAxisLabel(_offsetHistogramCenterAxisLabel);
+
+            _offsetHistogramRightAxisLabel = CreateHistogramLabel(_offsetHistogramContentRect, "Axis Right",
+                TextAlignmentOptions.Right);
+            ConfigureAxisLabel(_offsetHistogramRightAxisLabel);
+        }
+
+        private static void ConfigureAxisLabel(TextMeshProUGUI label)
+        {
+            var labelRect = label.rectTransform;
+            labelRect.anchorMin = new Vector2(0f, 0f);
+            labelRect.anchorMax = new Vector2(1f, 0f);
+            labelRect.pivot = new Vector2(0.5f, 0f);
+            labelRect.anchoredPosition = new Vector2(0f, -3f);
+            labelRect.sizeDelta = new Vector2(0f, OFFSET_HISTOGRAM_AXIS_LABEL_HEIGHT);
+        }
+
+        private void PopulateHistogramBars(IReadOnlyList<int> bins, int maxCount)
+        {
+            float barMaxHeight = OFFSET_HISTOGRAM_GRAPH_HEIGHT - 2f;
+            var barColor = _colorizer.CurrentColor;
+            barColor.a = 0.85f;
+            int barPoolIndex = 0;
+
+            Canvas.ForceUpdateCanvases();
+            LayoutRebuilder.ForceRebuildLayoutImmediate(_offsetHistogramRootRect);
+
+            float scaleFactor = GetCanvasScaleFactor(_offsetHistogramBarsRect);
+            float graphWidthUnits = _offsetHistogramBarsRect.rect.width;
+            bool canUsePixelSnapping = graphWidthUnits > 0.01f;
+            float graphWidthPixels = canUsePixelSnapping ? Mathf.Max(1f, graphWidthUnits * scaleFactor) : 0f;
+            float barBaseYPixels = Mathf.Round(1f * scaleFactor);
+            float halfGapUnits = 1f / scaleFactor * 0.5f;
+
+            for (int i = 0; i < bins.Count; i++)
+            {
+                int count = bins[i];
+                if (count <= 0)
+                {
+                    continue;
+                }
+
+                float normalizedHeight = (float) count / maxCount;
+                var barRect = GetOrCreateBar(barPoolIndex++);
+
+                if (canUsePixelSnapping)
+                {
+                    float barHeightPixels = Mathf.Max(1f, Mathf.Round(normalizedHeight * barMaxHeight * scaleFactor));
+                    float slotLeftPixels = Mathf.Round(i * graphWidthPixels / bins.Count);
+                    float slotRightPixels = Mathf.Round((i + 1f) * graphWidthPixels / bins.Count);
+                    float barLeftPixels = slotLeftPixels;
+                    float barRightPixels = slotRightPixels - 1f;
+
+                    if (barRightPixels <= barLeftPixels)
+                    {
+                        barRightPixels = Mathf.Min(graphWidthPixels, barLeftPixels + 1f);
+                    }
+
+                    if (barRightPixels <= barLeftPixels)
+                    {
+                        continue;
+                    }
+
+                    barRect.anchorMin = Vector2.zero;
+                    barRect.anchorMax = Vector2.zero;
+                    barRect.pivot = Vector2.zero;
+                    barRect.anchoredPosition = new Vector2(barLeftPixels / scaleFactor, barBaseYPixels / scaleFactor);
+                    barRect.sizeDelta = new Vector2((barRightPixels - barLeftPixels) / scaleFactor,
+                        barHeightPixels / scaleFactor);
+                }
+                else
+                {
+                    float height = Mathf.Max(1f, normalizedHeight * barMaxHeight);
+                    barRect.anchorMin = new Vector2(i / (float) bins.Count, 0f);
+                    barRect.anchorMax = new Vector2((i + 1f) / bins.Count, 0f);
+                    barRect.offsetMin = new Vector2(halfGapUnits, 1f);
+                    barRect.offsetMax = new Vector2(-halfGapUnits, 1f + height);
+                }
+
+                var image = barRect.GetComponent<Image>();
+                image.color = barColor;
+                image.raycastTarget = false;
+                barRect.gameObject.SetActive(true);
+            }
+
+            for (int i = barPoolIndex; i < _offsetHistogramBarPool.Count; i++)
+            {
+                _offsetHistogramBarPool[i].gameObject.SetActive(false);
+            }
+        }
+
+        private RectTransform GetOrCreateBar(int index)
+        {
+            while (_offsetHistogramBarPool.Count <= index)
+            {
+                var barObject = new GameObject($"Bar {_offsetHistogramBarPool.Count}", typeof(RectTransform),
+                    typeof(Image));
+                var barRect = (RectTransform) barObject.transform;
+                barRect.SetParent(_offsetHistogramBarsRect, false);
+                _offsetHistogramBarPool.Add(barRect);
+            }
+
+            return _offsetHistogramBarPool[index];
+        }
+
+        private static float GetCanvasScaleFactor(Component component)
+        {
+            var canvas = component.GetComponentInParent<Canvas>();
+            return canvas != null ? Mathf.Max(0.0001f, canvas.scaleFactor) : 1f;
+        }
+
+        private void SetOffsetHistogramActive(bool active)
+        {
+            if (_offsetHistogramObject != null && _offsetHistogramObject.activeSelf != active)
+            {
+                _offsetHistogramObject.SetActive(active);
+            }
+        }
+
+        private static int[] BuildHistogramBins(IReadOnlyList<double> offsetSamples, float minOffsetMs,
+            float maxOffsetMs, out int maxCount)
+        {
+            var bins = new int[OFFSET_HISTOGRAM_BIN_COUNT];
+            float totalRange = Mathf.Max(1f, maxOffsetMs - minOffsetMs);
+            maxCount = 0;
+
+            for (int i = 0; i < offsetSamples.Count; i++)
+            {
+                float offsetMs = Mathf.Clamp((float) (offsetSamples[i] * 1000d), minOffsetMs, maxOffsetMs);
+                float normalized = (offsetMs - minOffsetMs) / totalRange;
+                int index = Mathf.Clamp(Mathf.FloorToInt(normalized * OFFSET_HISTOGRAM_BIN_COUNT), 0,
+                    OFFSET_HISTOGRAM_BIN_COUNT - 1);
+
+                bins[index]++;
+                if (bins[index] > maxCount)
+                {
+                    maxCount = bins[index];
+                }
+            }
+
+            return bins;
+        }
+
+        private TextMeshProUGUI CreateHistogramLabel(Transform parent, string name, TextAlignmentOptions alignment)
+        {
+            var labelObject = new GameObject(name, typeof(RectTransform), typeof(TextMeshProUGUI));
+            labelObject.transform.SetParent(parent, false);
+
+            var label = labelObject.GetComponent<TextMeshProUGUI>();
+            label.font = _averageOffset.font;
+            label.fontSharedMaterial = _averageOffset.fontSharedMaterial;
+            label.color = _averageOffset.color;
+            label.enableWordWrapping = false;
+            label.richText = true;
+            label.alignment = alignment;
+            label.raycastTarget = false;
+
+            return label;
+        }
+
+        private static RectTransform CreateVerticalAxisLine(Transform parent, string name, Color color, float thickness)
+        {
+            var lineObject = new GameObject(name, typeof(RectTransform), typeof(Image));
+            var lineRect = (RectTransform) lineObject.transform;
+            lineRect.SetParent(parent, false);
+            SetVerticalAxisLinePosition(lineRect, 0.5f, thickness);
+
+            var lineImage = lineObject.GetComponent<Image>();
+            lineImage.color = color;
+            lineImage.raycastTarget = false;
+
+            return lineRect;
+        }
+
+        private static void SetVerticalAxisLinePosition(RectTransform lineRect, float normalizedX, float thickness)
+        {
+            float clampedX = Mathf.Clamp01(normalizedX);
+            float halfThickness = thickness * 0.5f;
+            lineRect.anchorMin = new Vector2(clampedX, 0f);
+            lineRect.anchorMax = new Vector2(clampedX, 1f);
+            lineRect.offsetMin = new Vector2(-halfThickness, halfThickness);
+            lineRect.offsetMax = new Vector2(halfThickness, halfThickness);
+        }
+
+        private static void CreateHorizontalAxisLine(Transform parent, string name, Color color, float thickness)
+        {
+            var lineObject = new GameObject(name, typeof(RectTransform), typeof(Image));
+            var lineRect = (RectTransform) lineObject.transform;
+            lineRect.SetParent(parent, false);
+            float clampedThickness = Mathf.Max(1f, thickness);
+            float halfThickness = clampedThickness * 0.5f;
+            float yShiftUnits = 1f / GetCanvasScaleFactor(parent);
+            lineRect.anchorMin = new Vector2(0f, 0f);
+            lineRect.anchorMax = new Vector2(1f, 0f);
+            lineRect.offsetMin = new Vector2(0f, -halfThickness - yShiftUnits);
+            lineRect.offsetMax = new Vector2(0f, halfThickness - yShiftUnits);
+
+            var lineImage = lineObject.GetComponent<Image>();
+            lineImage.color = color;
+            lineImage.raycastTarget = false;
         }
 
         private void ShowTag(string tagText)


### PR DESCRIPTION
Continuation of https://github.com/YARC-Official/YARG/pull/1302

* Rebased with dev and moved histogram to advanced score section


<img width="1514" height="851" alt="CleanShot 2026-02-20 at 13 38 40" src="https://github.com/user-attachments/assets/5bfbb62f-f1f7-4f29-962c-186ccc1dda0f" />




<img width="1515" height="855" alt="CleanShot 2026-02-20 at 13 38 32" src="https://github.com/user-attachments/assets/9cb76f9c-6746-419f-a318-7b9248c9b3c6" />



<img width="1517" height="848" alt="CleanShot 2026-02-20 at 13 37 51" src="https://github.com/user-attachments/assets/ec1832be-0e0e-445d-a1fd-93fc85b3c996" />


