### PR TITLE
Un-literalize posterize, give mirror its colors

### DIFF
--- a/Assets/Script/Venue/VenueCamera/CameraManager.PostProcessing.cs
+++ b/Assets/Script/Venue/VenueCamera/CameraManager.PostProcessing.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Rendering;
@@ -32,14 +32,26 @@ namespace YARG.Venue.VenueCamera
 
         private TextureCurve _invertCurve;
         private TextureCurve _defaultCurve;
+		private TextureCurve _defaultLumSatCurve;
         private TextureCurve _copierCurve;
         private TextureCurve _brightCurve;
         private TextureCurve _flatHalfCurve;
+		private TextureCurve _mirrorRCurve;
+		private TextureCurve _mirrorGCurve;
+		private TextureCurve _mirrorBCurve;
+		private TextureCurve _posterMasterCurve;
+		private TextureCurve _posterLumSatCurve;
 
         private TextureCurveParameter _invertCurveParam;
         private TextureCurveParameter _defaultCurveParam;
+        private TextureCurveParameter _defaultLumSatCurveParam;
         private TextureCurveParameter _copierCurveParam;
         private TextureCurveParameter _brightCurveParam;
+		private TextureCurveParameter _mirrorRCurveParam;
+		private TextureCurveParameter _mirrorGCurveParam;
+		private TextureCurveParameter _mirrorBCurveParam;
+		private TextureCurveParameter _posterMasterCurveParam;
+		private TextureCurveParameter _posterLumSatCurveParam;
 
         private ClampedFloatParameter _defaultGrainIntensity;
         private ClampedFloatParameter _defaultGrainResponse;
@@ -76,6 +88,8 @@ namespace YARG.Venue.VenueCamera
             _defaultCurve =
                 new TextureCurve(new AnimationCurve(new Keyframe(0f, 0f, 1f, 1f), new Keyframe(1f, 1f, 1f, 1f)), 0.5f,
                     false, in bounds);
+            _defaultLumSatCurve =
+                new TextureCurve(new AnimationCurve(new Keyframe(0f, 0.5f), new Keyframe(1f, 0.5f)), 0.5f, false, in bounds);
             _invertCurve =
                 new TextureCurve(new AnimationCurve(new Keyframe(0, 0.550f, -1f, -6f), new Keyframe(0.25f, 0f, 0f, 0f)),
                     0.5f, false, in bounds);
@@ -85,12 +99,29 @@ namespace YARG.Venue.VenueCamera
                 false, in bounds);
             _flatHalfCurve = new TextureCurve(new AnimationCurve(new Keyframe(0f, 0.5f), new Keyframe(1.0f, 0.5f)),
                 0.5f, false, in bounds);
+            _mirrorRCurve = new TextureCurve(new AnimationCurve(new Keyframe(0.2f, 0f, 8.1f, 8.1f), 
+				new Keyframe(0.375f, 1f, 0f, 0f)), 0.5f, false, in bounds);
+            _mirrorGCurve = new TextureCurve(new AnimationCurve(new Keyframe(0f, 0.012f, 1.65f, 1.65f), 
+				new Keyframe(0.8f, 1f, 0.9f, 0.9f)), 0.5f, false, in bounds);
+			_mirrorBCurve = new TextureCurve(new AnimationCurve(new Keyframe(0.25f, 0f, 2.1f, 2.1f), 
+				new Keyframe(1f, 1f, 0.9f, 0.9f)), 0.5f, false, in bounds);
+			_posterMasterCurve = new TextureCurve(new AnimationCurve(new Keyframe(0.02f, 0f), new Keyframe(0.02f, 0.005f), 
+				new Keyframe(0.1f, 0.005f), new Keyframe(0.1f, 0.1f, 1f, 1f), new Keyframe(1f, 1f, 1f, 1f)), 
+				0.5f, false, in bounds);
+			_posterLumSatCurve = 
+				new TextureCurve(new AnimationCurve(new Keyframe(0.05f, 0f, 180f, 0f), new Keyframe(0.1f, 0.5f, 180f, 0f)),
+				0.5f, false, in bounds);
 
 
             _defaultCurveParam = new TextureCurveParameter(_defaultCurve);
             _invertCurveParam = new TextureCurveParameter(_invertCurve, true);
             _copierCurveParam = new TextureCurveParameter(_copierCurve, true);
             _brightCurveParam = new TextureCurveParameter(_brightCurve, true);
+			_mirrorRCurveParam = new TextureCurveParameter(_mirrorRCurve, true);
+			_mirrorGCurveParam = new TextureCurveParameter(_mirrorGCurve, true);
+			_mirrorBCurveParam = new TextureCurveParameter(_mirrorBCurve, true);
+			_posterMasterCurveParam = new TextureCurveParameter(_posterMasterCurve, true);
+			_posterLumSatCurveParam = new TextureCurveParameter(_posterLumSatCurve, true);
 
             _isPostProcessingEnabled = SettingsManager.Settings.VenuePostProcessing.Value;
             SettingsManager.Settings.VenuePostProcessing.OnChange += SetPostProcessingEnabled;
@@ -140,8 +171,6 @@ namespace YARG.Venue.VenueCamera
                     SetInvertedColors(true);
                     break;
                 case PostProcessingType.Mirror:
-                    // TODO: This is supposed to also have a "psychadelic coloring" effect
-                    // "Polarizes everything to green/orange with some blue and purple here and there"
                     SetMirror(true);
                     break;
                 case PostProcessingType.BlackAndWhite:
@@ -151,7 +180,6 @@ namespace YARG.Venue.VenueCamera
                     SetLowFrameRate(true);
                     SetBlackAndWhite(true);
                     SetGrainy(true);
-                    // SetBadCopier(true);
                     SetContrast(true);
                     break;
                 case PostProcessingType.Scanlines_BlackAndWhite:
@@ -161,7 +189,6 @@ namespace YARG.Venue.VenueCamera
                 case PostProcessingType.Polarized_BlackAndWhite:
                     SetBlackAndWhite(true);
                     SetContrast(true);
-                    // SetPosterize(true);
                     break;
                 case PostProcessingType.SepiaTone:
                     SetSepiaTone(true);
@@ -210,19 +237,18 @@ namespace YARG.Venue.VenueCamera
                 case PostProcessingType.Trails_Desaturated:
                     SetPosterize(true, 10);
                     SetTrail(true, 0.67f);
-                    SetDesaturation(true);
+                    SetTrailsDesaturation(true);
                     break;
                 case PostProcessingType.Trails_Long:
                     SetTrail(true, 0.67f);
                     break;
                 case PostProcessingType.Trails_Spacey:
                     SetTrail(true, 0.9f);
-                    // SetDesaturation(true, 20f);
                     SetBrightness(true);
                     SetBloom(true);
                     SetChromaticAberration(true);
                     break;
-                case PostProcessingType.Desaturated_Red: // TODO: This almost certainly needs drastic adjustment
+                case PostProcessingType.Desaturated_Red:
                     SetDesaturatedRed(true);
                     break;
                 case PostProcessingType.Desaturated_Blue:
@@ -292,8 +318,6 @@ namespace YARG.Venue.VenueCamera
                     SetInvertedColors(false);
                     break;
                 case PostProcessingType.Mirror:
-                    // TODO: This is supposed to also have a "psychadelic coloring" effect
-                    // "Polarizes everything to green/orange with some blue and purple here and there"
                     SetMirror(false);
                     break;
                 case PostProcessingType.BlackAndWhite:
@@ -311,7 +335,6 @@ namespace YARG.Venue.VenueCamera
                     break;
                 case PostProcessingType.Polarized_BlackAndWhite:
                     SetBlackAndWhite(false);
-                    // SetPosterize(false);
                     SetContrast(false);
                     break;
                 case PostProcessingType.SepiaTone:
@@ -361,7 +384,7 @@ namespace YARG.Venue.VenueCamera
                 case PostProcessingType.Trails_Desaturated:
                     SetPosterize(false);
                     SetTrail(false);
-                    SetDesaturation(false);
+                    SetTrailsDesaturation(false);
                     break;
                 case PostProcessingType.Trails_Long:
                     SetTrail(false);
@@ -372,7 +395,7 @@ namespace YARG.Venue.VenueCamera
 					SetBloom(false);
                     SetChromaticAberration(false);
                     break;
-                case PostProcessingType.Desaturated_Red: // TODO: This almost certainly needs drastic adjustment
+                case PostProcessingType.Desaturated_Red:
                     SetDesaturatedRed(false);
                     break;
                 case PostProcessingType.Desaturated_Blue:
@@ -425,6 +448,7 @@ namespace YARG.Venue.VenueCamera
             SetExposure(false);
             SetChromaticAberration(false);
             SetDesaturation(false);
+			SetTrailsDesaturation(false);
             SetDesaturatedRed(false);
             SetDesaturatedBlue(false);
             SetTrail(false);
@@ -559,12 +583,13 @@ namespace YARG.Venue.VenueCamera
 
         private void SetPosterize(bool enabled, int steps = 4)
         {
-            if (!_profile.TryGet<PosterizeComponent>(out var posterize))
+			if (!_profile.TryGet<ColorCurves>(out var colorCurves))
             {
                 return;
             }
-
-            SetAnimation(posterize.Steps, enabled ? steps : posterize.Steps.max, 0.01f, enabled);
+			
+			SetAnimation(colorCurves.master, enabled ? _posterMasterCurve : _defaultCurve, 0.01f, enabled);
+			SetAnimation(colorCurves.lumVsSat, enabled ? _posterLumSatCurve : _defaultLumSatCurve, 0.01f, enabled);
         }
 
         private void SetContrast(bool enabled)
@@ -623,6 +648,15 @@ namespace YARG.Venue.VenueCamera
 
             mirror.enabled.value = enabled;
             mirror.enabled.overrideState = enabled;
+			
+            if (!_profile.TryGet<ColorCurves>(out var colorCurves))
+            {
+                return;
+            }
+			
+			SetAnimation(colorCurves.red, enabled ? _mirrorRCurve : _defaultCurve, 0.01f, enabled);
+			SetAnimation(colorCurves.green, enabled ? _mirrorGCurve : _defaultCurve, 0.01f, enabled);
+			SetAnimation(colorCurves.blue, enabled ? _mirrorBCurve : _defaultCurve, 0.01f, enabled);
         }
 
         private void SetDesaturation(bool enabled, float strength = -50.0f)
@@ -633,6 +667,17 @@ namespace YARG.Venue.VenueCamera
             }
 
             SetAnimation(colorAdjustments.saturation, (float)(enabled ? strength : 0.0f), 0.01f, enabled);
+        }
+		
+		private void SetTrailsDesaturation(bool enabled, float strength = -85.0f, float contrast = 100f)
+        {
+            if (!_profile.TryGet<ColorAdjustments>(out var colorAdjustments))
+            {
+                return;
+            }
+
+            SetAnimation(colorAdjustments.saturation, (float)(enabled ? strength : 0.0f), 0.01f, enabled);
+            SetAnimation(colorAdjustments.contrast, (float)(enabled ? contrast : 0.0f), 0.01f, enabled);
         }
 
         private void SetBlackAndWhite(bool enabled)


### PR DESCRIPTION
Honestly been meaning to get around to this for a *while* and just kind of forgot until a couple days ago, whoops- but this brings posterize to, despite its name, its intended black-crushing only and as a nice bonus, trails aren't immediately cut off. Mirror also gets its color changes rather than being JUST the mirroring effect.