### PR TITLE
Move global state into PlayerAudioManager

### DIFF
--- a/Assets/Script/Audio/Bass/BassMetronomeSampleChannel.cs
+++ b/Assets/Script/Audio/Bass/BassMetronomeSampleChannel.cs
@@ -63,7 +63,7 @@ namespace YARG.Audio.BASS
             _loHandle = loHandle;
             _loChannel = loChannel;
             SetOutputChannel_Internal(outputChannel);
-            SetVolume_Internal(GlobalAudioHandler.GetTrueVolume(SongStem.Metronome));
+            SetVolume_Internal(GlobalAudioHandler.GetSampleTrueVolume(SongStem.Metronome));
         }
 
         protected override void PlayHi_Internal()

--- a/Assets/Script/Audio/Bass/BassSampleChannel.cs
+++ b/Assets/Script/Audio/Bass/BassSampleChannel.cs
@@ -64,7 +64,7 @@ namespace YARG.Audio.BASS
             _channel = channel;
             _lastPlaybackTime = -1;
             SetOutputChannel_Internal(outputChannel);
-            SetVolume_Internal(GlobalAudioHandler.GetTrueVolume(SongStem.Sfx));
+            SetVolume_Internal(GlobalAudioHandler.GetSampleTrueVolume(SongStem.Sfx));
         }
 
         protected override void Play_Internal(double duration)

--- a/Assets/Script/Audio/Bass/BassStemChannel.cs
+++ b/Assets/Script/Audio/Bass/BassStemChannel.cs
@@ -103,16 +103,16 @@ namespace YARG.Audio.BASS
         {
             _volume = volume;
 
-            int slideTime = (int)(duration * 1000);
+            int fadeTime = (int)(duration * 1000);
 
-            if (!Bass.ChannelSlideAttribute(_streamHandles.Stream, ChannelAttribute.Volume, (float) volume, slideTime))
+            if (!Bass.ChannelSlideAttribute(_streamHandles.Stream, ChannelAttribute.Volume, (float) volume, fadeTime))
             {
                 YargLogger.LogFormatError("Failed to set stream volume: {0}!", Bass.LastError);
             }
 
             float reverbVolume = _isReverbing ? (float) volume * BassHelpers.REVERB_VOLUME_MULTIPLIER : 0;
 
-            if (!Bass.ChannelSlideAttribute(_reverbHandles.Stream, ChannelAttribute.Volume, reverbVolume, slideTime))
+            if (!Bass.ChannelSlideAttribute(_reverbHandles.Stream, ChannelAttribute.Volume, reverbVolume, fadeTime))
             {
                 YargLogger.LogFormatError("Failed to set reverb volume: {0}!", Bass.LastError);
             }

--- a/Assets/Script/Audio/Bass/BassStemChannel.cs
+++ b/Assets/Script/Audio/Bass/BassStemChannel.cs
@@ -99,20 +99,20 @@ namespace YARG.Audio.BASS
             }
         }
 
-        protected override void SetVolume_Internal(double volume)
+        protected override void SetVolume_Internal(double volume, double duration = 0)
         {
             _volume = volume;
 
-            // Using ChannelSlideAttribute with a duration of 0 here instead of ChannelSetAttribute
-            // This will cancel any slides in progress that were started SetReverb_Internal
-            if (!Bass.ChannelSlideAttribute(_streamHandles.Stream, ChannelAttribute.Volume, (float) volume, 0))
+            int slideTime = (int)(duration * 1000);
+
+            if (!Bass.ChannelSlideAttribute(_streamHandles.Stream, ChannelAttribute.Volume, (float) volume, slideTime))
             {
                 YargLogger.LogFormatError("Failed to set stream volume: {0}!", Bass.LastError);
             }
 
             float reverbVolume = _isReverbing ? (float) volume * BassHelpers.REVERB_VOLUME_MULTIPLIER : 0;
 
-            if (!Bass.ChannelSlideAttribute(_reverbHandles.Stream, ChannelAttribute.Volume, reverbVolume, 0))
+            if (!Bass.ChannelSlideAttribute(_reverbHandles.Stream, ChannelAttribute.Volume, reverbVolume, slideTime))
             {
                 YargLogger.LogFormatError("Failed to set reverb volume: {0}!", Bass.LastError);
             }

--- a/Assets/Script/Audio/Bass/BassStemChannel.cs
+++ b/Assets/Script/Audio/Bass/BassStemChannel.cs
@@ -31,7 +31,7 @@ namespace YARG.Audio.BASS
                 YargLogger.LogFormatError("Failed to get channel length in bytes: {0}!", Bass.LastError);
             }
 
-            double volume = GlobalAudioHandler.GetTrueVolume(stem);
+            double volume = MixerAudioHandler.GetTrueVolume(stem);
             if (clampStemVolume && volume < MINIMUM_STEM_VOLUME)
             {
                 volume = MINIMUM_STEM_VOLUME;

--- a/Assets/Script/Audio/Bass/BassVoxSampleChannel.cs
+++ b/Assets/Script/Audio/Bass/BassVoxSampleChannel.cs
@@ -95,7 +95,7 @@ namespace YARG.Audio.BASS
             _channel = channel;
             SetOutputChannel_Internal(outputChannel);
             Channels.Add(this);
-            SetVolume_Internal(GlobalAudioHandler.GetTrueVolume(SongStem.VoxSample));
+            SetVolume_Internal(GlobalAudioHandler.GetSampleTrueVolume(SongStem.VoxSample));
         }
 
         protected override void Play_Internal()

--- a/Assets/Script/Audio/PlayerAudioManager.cs
+++ b/Assets/Script/Audio/PlayerAudioManager.cs
@@ -67,14 +67,11 @@ namespace YARG.Audio
             var state = GetOrCreateStemState(stem);
             if (IsMultiTrack && _mixerStems.Contains(stem))
             {
-                ++state.Total;
-                ++state.Audible;
+                state.RegisterTrack();
             }
             else if (_mixerStems.Contains(_backgroundStem))
             {
-                // Ensures the stem will still play at a minimum of 50%, even if all players mute
-                state.Total += 2;
-                state.Audible += 2;
+                state.RegisterBackground();
             }
         }
 
@@ -89,7 +86,7 @@ namespace YARG.Audio
             return state;
         }
 
-        public void ChangeStemMuteState(StemState state, bool muted)
+        private void ChangeStemMuteState(StemState state, bool muted)
         {
             if (MuteOnMissSetting == AudioFxMode.Off
                 || (MuteOnMissSetting == AudioFxMode.MultitrackOnly && !IsMultiTrack))
@@ -103,16 +100,8 @@ namespace YARG.Audio
 
         private void ChangeStemReverbState(StemState state, bool reverb)
         {
-            if (reverb)
-            {
-                state.ReverbCount++;
-            }
-            else if (state.ReverbCount > 0)
-            {
-                state.ReverbCount--;
-            }
-
-            MixerAudioHandler.SetReverbSetting(state.Stem, state.ReverbCount > 0);
+            var hasReverb = state.SetReverb(reverb);
+            MixerAudioHandler.SetReverbSetting(state.Stem, hasReverb);
         }
 
         private void HandlePlayerEvent(PlayerContext context, PlayerEvent playerEvent)
@@ -252,7 +241,7 @@ namespace YARG.Audio
             context.IsMuted = muted;
         }
 
-        private void ChangeWhammyPitch(PlayerContext context, float percent)
+        private static void ChangeWhammyPitch(PlayerContext context, float percent)
         {
             // Ignore whammy on the background stem to avoid pitch-bending the full mix.
             if (!context.IsMultiTrack)
@@ -263,7 +252,7 @@ namespace YARG.Audio
             MixerAudioHandler.SetWhammyPitchSetting(context.StemState.Stem, percent);
         }
 
-        private void PlayOverstrumSfx()
+        private static void PlayOverstrumSfx()
         {
             const int min = (int) SfxSample.Overstrum1;
             const int max = (int) SfxSample.Overstrum4;
@@ -271,7 +260,7 @@ namespace YARG.Audio
             GlobalAudioHandler.PlaySoundEffect(randomOverstrum);
         }
 
-        private void PlayMissSfx()
+        private static void PlayMissSfx()
         {
             GlobalAudioHandler.PlaySoundEffect(SfxSample.NoteMiss);
         }

--- a/Assets/Script/Audio/PlayerAudioManager.cs
+++ b/Assets/Script/Audio/PlayerAudioManager.cs
@@ -14,20 +14,39 @@ namespace YARG.Audio
 {
     public class PlayerAudioManager : IDisposable
     {
-        private readonly List<AudioHandler> _handlers;
-        private readonly GameManager        _gameManager;
-        private readonly SongStem           _backgroundStem;
+        private readonly List<AudioHandler>        _handlers;
+        private readonly GameManager               _gameManager;
+        private readonly SongStem                  _backgroundStem;
+        private readonly Dictionary<SongStem, int> _reverbCounts;
 
         public PlayerAudioManager(GameManager gameManager, SongStem backgroundStem)
         {
             _gameManager = gameManager;
             _backgroundStem = backgroundStem;
             _handlers = new List<AudioHandler>();
+            _reverbCounts = new Dictionary<SongStem, int>();
         }
 
-        public void AddPlayer(SongStem stem, BasePlayer player)
+        public void AddPlayer(SongStem stem, SongStem reverbStem, BasePlayer player)
         {
-            _handlers.Add(new AudioHandler(stem, player, _gameManager, stem == _backgroundStem));
+            _handlers.Add(new AudioHandler(stem, reverbStem, player, _gameManager, this, stem != _backgroundStem));
+        }
+
+        private static AudioFxMode StarPowerFxSetting => SettingsManager.Settings.UseStarpowerFx.Value;
+
+        private void ChangeStemReverbState(SongStem stem, bool reverb)
+        {
+            int count = _reverbCounts.GetValueOrDefault(stem);
+            if (reverb)
+            {
+                count++;
+            }
+            else if (count > 0)
+            {
+                count--;
+            }
+            _reverbCounts[stem] = count;
+            MixerAudioHandler.SetReverbSetting(stem, count > 0);
         }
 
         public void Dispose()
@@ -41,21 +60,25 @@ namespace YARG.Audio
 
         private class AudioHandler : IDisposable
         {
-            private readonly SongStem    _stem;
-            private readonly BasePlayer  _player;
-            private readonly GameManager _gameManager;
-            private readonly bool        _isBackgroundStem;
-            private          bool        _isMuted;
+            private readonly SongStem           _stem;
+            private readonly SongStem           _reverbStem;
+            private readonly BasePlayer         _player;
+            private readonly GameManager        _gameManager;
+            private readonly PlayerAudioManager _audioManager;
+            private readonly bool               _isMultiTrack;
+            private          bool               _isMuted;
             private          Instrument CurrentInstrument => _player.Player.Profile.CurrentInstrument;
             private          bool IsSeekingReplay => _gameManager.IsSeekingReplay;
             private static   bool AllowOverhitSfx => SettingsManager.Settings.OverstrumAndOverhitSoundEffects.Value;
             private static   bool AllowWhammySetting => SettingsManager.Settings.UseWhammyFx.Value;
 
-            public AudioHandler(SongStem stem, BasePlayer player, GameManager gameManager, bool isBackgroundStem)
+            public AudioHandler(SongStem stem, SongStem reverbStem, BasePlayer player, GameManager gameManager, PlayerAudioManager audioManager, bool isMultiTrack)
             {
                 _stem = stem;
+                _reverbStem = reverbStem;
                 _gameManager = gameManager;
-                _isBackgroundStem = isBackgroundStem;
+                _audioManager = audioManager;
+                _isMultiTrack = isMultiTrack;
                 _player = player;
                 _player.Events += HandlePlayerEvent;
             }
@@ -115,12 +138,15 @@ namespace YARG.Audio
 
             private void OnStarPowerChanged(bool active)
             {
-                var reverbStem = SongStem.Song;
-                if (_stem is Drums or Bass or Rhythm or Guitar)
+                var isSettingOff = StarPowerFxSetting == AudioFxMode.Off;
+                var isMultiTrackOnlySetting = StarPowerFxSetting == AudioFxMode.MultitrackOnly;
+                bool shouldSkipReverb = isSettingOff || (isMultiTrackOnlySetting && !_isMultiTrack);
+                if (shouldSkipReverb)
                 {
-                    reverbStem = _stem;
+                    return;
                 }
-                _gameManager.ChangeStemReverbState(reverbStem, active);
+
+                _audioManager.ChangeStemReverbState(_reverbStem, active);
             }
 
             private void OnWhammyDuringSustain(float whammyFactor)
@@ -195,7 +221,7 @@ namespace YARG.Audio
             private void ChangeWhammyPitch(float percent)
             {
                 // Ignore whammy on the background stem to avoid pitch-bending the full mix.
-                if (_isBackgroundStem)
+                if (!_isMultiTrack)
                 {
                     return;
                 }

--- a/Assets/Script/Audio/PlayerAudioManager.cs
+++ b/Assets/Script/Audio/PlayerAudioManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using YARG.Core;
 using YARG.Core.Audio;
@@ -16,7 +16,6 @@ namespace YARG.Audio
     {
         private readonly List<AudioHandler> _handlers;
         private readonly GameManager        _gameManager;
-        private static   bool AllowOverhitSfx => SettingsManager.Settings.OverstrumAndOverhitSoundEffects.Value;
 
         public PlayerAudioManager(GameManager gameManager)
         {
@@ -44,8 +43,10 @@ namespace YARG.Audio
             private readonly BasePlayer  _player;
             private readonly GameManager _gameManager;
             private          bool        _isMuted;
-            private Instrument CurrentInstrument => _player.Player.Profile.CurrentInstrument;
-            private bool IsSeekingReplay => _gameManager.IsSeekingReplay;
+            private          Instrument CurrentInstrument => _player.Player.Profile.CurrentInstrument;
+            private          bool IsSeekingReplay => _gameManager.IsSeekingReplay;
+            private static   bool AllowOverhitSfx => SettingsManager.Settings.OverstrumAndOverhitSoundEffects.Value;
+            private static   bool AllowWhammySetting => SettingsManager.Settings.UseWhammyFx.Value;
 
             public AudioHandler(SongStem stem, BasePlayer player, GameManager gameManager)
             {
@@ -120,6 +121,11 @@ namespace YARG.Audio
 
             private void OnWhammyDuringSustain(float whammyFactor)
             {
+                if (!AllowWhammySetting)
+                {
+                    return;
+                }
+
                 _gameManager.ChangeStemWhammyPitch(_stem, whammyFactor);
             }
 
@@ -149,7 +155,7 @@ namespace YARG.Audio
 
                 if (isComboBreak)
                 {
-                    GlobalAudioHandler.PlaySoundEffect(SfxSample.NoteMiss);
+                    PlayMissSfx();
                 }
             }
 
@@ -177,6 +183,7 @@ namespace YARG.Audio
                 {
                     return;
                 }
+
                 _gameManager.ChangeStemMuteState(_stem, muted);
                 _isMuted = muted;
             }
@@ -187,6 +194,11 @@ namespace YARG.Audio
                 const int max = (int) SfxSample.Overstrum4;
                 var randomOverstrum = (SfxSample) Random.Range(min, max + 1);
                 GlobalAudioHandler.PlaySoundEffect(randomOverstrum);
+            }
+
+            private void PlayMissSfx()
+            {
+                GlobalAudioHandler.PlaySoundEffect(SfxSample.NoteMiss);
             }
 
             public void Dispose()

--- a/Assets/Script/Audio/PlayerAudioManager.cs
+++ b/Assets/Script/Audio/PlayerAudioManager.cs
@@ -16,16 +16,18 @@ namespace YARG.Audio
     {
         private readonly List<AudioHandler> _handlers;
         private readonly GameManager        _gameManager;
+        private readonly SongStem           _backgroundStem;
 
-        public PlayerAudioManager(GameManager gameManager)
+        public PlayerAudioManager(GameManager gameManager, SongStem backgroundStem)
         {
             _gameManager = gameManager;
+            _backgroundStem = backgroundStem;
             _handlers = new List<AudioHandler>();
         }
 
         public void AddPlayer(SongStem stem, BasePlayer player)
         {
-            _handlers.Add(new AudioHandler(stem, player, _gameManager));
+            _handlers.Add(new AudioHandler(stem, player, _gameManager, stem == _backgroundStem));
         }
 
         public void Dispose()
@@ -42,16 +44,18 @@ namespace YARG.Audio
             private readonly SongStem    _stem;
             private readonly BasePlayer  _player;
             private readonly GameManager _gameManager;
+            private readonly bool        _isBackgroundStem;
             private          bool        _isMuted;
             private          Instrument CurrentInstrument => _player.Player.Profile.CurrentInstrument;
             private          bool IsSeekingReplay => _gameManager.IsSeekingReplay;
             private static   bool AllowOverhitSfx => SettingsManager.Settings.OverstrumAndOverhitSoundEffects.Value;
             private static   bool AllowWhammySetting => SettingsManager.Settings.UseWhammyFx.Value;
 
-            public AudioHandler(SongStem stem, BasePlayer player, GameManager gameManager)
+            public AudioHandler(SongStem stem, BasePlayer player, GameManager gameManager, bool isBackgroundStem)
             {
                 _stem = stem;
                 _gameManager = gameManager;
+                _isBackgroundStem = isBackgroundStem;
                 _player = player;
                 _player.Events += HandlePlayerEvent;
             }
@@ -126,12 +130,12 @@ namespace YARG.Audio
                     return;
                 }
 
-                _gameManager.ChangeStemWhammyPitch(_stem, whammyFactor);
+                ChangeWhammyPitch(whammyFactor);
             }
 
             private void OnSustainEnded()
             {
-                _gameManager.ChangeStemWhammyPitch(_stem, 0);
+                ChangeWhammyPitch(0);
             }
 
             private void OnSustainBroken()
@@ -186,6 +190,16 @@ namespace YARG.Audio
 
                 _gameManager.ChangeStemMuteState(_stem, muted);
                 _isMuted = muted;
+            }
+
+            private void ChangeWhammyPitch(float percent)
+            {
+                // Ignore whammy on the background stem to avoid pitch-bending the full mix.
+                if (_isBackgroundStem)
+                {
+                    return;
+                }
+                MixerAudioHandler.SetWhammyPitchSetting(_stem, percent);
             }
 
             private void PlayOverstrumSfx()

--- a/Assets/Script/Audio/PlayerAudioManager.cs
+++ b/Assets/Script/Audio/PlayerAudioManager.cs
@@ -45,6 +45,17 @@ namespace YARG.Audio
             _mixerStems = new HashSet<SongStem>(mixerStems);
         }
 
+        public void AddPlayer(BasePlayer player)
+        {
+            var instrumentStem = player.Player.Profile.CurrentInstrument.ToSongStem();
+            if (instrumentStem == Bass && !_mixerStems.Contains(Bass))
+            {
+                instrumentStem = Rhythm;
+            }
+            var reverbStem = _mixerStems.Contains(instrumentStem) ? instrumentStem : _backgroundStem;
+            AddPlayer(instrumentStem, reverbStem, player);
+        }
+
         public void AddPlayer(SongStem stem, SongStem reverbStem, BasePlayer player)
         {
             var context = new PlayerContext

--- a/Assets/Script/Audio/PlayerAudioManager.cs
+++ b/Assets/Script/Audio/PlayerAudioManager.cs
@@ -14,27 +14,70 @@ namespace YARG.Audio
 {
     public class PlayerAudioManager : IDisposable
     {
-        private readonly List<AudioHandler>        _handlers;
-        private readonly GameManager               _gameManager;
-        private readonly SongStem                  _backgroundStem;
-        private readonly Dictionary<SongStem, int> _reverbCounts;
+        private readonly List<AudioHandler>              _handlers;
+        private readonly GameManager                     _gameManager;
+        private readonly SongStem                        _backgroundStem;
+        private readonly Dictionary<SongStem, int>       _reverbCounts;
+        private readonly Dictionary<SongStem, StemState>  _stemStates;
+        private readonly HashSet<SongStem>               _mixerStems;
+        private bool IsMultiTrack => _mixerStems.Count > 1;
 
-        public PlayerAudioManager(GameManager gameManager, SongStem backgroundStem)
+        private static AudioFxMode MuteOnMissSetting => SettingsManager.Settings.MuteOnMiss.Value;
+
+        public PlayerAudioManager(GameManager gameManager, SongStem backgroundStem, IEnumerable<SongStem> mixerStems)
         {
             _gameManager = gameManager;
             _backgroundStem = backgroundStem;
             _handlers = new List<AudioHandler>();
             _reverbCounts = new Dictionary<SongStem, int>();
+            _stemStates = new Dictionary<SongStem, StemState>();
+            _mixerStems = new HashSet<SongStem>(mixerStems);
         }
 
         public void AddPlayer(SongStem stem, SongStem reverbStem, BasePlayer player)
         {
             _handlers.Add(new AudioHandler(stem, reverbStem, player, _gameManager, this, stem != _backgroundStem));
+            RegisterStemForPlayer(stem);
         }
 
-        public void ChangeStemMuteState(SongStem stem, bool muted, float duration = 0.0f)
+        private void RegisterStemForPlayer(SongStem stem)
         {
-            _gameManager.ChangeStemMuteState(stem, muted, duration);
+            var state = GetOrCreateStemState(stem);
+            if (IsMultiTrack && _mixerStems.Contains(stem))
+            {
+                ++state.Total;
+                ++state.Audible;
+            }
+            else if (_mixerStems.Contains(_backgroundStem))
+            {
+                // Ensures the stem will still play at a minimum of 50%, even if all players mute
+                state.Total += 2;
+                state.Audible += 2;
+            }
+        }
+
+        private StemState GetOrCreateStemState(SongStem stem)
+        {
+            if (!_stemStates.TryGetValue(stem, out var state))
+            {
+                state = new StemState(stem);
+                _stemStates[stem] = state;
+            }
+
+            return state;
+        }
+
+        public void ChangeStemMuteState(SongStem stem, bool muted)
+        {
+            if (MuteOnMissSetting == AudioFxMode.Off
+                || !_stemStates.TryGetValue(stem, out var state)
+                || (MuteOnMissSetting == AudioFxMode.MultitrackOnly && !IsMultiTrack))
+            {
+                return;
+            }
+
+            double volume = state.SetMute(muted);
+            MixerAudioHandler.SetVolumeSetting(stem, volume);
         }
 
         private static AudioFxMode StarPowerFxSetting => SettingsManager.Settings.UseStarpowerFx.Value;
@@ -61,6 +104,12 @@ namespace YARG.Audio
                 handler.Dispose();
             }
             _handlers.Clear();
+
+            // Restore player-owned stems to current user settings
+            foreach (var (stem, state) in _stemStates)
+            {
+                MixerAudioHandler.SetVolumeSetting(stem, state.Volume);
+            }
         }
 
         private class AudioHandler : IDisposable

--- a/Assets/Script/Audio/PlayerAudioManager.cs
+++ b/Assets/Script/Audio/PlayerAudioManager.cs
@@ -14,29 +14,51 @@ namespace YARG.Audio
 {
     public class PlayerAudioManager : IDisposable
     {
-        private readonly List<AudioHandler>              _handlers;
+        private class PlayerContext
+        {
+            public StemState           StemState;
+            public StemState           ReverbStemState;
+            public BasePlayer          Player;
+            public bool                IsMultiTrack;
+            public bool                IsMuted;
+            public Action<PlayerEvent> EventHandler;
+        }
+
+        private readonly List<PlayerContext>             _contexts;
         private readonly GameManager                     _gameManager;
         private readonly SongStem                        _backgroundStem;
-        private readonly Dictionary<SongStem, int>       _reverbCounts;
-        private readonly Dictionary<SongStem, StemState>  _stemStates;
+        private readonly Dictionary<SongStem, StemState> _stemStates;
         private readonly HashSet<SongStem>               _mixerStems;
-        private bool IsMultiTrack => _mixerStems.Count > 1;
+        private          bool                            IsMultiTrack => _mixerStems.Count > 1;
 
-        private static AudioFxMode MuteOnMissSetting => SettingsManager.Settings.MuteOnMiss.Value;
+        private static AudioFxMode MuteOnMissSetting  => SettingsManager.Settings.MuteOnMiss.Value;
+        private static AudioFxMode StarPowerFxSetting => SettingsManager.Settings.UseStarpowerFx.Value;
+        private static bool        AllowOverhitSfx    => SettingsManager.Settings.OverstrumAndOverhitSoundEffects.Value;
+        private static bool        AllowWhammySetting => SettingsManager.Settings.UseWhammyFx.Value;
 
         public PlayerAudioManager(GameManager gameManager, SongStem backgroundStem, IEnumerable<SongStem> mixerStems)
         {
             _gameManager = gameManager;
             _backgroundStem = backgroundStem;
-            _handlers = new List<AudioHandler>();
-            _reverbCounts = new Dictionary<SongStem, int>();
+            _contexts = new List<PlayerContext>();
             _stemStates = new Dictionary<SongStem, StemState>();
             _mixerStems = new HashSet<SongStem>(mixerStems);
         }
 
         public void AddPlayer(SongStem stem, SongStem reverbStem, BasePlayer player)
         {
-            _handlers.Add(new AudioHandler(stem, reverbStem, player, _gameManager, this, stem != _backgroundStem));
+            var context = new PlayerContext
+            {
+                StemState = GetOrCreateStemState(stem),
+                ReverbStemState = GetOrCreateStemState(reverbStem),
+                Player = player,
+                IsMultiTrack = stem != _backgroundStem
+            };
+
+            context.EventHandler = (playerEvent) => HandlePlayerEvent(context, playerEvent);
+            player.Events += context.EventHandler;
+            _contexts.Add(context);
+
             RegisterStemForPlayer(stem);
         }
 
@@ -67,237 +89,206 @@ namespace YARG.Audio
             return state;
         }
 
-        public void ChangeStemMuteState(SongStem stem, bool muted)
+        public void ChangeStemMuteState(StemState state, bool muted)
         {
             if (MuteOnMissSetting == AudioFxMode.Off
-                || !_stemStates.TryGetValue(stem, out var state)
                 || (MuteOnMissSetting == AudioFxMode.MultitrackOnly && !IsMultiTrack))
             {
                 return;
             }
 
             double volume = state.SetMute(muted);
-            MixerAudioHandler.SetVolumeSetting(stem, volume);
+            MixerAudioHandler.SetVolumeSetting(state.Stem, volume);
         }
 
-        private static AudioFxMode StarPowerFxSetting => SettingsManager.Settings.UseStarpowerFx.Value;
-
-        private void ChangeStemReverbState(SongStem stem, bool reverb)
+        private void ChangeStemReverbState(StemState state, bool reverb)
         {
-            int count = _reverbCounts.GetValueOrDefault(stem);
             if (reverb)
             {
-                count++;
+                state.ReverbCount++;
             }
-            else if (count > 0)
+            else if (state.ReverbCount > 0)
             {
-                count--;
+                state.ReverbCount--;
             }
-            _reverbCounts[stem] = count;
-            MixerAudioHandler.SetReverbSetting(stem, count > 0);
+
+            MixerAudioHandler.SetReverbSetting(state.Stem, state.ReverbCount > 0);
+        }
+
+        private void HandlePlayerEvent(PlayerContext context, PlayerEvent playerEvent)
+        {
+            YargLogger.LogDebug($"Received event: {playerEvent} for stem {context.StemState.Stem}");
+            switch (playerEvent)
+            {
+                case StarPowerChanged(var active):
+                    OnStarPowerChanged(context, active);
+                    break;
+                case ReplayTimeChanged:
+                    OnReplayTimeChanged(context);
+                    break;
+                case VisualsReset:
+                    OnVisualsReset(context);
+                    break;
+                case NoteHit:
+                    OnNoteHit(context);
+                    break;
+                case NoteMissed(var isComboBreak):
+                    OnNoteMissed(context, isComboBreak);
+                    break;
+                case Overhit:
+                    OnOverhit(context);
+                    break;
+                case SustainBroken:
+                    OnSustainBroken(context);
+                    break;
+                case SustainEnded:
+                    OnSustainEnded(context);
+                    break;
+                case StarPowerPhraseHit:
+                    OnStarPowerPhraseHit();
+                    break;
+                case WhammyDuringSustain(var whammyFactor):
+                    OnWhammyDuringSustain(context, whammyFactor);
+                    break;
+            }
+        }
+
+        private void OnReplayTimeChanged(PlayerContext context)
+        {
+            SetMuteState(context, false);
+        }
+
+        private void OnStarPowerPhraseHit()
+        {
+            if (_gameManager.Paused || _gameManager.IsSeekingReplay)
+            {
+                return;
+            }
+
+            GlobalAudioHandler.PlaySoundEffect(SfxSample.StarPowerAward);
+        }
+
+        private void OnStarPowerChanged(PlayerContext context, bool active)
+        {
+            var isSettingOff = StarPowerFxSetting == AudioFxMode.Off;
+            var isMultiTrackOnlySetting = StarPowerFxSetting == AudioFxMode.MultitrackOnly;
+            bool shouldSkipReverb = isSettingOff || (isMultiTrackOnlySetting && !context.IsMultiTrack);
+            if (shouldSkipReverb)
+            {
+                return;
+            }
+
+            ChangeStemReverbState(context.ReverbStemState, active);
+        }
+
+        private void OnWhammyDuringSustain(PlayerContext context, float whammyFactor)
+        {
+            if (!AllowWhammySetting)
+            {
+                return;
+            }
+
+            ChangeWhammyPitch(context, whammyFactor);
+        }
+
+        private void OnSustainEnded(PlayerContext context)
+        {
+            ChangeWhammyPitch(context, 0);
+        }
+
+        private void OnSustainBroken(PlayerContext context)
+        {
+            SetMuteState(context, true);
+        }
+
+        private void OnVisualsReset(PlayerContext context)
+        {
+            SetMuteState(context, false);
+        }
+
+        private void OnNoteMissed(PlayerContext context, bool isComboBreak)
+        {
+            if (_gameManager.IsSeekingReplay)
+            {
+                return;
+            }
+
+            SetMuteState(context, true);
+
+            if (isComboBreak)
+            {
+                PlayMissSfx();
+            }
+        }
+
+        private void OnOverhit(PlayerContext context)
+        {
+            var shouldPlaySfx = !_gameManager.IsSeekingReplay &&
+                context.Player.Player.Profile.CurrentInstrument.IsFiveFret() && AllowOverhitSfx;
+            if (shouldPlaySfx)
+            {
+                PlayOverstrumSfx();
+            }
+        }
+
+        private void OnNoteHit(PlayerContext context)
+        {
+            if (_gameManager.IsSeekingReplay)
+            {
+                return;
+            }
+
+            SetMuteState(context, false);
+        }
+
+        private void SetMuteState(PlayerContext context, bool muted)
+        {
+            if (context.StemState.Stem == Vocals || context.IsMuted == muted)
+            {
+                return;
+            }
+
+            ChangeStemMuteState(context.StemState, muted);
+            context.IsMuted = muted;
+        }
+
+        private void ChangeWhammyPitch(PlayerContext context, float percent)
+        {
+            // Ignore whammy on the background stem to avoid pitch-bending the full mix.
+            if (!context.IsMultiTrack)
+            {
+                return;
+            }
+
+            MixerAudioHandler.SetWhammyPitchSetting(context.StemState.Stem, percent);
+        }
+
+        private void PlayOverstrumSfx()
+        {
+            const int min = (int) SfxSample.Overstrum1;
+            const int max = (int) SfxSample.Overstrum4;
+            var randomOverstrum = (SfxSample) Random.Range(min, max + 1);
+            GlobalAudioHandler.PlaySoundEffect(randomOverstrum);
+        }
+
+        private void PlayMissSfx()
+        {
+            GlobalAudioHandler.PlaySoundEffect(SfxSample.NoteMiss);
         }
 
         public void Dispose()
         {
-            foreach (var handler in _handlers)
+            foreach (var context in _contexts)
             {
-                handler.Dispose();
+                context.Player.Events -= context.EventHandler;
             }
-            _handlers.Clear();
+
+            _contexts.Clear();
 
             // Restore player-owned stems to current user settings
-            foreach (var (stem, state) in _stemStates)
+            foreach (var state in _stemStates.Values)
             {
-                MixerAudioHandler.SetVolumeSetting(stem, state.Volume);
-            }
-        }
-
-        private class AudioHandler : IDisposable
-        {
-            private readonly SongStem           _stem;
-            private readonly SongStem           _reverbStem;
-            private readonly BasePlayer         _player;
-            private readonly GameManager        _gameManager;
-            private readonly PlayerAudioManager _audioManager;
-            private readonly bool               _isMultiTrack;
-            private          bool               _isMuted;
-            private          Instrument CurrentInstrument => _player.Player.Profile.CurrentInstrument;
-            private          bool IsSeekingReplay => _gameManager.IsSeekingReplay;
-            private static   bool AllowOverhitSfx => SettingsManager.Settings.OverstrumAndOverhitSoundEffects.Value;
-            private static   bool AllowWhammySetting => SettingsManager.Settings.UseWhammyFx.Value;
-
-            public AudioHandler(SongStem stem, SongStem reverbStem, BasePlayer player, GameManager gameManager, PlayerAudioManager audioManager, bool isMultiTrack)
-            {
-                _stem = stem;
-                _reverbStem = reverbStem;
-                _gameManager = gameManager;
-                _audioManager = audioManager;
-                _isMultiTrack = isMultiTrack;
-                _player = player;
-                _player.Events += HandlePlayerEvent;
-            }
-
-            private void HandlePlayerEvent(PlayerEvent playerEvent)
-            {
-                YargLogger.LogDebug($"Received event: {playerEvent} for stem {_stem}");
-                switch (playerEvent)
-                {
-                    case StarPowerChanged(var active):
-                        OnStarPowerChanged(active);
-                        break;
-                    case ReplayTimeChanged:
-                        OnReplayTimeChanged();
-                        break;
-                    case VisualsReset:
-                        OnVisualsReset();
-                        break;
-                    case NoteHit:
-                        OnNoteHit();
-                        break;
-                    case NoteMissed(var isComboBreak):
-                        OnNoteMissed(isComboBreak);
-                        break;
-                    case Overhit:
-                        OnOverhit();
-                        break;
-                    case SustainBroken:
-                        OnSustainBroken();
-                        break;
-                    case SustainEnded:
-                        OnSustainEnded();
-                        break;
-                    case StarPowerPhraseHit:
-                        OnStarPowerPhraseHit();
-                        break;
-                    case WhammyDuringSustain(var whammyFactor):
-                        OnWhammyDuringSustain(whammyFactor);
-                        break;
-                }
-            }
-
-            private void OnReplayTimeChanged()
-            {
-                SetMuteState(false);
-            }
-
-            private void OnStarPowerPhraseHit()
-            {
-                if (_gameManager.Paused || IsSeekingReplay)
-                {
-                    return;
-                }
-
-                GlobalAudioHandler.PlaySoundEffect(SfxSample.StarPowerAward);
-            }
-
-            private void OnStarPowerChanged(bool active)
-            {
-                var isSettingOff = StarPowerFxSetting == AudioFxMode.Off;
-                var isMultiTrackOnlySetting = StarPowerFxSetting == AudioFxMode.MultitrackOnly;
-                bool shouldSkipReverb = isSettingOff || (isMultiTrackOnlySetting && !_isMultiTrack);
-                if (shouldSkipReverb)
-                {
-                    return;
-                }
-
-                _audioManager.ChangeStemReverbState(_reverbStem, active);
-            }
-
-            private void OnWhammyDuringSustain(float whammyFactor)
-            {
-                if (!AllowWhammySetting)
-                {
-                    return;
-                }
-
-                ChangeWhammyPitch(whammyFactor);
-            }
-
-            private void OnSustainEnded()
-            {
-                ChangeWhammyPitch(0);
-            }
-
-            private void OnSustainBroken()
-            {
-                SetMuteState(true);
-            }
-
-            private void OnVisualsReset()
-            {
-                SetMuteState(false);
-            }
-
-            private void OnNoteMissed(bool isComboBreak)
-            {
-                if (IsSeekingReplay)
-                {
-                    return;
-                }
-
-                SetMuteState(true);
-
-                if (isComboBreak)
-                {
-                    PlayMissSfx();
-                }
-            }
-
-            private void OnOverhit()
-            {
-                var shouldPlaySfx = !IsSeekingReplay && CurrentInstrument.IsFiveFret() && AllowOverhitSfx;
-                if (shouldPlaySfx)
-                {
-                    PlayOverstrumSfx();
-                }
-            }
-
-            private void OnNoteHit()
-            {
-                if (IsSeekingReplay)
-                {
-                    return;
-                }
-                SetMuteState(false);
-            }
-
-            private void SetMuteState(bool muted)
-            {
-                if (_stem == Vocals || _isMuted == muted)
-                {
-                    return;
-                }
-
-                _audioManager.ChangeStemMuteState(_stem, muted);
-                _isMuted = muted;
-            }
-
-            private void ChangeWhammyPitch(float percent)
-            {
-                // Ignore whammy on the background stem to avoid pitch-bending the full mix.
-                if (!_isMultiTrack)
-                {
-                    return;
-                }
-                MixerAudioHandler.SetWhammyPitchSetting(_stem, percent);
-            }
-
-            private void PlayOverstrumSfx()
-            {
-                const int min = (int) SfxSample.Overstrum1;
-                const int max = (int) SfxSample.Overstrum4;
-                var randomOverstrum = (SfxSample) Random.Range(min, max + 1);
-                GlobalAudioHandler.PlaySoundEffect(randomOverstrum);
-            }
-
-            private void PlayMissSfx()
-            {
-                GlobalAudioHandler.PlaySoundEffect(SfxSample.NoteMiss);
-            }
-
-            public void Dispose()
-            {
-                _player.Events -= HandlePlayerEvent;
+                MixerAudioHandler.SetVolumeSetting(state.Stem, state.Volume);
             }
         }
     }

--- a/Assets/Script/Audio/PlayerAudioManager.cs
+++ b/Assets/Script/Audio/PlayerAudioManager.cs
@@ -32,6 +32,11 @@ namespace YARG.Audio
             _handlers.Add(new AudioHandler(stem, reverbStem, player, _gameManager, this, stem != _backgroundStem));
         }
 
+        public void ChangeStemMuteState(SongStem stem, bool muted, float duration = 0.0f)
+        {
+            _gameManager.ChangeStemMuteState(stem, muted, duration);
+        }
+
         private static AudioFxMode StarPowerFxSetting => SettingsManager.Settings.UseStarpowerFx.Value;
 
         private void ChangeStemReverbState(SongStem stem, bool reverb)
@@ -214,7 +219,7 @@ namespace YARG.Audio
                     return;
                 }
 
-                _gameManager.ChangeStemMuteState(_stem, muted);
+                _audioManager.ChangeStemMuteState(_stem, muted);
                 _isMuted = muted;
             }
 

--- a/Assets/Script/Audio/StemState.cs
+++ b/Assets/Script/Audio/StemState.cs
@@ -7,15 +7,16 @@ namespace YARG.Audio
     {
         private const double DEFAULT_VOLUME = 1.0;
 
-        private readonly SongStem _stem;
+        public readonly SongStem Stem;
         public int Total;
         public int Audible;
+        public int ReverbCount;
 
         public double Volume => GetVolumeSetting();
 
         public StemState(SongStem stem)
         {
-            _stem = stem;
+            Stem = stem;
         }
 
         public double SetMute(bool muted)
@@ -34,7 +35,7 @@ namespace YARG.Audio
 
         private double GetVolumeSetting()
         {
-            return _stem switch
+            return Stem switch
             {
                 SongStem.Guitar    => SettingsManager.Settings.GuitarVolume.Value,
                 SongStem.Rhythm    => SettingsManager.Settings.RhythmVolume.Value,

--- a/Assets/Script/Audio/StemState.cs
+++ b/Assets/Script/Audio/StemState.cs
@@ -8,9 +8,9 @@ namespace YARG.Audio
         private const double DEFAULT_VOLUME = 1.0;
 
         public readonly SongStem Stem;
-        public int Total;
-        public int Audible;
-        public int ReverbCount;
+        private         int      _total;
+        private         int      _audible;
+        private         int      _reverbCount;
 
         public double Volume => GetVolumeSetting();
 
@@ -19,18 +19,44 @@ namespace YARG.Audio
             Stem = stem;
         }
 
+        public void RegisterTrack()
+        {
+            _total++;
+            _audible++;
+        }
+
+        public void RegisterBackground()
+        {
+            _total += 2;
+            _audible += 2;
+        }
+
         public double SetMute(bool muted)
         {
             if (muted)
             {
-                --Audible;
+                --_audible;
             }
-            else if (Audible < Total)
+            else if (_audible < _total)
             {
-                ++Audible;
+                ++_audible;
             }
 
-            return Volume * Audible / Total;
+            return Volume * _audible / _total;
+        }
+
+        public bool SetReverb(bool reverb)
+        {
+            if (reverb)
+            {
+                _reverbCount++;
+            }
+            else if (_reverbCount > 0)
+            {
+                _reverbCount--;
+            }
+
+            return _reverbCount > 0;
         }
 
         private double GetVolumeSetting()

--- a/Assets/Script/Audio/StemState.cs
+++ b/Assets/Script/Audio/StemState.cs
@@ -1,0 +1,54 @@
+using YARG.Core.Audio;
+using YARG.Settings;
+
+namespace YARG.Audio
+{
+    public class StemState
+    {
+        private const double DEFAULT_VOLUME = 1.0;
+
+        private readonly SongStem _stem;
+        public int Total;
+        public int Audible;
+
+        public double Volume => GetVolumeSetting();
+
+        public StemState(SongStem stem)
+        {
+            _stem = stem;
+        }
+
+        public double SetMute(bool muted)
+        {
+            if (muted)
+            {
+                --Audible;
+            }
+            else if (Audible < Total)
+            {
+                ++Audible;
+            }
+
+            return Volume * Audible / Total;
+        }
+
+        private double GetVolumeSetting()
+        {
+            return _stem switch
+            {
+                SongStem.Guitar    => SettingsManager.Settings.GuitarVolume.Value,
+                SongStem.Rhythm    => SettingsManager.Settings.RhythmVolume.Value,
+                SongStem.Bass      => SettingsManager.Settings.BassVolume.Value,
+                SongStem.Keys      => SettingsManager.Settings.KeysVolume.Value,
+                SongStem.Drums     => SettingsManager.Settings.DrumsVolume.Value,
+                SongStem.Vocals    => SettingsManager.Settings.VocalsVolume.Value,
+                SongStem.Song      => SettingsManager.Settings.SongVolume.Value,
+                SongStem.Crowd     => SettingsManager.Settings.CrowdVolume.Value,
+                SongStem.Sfx       => SettingsManager.Settings.SfxVolume.Value,
+                SongStem.DrumSfx   => SettingsManager.Settings.DrumSfxVolume.Value,
+                SongStem.Metronome => SettingsManager.Settings.MetronomeVolume.Value,
+                _                  => DEFAULT_VOLUME
+            };
+        }
+    }
+}

--- a/Assets/Script/Audio/StemState.cs.meta
+++ b/Assets/Script/Audio/StemState.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c3c3aac7a494c4065ae0531526956799

--- a/Assets/Script/Gameplay/GameManager.Audio.cs
+++ b/Assets/Script/Gameplay/GameManager.Audio.cs
@@ -12,59 +12,13 @@ namespace YARG.Gameplay
     public partial class GameManager
     {
         private const double DEFAULT_VOLUME = 1.0;
-        public class StemState
-        {
-            private SongStem _stem;
-            public double Volume => GetVolumeSetting();
-            public int Total;
-            public int Audible;
-            public StemState(SongStem stem)
-            {
-                _stem = stem;
-            }
 
-            public double SetMute(bool muted)
-            {
-                if (muted)
-                {
-                    --Audible;
-                }
-                else if (Audible < Total)
-                {
-                    ++Audible;
-                }
-
-                return Volume * Audible / Total;
-            }
-
-            private double GetVolumeSetting()
-            {
-                return _stem switch
-                {
-                    SongStem.Guitar    => SettingsManager.Settings.GuitarVolume.Value,
-                    SongStem.Rhythm    => SettingsManager.Settings.RhythmVolume.Value,
-                    SongStem.Bass      => SettingsManager.Settings.BassVolume.Value,
-                    SongStem.Keys      => SettingsManager.Settings.KeysVolume.Value,
-                    SongStem.Drums     => SettingsManager.Settings.DrumsVolume.Value,
-                    SongStem.Vocals    => SettingsManager.Settings.VocalsVolume.Value,
-                    SongStem.Song      => SettingsManager.Settings.SongVolume.Value,
-                    SongStem.Crowd     => SettingsManager.Settings.CrowdVolume.Value,
-                    SongStem.Sfx       => SettingsManager.Settings.SfxVolume.Value,
-                    SongStem.DrumSfx   => SettingsManager.Settings.DrumSfxVolume.Value,
-                    SongStem.Metronome => SettingsManager.Settings.MetronomeVolume.Value,
-                    _                  => DEFAULT_VOLUME
-                };
-            }
-        }
-
-        private readonly Dictionary<SongStem, StemState>        _stemStates = new();
-        private          SongStem                               _backgroundStem;
-        private          TweenerCore<double, double, NoOptions> _volumeTween;
-        private          TweenerCore<double, double, NoOptions> _crowdVolumeTween;
+        private SongStem                               _backgroundStem;
+        private TweenerCore<double, double, NoOptions> _crowdVolumeTween;
+        private bool                                   _hasCrowdStem;
 
         private void LoadAudio()
         {
-            _stemStates.Clear();
             _mixer = Song.LoadAudio(GlobalVariables.State.SongSpeed, DEFAULT_VOLUME);
             if (_mixer == null)
             {
@@ -73,14 +27,15 @@ namespace YARG.Gameplay
                 return;
             }
 
-            _backgroundStem = SongStem.Song;
+            var mixerStems = new HashSet<SongStem>();
             foreach (var channel in _mixer.Channels)
             {
-                var stemState = new StemState(channel.Stem);
-                _stemStates.Add(channel.Stem, stemState);
+                mixerStems.Add(channel.Stem);
             }
 
-            _backgroundStem = _stemStates.Count > 1 ? SongStem.Song : _stemStates.First().Key;
+            _hasCrowdStem = mixerStems.Contains(SongStem.Crowd);
+            _backgroundStem = mixerStems.Count > 1 ? SongStem.Song : mixerStems.First();
+            _mixerStems = mixerStems;
         }
 
         public void ChangeStarPowerStatus(bool active)
@@ -93,38 +48,18 @@ namespace YARG.Gameplay
                 StarPowerActivations = 0;
         }
 
-        public void ChangeStemMuteState(SongStem stem, bool muted, float duration = 0.0f)
+        private void RestoreCrowdAudio()
         {
-            var setting = SettingsManager.Settings.MuteOnMiss.Value;
-            if (setting == AudioFxMode.Off
-            || !_stemStates.TryGetValue(stem, out var state)
-            || (setting == AudioFxMode.MultitrackOnly && stem == _backgroundStem))
+            _crowdVolumeTween?.Kill();
+            if (_hasCrowdStem)
             {
-                return;
-            }
-
-            double volume = state.SetMute(muted);
-
-            if (duration <= 0.0f)
-            {
-                MixerAudioHandler.SetVolumeSetting(stem, volume);
-                return;
-            }
-
-            if (_volumeTween == null || !_volumeTween.IsPlaying())
-            {
-                _volumeTween = DOTween.To(() => MixerAudioHandler.GetVolumeSetting(stem),
-                    x => MixerAudioHandler.SetVolumeSetting(stem, x), volume, duration);
-            }
-            else
-            {
-                _volumeTween.ChangeEndValue(volume);
+                MixerAudioHandler.SetVolumeSetting(SongStem.Crowd, SettingsManager.Settings.CrowdVolume.Value);
             }
         }
 
         public void ChangeCrowdMuteState(bool muted, float duration = 0.0f)
         {
-            if (!_stemStates.ContainsKey(SongStem.Crowd))
+            if (!_hasCrowdStem)
             {
                 return;
             }

--- a/Assets/Script/Gameplay/GameManager.Audio.cs
+++ b/Assets/Script/Gameplay/GameManager.Audio.cs
@@ -1,8 +1,5 @@
 using System.Collections.Generic;
 using System.Linq;
-using DG.Tweening;
-using DG.Tweening.Core;
-using DG.Tweening.Plugins.Options;
 using YARG.Core.Audio;
 using YARG.Playback;
 using YARG.Settings;
@@ -13,9 +10,8 @@ namespace YARG.Gameplay
     {
         private const double DEFAULT_VOLUME = 1.0;
 
-        private SongStem                               _backgroundStem;
-        private TweenerCore<double, double, NoOptions> _crowdVolumeTween;
-        private bool                                   _hasCrowdStem;
+        private SongStem _backgroundStem;
+        private bool     _hasCrowdStem;
 
         private void LoadAudio()
         {
@@ -45,12 +41,13 @@ namespace YARG.Gameplay
 
             StarPowerActivations += active ? 1 : -1;
             if (StarPowerActivations < 0)
+            {
                 StarPowerActivations = 0;
+            }
         }
 
         private void RestoreCrowdAudio()
         {
-            _crowdVolumeTween?.Kill();
             if (_hasCrowdStem)
             {
                 MixerAudioHandler.SetVolumeSetting(SongStem.Crowd, SettingsManager.Settings.CrowdVolume.Value);
@@ -65,24 +62,7 @@ namespace YARG.Gameplay
             }
 
             double volume = muted ? 0.0 : SettingsManager.Settings.CrowdVolume.Value;
-
-            if (duration <= 0.0f)
-            {
-                MixerAudioHandler.SetVolumeSetting(SongStem.Crowd, volume);
-                return;
-            }
-
-            if (_crowdVolumeTween == null || !_crowdVolumeTween.IsPlaying())
-            {
-                _crowdVolumeTween = DOTween.To(
-                    () => MixerAudioHandler.GetVolumeSetting(SongStem.Crowd),
-                    x => MixerAudioHandler.SetVolumeSetting(SongStem.Crowd, x),
-                    volume, duration);
-            }
-            else
-            {
-                _crowdVolumeTween.ChangeEndValue(volume);
-            }
+            MixerAudioHandler.SetVolumeSetting(SongStem.Crowd, volume, duration);
         }
 
     }

--- a/Assets/Script/Gameplay/GameManager.Audio.cs
+++ b/Assets/Script/Gameplay/GameManager.Audio.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using DG.Tweening;
 using DG.Tweening.Core;
 using DG.Tweening.Plugins.Options;
-using UnityEngine;
 using YARG.Core.Audio;
 using YARG.Playback;
 using YARG.Settings;
@@ -20,7 +19,6 @@ namespace YARG.Gameplay
             public int Total;
             public int Audible;
             public int ReverbCount;
-            public float WhammyPitch;
 
             public StemState(SongStem stem)
             {
@@ -52,14 +50,6 @@ namespace YARG.Gameplay
                     --ReverbCount;
                 }
                 return ReverbCount > 0;
-            }
-
-            public float SetWhammyPitch(float percent)
-            {
-                // TODO: Would be nice to handle multiple inputs
-                // but for now last one wins
-                WhammyPitch = Mathf.Clamp01(percent);
-                return WhammyPitch;
             }
 
             private double GetVolumeSetting()
@@ -173,26 +163,5 @@ namespace YARG.Gameplay
             MixerAudioHandler.SetReverbSetting(stem, reverbActive);
         }
 
-        public void ChangeStemWhammyPitch(SongStem stem, float percent)
-        {
-            // If the specified stem is the same as the background stem,
-            // ignore the request. This may be a chart without separate
-            // stems for each instrument. In that scenario we don't want
-            // to pitch bend because we'd be bending the entire track.
-            if (stem == _backgroundStem)
-            {
-                return;
-            }
-
-            // If we can't get the state for the stem, bail.
-            if (!_stemStates.TryGetValue(stem, out var state))
-            {
-                return;
-            }
-
-            // Set the pitch
-            float percentActive = state.SetWhammyPitch(percent);
-            MixerAudioHandler.SetWhammyPitchSetting(stem, percentActive);
-        }
     }
 }

--- a/Assets/Script/Gameplay/GameManager.Audio.cs
+++ b/Assets/Script/Gameplay/GameManager.Audio.cs
@@ -175,12 +175,6 @@ namespace YARG.Gameplay
 
         public void ChangeStemWhammyPitch(SongStem stem, float percent)
         {
-            // If Whammy FX is turned off, ignore.
-            if (!SettingsManager.Settings.UseWhammyFx.Value)
-            {
-                return;
-            }
-
             // If the specified stem is the same as the background stem,
             // ignore the request. This may be a chart without separate
             // stems for each instrument. In that scenario we don't want

--- a/Assets/Script/Gameplay/GameManager.Audio.cs
+++ b/Assets/Script/Gameplay/GameManager.Audio.cs
@@ -131,14 +131,14 @@ namespace YARG.Gameplay
 
             if (duration <= 0.0f)
             {
-                GlobalAudioHandler.SetVolumeSetting(stem, volume);
+                MixerAudioHandler.SetVolumeSetting(stem, volume);
                 return;
             }
 
             if (_volumeTween == null || !_volumeTween.IsPlaying())
             {
-                _volumeTween = DOTween.To(() => GlobalAudioHandler.GetVolumeSetting(stem),
-                    x => GlobalAudioHandler.SetVolumeSetting(stem, x), volume, duration);
+                _volumeTween = DOTween.To(() => MixerAudioHandler.GetVolumeSetting(stem),
+                    x => MixerAudioHandler.SetVolumeSetting(stem, x), volume, duration);
             }
             else
             {
@@ -170,7 +170,7 @@ namespace YARG.Gameplay
             }
 
             bool reverbActive = state.SetReverb(reverb);
-            GlobalAudioHandler.SetReverbSetting(stem, reverbActive);
+            MixerAudioHandler.SetReverbSetting(stem, reverbActive);
         }
 
         public void ChangeStemWhammyPitch(SongStem stem, float percent)
@@ -192,7 +192,7 @@ namespace YARG.Gameplay
 
             // Set the pitch
             float percentActive = state.SetWhammyPitch(percent);
-            GlobalAudioHandler.SetWhammyPitchSetting(stem, percentActive);
+            MixerAudioHandler.SetWhammyPitchSetting(stem, percentActive);
         }
     }
 }

--- a/Assets/Script/Gameplay/GameManager.Audio.cs
+++ b/Assets/Script/Gameplay/GameManager.Audio.cs
@@ -18,8 +18,6 @@ namespace YARG.Gameplay
             public double Volume => GetVolumeSetting();
             public int Total;
             public int Audible;
-            public int ReverbCount;
-
             public StemState(SongStem stem)
             {
                 _stem = stem;
@@ -37,19 +35,6 @@ namespace YARG.Gameplay
                 }
 
                 return Volume * Audible / Total;
-            }
-
-            public bool SetReverb(bool reverb)
-            {
-                if (reverb)
-                {
-                    ++ReverbCount;
-                }
-                else if (ReverbCount > 0)
-                {
-                    --ReverbCount;
-                }
-                return ReverbCount > 0;
             }
 
             private double GetVolumeSetting()
@@ -134,33 +119,6 @@ namespace YARG.Gameplay
             {
                 _volumeTween.ChangeEndValue(volume);
             }
-        }
-
-        public void ChangeStemReverbState(SongStem stem, bool reverb)
-        {
-            var setting = SettingsManager.Settings.UseStarpowerFx.Value;
-            if (setting == AudioFxMode.Off)
-            {
-                return;
-            }
-
-            StemState state;
-            while (!_stemStates.TryGetValue(stem, out state))
-            {
-                if (stem == _backgroundStem)
-                {
-                    return;
-                }
-                stem = _backgroundStem;
-            }
-
-            if (setting == AudioFxMode.MultitrackOnly && stem == _backgroundStem)
-            {
-                return;
-            }
-
-            bool reverbActive = state.SetReverb(reverb);
-            MixerAudioHandler.SetReverbSetting(stem, reverbActive);
         }
 
     }

--- a/Assets/Script/Gameplay/GameManager.Audio.cs
+++ b/Assets/Script/Gameplay/GameManager.Audio.cs
@@ -60,6 +60,7 @@ namespace YARG.Gameplay
         private readonly Dictionary<SongStem, StemState>        _stemStates = new();
         private          SongStem                               _backgroundStem;
         private          TweenerCore<double, double, NoOptions> _volumeTween;
+        private          TweenerCore<double, double, NoOptions> _crowdVolumeTween;
 
         private void LoadAudio()
         {
@@ -118,6 +119,34 @@ namespace YARG.Gameplay
             else
             {
                 _volumeTween.ChangeEndValue(volume);
+            }
+        }
+
+        public void ChangeCrowdMuteState(bool muted, float duration = 0.0f)
+        {
+            if (!_stemStates.ContainsKey(SongStem.Crowd))
+            {
+                return;
+            }
+
+            double volume = muted ? 0.0 : SettingsManager.Settings.CrowdVolume.Value;
+
+            if (duration <= 0.0f)
+            {
+                MixerAudioHandler.SetVolumeSetting(SongStem.Crowd, volume);
+                return;
+            }
+
+            if (_crowdVolumeTween == null || !_crowdVolumeTween.IsPlaying())
+            {
+                _crowdVolumeTween = DOTween.To(
+                    () => MixerAudioHandler.GetVolumeSetting(SongStem.Crowd),
+                    x => MixerAudioHandler.SetVolumeSetting(SongStem.Crowd, x),
+                    volume, duration);
+            }
+            else
+            {
+                _crowdVolumeTween.ChangeEndValue(volume);
             }
         }
 

--- a/Assets/Script/Gameplay/GameManager.Loading.cs
+++ b/Assets/Script/Gameplay/GameManager.Loading.cs
@@ -257,7 +257,7 @@ namespace YARG.Gameplay
 
         private void SetupPlayerAudio()
         {
-            _playerAudioManager = new PlayerAudioManager(this, _backgroundStem);
+            _playerAudioManager = new PlayerAudioManager(this, _backgroundStem, _mixerStems);
             foreach (var player in _players)
             {
                 var instrumentStem = player.Player.Profile.CurrentInstrument.ToSongStem();
@@ -486,24 +486,6 @@ namespace YARG.Gameplay
                         _players.Add(vocalsPlayer);
                     }
 
-                    // Add (or increase total of) the stem state
-                    var stem = player.Profile.CurrentInstrument.ToSongStem();
-                    if (stem == SongStem.Bass && !_stemStates.ContainsKey(SongStem.Bass))
-                    {
-                        stem = SongStem.Rhythm;
-                    }
-
-                    if (stem != _backgroundStem && _stemStates.TryGetValue(stem, out var state))
-                    {
-                        ++state.Total;
-                        ++state.Audible;
-                    }
-                    else if (_stemStates.TryGetValue(_backgroundStem, out state))
-                    {
-                        // Ensures the stem will still play at a minimum of 50%, even if all players mute
-                        state.Total += 2;
-                        state.Audible += 2;
-                    }
                 }
             }
             catch (Exception ex)

--- a/Assets/Script/Gameplay/GameManager.Loading.cs
+++ b/Assets/Script/Gameplay/GameManager.Loading.cs
@@ -198,13 +198,6 @@ namespace YARG.Gameplay
             CreatePlayers();
             SetupPlayerAudio();
 
-            // Set up the crowd stem so it can be restored after muting (if it exists)
-            if (_stemStates.TryGetValue(SongStem.Crowd, out var state))
-            {
-                state.Total = 1;
-                state.Audible = 1;
-            }
-
             if (_loadState == LoadFailureState.Error)
             {
                 ToastManager.ToastError(_loadFailureMessage);

--- a/Assets/Script/Gameplay/GameManager.Loading.cs
+++ b/Assets/Script/Gameplay/GameManager.Loading.cs
@@ -264,7 +264,7 @@ namespace YARG.Gameplay
 
         private void SetupPlayerAudio()
         {
-            _playerAudioManager = new PlayerAudioManager(this);
+            _playerAudioManager = new PlayerAudioManager(this, _backgroundStem);
             foreach (var player in _players)
             {
                 var songStem = player.Player.Profile.CurrentInstrument.ToSongStem();

--- a/Assets/Script/Gameplay/GameManager.Loading.cs
+++ b/Assets/Script/Gameplay/GameManager.Loading.cs
@@ -260,13 +260,7 @@ namespace YARG.Gameplay
             _playerAudioManager = new PlayerAudioManager(this, _backgroundStem, _mixerStems);
             foreach (var player in _players)
             {
-                var instrumentStem = player.Player.Profile.CurrentInstrument.ToSongStem();
-                if (instrumentStem == SongStem.Bass && _mixer[SongStem.Bass] == null)
-                {
-                    instrumentStem = SongStem.Rhythm;
-                }
-                var reverbStem = _mixer[instrumentStem] != null ? instrumentStem : _backgroundStem;
-                _playerAudioManager.AddPlayer(instrumentStem, reverbStem, player);
+                _playerAudioManager.AddPlayer(player);
             }
         }
 

--- a/Assets/Script/Gameplay/GameManager.Loading.cs
+++ b/Assets/Script/Gameplay/GameManager.Loading.cs
@@ -267,12 +267,13 @@ namespace YARG.Gameplay
             _playerAudioManager = new PlayerAudioManager(this, _backgroundStem);
             foreach (var player in _players)
             {
-                var songStem = player.Player.Profile.CurrentInstrument.ToSongStem();
-                if (songStem == SongStem.Bass && _mixer[SongStem.Bass] == null)
+                var instrumentStem = player.Player.Profile.CurrentInstrument.ToSongStem();
+                if (instrumentStem == SongStem.Bass && _mixer[SongStem.Bass] == null)
                 {
-                    songStem = SongStem.Rhythm;
+                    instrumentStem = SongStem.Rhythm;
                 }
-                _playerAudioManager.AddPlayer(songStem, player);
+                var reverbStem = _mixer[instrumentStem] != null ? instrumentStem : _backgroundStem;
+                _playerAudioManager.AddPlayer(instrumentStem, reverbStem, player);
             }
         }
 

--- a/Assets/Script/Gameplay/GameManager.cs
+++ b/Assets/Script/Gameplay/GameManager.cs
@@ -165,6 +165,7 @@ namespace YARG.Gameplay
         private int _originalSleepTimeout;
 
         private StemMixer _mixer;
+        private HashSet<SongStem> _mixerStems;
 
         private List<double> _frameTimes;
 
@@ -233,15 +234,8 @@ namespace YARG.Gameplay
             SettingsManager.Settings.NoFailMode.OnChange -= OnNoFailModeChanged;
             EngineManager.OnSongFailed -= OnSongFailed;
 
-            // Kill active volume tweens before restoring
-            _volumeTween?.Kill();
-            _crowdVolumeTween?.Kill();
-
-            //Restore stem volumes to their original state
-            foreach (var (stem, state) in _stemStates)
-            {
-                MixerAudioHandler.SetVolumeSetting(stem, state.Volume);
-            }
+            // Restore crowd audio before disposing
+            RestoreCrowdAudio();
 
             DisposeDebug();
             _pauseMenu.PopAllMenus();

--- a/Assets/Script/Gameplay/GameManager.cs
+++ b/Assets/Script/Gameplay/GameManager.cs
@@ -236,7 +236,7 @@ namespace YARG.Gameplay
             //Restore stem volumes to their original state
             foreach (var (stem, state) in _stemStates)
             {
-                GlobalAudioHandler.SetVolumeSetting(stem, state.Volume);
+                MixerAudioHandler.SetVolumeSetting(stem, state.Volume);
             }
 
             DisposeDebug();

--- a/Assets/Script/Gameplay/GameManager.cs
+++ b/Assets/Script/Gameplay/GameManager.cs
@@ -233,6 +233,10 @@ namespace YARG.Gameplay
             SettingsManager.Settings.NoFailMode.OnChange -= OnNoFailModeChanged;
             EngineManager.OnSongFailed -= OnSongFailed;
 
+            // Kill active volume tweens before restoring
+            _volumeTween?.Kill();
+            _crowdVolumeTween?.Kill();
+
             //Restore stem volumes to their original state
             foreach (var (stem, state) in _stemStates)
             {

--- a/Assets/Script/Playback/CrowdEventHandler.cs
+++ b/Assets/Script/Playback/CrowdEventHandler.cs
@@ -216,7 +216,7 @@ namespace YARG.Playback
         {
             if (IsCrowdMuted != muted)
             {
-                _gameManager.ChangeStemMuteState(SongStem.Crowd, muted, 1.0f);
+                _gameManager.ChangeCrowdMuteState(muted, 1.0f);
                 IsCrowdMuted = muted;
             }
         }

--- a/Assets/Script/Settings/SettingsManager.Settings.cs
+++ b/Assets/Script/Settings/SettingsManager.Settings.cs
@@ -191,37 +191,37 @@ namespace YARG.Settings
             public VolumeSetting MasterMusicVolume { get; } = new(0.75f, v => GlobalAudioHandler.SetMasterVolume(v));
 
             public VolumeSetting GuitarVolume { get; } =
-                new(1f, v => GlobalAudioHandler.SetVolumeSetting(SongStem.Guitar, v));
+                new(1f, v => MixerAudioHandler.SetVolumeSetting(SongStem.Guitar, v));
 
             public VolumeSetting RhythmVolume { get; } =
-                new(1f, v => GlobalAudioHandler.SetVolumeSetting(SongStem.Rhythm, v));
+                new(1f, v => MixerAudioHandler.SetVolumeSetting(SongStem.Rhythm, v));
 
             public VolumeSetting BassVolume { get; } =
-                new(1f, v => GlobalAudioHandler.SetVolumeSetting(SongStem.Bass, v));
+                new(1f, v => MixerAudioHandler.SetVolumeSetting(SongStem.Bass, v));
 
             public VolumeSetting KeysVolume { get; } =
-                new(1f, v => GlobalAudioHandler.SetVolumeSetting(SongStem.Keys, v));
+                new(1f, v => MixerAudioHandler.SetVolumeSetting(SongStem.Keys, v));
 
             public VolumeSetting DrumsVolume { get; } =
-                new(1f, v => GlobalAudioHandler.SetVolumeSetting(SongStem.Drums, v));
+                new(1f, v => MixerAudioHandler.SetVolumeSetting(SongStem.Drums, v));
 
             public VolumeSetting VocalsVolume { get; } =
-                new(1f, v => GlobalAudioHandler.SetVolumeSetting(SongStem.Vocals, v));
+                new(1f, v => MixerAudioHandler.SetVolumeSetting(SongStem.Vocals, v));
 
             public VolumeSetting SongVolume { get; } =
-                new(1f, v => GlobalAudioHandler.SetVolumeSetting(SongStem.Song, v));
+                new(1f, v => MixerAudioHandler.SetVolumeSetting(SongStem.Song, v));
 
             public VolumeSetting CrowdVolume { get; } =
-                new(1f, v => GlobalAudioHandler.SetVolumeSetting(SongStem.Crowd, v));
+                new(1f, v => MixerAudioHandler.SetVolumeSetting(SongStem.Crowd, v));
 
             public VolumeSetting SfxVolume { get; } =
-                new(0.8f, v => GlobalAudioHandler.SetVolumeSetting(SongStem.Sfx, v));
+                new(0.8f, v => GlobalAudioHandler.SetSampleVolumeSetting(SongStem.Sfx, v));
 
             public VolumeSetting DrumSfxVolume { get; } =
-                new(0.8f, v => GlobalAudioHandler.SetVolumeSetting(SongStem.DrumSfx, v));
+                new(0.8f, v => GlobalAudioHandler.SetSampleVolumeSetting(SongStem.DrumSfx, v));
 
             public VolumeSetting MetronomeVolume { get; } =
-                new(0.5f, v => GlobalAudioHandler.SetVolumeSetting(SongStem.Metronome, v));
+                new(0.5f, v => GlobalAudioHandler.SetSampleVolumeSetting(SongStem.Metronome, v));
 
             public VolumeSetting PreviewVolume { get; } = new(0.25f);
             public VolumeSetting MusicPlayerVolume { get; } = new(0.15f, MusicPlayerVolumeCallback);


### PR DESCRIPTION
Corresponding YARG.Core pr: https://github.com/YARC-Official/YARG.Core/pull/339

This moves things out of GlobalAudioHandler and GameManager.cs into PlayerAudioManager to reduce global state and simplify our audio handling

