### PR TITLE
Enable mipmapping for song row icons to reduce texture aliasing

### DIFF
--- a/Assets/Art/Menu/Common/DifficultyIcons.png.meta
+++ b/Assets/Art/Menu/Common/DifficultyIcons.png.meta
@@ -6,7 +6,7 @@ TextureImporter:
   serializedVersion: 12
   mipmaps:
     mipMapMode: 0
-    enableMipMap: 0
+    enableMipMap: 1
     sRGBTexture: 1
     linearTexture: 0
     fadeOut: 0
@@ -35,7 +35,7 @@ TextureImporter:
     serializedVersion: 2
     filterMode: 1
     aniso: 1
-    mipBias: 0
+    mipBias: -1
     wrapU: 1
     wrapV: 1
     wrapW: 0

--- a/Assets/Art/Menu/Common/InstrumentIcons.png.meta
+++ b/Assets/Art/Menu/Common/InstrumentIcons.png.meta
@@ -6,7 +6,7 @@ TextureImporter:
   serializedVersion: 12
   mipmaps:
     mipMapMode: 1
-    enableMipMap: 0
+    enableMipMap: 1
     sRGBTexture: 1
     linearTexture: 0
     fadeOut: 0
@@ -35,7 +35,7 @@ TextureImporter:
     serializedVersion: 2
     filterMode: 1
     aniso: 1
-    mipBias: 0
+    mipBias: -1
     wrapU: 0
     wrapV: 0
     wrapW: 0

--- a/Assets/Prefabs/Menu/MusicLibrary/Instrument Difficulty.prefab
+++ b/Assets/Prefabs/Menu/MusicLibrary/Instrument Difficulty.prefab
@@ -259,10 +259,20 @@ MonoBehaviour:
   m_GameObject: {fileID: 4178860913408610405}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 31a19414c41e5ae4aae2af33fee712f6, type: 3}
+  m_Script: {fileID: 11500000, guid: 385b7d1277b6c4007a84c065696e0f8c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   m_ShowMaskGraphic: 0
+  m_MaskingMode: 1
+  m_AlphaHitTest: 0
+  m_SoftnessRange:
+    m_Min: 0
+    m_Max: 1
+  m_DownSamplingRate: 1
+  m_AntiAliasingThreshold: 0
+  m_Alpha: 1
+  m_Softness: -1
+  m_PartOfParent: 0
 --- !u!1 &4453992032869984373
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
Before:
<img width="387" height="185" alt="before" src="https://github.com/user-attachments/assets/3c5be3e3-2329-4759-a36b-e59a7cb3f7b3" />

After:
<img width="389" height="189" alt="image" src="https://github.com/user-attachments/assets/cecdca05-068c-48a0-89e3-ed36aa9e9a1f" />