### PR TITLE
Reduce vertical padding of music library song row

### DIFF
--- a/Assets/Script/Menu/MusicLibrary/SongView.cs
+++ b/Assets/Script/Menu/MusicLibrary/SongView.cs
@@ -150,13 +150,9 @@ namespace YARG.Menu.MusicLibrary
             {
                 gameObject.GetComponent<RectTransform>().SetSizeWithCurrentAnchors(RectTransform.Axis.Vertical, 60);
             }
-            else if (viewType is ButtonViewType)
-            {
-                gameObject.GetComponent<RectTransform>().SetSizeWithCurrentAnchors(RectTransform.Axis.Vertical, 70);
-            }
             else
             {
-                gameObject.GetComponent<RectTransform>().SetSizeWithCurrentAnchors(RectTransform.Axis.Vertical, 80);
+                gameObject.GetComponent<RectTransform>().SetSizeWithCurrentAnchors(RectTransform.Axis.Vertical, 70);
             }
 
             StarAmount starHeaderAmount = StarAmount.None;


### PR DESCRIPTION
This change is very opionated so I wouldn't mind if you just close the PR as rejected. However, I think it looks a bit better this way.

Before:
<img width="3840" height="1493" alt="before" src="https://github.com/user-attachments/assets/42216044-502e-4673-be9f-019836ebb88c" />

After:
<img width="3840" height="1493" alt="after" src="https://github.com/user-attachments/assets/24577f6c-0207-46ca-9029-95386d803951" />