### PR TITLE
Fix display bug for folder names in Settings menu

### DIFF
--- a/Assets/Prefabs/Menu/Settings/SongManager/SongManagerDirectory.prefab
+++ b/Assets/Prefabs/Menu/Settings/SongManager/SongManagerDirectory.prefab
@@ -257,7 +257,7 @@ MonoBehaviour:
   checkPaddingRequired: 0
   m_isRichText: 1
   m_EmojiFallbackSupport: 1
-  m_parseCtrlCharacters: 1
+  m_parseCtrlCharacters: 0
   m_isOrthographic: 1
   m_isCullingEnabled: 0
   m_horizontalMapping: 0


### PR DESCRIPTION
Probably mostly happens on windows but folder names with escape characters in them display funny in the settings menu:
<img width="1347" height="118" alt="image" src="https://github.com/user-attachments/assets/eedc4948-5833-45b2-adff-90c8f1b43843" />

With the change to not parse escape characters in the folder name text box:
<img width="691" height="70" alt="image" src="https://github.com/user-attachments/assets/f5bd792a-a728-40b4-97d5-ca2b76d0512c" />
