### PR TITLE
Auto-set practice positions from current song position

### DIFF
--- a/Assets/Script/Gameplay/HUD/Pause/GenericPause.cs
+++ b/Assets/Script/Gameplay/HUD/Pause/GenericPause.cs
@@ -45,6 +45,7 @@ namespace YARG.Gameplay.HUD
         public void TogglePractice()
         {
             GlobalVariables.State.IsPractice = !GlobalVariables.State.IsPractice;
+            GlobalVariables.State.SavedInputTime = GameManager.InputTime;
             PauseMenuManager.Restart();
         }
 

--- a/Assets/Script/Gameplay/PracticeManager.cs
+++ b/Assets/Script/Gameplay/PracticeManager.cs
@@ -12,6 +12,7 @@ namespace YARG.Gameplay
     public class PracticeManager : GameplayBehaviour
     {
         private const double SECTION_RESTART_DELAY = 2;
+        private const double PRACTICE_ENTRY_LOOKBACK = 10; // seconds
 
         [Header("References")]
         [SerializeField]
@@ -108,26 +109,22 @@ namespace YARG.Gameplay
         {
             GameManager.Pause(showMenu: false);
 
-            if (GlobalVariables.State.SavedInputTime.HasValue)
+            var savedInputTime = GlobalVariables.State.SavedInputTime;
+            if (savedInputTime.HasValue)
             {
-                double endTime = GlobalVariables.State.SavedInputTime.Value;
-                double startTime = Math.Max(0.0, endTime - 10.0);
+                double endTime = savedInputTime.Value;
+                double startTime = Math.Max(0.0, endTime - PRACTICE_ENTRY_LOOKBACK);
 
                 var sections = _chart.Sections;
                 if (startTime < endTime && sections.Count > 0)
                 {
-                    // Fall back to sections[0] when startTime or endTime precedes the first
-                    // section — some charts have an unsectioned intro before the first marker.
-                    var startSection = sections[0].Time <= startTime
-                        ? sections.Last(s => s.Time <= startTime)
-                        : sections[0];
-                    var endSection = sections[0].Time <= endTime
-                        ? sections.Last(s => s.Time <= endTime)
-                        : sections[0];
+                    var startSection = FindSectionAtTime(startTime);
+                    var endSection = FindSectionAtTime(endTime);
                     SetPracticeSection(startSection, endSection);
                     SetAPosition(startTime);
                     SetBPosition(endTime);
-                    GameManager.SetSongTime(TimeStart, SettingsManager.Settings.PracticeRestartDelay.Value);
+                    double restartDelay = SettingsManager.Settings.PracticeRestartDelay.Value;
+                    GameManager.SetSongTime(TimeStart, restartDelay);
                     _pauseMenu.PushMenu(PauseMenuManager.Menu.PracticePause);
                     return;
                 }
@@ -259,6 +256,16 @@ namespace YARG.Gameplay
         private Section[] GetSectionsInPractice(uint start, uint end)
         {
             return _chart.Sections.Where(s => s.Tick >= start && s.TickEnd <= end).ToArray();
+        }
+        
+        private Section FindSectionAtTime(double time)
+        {
+            var sections = _chart.Sections;
+            // Fall back to sections[0] when time precedes the first section —
+            // some charts have an unsectioned intro before the first marker.
+            return sections[0].Time <= time
+                ? sections.Last(s => s.Time <= time)
+                : sections[0];
         }
     }
 }

--- a/Assets/Script/Gameplay/PracticeManager.cs
+++ b/Assets/Script/Gameplay/PracticeManager.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using UnityEngine;
 using YARG.Core.Chart;
 using YARG.Core.Input;
@@ -106,6 +107,32 @@ namespace YARG.Gameplay
         public void DisplayPracticeMenu()
         {
             GameManager.Pause(showMenu: false);
+
+            if (GlobalVariables.State.SavedInputTime.HasValue)
+            {
+                double endTime = GlobalVariables.State.SavedInputTime.Value;
+                double startTime = Math.Max(0.0, endTime - 10.0);
+
+                var sections = _chart.Sections;
+                if (startTime < endTime && sections.Count > 0)
+                {
+                    // Fall back to sections[0] when startTime or endTime precedes the first
+                    // section — some charts have an unsectioned intro before the first marker.
+                    var startSection = sections[0].Time <= startTime
+                        ? sections.Last(s => s.Time <= startTime)
+                        : sections[0];
+                    var endSection = sections[0].Time <= endTime
+                        ? sections.Last(s => s.Time <= endTime)
+                        : sections[0];
+                    SetPracticeSection(startSection, endSection);
+                    SetAPosition(startTime);
+                    SetBPosition(endTime);
+                    GameManager.SetSongTime(TimeStart, SettingsManager.Settings.PracticeRestartDelay.Value);
+                    _pauseMenu.PushMenu(PauseMenuManager.Menu.PracticePause);
+                    return;
+                }
+            }
+
             _pauseMenu.PushMenu(PauseMenuManager.Menu.SelectSections);
         }
 

--- a/Assets/Script/Persistent/PersistentState.cs
+++ b/Assets/Script/Persistent/PersistentState.cs
@@ -27,9 +27,10 @@ namespace YARG
         public          List<SongEntry> ShowSongs    { get; set; }
         public          int             ShowIndex    { get; set; }
 
-        public          bool IsPractice;
-        public readonly bool IsReplay => CurrentReplay is not null;
-        public          bool PlayingWithReplay;
+        public          bool    IsPractice;
+        public readonly bool    IsReplay => CurrentReplay is not null;
+        public          bool    PlayingWithReplay;
+        public          double? SavedInputTime;
 
     }
 }


### PR DESCRIPTION
Finding a troublesome sequence in Practice Mode is awkward.  This PR attempts to make it easier to transition from playing a song to practicing those sequences.  The idea is that after messing up a sequence, the player can pause gameplay and then enter practice mode already initialized with the current song position.  This applies to both starting a practice from the pause menu and starting a practice from the fail menu.  It does not apply when starting practice after using the Practice main menu item.

When practice mode is entered, the current song position is used for the end/B position.  The start/A position is ten seconds earlier.  The player can adjust either before starting practice.