### PR TITLE
FIx kick fret color

### DIFF
--- a/Assets/Script/Gameplay/Visuals/Fret/FretArray.cs
+++ b/Assets/Script/Gameplay/Visuals/Fret/FretArray.cs
@@ -123,6 +123,11 @@ namespace YARG.Gameplay.Visuals
             {
                 _activeFrets.Add(fretIdx);
             }
+
+            foreach (var kickFret in _kickFrets)
+            {
+                kickFret.Initialize(fretColorProvider.GetFretColor(0));
+            }
         }
 
         public void SetPressed(int index, bool pressed)

--- a/Assets/Script/Gameplay/Visuals/Fret/FretArray.cs
+++ b/Assets/Script/Gameplay/Visuals/Fret/FretArray.cs
@@ -126,6 +126,9 @@ namespace YARG.Gameplay.Visuals
 
             foreach (var kickFret in _kickFrets)
             {
+                // 0 resolves to kick in both FourLaneDrumsFret and FiveFretDrumsFret, so it isn't worth doing this the "right"
+                // way via an extra argument. If another format comes along that wants something other than 0 for the kick fret
+                // color profile index, this should be updated to remove the magic number
                 kickFret.Initialize(fretColorProvider.GetFretColor(0));
             }
         }


### PR DESCRIPTION
Restores an accidentally-removed piece of `FretArray::Initialize` that sets the color for the kick frets.

This is technically a slight kludge since it uses a magic `0` rather than properly getting the `Kick` value from the proper enum. As of now, we only support two enums (4L and 5L) when using kick frets and they both have kick at `0`, so I don't think it's worth passing in some extra argument just so that we can know which enum we're supposed to check to ultimately arrive at `0` either way.