### PR TITLE
Fix venue not being visible with vocals only

### DIFF
--- a/Assets/Art/Shaders/UberPP.shader
+++ b/Assets/Art/Shaders/UberPP.shader
@@ -327,14 +327,13 @@ Shader "Artificial Artists/Universal Render Pipeline/AA_UberPost"
                 return half4(color, min(alpha, alpha_mask));
             }
 
-            return YargVenuePP(color, uvDistorted, uv);
+            if (_YargPosterizeSteps + _YargScanlineSize + _YargTrailLength > 0)
+            {
+                return YargVenuePP(color, uvDistorted, uv);
+            }
 
-            // #if _ENABLE_ALPHA_OUTPUT
-            // // Saturate is necessary to avoid issues when additive blending pushes the alpha over 1.
-            // return half4(color, saturate(inputColor.a));
-            // #else
-            // return half4(color, 1);
-            // #endif
+            // Saturate is necessary to avoid issues when additive blending pushes the alpha over 1.
+            return half4(color, saturate(inputColor.a));
         }
 
     ENDHLSL


### PR DESCRIPTION
The issue is that post processing shader uses number of highways being greater than zero as indicator that we're rendering highway texture and venue otherwise. with zero highways and just vocals we end up hardcoding alpha to 1 making highway texture opaque and hiding venue underneath it.

Fix by checking if any venue pp is enabled and if none then simply retain alpha channel (saturated) of the input texture.