### PR TITLE
Fix split lanes applying to non-Pro 4L

### DIFF
--- a/Assets/Script/Gameplay/Player/DrumsPlayer.cs
+++ b/Assets/Script/Gameplay/Player/DrumsPlayer.cs
@@ -205,7 +205,7 @@ namespace YARG.Gameplay.Player
                 kickFretPrefab,
                 colors,
                 Player.ThemePreset,
-                VisualStyle.FiveLaneDrums
+                _fiveLaneMode ? VisualStyle.FiveLaneDrums : VisualStyle.FourLaneDrums
             );
 
             // Particle 0 is always kick fret
@@ -768,7 +768,7 @@ namespace YARG.Gameplay.Player
                     { (int)FiveLaneDrumPad.Green,  new(ApplyHandednessToPosition(4),                                        ApplyHandednessToFiveLaneColor(FiveLaneDrumsFret.Green) ) }
                 };
             }
-            else if (Player.Profile.SplitProTomsAndCymbals)
+            else if (Player.Profile.SplitProTomsAndCymbals && Player.Profile.CurrentInstrument is Instrument.ProDrums)
             {
                 LaneCount = 7;
                 _highwayOrdering = new()


### PR DESCRIPTION
Fixes the bug where the Split Lanes option was applying to non-Pro 4L Drums. Also passes the correct VisualStyle to FretArray, although that wasn't really a noticeable problem in the first place