### PR TITLE
Fix lyric bar behaviour in replays when scrubbing

### DIFF
--- a/Assets/Script/Gameplay/HUD/LyricBar.cs
+++ b/Assets/Script/Gameplay/HUD/LyricBar.cs
@@ -38,7 +38,8 @@ namespace YARG.Gameplay.HUD
         private const double MAX_TRANSITION_DURATION   = 0.3;
         private const double FADE_DURATION             = 0.5;
 
-        private bool ShouldEnable => !(GameManager.IsPractice || SettingsManager.Settings.LyricDisplay.Value == LyricDisplayMode.Disabled);
+        private bool ShouldEnable =>
+            !(GameManager.IsPractice || SettingsManager.Settings.LyricDisplay.Value == LyricDisplayMode.Disabled);
 
         protected override void GameplayAwake()
         {
@@ -92,20 +93,14 @@ namespace YARG.Gameplay.HUD
             BuildLyricQueue();
         }
 
-        private void BuildLyricQueue(double time = 0)
+        private void BuildLyricQueue()
         {
             var phrases = _songChart.Lyrics.Phrases;
             LyricBarPhrase.PhraseTransitionData previousPhraseTransitionData = null;
-            bool firstPhrase = true;
             for (int i = 0; i < phrases.Count; i++)
             {
                 var currentPhrase = phrases[i];
                 int textObjectIndex = i % PHRASE_OBJECT_COUNT;
-
-                if (currentPhrase.Time < time)
-                {
-                    continue;
-                }
 
                 var phraseData = new LyricBarPhrase.PhraseTransitionData
                 {
@@ -113,10 +108,8 @@ namespace YARG.Gameplay.HUD
                 };
 
                 // Can't use i == 0 since we may not be building from the start
-                if (firstPhrase)
+                if (i == 0)
                 {
-                    firstPhrase = false;
-
                     // First phrase fades in
                     double initialFadeInTime = currentPhrase.Time - FADE_DURATION;
                     phraseData.UpcomingTransition =
@@ -124,7 +117,7 @@ namespace YARG.Gameplay.HUD
                     phraseData.ActiveTransition =
                         new LyricBarPhrase.TransitionTiming(initialFadeInTime, initialFadeInTime);
                     previousPhraseTransitionData = phraseData;
-                    _lyricTextObjects[textObjectIndex].EnqueuePhrase(phraseData);
+                    _lyricTextObjects[textObjectIndex].AddPhrase(phraseData);
                     _fadeStartTimings.Add(initialFadeInTime);
                     continue;
                 }
@@ -181,7 +174,7 @@ namespace YARG.Gameplay.HUD
                 }
 
                 previousPhraseTransitionData = phraseData;
-                _lyricTextObjects[textObjectIndex].EnqueuePhrase(phraseData);
+                _lyricTextObjects[textObjectIndex].AddPhrase(phraseData);
             }
         }
 
@@ -195,17 +188,7 @@ namespace YARG.Gameplay.HUD
             // In case we are disabled already
             enabled = true;
 
-            // Clear everything
-            foreach (var lyricTextObject in _lyricTextObjects)
-            {
-                lyricTextObject.Reset();
-            }
-
-            _fadeStartTimings.Clear();
             _fadeIndex = 0;
-
-            // Rebuild lyric queue
-            BuildLyricQueue(time);
 
             // Tell LyricBarPhrase about the new time
             foreach (var lyricTextObject in _lyricTextObjects)
@@ -215,7 +198,8 @@ namespace YARG.Gameplay.HUD
             }
 
             // set the fade start index
-            while (_fadeStartTimings.Count > 0 && _fadeIndex < _fadeStartTimings.Count && _fadeStartTimings[_fadeIndex] < time + FADE_DURATION)
+            while (_fadeStartTimings.Count > 0 && _fadeIndex < _fadeStartTimings.Count &&
+                _fadeStartTimings[_fadeIndex] < time + FADE_DURATION)
             {
                 _fadeIndex++;
             }
@@ -223,35 +207,49 @@ namespace YARG.Gameplay.HUD
             if (_fadeIndex > _fadeStartTimings.Count - 1)
             {
                 enabled = false;
-            }
-        }
-
-        private void Update()
-        {
-            var fadeStartTime = _fadeStartTimings[_fadeIndex];
-            if (GameManager.VisualTime < fadeStartTime)
-            {
                 return;
             }
 
+            // We don't want to call SetAlpha when we are not in a fade in Update for performance,
+            // so call it once here to set the alpha to whatever it should be at the current time
+            SetAlpha(_fadeStartTimings[_fadeIndex]);
+        }
+
+        private void SetAlpha(double fadeStartTime)
+        {
             var startValue = _fadeIndex % 2 == 0 ? 0f : 1f;
             var targetValue = _fadeIndex % 2 == 0 ? 1f : 0f;
             var progress = Mathf.Clamp01((float) (1 - (fadeStartTime + FADE_DURATION - GameManager.VisualTime) /
                 FADE_DURATION));
             _canvas.alpha = DOVirtual.EasedValue(startValue, targetValue, progress, Ease.InOutSine);
-            if (GameManager.VisualTime >= fadeStartTime + FADE_DURATION)
-            {
-                if (_fadeIndex == _fadeStartTimings.Count - 1)
-                {
-                    // No more fades, lyric bar is done
-                    enabled = false;
-                    return;
-                }
+        }
 
-                YargLogger.LogFormatTrace("Lyric bar fade {0} complete at time {1}, from {2} to {3} alpha", _fadeIndex,
-                    GameManager.VisualTime, startValue, targetValue);
-                _fadeIndex++;
+        private void Update()
+        {
+            var fadeStartTime = _fadeStartTimings[_fadeIndex];
+
+            if (GameManager.VisualTime <= fadeStartTime)
+            {
+                return;
             }
+
+            SetAlpha(fadeStartTime);
+
+            if (GameManager.VisualTime < fadeStartTime + FADE_DURATION)
+            {
+                return;
+            }
+
+            YargLogger.LogFormatTrace("Lyric bar fade {0} complete at time {1}", _fadeIndex,
+                GameManager.VisualTime);
+            if (_fadeIndex == _fadeStartTimings.Count - 1)
+            {
+                // No more fades, lyric bar is done
+                enabled = false;
+                return;
+            }
+
+            _fadeIndex++;
         }
     }
 }

--- a/Assets/Script/Gameplay/HUD/LyricBar.cs
+++ b/Assets/Script/Gameplay/HUD/LyricBar.cs
@@ -90,10 +90,10 @@ namespace YARG.Gameplay.HUD
                 _lyricTextObjects[i] = phraseObject;
             }
 
-            BuildLyricQueue();
+            BuildLyricTimings();
         }
 
-        private void BuildLyricQueue()
+        private void BuildLyricTimings()
         {
             var phrases = _songChart.Lyrics.Phrases;
             LyricBarPhrase.PhraseTransitionData previousPhraseTransitionData = null;
@@ -107,7 +107,6 @@ namespace YARG.Gameplay.HUD
                     Phrase = currentPhrase,
                 };
 
-                // Can't use i == 0 since we may not be building from the start
                 if (i == 0)
                 {
                     // First phrase fades in

--- a/Assets/Script/Gameplay/HUD/LyricBarPhrase.cs
+++ b/Assets/Script/Gameplay/HUD/LyricBarPhrase.cs
@@ -35,10 +35,9 @@ namespace YARG.Gameplay.HUD
 
         private const float MINIMUM_TRANSITION_DURATION = 0.02f;
 
-        private readonly Queue<PhraseTransitionData> _phraseQueue = new();
-        private          PhraseTransitionData        _currentPhrase;
-
-        private readonly Vector2 _inactivePosition = new(0f, -90f);
+        private readonly List<PhraseTransitionData> _phrases = new();
+        private          int                        _currentPhraseIndex;
+        private readonly Vector2                    _inactivePosition = new(0f, -90f);
 
         private readonly Vector2 _upcomingPosition = new(0f, -72f);
         private readonly Vector2 _upcomingScale    = new(0.7f, 0.7f);
@@ -63,40 +62,24 @@ namespace YARG.Gameplay.HUD
             _builder.Dispose();
         }
 
-        public void EnqueuePhrase(PhraseTransitionData phrase)
+        public void AddPhrase(PhraseTransitionData phrase)
         {
-            _phraseQueue.Enqueue(phrase);
-            if (_currentPhrase == null)
+            _phrases.Add(phrase);
+            if (_phrases.Count == 1)
             {
-                MoveToNextPhrase();
+                MoveToPhraseAtTime(0);
             }
         }
 
-        private void MoveToNextPhrase()
+        private void MoveToPhraseAtTime(double time)
         {
-            // It appears that GameManager.VisualTime cannot be used in InChartLoaded,
-            // so when the first phrase is enqueued, we can't use it
-            if (_currentPhrase == null)
+            while (_phrases[_currentPhraseIndex].ExitTransition.TimeEnd < time)
             {
-                if (_phraseQueue.Count == 0)
+                _currentPhraseIndex++;
+                if (_currentPhraseIndex >= _phrases.Count)
                 {
                     gameObject.SetActive(false);
                     return;
-                }
-
-                _currentPhrase = _phraseQueue.Dequeue();
-            }
-            else
-            {
-                if (_phraseQueue.Count == 0)
-                {
-                    gameObject.SetActive(false);
-                    return;
-                }
-
-                while (_currentPhrase.ExitTransition.TimeEnd < GameManager.VisualTime)
-                {
-                    _currentPhrase = _phraseQueue.Dequeue();
                 }
             }
 
@@ -127,30 +110,31 @@ namespace YARG.Gameplay.HUD
 
         private void UpdatePosition()
         {
+            var currentPhrase = _phrases[_currentPhraseIndex];
             float timeFraction;
             var time = GameManager.VisualTime;
-            if (time >= _currentPhrase.ExitTransition.Time)
+            if (time >= currentPhrase.ExitTransition.Time)
             {
                 if (Mathf.Approximately(_lyricTextTransform.anchoredPosition.y, _finishedPosition.y))
                 {
                     return;
                 }
 
-                timeFraction = CalculateTimeFraction(_currentPhrase.ExitTransition);
+                timeFraction = CalculateTimeFraction(currentPhrase.ExitTransition);
                 _lyricTextTransform.anchoredPosition = DOVirtual.EasedValue(_activePosition, _finishedPosition,
                     timeFraction, Ease.InOutSine);
                 _lyricText.alpha = DOVirtual.EasedValue(1.0f, 0.0f, timeFraction, Ease.InOutSine);
                 return;
             }
 
-            if (time >= _currentPhrase.ActiveTransition.Time)
+            if (time >= currentPhrase.ActiveTransition.Time)
             {
                 if (Mathf.Approximately(_lyricTextTransform.anchoredPosition.y, _activePosition.y))
                 {
                     return;
                 }
 
-                timeFraction = CalculateTimeFraction(_currentPhrase.ActiveTransition);
+                timeFraction = CalculateTimeFraction(currentPhrase.ActiveTransition);
                 _lyricTextTransform.anchoredPosition = DOVirtual.EasedValue(_upcomingPosition, _activePosition,
                     timeFraction, Ease.InOutSine);
                 _lyricTextTransform.localScale = DOVirtual.EasedValue(
@@ -159,14 +143,14 @@ namespace YARG.Gameplay.HUD
                 return;
             }
 
-            if (time >= _currentPhrase.UpcomingTransition.Time)
+            if (time >= currentPhrase.UpcomingTransition.Time)
             {
                 if (Mathf.Approximately(_lyricTextTransform.anchoredPosition.y, _upcomingPosition.y))
                 {
                     return;
                 }
 
-                timeFraction = CalculateTimeFraction(_currentPhrase.UpcomingTransition);
+                timeFraction = CalculateTimeFraction(currentPhrase.UpcomingTransition);
                 _lyricTextTransform.anchoredPosition = DOVirtual.EasedValue(_inactivePosition,
                     _upcomingPosition, timeFraction, Ease.InOutSine);
                 _lyricText.alpha = DOVirtual.EasedValue(0.0f, UPCOMING_ALPHA, timeFraction, Ease.InOutSine);
@@ -175,18 +159,24 @@ namespace YARG.Gameplay.HUD
 
         private void Update()
         {
-            if (_currentPhrase == null)
+            var currentPhrase = _phrases[_currentPhraseIndex];
+            if (currentPhrase == null)
             {
                 return;
             }
 
             var time = GameManager.VisualTime;
-            if (GameManager.VisualTime >= _currentPhrase.ExitTransition.TimeEnd)
+            if (GameManager.VisualTime >= currentPhrase.ExitTransition.TimeEnd)
             {
-                MoveToNextPhrase();
+                MoveToPhraseAtTime(time);
+                // Make sure the rest of the function doesn't run if we ran out of phrases after moving to the next one
+                if (_currentPhraseIndex >= _phrases.Count)
+                {
+                    return;
+                }
             }
 
-            if (time >= _currentPhrase.ActiveTransition.TimeEnd && time <= _currentPhrase.ExitTransition.TimeEnd)
+            if (time >= currentPhrase.ActiveTransition.TimeEnd && time <= currentPhrase.ExitTransition.TimeEnd)
             {
                 UpdateHighlighting();
             }
@@ -196,7 +186,7 @@ namespace YARG.Gameplay.HUD
 
         private void UpdateHighlighting()
         {
-            var lyrics = _currentPhrase.Phrase.Lyrics;
+            var lyrics = _phrases[_currentPhraseIndex].Phrase.Lyrics;
             int currentIndex = _currentLyricIndex;
 
             while (currentIndex < lyrics.Count && lyrics[currentIndex].Time <= GameManager.VisualTime)
@@ -216,7 +206,7 @@ namespace YARG.Gameplay.HUD
 
         private void UpdatePhraseString()
         {
-            var lyrics = _currentPhrase.Phrase.Lyrics;
+            var lyrics = _phrases[_currentPhraseIndex].Phrase.Lyrics;
             _builder.Clear();
             // Highlighted words
             _builder.Append("<color=#5CB9FF>");
@@ -247,29 +237,10 @@ namespace YARG.Gameplay.HUD
             _lyricText.SetText(_builder);
         }
 
-        // Since it isn't super obvious, the way this works is that when song time changes, LyricBar calls Reset()
-        // to clear the queues and reset the lyric index, rebuilds everything from scratch, then calls SetSongTime
-        // to put things where they need to be without actually running all the tweens
-
-        public void Reset()
-        {
-            // Clear queues and reset index
-            _phraseQueue.Clear();
-            _currentPhrase = null;
-            _currentLyricIndex = 0;
-        }
-
         public void SetSongTime(double time)
         {
-            for (int i = 0; i < _phraseQueue.Count; i++)
-            {
-                if (_phraseQueue.TryPeek(out var phrase) && phrase.Phrase.TimeEnd < time)
-                {
-                    _currentPhrase = _phraseQueue.Dequeue();
-                }
-            }
-
-            // MoveToNextPhrase();
+            _currentPhraseIndex = 0;
+            MoveToPhraseAtTime(time);
         }
     }
 }


### PR DESCRIPTION
I ended up mostly just switching to using a list, which means that we don't need to remove and rebuild the data when scrubbing, we can just move to any arbitrary time in the song, and all the data should be updated to match.