### PR TITLE
More descriptive exception when attempting to build Venue / Character without MacOS build support

### DIFF
--- a/Assets/Script/Venue/BundleBackgroundManager.cs
+++ b/Assets/Script/Venue/BundleBackgroundManager.cs
@@ -164,6 +164,13 @@ namespace YARG.Venue
                         BuildTarget.StandaloneOSX);
 
                     var filePath = Path.Combine(Application.temporaryCachePath, BACKGROUND_SHADER_BUNDLE_NAME);
+
+                    if (!File.Exists(filePath))
+                    {
+                        EditorUtility.DisplayDialog("Export Unsuccessful", "Failed to build MacOS Shader bundle. See console for more info.", "OK");
+                        throw new FileNotFoundException("MacOS Shader bundle failed to build. <a href=\"https://wiki.yarg.in/wiki/Venue_Creation\">Please ensure you have the \"MacOS Build Support (Mono)\" module installed.</a>");
+                    }
+                    
                     var assetPath = Path.Combine(Application.dataPath, BACKGROUND_SHADER_BUNDLE_NAME);
                     File.Move(filePath, assetPath);
                     AssetDatabase.ImportAsset(Path.Combine("Assets", BACKGROUND_SHADER_BUNDLE_NAME));


### PR DESCRIPTION
If the `_metal_shaders.bytes` file is still missing after running BuildAssetBundles, create a log and popup guiding to the Venue Creation wiki page