### PR TITLE
Update Settings content to remembered tab

### DIFF
--- a/Assets/Script/Menu/Settings/SettingsMenu.cs
+++ b/Assets/Script/Menu/Settings/SettingsMenu.cs
@@ -134,9 +134,20 @@ namespace YARG.Menu.Settings
 
             if (CurrentTab == null)
             {
-                CurrentTab = SettingsManager.DisplayedSettingsTabs[0];
-                _searchBarContainer.SetActive(false);
-                Refresh();
+                var tabId = !string.IsNullOrEmpty(_pendingTabName)
+                    ? _pendingTabName
+                    : _headerTabs.SelectedTabId;
+
+                if (!string.IsNullOrEmpty(tabId))
+                {
+                    SelectTabByName(tabId);
+                }
+                else
+                {
+                    CurrentTab = SettingsManager.DisplayedSettingsTabs[0];
+                    _searchBarContainer.SetActive(false);
+                    Refresh();
+                }
             }
         }
 


### PR DESCRIPTION
As of 2/17 in `Nightly`, there was an enhancement to remember what tab you were on in the Settings Menu.  This was necessary for navigating to the "Songs" tab specifically from the Music Library Menu when a song required a rescan.
However, this introduced a bug.  When leaving and returning to the Settings Menu, the tab was remembered, but the content would still show "General" *(see image)*, leaving users in a mixed state where they couldn't go to the tab they wanted unless they left first.  In other words, you couldn't click the tab you were *on* but not *on*.

<img width="1763" height="958" alt="image" src="https://github.com/user-attachments/assets/1eb9ce34-e045-4e61-be9a-851ffa467b31" />

Resolves threads:
https://discord.com/channels/1086048856678084609/1483461594070519919
https://discord.com/channels/1086048856678084609/1483562050197127168 *(duplicate)*