### PR TITLE
Add DrumHighwayOrderingCalculators, moved HighwayOrdering logic to them

### DIFF
--- a/Assets/Prefabs/Gameplay/Visual/FiveFretGuitarVisual.prefab
+++ b/Assets/Prefabs/Gameplay/Visual/FiveFretGuitarVisual.prefab
@@ -45,7 +45,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   FretCount: 5
-  DontFlipColorsLeftyFlip: 0
   UseKickFrets: 0
   _trackWidth: 2
   _leftKickFretPosition: {fileID: 1059056642713352937}

--- a/Assets/Prefabs/Gameplay/Visual/FiveLaneKeysVisual.prefab
+++ b/Assets/Prefabs/Gameplay/Visual/FiveLaneKeysVisual.prefab
@@ -45,7 +45,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   FretCount: 5
-  DontFlipColorsLeftyFlip: 0
   UseKickFrets: 0
   _trackWidth: 2
   _leftKickFretPosition: {fileID: 1059056642713352937}

--- a/Assets/Prefabs/Gameplay/Visual/FourLaneDrumsVisual.prefab
+++ b/Assets/Prefabs/Gameplay/Visual/FourLaneDrumsVisual.prefab
@@ -45,7 +45,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   FretCount: 4
-  DontFlipColorsLeftyFlip: 1
   UseKickFrets: 1
   _trackWidth: 2
   _leftKickFretPosition: {fileID: 67120744706637061}

--- a/Assets/Script/Gameplay/Player/Drums.meta
+++ b/Assets/Script/Gameplay/Player/Drums.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: aff7ce69c84f3c1448a7f4e863934028
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Script/Gameplay/Player/Drums/DrumHighwayOrderingCalculator.cs
+++ b/Assets/Script/Gameplay/Player/Drums/DrumHighwayOrderingCalculator.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+using YARG.Core;
+using YARG.Core.Audio;
+using YARG.Core.Chart;
+using YARG.Core.Engine.Drums;
+using YARG.Core.Engine.Drums.Engines;
+using YARG.Core.Game;
+using YARG.Core.Input;
+using YARG.Core.Logging;
+using YARG.Core.Replays;
+using YARG.Gameplay.HUD;
+using YARG.Gameplay.Visuals;
+using YARG.Helpers.Extensions;
+using YARG.Player;
+using YARG.Settings;
+using YARG.Themes;
+
+namespace YARG.Gameplay.Player.Drums
+{
+    public abstract class DrumHighwayOrderingCalculator
+    {
+        /** Number of frets/display lanes to show. Does not include the kick. **/
+        public abstract int FretCount { get; }
+
+        /** True for five-lane drums, false for four-lane and four-lane pro drums. **/
+        public abstract bool IsFiveLaneMode { get; }
+
+        /** The list of all pad enum values (eg. FourFretDrumPad). **/
+        protected abstract int[] AllPads { get; }
+
+        /** Returns the drum pad enum value (eg. FourFretDrumPad) for the given DrumsAction. **/
+        public abstract int GetPad(DrumsAction action);
+
+        /** Returns the 0-based lane position for a given drum pad. **/
+        protected abstract int GetPosition(int pad);
+
+        /**
+         * Returns the color index for a given drum pad.
+         * The first index is the kick color, and the rest are the 1-indexed frets lanes.
+         * The int values returned are the ColorProfileIndex values defined in the ColorProfile classes.
+         * Note that when LeftyFlip is enabled, this method reverses the colors. This is because the lanes are switched visually,
+         * but we still want eg. the red lane to be the first lane, even when the snare is on the right.
+         **/
+        protected abstract int GetColorIndex(int pad);
+
+        public Dictionary<int, HighwayOrderingInfo> HighwayOrdering { get; private set; }
+
+        protected YargPlayer Player { get; }
+
+        protected DrumHighwayOrderingCalculator(YargPlayer player)
+        {
+            Player = player;
+            HighwayOrdering = GenerateHighwayOrdering();
+        }
+
+#region HighwayOrdering
+        private Dictionary<int, HighwayOrderingInfo> GenerateHighwayOrdering()
+        {
+            return AllPads.ToDictionary(pad => pad, GenerateHighwayOrderingInfo);
+        }
+
+        private HighwayOrderingInfo GenerateHighwayOrderingInfo(int pad)
+        {
+            return new(GetPosition(pad), GetColorIndex(pad));
+        }
+
+        public HighwayOrderingInfo GetHighwayOrderingInfo(int pad)
+        {
+            if (HighwayOrdering.TryGetValue(pad, out var info))
+            {
+                return info;
+            }
+
+            return new(-1, pad);
+        }
+#endregion
+    }
+}

--- a/Assets/Script/Gameplay/Player/Drums/DrumHighwayOrderingCalculator.cs.meta
+++ b/Assets/Script/Gameplay/Player/Drums/DrumHighwayOrderingCalculator.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 836750e83db43a94bb04586b3e00f214

--- a/Assets/Script/Gameplay/Player/Drums/FiveDrumHighwayOrderingCalculator.cs
+++ b/Assets/Script/Gameplay/Player/Drums/FiveDrumHighwayOrderingCalculator.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+using YARG.Core;
+using YARG.Core.Audio;
+using YARG.Core.Chart;
+using YARG.Core.Engine.Drums;
+using YARG.Core.Engine.Drums.Engines;
+using YARG.Core.Game;
+using YARG.Core.Input;
+using YARG.Core.Replays;
+using YARG.Gameplay.HUD;
+using YARG.Gameplay.Visuals;
+using YARG.Helpers.Extensions;
+using YARG.Player;
+using YARG.Settings;
+using YARG.Themes;
+
+namespace YARG.Gameplay.Player.Drums
+{
+    public class FiveDrumHighwayOrderingCalculator : DrumHighwayOrderingCalculator
+    {
+        public override int FretCount => 5;
+
+        public override bool IsFiveLaneMode => true;
+        private bool ShouldSwapSnareAndHiHat => Player.Profile.SwapSnareAndHiHat;
+        private bool LeftyFlip => Player.Profile.LeftyFlip;
+        protected override int[] AllPads => Enum.GetValues(typeof(FiveLaneDrumPad)).Cast<int>().Except(new[] { (int) FiveLaneDrumPad.Kick }).ToArray();
+
+        public FiveDrumHighwayOrderingCalculator(YargPlayer player) : base(player) {}
+
+#region GetPosition methods
+        public override int GetPad(DrumsAction action)
+        {
+            return action switch
+            {
+                DrumsAction.RedDrum => (int)FiveLaneDrumPad.Red,
+                DrumsAction.YellowCymbal => (int)FiveLaneDrumPad.Yellow,
+                DrumsAction.BlueDrum => (int)FiveLaneDrumPad.Blue,
+                DrumsAction.OrangeCymbal => (int)FiveLaneDrumPad.Orange,
+                DrumsAction.GreenDrum => (int)FiveLaneDrumPad.Green,
+                _ => -1,
+            };
+        }
+
+        protected override int GetPosition(int pad)
+        {
+            int position = pad switch
+            {
+                (int) FiveLaneDrumPad.Red    => ShouldSwapSnareAndHiHat ? 1 : 0,
+                (int) FiveLaneDrumPad.Yellow => ShouldSwapSnareAndHiHat ? 0 : 1,
+                (int) FiveLaneDrumPad.Blue   => 2,
+                (int) FiveLaneDrumPad.Orange => 3,
+                (int) FiveLaneDrumPad.Green  => 4,
+                _                            => -1,
+            };
+            return LeftyFlip ? FretCount - position - 1 : position;
+        }
+        #endregion
+
+        #region Colors
+        protected override int GetColorIndex(int pad)
+        {
+            var color = (FiveLaneDrumPad)pad switch
+            {
+                FiveLaneDrumPad.Kick   => ColorProfile.FiveLaneDrumsFret.Kick,
+                FiveLaneDrumPad.Red    => ColorProfile.FiveLaneDrumsFret.Red,
+                FiveLaneDrumPad.Yellow => ColorProfile.FiveLaneDrumsFret.Yellow,
+                FiveLaneDrumPad.Blue   => ColorProfile.FiveLaneDrumsFret.Blue,
+                FiveLaneDrumPad.Orange => ColorProfile.FiveLaneDrumsFret.Orange,
+                FiveLaneDrumPad.Green  => ColorProfile.FiveLaneDrumsFret.Green,
+                _                      => ColorProfile.FiveLaneDrumsFret.Red,
+            };
+            return LeftyFlip ? (int)UpdateColorForLeftyFlip(color) : (int)color;
+        }
+
+        private ColorProfile.FiveLaneDrumsFret UpdateColorForLeftyFlip(ColorProfile.FiveLaneDrumsFret color)
+        {
+            // When LeftyMode is enabled, the lanes are switched visually, but not internally.
+            // This leads to the colors being wrong, so we need to swap them around.
+            return color switch
+            {
+                ColorProfile.FiveLaneDrumsFret.Red    => ColorProfile.FiveLaneDrumsFret.Green,
+                ColorProfile.FiveLaneDrumsFret.Yellow => ColorProfile.FiveLaneDrumsFret.Orange,
+                ColorProfile.FiveLaneDrumsFret.Orange => ColorProfile.FiveLaneDrumsFret.Yellow,
+                ColorProfile.FiveLaneDrumsFret.Green  => ColorProfile.FiveLaneDrumsFret.Red,
+                _                                     => color,
+            };
+        }
+#endregion
+    }
+}

--- a/Assets/Script/Gameplay/Player/Drums/FiveDrumHighwayOrderingCalculator.cs.meta
+++ b/Assets/Script/Gameplay/Player/Drums/FiveDrumHighwayOrderingCalculator.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 771cd3f28ace2c44faf83cb3a3fd77b2

--- a/Assets/Script/Gameplay/Player/Drums/FourDrumHighwayOrderingCalculator.cs
+++ b/Assets/Script/Gameplay/Player/Drums/FourDrumHighwayOrderingCalculator.cs
@@ -1,0 +1,174 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+using UnityEngine.UIElements;
+using YARG.Core;
+using YARG.Core.Audio;
+using YARG.Core.Chart;
+using YARG.Core.Engine.Drums;
+using YARG.Core.Engine.Drums.Engines;
+using YARG.Core.Game;
+using YARG.Core.Input;
+using YARG.Core.Replays;
+using YARG.Gameplay.HUD;
+using YARG.Gameplay.Visuals;
+using YARG.Helpers.Extensions;
+using YARG.Player;
+using YARG.Settings;
+using YARG.Themes;
+using FourLaneDrumsFret = YARG.Core.Game.ColorProfile.FourLaneDrumsFret;
+
+namespace YARG.Gameplay.Player.Drums
+{
+    public class FourDrumHighwayOrderingCalculator : DrumHighwayOrderingCalculator
+    {
+        public override bool IsFiveLaneMode => false;
+        private bool IsSplitMode => Player.Profile.CurrentInstrument is Instrument.ProDrums && Player.Profile.SplitProTomsAndCymbals;
+        private bool ShouldSwapSnareAndHiHat => IsSplitMode && Player.Profile.SwapSnareAndHiHat;
+        private bool ShouldSwapCrashAndRide => IsSplitMode && Player.Profile.SwapCrashAndRide;
+        private bool LeftyFlip => Player.Profile.LeftyFlip;
+        public override int FretCount => IsSplitMode ? 7 : 4;
+        protected override int[] AllPads => Enum.GetValues(typeof(FourLaneDrumPad)).Cast<int>().Except(new[] { (int)FourLaneDrumPad.Kick }).ToArray();
+
+        public FourDrumHighwayOrderingCalculator(YargPlayer player) : base(player) {}
+
+#region GetPosition methods
+        public override int GetPad(DrumsAction action)
+        {
+            return action switch
+            {
+                DrumsAction.RedDrum      => (int) FourLaneDrumPad.RedDrum,
+                DrumsAction.YellowDrum   => (int) FourLaneDrumPad.YellowDrum,
+                DrumsAction.BlueDrum     => (int) FourLaneDrumPad.BlueDrum,
+                DrumsAction.GreenDrum    => (int) FourLaneDrumPad.GreenDrum,
+                DrumsAction.YellowCymbal => (int) FourLaneDrumPad.YellowCymbal,
+                DrumsAction.BlueCymbal   => (int) FourLaneDrumPad.BlueCymbal,
+                DrumsAction.GreenCymbal  => (int) FourLaneDrumPad.GreenCymbal,
+                _                        => -1,
+            };
+        }
+
+        protected override int GetPosition(int pad)
+        {
+            var (leftCymbalFret, midCymbalFret, rightCymbalFret) = GetCymbalFrets();
+            var (redDrum, yellowDrum, blueDrum, greenDrum) = GetDrumFrets();
+
+            int position = (FourLaneDrumPad)pad switch
+            {
+                FourLaneDrumPad.RedDrum      => redDrum,
+                FourLaneDrumPad.YellowDrum   => yellowDrum,
+                FourLaneDrumPad.BlueDrum     => blueDrum,
+                FourLaneDrumPad.GreenDrum    => greenDrum,
+                FourLaneDrumPad.YellowCymbal => leftCymbalFret,
+                FourLaneDrumPad.BlueCymbal   => midCymbalFret,
+                FourLaneDrumPad.GreenCymbal  => rightCymbalFret,
+                _ => -1,
+            };
+
+            return LeftyFlip ? FretCount - position - 1 : position;
+        }
+
+        private (int leftCymbalFret, int midCymbalFret, int rightCymbalFret) GetDefaultCymbalFretsForNonSplitMode()
+        {
+            // BlueRaja - This method will be used by the upcoming "Cymbal Lanes" feature
+            return (1, 2, 3);
+        }
+
+        private (int leftCymbalFret, int midCymbalFret, int rightCymbalFret) GetDefaultCymbalFretsForSplitMode()
+        {
+            // BlueRaja - This method will be used by the upcoming "Cymbal Lanes" feature
+            return (1, 3, 5);
+        }
+
+        private (int leftCymbalFret, int midCymbalFret, int rightCymbalFret) GetCymbalFrets()
+        {
+            var (leftCymbalFret, midCymbalFret, rightCymbalFret) = IsSplitMode
+                ? GetDefaultCymbalFretsForSplitMode()
+                : GetDefaultCymbalFretsForNonSplitMode();
+
+            if (ShouldSwapSnareAndHiHat)
+            {
+                leftCymbalFret = 0; // BlueRaja - This logic will updated by the upcoming "Cymbal Lanes" feature
+            }
+
+            if (ShouldSwapCrashAndRide)
+            {
+                (midCymbalFret, rightCymbalFret) = (rightCymbalFret, midCymbalFret);
+            }
+
+            return (leftCymbalFret, midCymbalFret, rightCymbalFret);
+        }
+
+        private (int redDrum, int yellowDrum, int blueDrum, int greenDrum) GetDefaultDrumFretsForNonSplitMode()
+        {
+            return (0, 1, 2, 3);
+        }
+
+        private (int redDrum, int yellowDrum, int blueDrum, int greenDrum) GetDefaultDrumFretsForSplitMode()
+        {
+            // BlueRaja - This method will be used by the upcoming "Cymbal Lanes" feature
+            return (0, 2, 4, 6);
+        }
+
+        private (int redDrum, int yellowDrum, int blueDrum, int greenDrum) GetDrumFrets()
+        {
+            var (redDrum, yellowDrum, blueDrum, greenDrum) = IsSplitMode
+                ? GetDefaultDrumFretsForSplitMode()
+                : GetDefaultDrumFretsForNonSplitMode();
+            if (ShouldSwapSnareAndHiHat)
+            {
+                redDrum = 1; // BlueRaja - This logic will updated by the upcoming "Cymbal Lanes" feature
+            }
+            return (redDrum, yellowDrum, blueDrum, greenDrum);
+        }
+#endregion
+
+#region Colors
+        protected override int GetColorIndex(int pad)
+        {
+            var (leftCymbalColor, midCymbalColor, rightCymbalColor) = GetCymbalColors();
+            var color = (FourLaneDrumPad)pad switch
+            {
+                FourLaneDrumPad.Kick         => FourLaneDrumsFret.Kick,
+                FourLaneDrumPad.RedDrum      => FourLaneDrumsFret.RedDrum,
+                FourLaneDrumPad.YellowDrum   => FourLaneDrumsFret.YellowDrum,
+                FourLaneDrumPad.BlueDrum     => FourLaneDrumsFret.BlueDrum,
+                FourLaneDrumPad.GreenDrum    => FourLaneDrumsFret.GreenDrum,
+                FourLaneDrumPad.YellowCymbal => leftCymbalColor,
+                FourLaneDrumPad.BlueCymbal   => midCymbalColor,
+                FourLaneDrumPad.GreenCymbal  => rightCymbalColor,
+                _                            => FourLaneDrumsFret.RedDrum,
+            };
+            return LeftyFlip ? (int)UpdateColorForLeftyFlip(color) : (int)color;
+        }
+
+        private (FourLaneDrumsFret leftCymbalColor, FourLaneDrumsFret midCymbalColor, FourLaneDrumsFret rightCymbalColor) GetCymbalColors()
+        {
+            // BlueRaja - This method will be used by the upcoming "Lanes to Show" feature
+            return (FourLaneDrumsFret.YellowCymbal, FourLaneDrumsFret.BlueCymbal, FourLaneDrumsFret.GreenCymbal);
+        }
+
+        private FourLaneDrumsFret UpdateColorForLeftyFlip(FourLaneDrumsFret color)
+        {
+            // When LeftyMode is enabled, the Frets are switched visually, but not internally.
+            // This leads to the colors being wrong, so we need to swap them around.
+            return color switch
+            {
+                FourLaneDrumsFret.RedDrum => FourLaneDrumsFret.GreenDrum,
+                FourLaneDrumsFret.YellowDrum => FourLaneDrumsFret.BlueDrum,
+                FourLaneDrumsFret.BlueDrum => FourLaneDrumsFret.YellowDrum,
+                FourLaneDrumsFret.GreenDrum => FourLaneDrumsFret.RedDrum,
+
+                // We still associate each cymbal with the drum to its right, so the color associations
+                // end up different for cymbals than drums
+                FourLaneDrumsFret.RedCymbal => FourLaneDrumsFret.GreenCymbal,
+                FourLaneDrumsFret.YellowCymbal => FourLaneDrumsFret.BlueCymbal,
+                FourLaneDrumsFret.BlueCymbal => FourLaneDrumsFret.YellowCymbal,
+                FourLaneDrumsFret.GreenCymbal => FourLaneDrumsFret.RedCymbal, 
+                _ => color,
+            };
+        }
+#endregion
+    }
+}

--- a/Assets/Script/Gameplay/Player/Drums/FourDrumHighwayOrderingCalculator.cs.meta
+++ b/Assets/Script/Gameplay/Player/Drums/FourDrumHighwayOrderingCalculator.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: cf6fc9ce91faa914ba894d843a5e56f1

--- a/Assets/Script/Gameplay/Player/DrumsPlayer.cs
+++ b/Assets/Script/Gameplay/Player/DrumsPlayer.cs
@@ -10,6 +10,7 @@ using YARG.Core.Engine.Drums.Engines;
 using YARG.Core.Input;
 using YARG.Core.Replays;
 using YARG.Gameplay.HUD;
+using YARG.Gameplay.Player.Drums;
 using YARG.Gameplay.Visuals;
 using YARG.Helpers.Extensions;
 using YARG.Player;
@@ -23,83 +24,19 @@ namespace YARG.Gameplay.Player
     {
         private const float DRUM_PAD_FLASH_HOLD_DURATION = 0.2f;
 
-        // Key is a FourLaneDrumPad or FiveLaneDrumPad
-        private Dictionary<int, HighwayOrderingInfo> _highwayOrdering;
-
-        // Number of distinct frets in the fret array.
-        // Derivable, but predetermined by MakeHighwayOrdering() for performance reasons
-        public int LaneCount { get; private set; }
-
-        private int DrumsActionToHighwayIndex(DrumsAction action)
-        {
-            if (_fiveLaneMode)
-            {
-                return action switch
-                {
-                    DrumsAction.Kick => (int) FiveLaneDrumPad.Kick,
-                    DrumsAction.RedDrum => (int) FiveLaneDrumPad.Red,
-                    DrumsAction.YellowCymbal => (int) FiveLaneDrumPad.Yellow,
-                    DrumsAction.BlueDrum => (int) FiveLaneDrumPad.Blue,
-                    DrumsAction.OrangeCymbal => (int) FiveLaneDrumPad.Orange,
-                    DrumsAction.GreenDrum => (int) FiveLaneDrumPad.Green,
-                    _ => throw new ArgumentOutOfRangeException(nameof(action))
-                };
-            }
-
-            return action switch
-            {
-                DrumsAction.Kick =>         (int) FourLaneDrumPad.Kick,
-                DrumsAction.RedDrum =>      (int) FourLaneDrumPad.RedDrum,
-                DrumsAction.YellowDrum =>   (int) FourLaneDrumPad.YellowDrum,
-                DrumsAction.BlueDrum =>     (int) FourLaneDrumPad.BlueDrum,
-                DrumsAction.GreenDrum =>    (int) FourLaneDrumPad.GreenDrum,
-                DrumsAction.YellowCymbal => (int) (Player.Profile.SplitProTomsAndCymbals ? FourLaneDrumPad.YellowCymbal : FourLaneDrumPad.YellowDrum),
-                DrumsAction.BlueCymbal =>   (int) (Player.Profile.SplitProTomsAndCymbals ? FourLaneDrumPad.BlueCymbal : FourLaneDrumPad.BlueDrum),
-                DrumsAction.GreenCymbal =>  (int) (Player.Profile.SplitProTomsAndCymbals ? FourLaneDrumPad.GreenCymbal : FourLaneDrumPad.GreenDrum),
-                _ => throw new ArgumentOutOfRangeException(nameof(action))
-            };
-        }
-
-        public HighwayOrderingInfo GetHighwayOrderingInfo(int pad)
-        {
-            if (_highwayOrdering.ContainsKey(pad))
-            {
-                return _highwayOrdering[pad];
-            }
-
-            return new(-1, pad);
-        }
-
-
-        public static Dictionary<int, int> DEFAULT_FOUR_LANE_HIGHWAY_ORDERING = new()
-        {
-            { (int)FourLaneDrumPad.RedDrum,       0 },
-            { (int)FourLaneDrumPad.YellowCymbal,  1 },
-            { (int)FourLaneDrumPad.YellowDrum,    1 },
-            { (int)FourLaneDrumPad.BlueCymbal,    2 },
-            { (int)FourLaneDrumPad.BlueDrum,      2 },
-            { (int)FourLaneDrumPad.GreenCymbal,   3 },
-            { (int)FourLaneDrumPad.GreenDrum,     3 }
-        };
-
-        public static Dictionary<int, int> DEFAULT_FIVE_LANE_HIGHWAY_ORDERING = new()
-        {
-            { (int)FiveLaneDrumPad.Red,       0 },
-            { (int)FiveLaneDrumPad.Yellow,    1 },
-            { (int)FiveLaneDrumPad.Blue,      2 },
-            { (int)FiveLaneDrumPad.Orange,    3 },
-            { (int)FiveLaneDrumPad.Green,     4 }
-        };
-
         public DrumsEngineParameters EngineParams { get; private set; }
 
         [Header("Drums Specific")]
         [SerializeField]
-        private bool _fiveLaneMode;
-        [SerializeField]
         private FretArray _fretArray;
         [SerializeField]
         private KickFretFlash _kickFretFlash;
+
+        private DrumHighwayOrderingCalculator _drumCalculator;
+        private Dictionary<int, HighwayOrderingInfo> HighwayOrdering => _drumCalculator.HighwayOrdering;
+        private bool IsFiveLaneMode => _drumCalculator.IsFiveLaneMode;
+        public HighwayOrderingInfo GetHighwayOrderingInfo(int pad) => _drumCalculator.GetHighwayOrderingInfo(pad);
+        public int FretCount => _drumCalculator.FretCount;
 
         public override bool ShouldUpdateInputsOnResume => false;
 
@@ -116,13 +53,13 @@ namespace YARG.Gameplay.Player
         private Dictionary<int, float> _fretToLastPressedTimeDelta                                  = new();
         private Dictionary<Fret.AnimType, Dictionary<int, float>> _animTypeToFretToLastPressedDelta = new();
 
-        private bool IsSplitMode => Player.Profile.CurrentInstrument is Instrument.ProDrums && Player.Profile.SplitProTomsAndCymbals;
-
         public override void Initialize(int index, YargPlayer player, SongChart chart, TrackView trackView, StemMixer mixer,
             int? currentHighScore)
         {
             // Before we do anything, see if we're in five lane mode or not
-            _fiveLaneMode = player.Profile.CurrentInstrument == Instrument.FiveLaneDrums;
+            bool fiveLaneMode = player.Profile.CurrentInstrument == Instrument.FiveLaneDrums;
+            _drumCalculator = fiveLaneMode ? new FiveDrumHighwayOrderingCalculator(player) : new FourDrumHighwayOrderingCalculator(player);
+
             base.Initialize(index, player, chart, trackView, mixer, currentHighScore);
         }
 
@@ -189,19 +126,17 @@ namespace YARG.Gameplay.Player
             StarScoreThresholds = PopulateStarScoreThresholds(StarMultiplierThresholds, Engine.BaseScore);
 
             // Get the proper info for four/five lane
-            IFretColorProvider colors = !_fiveLaneMode
+            IFretColorProvider colors = !IsFiveLaneMode
                 ? Player.ColorProfile.FourLaneDrums
                 : Player.ColorProfile.FiveLaneDrums;
 
 
-            var kickFretPrefab = _fiveLaneMode ? ThemeManager.Instance.CreateKickFretPrefabFromTheme(Player.ThemePreset, VisualStyle.FiveLaneDrums) :
+            var kickFretPrefab = IsFiveLaneMode ? ThemeManager.Instance.CreateKickFretPrefabFromTheme(Player.ThemePreset, VisualStyle.FiveLaneDrums) :
                 ThemeManager.Instance.CreateKickFretPrefabFromTheme(Player.ThemePreset, VisualStyle.FourLaneDrums);
 
-            MakeHighwayOrdering();
-
             _fretArray.Initialize(
-                _highwayOrdering,
-                LaneCount,
+                HighwayOrdering,
+                _drumCalculator.FretCount,
                 kickFretPrefab,
                 colors,
                 Player.ThemePreset,
@@ -225,7 +160,7 @@ namespace YARG.Gameplay.Player
             InitializeAnimTypes();
 
             base.FinishInitialization();
-            LaneElement.DefineLaneScale(Player.Profile.CurrentInstrument, _fiveLaneMode ? 5 : 4);
+            LaneElement.DefineLaneScale(Player.Profile.CurrentInstrument, IsFiveLaneMode ? 5 : 4);
         }
 
         private void SetDrumFillEffects()
@@ -257,7 +192,7 @@ namespace YARG.Gameplay.Player
                     continue;
                 }
 
-                var fillLanePosition = GetHighwayOrderingInfo(rightmostNote.Pad).Position;
+                var fillLanePosition = HighwayOrdering[rightmostNote.Pad].Position;
 
                 int candidateIndex = -1;
 
@@ -284,7 +219,7 @@ namespace YARG.Gameplay.Player
                 if (candidateIndex != -1)
                 {
                     _trackEffects[candidateIndex].FillLanePosition = fillLanePosition;
-                    _trackEffects[candidateIndex].TotalLanes = LaneCount;
+                    _trackEffects[candidateIndex].TotalLanes = _drumCalculator.FretCount;
                     pairedFillIndexes.Add(candidateIndex);
                     checkpoint = candidateIndex;
 
@@ -334,9 +269,9 @@ namespace YARG.Gameplay.Player
 
         protected override void InitializeSpawnedLane(LaneElement lane, DrumNote note)
         {
-            var highwayOrderingInfo = _highwayOrdering[note.Pad];
+            var highwayOrderingInfo = HighwayOrdering[note.Pad];
 
-            var laneColor = (_fiveLaneMode ?
+            var laneColor = (IsFiveLaneMode ?
                 Player.ColorProfile.FiveLaneDrums.GetNoteColor(highwayOrderingInfo.ColorIndex) :
                 Player.ColorProfile.FourLaneDrums.GetNoteColor(highwayOrderingInfo.ColorIndex)
             ).ToUnityColor();
@@ -345,7 +280,7 @@ namespace YARG.Gameplay.Player
                 Player.Profile.CurrentInstrument,
                 note.LaneNote,
                 highwayOrderingInfo.Position,
-                LaneCount,
+                _drumCalculator.FretCount,
                 laneColor
             );
 
@@ -462,7 +397,7 @@ namespace YARG.Gameplay.Player
                 }
                 else
                 {
-                    int fret = DrumsActionToHighwayIndex(action);
+                    int fret = _drumCalculator.GetPad(action);
                     _fretArray.PlayMissAnimation(fret);
                 }
             }
@@ -532,18 +467,6 @@ namespace YARG.Gameplay.Player
             return (frame, Engine.EngineStats.ConstructReplayStats(Player.Profile.Name));
         }
 
-        private bool ShouldSwapSnareAndHiHat()
-        {
-            if (Player.Profile.CurrentInstrument is Instrument.FiveLaneDrums || IsSplitMode)
-            {
-                return Player.Profile.SwapSnareAndHiHat;
-            }
-
-            return false;
-        }
-
-        private bool ShouldSwapCrashAndRide() => IsSplitMode && Player.Profile.SwapCrashAndRide;
-
         protected override void UpdateVisuals(double visualTime)
         {
             base.UpdateVisuals(visualTime);
@@ -554,7 +477,7 @@ namespace YARG.Gameplay.Player
 
         private void InitializeHitTimes()
         {
-            foreach (var fretIdx in _highwayOrdering.Keys)
+            foreach (var fretIdx in HighwayOrdering.Keys)
             {
                 _fretToLastPressedTimeDelta[fretIdx] = float.MaxValue;
             }
@@ -566,7 +489,7 @@ namespace YARG.Gameplay.Player
             {
                 _animTypeToFretToLastPressedDelta[animType] = new Dictionary<int, float>();
 
-                foreach (var fretIdx in _highwayOrdering.Keys)
+                foreach (var fretIdx in HighwayOrdering.Keys)
                 {
                     _animTypeToFretToLastPressedDelta[animType][fretIdx] = float.MaxValue;
                 }
@@ -576,14 +499,14 @@ namespace YARG.Gameplay.Player
         // i.e., flash this fret by making it seem pressed
         private void ZeroOutHitTime(DrumsAction action, Fret.AnimType animType)
         {
-            int fretIdx = DrumsActionToHighwayIndex(action);
+            int fretIdx = _drumCalculator.GetPad(action);
             _fretToLastPressedTimeDelta[fretIdx] = 0f;
             _animTypeToFretToLastPressedDelta[animType][fretIdx] = 0f;
         }
 
         private void UpdateHitTimes()
         {
-            foreach (var fretIdx in _highwayOrdering.Keys)
+            foreach (var fretIdx in HighwayOrdering.Keys)
             {
                 _fretToLastPressedTimeDelta[fretIdx] += Time.deltaTime;
             }
@@ -593,7 +516,7 @@ namespace YARG.Gameplay.Player
         {
             foreach (Fret.AnimType animType in Enum.GetValues(typeof(Fret.AnimType)))
             {
-                foreach (var fretIdx in _highwayOrdering.Keys)
+                foreach (var fretIdx in HighwayOrdering.Keys)
                 {
                     _animTypeToFretToLastPressedDelta[animType][fretIdx] += Time.deltaTime;
                 }
@@ -602,7 +525,7 @@ namespace YARG.Gameplay.Player
 
         private void UpdateFretArray()
         {
-            foreach (var fretIdx in _highwayOrdering.Keys)
+            foreach (var fretIdx in HighwayOrdering.Keys)
             {
                 _fretArray.SetPressedDrum(fretIdx, _fretToLastPressedTimeDelta[fretIdx] < DRUM_PAD_FLASH_HOLD_DURATION, GetAnimType(fretIdx));
                 _fretArray.UpdateAccentColorState(fretIdx,
@@ -637,18 +560,18 @@ namespace YARG.Gameplay.Player
 
         private void AnimateAction(DrumsAction action)
         {
-            var index = DrumsActionToHighwayIndex(action);
+            var fret = _drumCalculator.GetPad(action);
 
-            if (_fiveLaneMode)
+            if (IsFiveLaneMode)
             {
                 // Only use cymbal animation if the cymbal gems are being used
                 if (Player.Profile.UseCymbalModels && action is DrumsAction.YellowCymbal or DrumsAction.OrangeCymbal)
                 {
-                    _fretArray.PlayCymbalHitAnimation(index);
+                    _fretArray.PlayCymbalHitAnimation(fret);
                 }
                 else
                 {
-                    _fretArray.PlayHitAnimation(index);
+                    _fretArray.PlayHitAnimation(fret);
                 }
 
                 return;
@@ -657,11 +580,11 @@ namespace YARG.Gameplay.Player
             // Can technically merge this condition with the above, but it's more readable like this
             if (action is DrumsAction.YellowCymbal or DrumsAction.BlueCymbal or DrumsAction.GreenCymbal)
             {
-                _fretArray.PlayCymbalHitAnimation(index);
+                _fretArray.PlayCymbalHitAnimation(fret);
             }
             else
             {
-                _fretArray.PlayHitAnimation(index);
+                _fretArray.PlayHitAnimation(fret);
             }
         }
 
@@ -676,7 +599,7 @@ namespace YARG.Gameplay.Player
                 return;
             }
 
-            if (_fiveLaneMode)
+            if (IsFiveLaneMode)
             {
                 // Only use cymbal animation if the cymbal gems are being used
                 if (Player.Profile.UseCymbalModels && (FiveLaneDrumPad) pad
@@ -704,97 +627,6 @@ namespace YARG.Gameplay.Player
             else
             {
                 _fretArray.PlayHitAnimation(pad);
-            }
-        }
-
-        private int ApplyHandednessToPosition(int position)
-        {
-            if (Player.Profile.LeftyFlip)
-            {
-                return LaneCount - position - 1;
-            }
-
-            return position;
-        }
-
-        private int ApplyHandednessToFourLaneColor(FourLaneDrumsFret fret)
-        {
-            if (Player.Profile.LeftyFlip)
-            {
-                return fret switch
-                {
-                    FourLaneDrumsFret.RedDrum =>        (int)FourLaneDrumsFret.GreenDrum,
-                    FourLaneDrumsFret.YellowDrum =>     (int)FourLaneDrumsFret.BlueDrum,
-                    FourLaneDrumsFret.BlueDrum =>       (int)FourLaneDrumsFret.YellowDrum,
-                    FourLaneDrumsFret.GreenDrum =>      (int)FourLaneDrumsFret.RedDrum,
-                    FourLaneDrumsFret.YellowCymbal =>   (int)FourLaneDrumsFret.BlueCymbal,
-                    FourLaneDrumsFret.BlueCymbal =>     (int)FourLaneDrumsFret.YellowCymbal,
-                    FourLaneDrumsFret.GreenCymbal =>    (int)FourLaneDrumsFret.RedCymbal,
-                    _ => (int) fret
-                };
-            }
-
-            return (int) fret;
-        }
-
-        private int ApplyHandednessToFiveLaneColor(FiveLaneDrumsFret fret)
-        {
-            if (Player.Profile.LeftyFlip)
-            {
-                return fret switch {
-                    FiveLaneDrumsFret.Red =>    (int)FiveLaneDrumsFret.Green,
-                    FiveLaneDrumsFret.Yellow => (int)FiveLaneDrumsFret.Orange,
-                    FiveLaneDrumsFret.Blue =>   (int)FiveLaneDrumsFret.Blue,
-                    FiveLaneDrumsFret.Orange => (int)FiveLaneDrumsFret.Yellow,
-                    FiveLaneDrumsFret.Green =>  (int)FiveLaneDrumsFret.Red,
-                    _ => (int)fret
-                };
-            }
-
-            return (int)fret;
-        }
-
-        private void MakeHighwayOrdering()
-        {
-            if (Player.Profile.CurrentInstrument is Instrument.FiveLaneDrums)
-            {
-                LaneCount = 5;
-                _highwayOrdering = new()
-                {
-                    { (int)FiveLaneDrumPad.Red,    new(ApplyHandednessToPosition(Player.Profile.SwapSnareAndHiHat ? 1 : 0), ApplyHandednessToFiveLaneColor(FiveLaneDrumsFret.Red) ) },
-                    { (int)FiveLaneDrumPad.Yellow, new(ApplyHandednessToPosition(Player.Profile.SwapSnareAndHiHat ? 0 : 1), ApplyHandednessToFiveLaneColor(FiveLaneDrumsFret.Yellow) ) },
-                    { (int)FiveLaneDrumPad.Blue,   new(ApplyHandednessToPosition(2),                                        (int)FiveLaneDrumsFret.Blue) }, // No need to waste a function call on this
-                    { (int)FiveLaneDrumPad.Orange, new(ApplyHandednessToPosition(3),                                        ApplyHandednessToFiveLaneColor(FiveLaneDrumsFret.Orange) ) },
-                    { (int)FiveLaneDrumPad.Green,  new(ApplyHandednessToPosition(4),                                        ApplyHandednessToFiveLaneColor(FiveLaneDrumsFret.Green) ) }
-                };
-            }
-            else if (Player.Profile.SplitProTomsAndCymbals)
-            {
-                LaneCount = 7;
-                _highwayOrdering = new()
-                {
-                    { (int)FourLaneDrumPad.RedDrum,       new(ApplyHandednessToPosition(Player.Profile.SwapSnareAndHiHat ? 1 : 0),   ApplyHandednessToFourLaneColor(FourLaneDrumsFret.RedDrum)) },
-                    { (int)FourLaneDrumPad.YellowCymbal,  new(ApplyHandednessToPosition(Player.Profile.SwapSnareAndHiHat ? 0 : 1),   ApplyHandednessToFourLaneColor(FourLaneDrumsFret.YellowCymbal)) },
-                    { (int)FourLaneDrumPad.YellowDrum,    new(ApplyHandednessToPosition(2),                                          ApplyHandednessToFourLaneColor(FourLaneDrumsFret.YellowDrum)) },
-                    { (int)FourLaneDrumPad.BlueCymbal,    new(ApplyHandednessToPosition(Player.Profile.SwapCrashAndRide ? 5 : 3),    ApplyHandednessToFourLaneColor(FourLaneDrumsFret.BlueCymbal)) },
-                    { (int)FourLaneDrumPad.BlueDrum,      new(ApplyHandednessToPosition(4),                                          ApplyHandednessToFourLaneColor(FourLaneDrumsFret.BlueDrum)) },
-                    { (int)FourLaneDrumPad.GreenCymbal,   new(ApplyHandednessToPosition(Player.Profile.SwapCrashAndRide ? 3 : 5),    ApplyHandednessToFourLaneColor(FourLaneDrumsFret.GreenCymbal)) },
-                    { (int)FourLaneDrumPad.GreenDrum,     new(ApplyHandednessToPosition(6),                                          ApplyHandednessToFourLaneColor(FourLaneDrumsFret.GreenDrum)) },
-                };
-            }
-            else
-            {
-                LaneCount = 4;
-                _highwayOrdering = new()
-                {
-                    { (int)FourLaneDrumPad.RedDrum,       new(ApplyHandednessToPosition(0), ApplyHandednessToFourLaneColor(FourLaneDrumsFret.RedDrum)) },
-                    { (int)FourLaneDrumPad.YellowCymbal,  new(ApplyHandednessToPosition(1), ApplyHandednessToFourLaneColor(FourLaneDrumsFret.YellowCymbal)) },
-                    { (int)FourLaneDrumPad.YellowDrum,    new(ApplyHandednessToPosition(1), ApplyHandednessToFourLaneColor(FourLaneDrumsFret.YellowDrum)) },
-                    { (int)FourLaneDrumPad.BlueCymbal,    new(ApplyHandednessToPosition(2), ApplyHandednessToFourLaneColor(FourLaneDrumsFret.BlueCymbal)) },
-                    { (int)FourLaneDrumPad.BlueDrum,      new(ApplyHandednessToPosition(2), ApplyHandednessToFourLaneColor(FourLaneDrumsFret.BlueDrum)) },
-                    { (int)FourLaneDrumPad.GreenCymbal,   new(ApplyHandednessToPosition(3), ApplyHandednessToFourLaneColor(FourLaneDrumsFret.GreenCymbal)) },
-                    { (int)FourLaneDrumPad.GreenDrum,     new(ApplyHandednessToPosition(3), ApplyHandednessToFourLaneColor(FourLaneDrumsFret.GreenDrum)) },
-                };
             }
         }
     }

--- a/Assets/Script/Gameplay/Visuals/Fret/FretArray.cs
+++ b/Assets/Script/Gameplay/Visuals/Fret/FretArray.cs
@@ -23,9 +23,6 @@ namespace YARG.Gameplay.Visuals
 
         public int Position { get; }
         public int ColorIndex { get; }
-
-        // The DisplayLane is the same as the fret, except that it's 1-indexed instead of 0-indexed
-        public int DisplayLane => Position + 1;
     }
 
     public class FretArray : MonoBehaviour

--- a/Assets/Script/Gameplay/Visuals/Fret/FretArray.cs
+++ b/Assets/Script/Gameplay/Visuals/Fret/FretArray.cs
@@ -15,14 +15,17 @@ namespace YARG.Gameplay.Visuals
 {
     public readonly struct HighwayOrderingInfo
     {
-        public HighwayOrderingInfo(float position, int colorIndex)
+        public HighwayOrderingInfo(int position, int colorIndex)
         {
             Position = position;
             ColorIndex = colorIndex;
         }
 
-        public float Position { get; }
+        public int Position { get; }
         public int ColorIndex { get; }
+
+        // The DisplayLane is the same as the fret, except that it's 1-indexed instead of 0-indexed
+        public int DisplayLane => Position + 1;
     }
 
     public class FretArray : MonoBehaviour
@@ -30,7 +33,6 @@ namespace YARG.Gameplay.Visuals
         private const float WIDTH_NUMERATOR   = 2f;
         private const float WIDTH_DENOMINATOR = 5f;
 
-        public bool DontFlipColorsLeftyFlip;
         public bool UseKickFrets;
 
         [SerializeField]

--- a/Assets/Script/Gameplay/Visuals/TrackElements/Drums/FiveLaneDrumsNoteElement.cs
+++ b/Assets/Script/Gameplay/Visuals/TrackElements/Drums/FiveLaneDrumsNoteElement.cs
@@ -21,7 +21,7 @@ namespace YARG.Gameplay.Visuals
                 var position = Player.GetHighwayOrderingInfo(NoteRef.Pad).Position;
                 
                 // Set the position
-                transform.localPosition = new Vector3(GetElementX(position, Player.LaneCount), 0f, 0f);
+                transform.localPosition = new Vector3(GetElementX(position, Player.FretCount), 0f, 0f);
 
                 // Get which note model to use
                 if (Player.Player.Profile.UseCymbalModels)

--- a/Assets/Script/Gameplay/Visuals/TrackElements/Drums/FourLaneDrumsNoteElement.cs
+++ b/Assets/Script/Gameplay/Visuals/TrackElements/Drums/FourLaneDrumsNoteElement.cs
@@ -23,7 +23,7 @@ namespace YARG.Gameplay.Visuals
                 bool isCymbal = NoteRef.Pad >= (int) FourLaneDrumPad.YellowCymbal;
 
                 // Set the position
-                transform.localPosition = new Vector3(GetElementX(position, Player.LaneCount), 0f, 0f);
+                transform.localPosition = new Vector3(GetElementX(position, Player.FretCount), 0f, 0f);
 
                 // Get which note model to use
                 NoteGroup = noteGroups[GetNoteGroup(isCymbal)];

--- a/Assets/Script/Settings/Preview/FakeTrackPlayer.cs
+++ b/Assets/Script/Settings/Preview/FakeTrackPlayer.cs
@@ -104,7 +104,15 @@ namespace YARG.Settings.Preview
                 {
                     UseKickFrets = true,
 
-                    HighwayOrdering = DrumsPlayer.DEFAULT_FOUR_LANE_HIGHWAY_ORDERING,
+                    HighwayOrdering = {
+                        { (int)FourLaneDrumPad.RedDrum,       0 },
+                        { (int)FourLaneDrumPad.YellowCymbal,  1 },
+                        { (int)FourLaneDrumPad.YellowDrum,    1 },
+                        { (int)FourLaneDrumPad.BlueCymbal,    2 },
+                        { (int)FourLaneDrumPad.BlueDrum,      2 },
+                        { (int)FourLaneDrumPad.GreenCymbal,   3 },
+                        { (int)FourLaneDrumPad.GreenDrum,     3 }
+                    },
                     LaneCount = 4,
 
                     FretColorProvider = (colorProfile) => colorProfile.FourLaneDrums,
@@ -178,7 +186,13 @@ namespace YARG.Settings.Preview
                         .GetNoteColor(note.Fret)
                         .ToUnityColor(),
 
-                    HighwayOrdering = DrumsPlayer.DEFAULT_FIVE_LANE_HIGHWAY_ORDERING,
+                    HighwayOrdering = {
+                        { (int)FiveLaneDrumPad.Red,       0 },
+                        { (int)FiveLaneDrumPad.Yellow,    1 },
+                        { (int)FiveLaneDrumPad.Blue,      2 },
+                        { (int)FiveLaneDrumPad.Orange,    3 },
+                        { (int)FiveLaneDrumPad.Green,     4 }
+                    },
                     LaneCount = 5,
 
                     HitWindowProvider = (enginePreset) => enginePreset.Drums.HitWindow,


### PR DESCRIPTION
Background
---

This is PR 1/2 for the "Cymbal Lanes" feature, which will allow cymbals to move around and change colors (so that eg. the hi-hat can be red instead of yellow).

I spent four days cleaning up the code for displaying drum lanes/colors in preparation for this, only to find that 90% of it had already been implemented [right after I started working](http://github.com/YARC-Official/YARG/pull/1329) by [Frickitickitavi](https://github.com/Frickitickitavi). This PR implements the remaining 10%.

What this PR does
---

Right now, `DrumPlayer` handles playing audio/visual effects when notes are hit, as well as calculating the note positions and colors. This PR splits out that latter logic out into other classes: `FourDrumHighwayOrderingCalculator` for four-lane mode, `FiveDrumHighwayOrderingCalculator` for five-lane mode, and `DrumHighwayOrderingCalculator`, an abstract base class which contains some shared code.

It also updates the logic slightly, in a way that will make it easier to move the cymbals around (which is my next PR).

How did you test this?
---

I manually tested every combination of "4/5 lane mode", "Left-hand mode", "Split drums and cymbals", "Swap snare/hi-hat", "Swap crash/ride" and made sure that the colors/positions match the Stable branch, and that hitting the pads works as expected.

Here are some screenshots from some (but not all) of my test cases:

5-lane mode
<img width="591" height="537" alt="2026-02-28 03_58_41-YARG - Gameplay - Windows, Mac, Linux - Unity 6 3 LTS (6000 3 5f2) _DX11_" src="https://github.com/user-attachments/assets/feb0cb27-00a1-416b-939c-8a543fb19fbe" />

5-lane + lefty
<img width="582" height="536" alt="2026-02-28 04_05_23-YARG - Gameplay - Windows, Mac, Linux - Unity 6 3 LTS (6000 3 5f2) _DX11_" src="https://github.com/user-attachments/assets/8561d0b9-88a6-44c4-a0d4-39d1503f1bfc" />

5-lane + snare/hi-hat
<img width="588" height="531" alt="2026-02-28 04_06_05-YARG - Gameplay - Windows, Mac, Linux - Unity 6 3 LTS (6000 3 5f2) _DX11_" src="https://github.com/user-attachments/assets/8263ed70-9bae-4fe4-9cc5-9c6c18c137ab" />

5-lane + lefty + snare/hi-hat
<img width="591" height="529" alt="2026-02-28 04_06_38-YARG - Gameplay - Windows, Mac, Linux - Unity 6 3 LTS (6000 3 5f2) _DX11_" src="https://github.com/user-attachments/assets/b2b37ee2-8684-4c43-935d-aca7e2ad5935" />

4-lane
<img width="593" height="535" alt="2026-02-28 04_07_27-YARG - Gameplay - Windows, Mac, Linux - Unity 6 3 LTS (6000 3 5f2) _DX11_" src="https://github.com/user-attachments/assets/cd60ee1d-ee2e-4b98-a859-f6c518e02e85" />

4-lane + lefty
<img width="594" height="537" alt="2026-02-28 04_08_10-YARG - Gameplay - Windows, Mac, Linux - Unity 6 3 LTS (6000 3 5f2) _DX11_" src="https://github.com/user-attachments/assets/d1f92986-29ed-400b-ad35-96b1ab743edd" />

4-lane + split
<img width="580" height="528" alt="2026-02-28 04_08_53-YARG - Gameplay - Windows, Mac, Linux - Unity 6 3 LTS (6000 3 5f2) _DX11_" src="https://github.com/user-attachments/assets/24d0dfc5-0850-4cb2-a385-7f904231f374" />

4-lane + split + snare/hi-hat + ride/crash
<img width="594" height="528" alt="2026-02-28 04_17_18-YARG - Gameplay - Windows, Mac, Linux - Unity 6 3 LTS (6000 3 5f2) _DX11_" src="https://github.com/user-attachments/assets/93995395-11b1-435c-82df-f8e2bdf324f4" />

4-lane + split + lefty
<img width="597" height="538" alt="2026-02-28 04_17_51-YARG - Gameplay - Windows, Mac, Linux - Unity 6 3 LTS (6000 3 5f2) _DX11_" src="https://github.com/user-attachments/assets/99e71667-f3f7-424b-bdf1-8e0d27783498" />

4-lane + split + lefty + snare/hi-hat + ride/crash
<img width="597" height="528" alt="2026-02-28 04_18_24-YARG - Gameplay - Windows, Mac, Linux - Unity 6 3 LTS (6000 3 5f2) _DX11_" src="https://github.com/user-attachments/assets/88ac48b1-23eb-47c2-88ab-856b39907636" />
