### PR TITLE
Misc lyric bar fixes

### DIFF
--- a/Assets/Prefabs/Gameplay/HUD/LyricBarText.prefab
+++ b/Assets/Prefabs/Gameplay/HUD/LyricBarText.prefab
@@ -56,8 +56,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name:
-  m_EditorClassIdentifier:
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_RaycastTarget: 0
@@ -96,12 +96,12 @@ MonoBehaviour:
   m_fontSize: 36
   m_fontSizeBase: 36
   m_fontWeight: 400
-  m_enableAutoSizing: 0
+  m_enableAutoSizing: 1
   m_fontSizeMin: 18
-  m_fontSizeMax: 72
+  m_fontSizeMax: 36
   m_fontStyle: 0
   m_HorizontalAlignment: 2
-  m_VerticalAlignment: 256
+  m_VerticalAlignment: 512
   m_textAlignment: 65535
   m_characterSpacing: 0
   m_characterHorizontalScale: 1
@@ -110,7 +110,7 @@ MonoBehaviour:
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_TextWrappingMode: 1
+  m_TextWrappingMode: 0
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}
@@ -132,7 +132,7 @@ MonoBehaviour:
   m_VertexBufferAutoSizeReduction: 0
   m_useMaxVisibleDescender: 1
   m_pageToDisplay: 1
-  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_margin: {x: 133, y: 0, z: 133, w: 0}
   m_isUsingLegacyAnimationComponent: 0
   m_isVolumetricText: 0
   m_hasFontAssetChanged: 0
@@ -148,6 +148,6 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 7bead3b3ac094997a9e0f545e1496c5f, type: 3}
-  m_Name:
+  m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::YARG.Gameplay.HUD.LyricBarPhrase
   _lyricText: {fileID: 4873012408967528720}

--- a/Assets/Script/Gameplay/HUD/LyricBar.cs
+++ b/Assets/Script/Gameplay/HUD/LyricBar.cs
@@ -82,14 +82,15 @@ namespace YARG.Gameplay.HUD
                 // The object is already disabled in GameplayAwake, but that doesn't stop OnChartLoaded from being called
                 return;
             }
+            // If there are fewer phrases than PHRASE_OBJECT_COUNT, don't create more than we need
+            var phraseCount = Math.Min(_songChart.Lyrics.Phrases.Count, PHRASE_OBJECT_COUNT);
 
-            _lyricTextObjects = new LyricBarPhrase[PHRASE_OBJECT_COUNT];
-            for (int i = 0; i < PHRASE_OBJECT_COUNT; i++)
+            _lyricTextObjects = new LyricBarPhrase[phraseCount];
+            for (int i = 0; i < phraseCount; i++)
             {
                 var phraseObject = Instantiate(_phrasePrefab, _canvas.transform);
                 _lyricTextObjects[i] = phraseObject;
             }
-
             BuildLyricTimings();
         }
 


### PR DESCRIPTION
This fixes the lyric bar behavior when there is less than 3 but more than 0 phrases. For reference this is what happened before:
<img width="667" height="131" alt="image" src="https://github.com/user-attachments/assets/abc2ab6c-aa94-465e-8696-1dda2b433326" />

I also changed the lyric text prefab to automatically change font size based on width, set vertical alignment to center to prevent it from looking weird when shrunk, and reduced the horizontal margins slightly to prevent the text from going off of the edge of the default background. Example:

https://github.com/user-attachments/assets/53446ff6-3e6f-467b-b202-df80f3f57fa0

