### PR TITLE
Fix Reggae/Ska special case in CONs

### DIFF
--- a/Assets/Script/Song/Genrelizer.Lists.cs
+++ b/Assets/Script/Song/Genrelizer.Lists.cs
@@ -87,6 +87,7 @@ namespace YARG.Song
         private const string POP_DANCE_ELECTRONIC = "pop/dance/electronic";
         private const string PROG = "prog";
         private const string REGGAE_SKA = "reggae/ska";
+        private const string REGGAE_SKA_RAW = "reggaeska"; // As rendered in raw CONs
         private const string URBAN = "urban";
 
         

--- a/Assets/Script/Song/Genrelizer.cs
+++ b/Assets/Script/Song/Genrelizer.cs
@@ -368,7 +368,7 @@ namespace YARG.Song
         private static Mapping _handleLoneGenre(string rawGenre, string artist) {
 
             // Scan up front for the Reggae/Ska special case
-            if (rawGenre.ToLower() is REGGAE_SKA)
+            if (rawGenre.ToLower() is REGGAE_SKA or REGGAE_SKA_RAW)
             {
                 return _handleReggaeSkaSpecialCase(artist);
             }


### PR DESCRIPTION
Genrelizer's Reggae/Ska special case only accounts for how the genre is rendered in MID/.chart conversions (`reggae/ska`), not in raw CONs (`reggaeska`). This fixes that by checking both renderings.