### PR TITLE
Alternate hands on drum animations

### DIFF
--- a/Assets/Script/Venue/Characters/CharacterManager.cs
+++ b/Assets/Script/Venue/Characters/CharacterManager.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using Discord;
 using UnityEngine;
 using YARG.Core;
 using YARG.Core.Chart;

--- a/Assets/Script/Venue/Characters/CharacterManager.cs
+++ b/Assets/Script/Venue/Characters/CharacterManager.cs
@@ -483,7 +483,7 @@ namespace YARG.Venue.Characters
                 if (!character.IsAnimating())
                 {
                     character.StartAnimation(_currentTempo.SecondsPerBeat);
-                    return;
+                    break;
                 }
 
                 // If next note is more than secondsPerBeat away, stop animating
@@ -491,20 +491,29 @@ namespace YARG.Venue.Characters
                 {
                     character.StopAnimation();
                 }
+            }
 
-                while (_drumAnimationEvents.Count > 0 && _drumAnimationIndex < _drumAnimationEvents.Count &&
-                    _drumAnimationEvents[_drumAnimationIndex].Time - character.TimeToFirstHit <= GameManager.SongTime)
+            // Process animation events separately so they don't get skipped when StartAnimation exits early
+            var hasAnimationEvents = _drumAnimationIndex < _drumAnimationEvents.Count;
+            while (hasAnimationEvents)
+            {
+                var animEvent = _drumAnimationEvents[_drumAnimationIndex];
+                var animationIsReady = animEvent.Time - character.TimeToFirstHit <= GameManager.SongTime;
+                if (!animationIsReady)
                 {
-                    var animEvent = _drumAnimationEvents[_drumAnimationIndex];
-                    _drumAnimationIndex++;
-
-                    character.OnDrumAnimation(animEvent.Type);
-
-                    if (animEvent.Type == AnimationEvent.AnimationType.OpenHiHat)
-                    {
-                        _hatTimer = animEvent.TimeLength;
-                    }
+                    break;
                 }
+
+                _drumAnimationIndex++;
+
+                character.OnDrumAnimation(animEvent.Type);
+
+                if (animEvent.Type == AnimationEvent.AnimationType.OpenHiHat)
+                {
+                    _hatTimer = animEvent.TimeLength;
+                }
+
+                hasAnimationEvents = _drumAnimationIndex < _drumAnimationEvents.Count;
             }
         }
 

--- a/Assets/Script/Venue/Characters/CharacterManager.cs
+++ b/Assets/Script/Venue/Characters/CharacterManager.cs
@@ -512,17 +512,8 @@ namespace YARG.Venue.Characters
         {
             YargLogger.LogDebug("Auto-generating missing drum animations");
             _drumAnimationEvents.Clear();
-
-            // Create a drum animation event for each note, using GetDrumAnimationForNote
-            foreach (var parent in _drumNotes)
-            {
-                foreach (var note in parent.AllNotes)
-                {
-                    var anim = _drumCharacterHelper.GetDrumAnimationForNote(note);
-
-                    _drumAnimationEvents.Add(new AnimationEvent(anim, note.Time, note.TimeLength, note.Tick, note.TickLength));
-                }
-            }
+            var animationEvents = _drumCharacterHelper.GetDrumAnimations(_drumNotes);
+            _drumAnimationEvents.AddRange(animationEvents);
         }
 
         private static List<AnimationTrigger> GenerateMap<T>(List<T> notes) where T : Note<T>

--- a/Assets/Script/Venue/Characters/CharacterManager.cs
+++ b/Assets/Script/Venue/Characters/CharacterManager.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using Discord;
 using UnityEngine;
 using YARG.Core;
 using YARG.Core.Chart;
@@ -20,6 +21,8 @@ namespace YARG.Venue.Characters
         private GameObject _venue;
 
         private readonly Dictionary<VenueCharacter.CharacterType, VenueCharacter> _characters = new();
+
+        private DrumCharacterHelper _drumCharacterHelper = new();
 
         // Ugh, the different note types ruin me again
         private List<VocalNote>    _vocalNotes;
@@ -515,7 +518,7 @@ namespace YARG.Venue.Characters
             {
                 foreach (var note in parent.AllNotes)
                 {
-                    var anim = GetDrumAnimationForNote(note);
+                    var anim = _drumCharacterHelper.GetDrumAnimationForNote(note);
 
                     _drumAnimationEvents.Add(new AnimationEvent(anim, note.Time, note.TimeLength, note.Tick, note.TickLength));
                 }
@@ -628,23 +631,6 @@ namespace YARG.Venue.Characters
             triggers.Sort((a, b) => a.Time.CompareTo(b.Time));
 
             return triggers;
-        }
-
-        public static AnimationEvent.AnimationType GetDrumAnimationForNote(DrumNote child)
-        {
-            var pad = (FourLaneDrumPad) child.Pad;
-            return pad switch
-            {
-                FourLaneDrumPad.Kick => AnimationEvent.AnimationType.Kick,
-                FourLaneDrumPad.YellowCymbal => AnimationEvent.AnimationType.HihatRightHand,
-                FourLaneDrumPad.BlueCymbal => AnimationEvent.AnimationType.RideRh,
-                FourLaneDrumPad.GreenCymbal => AnimationEvent.AnimationType.Crash1RhHard,
-                FourLaneDrumPad.GreenDrum => AnimationEvent.AnimationType.FloorTomRightHand,
-                FourLaneDrumPad.BlueDrum => AnimationEvent.AnimationType.Tom2RightHand,
-                FourLaneDrumPad.YellowDrum => AnimationEvent.AnimationType.Tom1RightHand,
-                FourLaneDrumPad.RedDrum => AnimationEvent.AnimationType.SnareLhHard,
-                _ => throw new ArgumentOutOfRangeException(nameof(pad), pad, "Bad drum pad how?")
-            };
         }
 
         public enum TriggerType

--- a/Assets/Script/Venue/Characters/DrumCharacterHelper.cs
+++ b/Assets/Script/Venue/Characters/DrumCharacterHelper.cs
@@ -8,6 +8,8 @@ namespace YARG.Venue.Characters
     public class DrumCharacterHelper
     {
         private const double REPEAT_THRESHOLD = 0.125;
+        private readonly Random _random = new();
+
         private enum Hand
         {
             LEFT,
@@ -50,7 +52,9 @@ namespace YARG.Venue.Characters
                 var animations = GetAnimationsForParentNote(parent);
                 foreach (var animation in animations)
                 {
-                    drumAnimationEvents.Add(new AnimationEvent(animation, parent.Time, parent.TimeLength, parent.Tick, parent.TickLength));
+                    drumAnimationEvents.Add(
+                        new AnimationEvent(animation, parent.Time, parent.TimeLength, parent.Tick, parent.TickLength)
+                    );
                 }
             }
 
@@ -62,12 +66,12 @@ namespace YARG.Venue.Characters
             var animations = new List<AnimationEvent.AnimationType>();
             var padHands = new List<(FourLaneDrumPad Pad, Hand Hand)>();
 
+            //Map each pad to a hand
             foreach (var note in parentNote.AllNotes)
             {
                 var pad = (FourLaneDrumPad) note.Pad;
                 if (pad == FourLaneDrumPad.Kick)
                 {
-                    animations.Add(AnimationEvent.AnimationType.Kick);
                     continue;
                 }
 
@@ -75,28 +79,24 @@ namespace YARG.Venue.Characters
                 padHands.Add((pad, hand));
             }
 
-            // Resolve conflicting hands when two non-kick pads want the same hand
+            // Resolve conflicting hands by switching the first hand
             if (padHands.Count >= 2 && padHands[0].Hand == padHands[1].Hand)
             {
                 var first = padHands[0];
-                var second = padHands[1];
-                var firstDefault = _handStateByPad[first.Pad].DefaultHand;
-                var secondDefault = _handStateByPad[second.Pad].DefaultHand;
-
-                if (firstDefault != second.Hand)
-                {
-                    padHands[0] = (first.Pad, firstDefault);
-                }
-                else if (secondDefault != first.Hand)
-                {
-                    padHands[1] = (second.Pad, secondDefault);
-                }
-                else
-                {
-                    padHands[0] = (first.Pad, AlternateHand(first.Hand));
-                }
+                padHands[0] = (first.Pad, SwitchHand(first.Hand));
             }
 
+            // Special case: consecutive solo snare notes at non-fast tempo use right hand
+            var isSoloSnare = padHands.Count == 1 && padHands[0].Pad == FourLaneDrumPad.RedDrum;
+            var previousWasSnare = PreviousWasSnareHit(parentNote.PreviousNote);
+            var isNotFastRepeat = parentNote.PreviousNote is null
+                || parentNote.Time - parentNote.PreviousNote.Time > REPEAT_THRESHOLD;
+            if (isSoloSnare && previousWasSnare && isNotFastRepeat)
+            {
+                padHands[0] = (FourLaneDrumPad.RedDrum, Hand.RIGHT);
+            }
+
+            //Map each pad and hand to an animation
             foreach (var (pad, hand) in padHands)
             {
                 animations.Add(GetAnimationType(pad, hand));
@@ -110,7 +110,7 @@ namespace YARG.Venue.Characters
             var state = _handStateByPad.GetValueOrDefault(pad);
             if (state is null)
             {
-                YargLogger.LogFormatWarning("Unknown drum pad {0}, defaulting to right hand", pad);
+                YargLogger.LogFormatWarning("Unknown drum pad {0}, defaulting to right", pad);
                 return Hand.RIGHT;
             }
 
@@ -118,17 +118,49 @@ namespace YARG.Venue.Characters
             var isRepeatedNote = noteTime - previousHitTime <= REPEAT_THRESHOLD;
             var previousHand = state.LastUsedHand.GetValueOrDefault();
             var shouldAlternateHand = state.LastUsedHand.HasValue && isRepeatedNote;
-            var hand = shouldAlternateHand ? AlternateHand(previousHand) : state.DefaultHand;
+            var hand = shouldAlternateHand ? SwitchHand(previousHand) : state.DefaultHand;
             state.RecordHit(hand, noteTime);
             return hand;
         }
 
-        private static Hand AlternateHand(Hand hand)
+        private static bool PreviousWasSnareHit(DrumNote previousNote)
+        {
+            if (previousNote is null)
+            {
+                return false;
+            }
+
+            foreach (var note in previousNote.AllNotes)
+            {
+                var pad = (FourLaneDrumPad) note.Pad;
+                if (pad != FourLaneDrumPad.RedDrum && pad != FourLaneDrumPad.Kick)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private static Hand SwitchHand(Hand hand)
         {
             return hand == Hand.LEFT ? Hand.RIGHT : Hand.LEFT;
         }
 
-        private static AnimationEvent.AnimationType GetAnimationType(FourLaneDrumPad pad, Hand hand)
+        private AnimationEvent.AnimationType GetRandomCrashAnimation(Hand hand)
+        {
+            bool useCrash2 = _random.Next(2) == 0;
+            return (useCrash2, hand) switch
+            {
+                (false, Hand.LEFT)  => AnimationEvent.AnimationType.Crash1LhHard,
+                (false, Hand.RIGHT) => AnimationEvent.AnimationType.Crash1RhHard,
+                (true,  Hand.LEFT)  => AnimationEvent.AnimationType.Crash2LhHard,
+                (true,  Hand.RIGHT) => AnimationEvent.AnimationType.Crash2RhHard,
+                _ => AnimationEvent.AnimationType.Crash1LhHard,
+            };
+        }
+
+        private AnimationEvent.AnimationType GetAnimationType(FourLaneDrumPad pad, Hand hand)
         {
             return pad switch
             {
@@ -144,9 +176,7 @@ namespace YARG.Venue.Characters
                     ? AnimationEvent.AnimationType.RideLh
                     : AnimationEvent.AnimationType.RideRh,
 
-                FourLaneDrumPad.GreenCymbal => hand == Hand.LEFT
-                    ? AnimationEvent.AnimationType.Crash1LhHard
-                    : AnimationEvent.AnimationType.Crash1RhHard,
+                FourLaneDrumPad.GreenCymbal => GetRandomCrashAnimation(hand),
 
                 FourLaneDrumPad.YellowDrum => hand == Hand.LEFT
                     ? AnimationEvent.AnimationType.Tom1LeftHand
@@ -159,6 +189,8 @@ namespace YARG.Venue.Characters
                 FourLaneDrumPad.GreenDrum => hand == Hand.LEFT
                     ? AnimationEvent.AnimationType.FloorTomLeftHand
                     : AnimationEvent.AnimationType.FloorTomRightHand,
+
+                FourLaneDrumPad.Kick => AnimationEvent.AnimationType.Kick,
 
                 _ => throw new ArgumentOutOfRangeException(nameof(pad), pad, "Unsupported drum pad for animation mapping."),
             };

--- a/Assets/Script/Venue/Characters/DrumCharacterHelper.cs
+++ b/Assets/Script/Venue/Characters/DrumCharacterHelper.cs
@@ -74,16 +74,16 @@ namespace YARG.Venue.Characters
                 {
                     continue;
                 }
-
                 var hand = GetHandForPad(pad, note.Time);
                 padHands.Add((pad, hand));
             }
 
-            // Resolve conflicting hands by switching the first hand
+            // Resolve conflicting hands by switching one hand, preferring to keep blue unchanged
             if (padHands.Count >= 2 && padHands[0].Hand == padHands[1].Hand)
             {
-                var first = padHands[0];
-                padHands[0] = (first.Pad, SwitchHand(first.Hand));
+                var indexToSwitch = IsBlueCymbal(padHands[0].Pad) ? 1 : 0;
+                var toSwitch = padHands[indexToSwitch];
+                padHands[indexToSwitch] = (toSwitch.Pad, SwitchHand(toSwitch.Hand));
             }
 
             // Special case: consecutive solo snare notes at non-fast tempo use right hand
@@ -114,6 +114,13 @@ namespace YARG.Venue.Characters
                 return Hand.RIGHT;
             }
 
+            // Blue cymbal should stay right hand to prevent excessive twisting
+            if (IsBlueCymbal(pad))
+            {
+                state.RecordHit(state.DefaultHand, noteTime);
+                return state.DefaultHand;
+            }
+
             var previousHitTime = state.LastHitTime.GetValueOrDefault(double.MaxValue);
             var isRepeatedNote = noteTime - previousHitTime <= REPEAT_THRESHOLD;
             var previousHand = state.LastUsedHand.GetValueOrDefault();
@@ -140,6 +147,11 @@ namespace YARG.Venue.Characters
             }
 
             return true;
+        }
+
+        private static bool IsBlueCymbal(FourLaneDrumPad pad)
+        {
+            return pad == FourLaneDrumPad.BlueCymbal;
         }
 
         private static Hand SwitchHand(Hand hand)

--- a/Assets/Script/Venue/Characters/DrumCharacterHelper.cs
+++ b/Assets/Script/Venue/Characters/DrumCharacterHelper.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using YARG.Core.Chart;
+using YARG.Core.Logging;
 
 namespace YARG.Venue.Characters
 {
@@ -41,25 +42,75 @@ namespace YARG.Venue.Characters
                 { FourLaneDrumPad.RedDrum, new PadState(Hand.LEFT) },
             };
 
-        public AnimationEvent.AnimationType GetDrumAnimationForNote(DrumNote note)
+        public List<AnimationEvent> GetDrumAnimations(List<DrumNote> drumNotes)
         {
-            var pad = (FourLaneDrumPad) note.Pad;
-            if (pad == FourLaneDrumPad.Kick)
+            var drumAnimationEvents = new List<AnimationEvent>();
+            foreach (var parent in drumNotes)
             {
-                return AnimationEvent.AnimationType.Kick;
+                var animations = GetAnimationsForParentNote(parent);
+                foreach (var animation in animations)
+                {
+                    drumAnimationEvents.Add(new AnimationEvent(animation, parent.Time, parent.TimeLength, parent.Tick, parent.TickLength));
+                }
             }
 
-            var noteTime = note.Time;
-            var hand = GetHandForAnimation(pad, noteTime);
-            return GetAnimationType(pad, hand);
+            return drumAnimationEvents;
         }
 
-        private Hand GetHandForAnimation(FourLaneDrumPad pad, double noteTime)
+        private List<AnimationEvent.AnimationType> GetAnimationsForParentNote(DrumNote parentNote)
+        {
+            var animations = new List<AnimationEvent.AnimationType>();
+            var padHands = new List<(FourLaneDrumPad Pad, Hand Hand)>();
+
+            foreach (var note in parentNote.AllNotes)
+            {
+                var pad = (FourLaneDrumPad) note.Pad;
+                if (pad == FourLaneDrumPad.Kick)
+                {
+                    animations.Add(AnimationEvent.AnimationType.Kick);
+                    continue;
+                }
+
+                var hand = GetHandForPad(pad, note.Time);
+                padHands.Add((pad, hand));
+            }
+
+            // Resolve conflicting hands when two non-kick pads want the same hand
+            if (padHands.Count >= 2 && padHands[0].Hand == padHands[1].Hand)
+            {
+                var first = padHands[0];
+                var second = padHands[1];
+                var firstDefault = _handStateByPad[first.Pad].DefaultHand;
+                var secondDefault = _handStateByPad[second.Pad].DefaultHand;
+
+                if (firstDefault != second.Hand)
+                {
+                    padHands[0] = (first.Pad, firstDefault);
+                }
+                else if (secondDefault != first.Hand)
+                {
+                    padHands[1] = (second.Pad, secondDefault);
+                }
+                else
+                {
+                    padHands[0] = (first.Pad, AlternateHand(first.Hand));
+                }
+            }
+
+            foreach (var (pad, hand) in padHands)
+            {
+                animations.Add(GetAnimationType(pad, hand));
+            }
+
+            return animations;
+        }
+
+        private Hand GetHandForPad(FourLaneDrumPad pad, double noteTime)
         {
             var state = _handStateByPad.GetValueOrDefault(pad);
             if (state is null)
             {
-                //TODO log it
+                YargLogger.LogFormatWarning("Unknown drum pad {0}, defaulting to right hand", pad);
                 return Hand.RIGHT;
             }
 

--- a/Assets/Script/Venue/Characters/DrumCharacterHelper.cs
+++ b/Assets/Script/Venue/Characters/DrumCharacterHelper.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Collections.Generic;
+using YARG.Core.Chart;
+
+namespace YARG.Venue.Characters
+{
+    public class DrumCharacterHelper
+    {
+        private const double REPEAT_THRESHOLD = 0.125;
+        private enum Hand
+        {
+            LEFT,
+            RIGHT,
+        }
+
+        private sealed class PadState
+        {
+            public Hand    DefaultHand  { get; }
+            public Hand?   LastUsedHand { get; private set; }
+            public double? LastHitTime  { get; private set; }
+            public PadState(Hand defaultHand)
+            {
+                DefaultHand = defaultHand;
+            }
+            public void RecordHit(Hand selectedHand, double noteTime)
+            {
+                LastUsedHand = selectedHand;
+                LastHitTime = noteTime;
+            }
+        }
+
+        private readonly IReadOnlyDictionary<FourLaneDrumPad, PadState> _handStateByPad
+            = new Dictionary<FourLaneDrumPad, PadState>
+            {
+                { FourLaneDrumPad.YellowCymbal, new PadState(Hand.RIGHT) },
+                { FourLaneDrumPad.BlueCymbal, new PadState(Hand.RIGHT) },
+                { FourLaneDrumPad.GreenCymbal, new PadState(Hand.RIGHT) },
+                { FourLaneDrumPad.GreenDrum, new PadState(Hand.RIGHT) },
+                { FourLaneDrumPad.BlueDrum, new PadState(Hand.RIGHT) },
+                { FourLaneDrumPad.YellowDrum, new PadState(Hand.RIGHT) },
+                { FourLaneDrumPad.RedDrum, new PadState(Hand.LEFT) },
+            };
+
+        public AnimationEvent.AnimationType GetDrumAnimationForNote(DrumNote note)
+        {
+            var pad = (FourLaneDrumPad) note.Pad;
+            if (pad == FourLaneDrumPad.Kick)
+            {
+                return AnimationEvent.AnimationType.Kick;
+            }
+
+            var noteTime = note.Time;
+            var hand = GetHandForAnimation(pad, noteTime);
+            return GetAnimationType(pad, hand);
+        }
+
+        private Hand GetHandForAnimation(FourLaneDrumPad pad, double noteTime)
+        {
+            var state = _handStateByPad.GetValueOrDefault(pad);
+            if (state is null)
+            {
+                //TODO log it
+                return Hand.RIGHT;
+            }
+
+            var previousHitTime = state.LastHitTime.GetValueOrDefault(double.MaxValue);
+            var isRepeatedNote = noteTime - previousHitTime <= REPEAT_THRESHOLD;
+            var previousHand = state.LastUsedHand.GetValueOrDefault();
+            var shouldAlternateHand = state.LastUsedHand.HasValue && isRepeatedNote;
+            var hand = shouldAlternateHand ? AlternateHand(previousHand) : state.DefaultHand;
+            state.RecordHit(hand, noteTime);
+            return hand;
+        }
+
+        private static Hand AlternateHand(Hand hand)
+        {
+            return hand == Hand.LEFT ? Hand.RIGHT : Hand.LEFT;
+        }
+
+        private static AnimationEvent.AnimationType GetAnimationType(FourLaneDrumPad pad, Hand hand)
+        {
+            return pad switch
+            {
+                FourLaneDrumPad.RedDrum => hand == Hand.LEFT
+                    ? AnimationEvent.AnimationType.SnareLhHard
+                    : AnimationEvent.AnimationType.SnareRhHard,
+
+                FourLaneDrumPad.YellowCymbal => hand == Hand.LEFT
+                    ? AnimationEvent.AnimationType.HihatLeftHand
+                    : AnimationEvent.AnimationType.HihatRightHand,
+
+                FourLaneDrumPad.BlueCymbal => hand == Hand.LEFT
+                    ? AnimationEvent.AnimationType.RideLh
+                    : AnimationEvent.AnimationType.RideRh,
+
+                FourLaneDrumPad.GreenCymbal => hand == Hand.LEFT
+                    ? AnimationEvent.AnimationType.Crash1LhHard
+                    : AnimationEvent.AnimationType.Crash1RhHard,
+
+                FourLaneDrumPad.YellowDrum => hand == Hand.LEFT
+                    ? AnimationEvent.AnimationType.Tom1LeftHand
+                    : AnimationEvent.AnimationType.Tom1RightHand,
+
+                FourLaneDrumPad.BlueDrum => hand == Hand.LEFT
+                    ? AnimationEvent.AnimationType.Tom2LeftHand
+                    : AnimationEvent.AnimationType.Tom2RightHand,
+
+                FourLaneDrumPad.GreenDrum => hand == Hand.LEFT
+                    ? AnimationEvent.AnimationType.FloorTomLeftHand
+                    : AnimationEvent.AnimationType.FloorTomRightHand,
+
+                _ => throw new ArgumentOutOfRangeException(nameof(pad), pad, "Unsupported drum pad for animation mapping."),
+            };
+        }
+    }
+}

--- a/Assets/Script/Venue/Characters/DrumCharacterHelper.cs.meta
+++ b/Assets/Script/Venue/Characters/DrumCharacterHelper.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c28a690ba79c34bd48762a40c2119eb0

--- a/Assets/Script/Venue/Characters/VenueCharacter.AnimationLookups.cs
+++ b/Assets/Script/Venue/Characters/VenueCharacter.AnimationLookups.cs
@@ -640,7 +640,7 @@ namespace YARG.Venue.Characters
                 FourLaneDrumPad.Kick => AnimationStateType.Kick,
                 FourLaneDrumPad.YellowCymbal => AnimationStateType.HihatRightHand,
                 FourLaneDrumPad.BlueCymbal => AnimationStateType.RideRh,
-                FourLaneDrumPad.GreenCymbal => AnimationStateType.Crash1RhHard,
+                FourLaneDrumPad.GreenCymbal => AnimationStateType.Crash2RhHard,
                 FourLaneDrumPad.GreenDrum => AnimationStateType.FloorTomRightHand,
                 FourLaneDrumPad.BlueDrum => AnimationStateType.Tom2RightHand,
                 FourLaneDrumPad.YellowDrum => AnimationStateType.Tom1RightHand,

--- a/Assets/Script/Venue/Characters/VenueCharacter.AnimationLookups.cs
+++ b/Assets/Script/Venue/Characters/VenueCharacter.AnimationLookups.cs
@@ -640,7 +640,7 @@ namespace YARG.Venue.Characters
                 FourLaneDrumPad.Kick => AnimationStateType.Kick,
                 FourLaneDrumPad.YellowCymbal => AnimationStateType.HihatRightHand,
                 FourLaneDrumPad.BlueCymbal => AnimationStateType.RideRh,
-                FourLaneDrumPad.GreenCymbal => AnimationStateType.Crash2RhHard,
+                FourLaneDrumPad.GreenCymbal => AnimationStateType.Crash1RhHard,
                 FourLaneDrumPad.GreenDrum => AnimationStateType.FloorTomRightHand,
                 FourLaneDrumPad.BlueDrum => AnimationStateType.Tom2RightHand,
                 FourLaneDrumPad.YellowDrum => AnimationStateType.Tom1RightHand,


### PR DESCRIPTION
The drummer now uses both hands for rolls and quick hits on the same drum.  This applies only to auto generated drum animations.

- We disable alternating hands on blue cymbal as this causes YARG drummer to twist excessively, which looks funny
- Repeated slow snare hits use right hand instead of default left which looks more natural
- Green cymbal is randomly mapped to Crash1 or Crash2 to make use of both crash cymbals

Video:



https://github.com/user-attachments/assets/c330e5d0-84c1-48ab-83e6-738498ed18e5

