### PR TITLE
Use default keyboard binds when not bound to profile

### DIFF
--- a/Assets/Script/Input/Bindings/DefaultKeyboardMenuBindings.cs
+++ b/Assets/Script/Input/Bindings/DefaultKeyboardMenuBindings.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine.InputSystem;
+using YARG.Core.Input;
+
+namespace YARG.Input
+{
+    public sealed class DefaultKeyboardMenuBindings : IDisposable
+    {
+        private static readonly (MenuAction action, Key key)[] DefaultBindings =
+        {
+            (MenuAction.Green,  Key.Digit1),
+            (MenuAction.Red,    Key.Escape),
+            (MenuAction.Red,    Key.Digit2),
+            (MenuAction.Green,  Key.Enter),
+            (MenuAction.Yellow, Key.Digit3),
+            (MenuAction.Blue,   Key.Digit4),
+            (MenuAction.Orange, Key.Digit5),
+            (MenuAction.Start,  Key.Space),
+            (MenuAction.Select, Key.Backspace),
+            (MenuAction.Up,     Key.UpArrow),
+            (MenuAction.Down,   Key.DownArrow),
+            (MenuAction.Left,   Key.LeftArrow),
+            (MenuAction.Right,  Key.RightArrow),
+        };
+
+        private readonly InputAction[] _inputActions = new InputAction[DefaultBindings.Length];
+
+        public DefaultKeyboardMenuBindings()
+        {
+            SetupBinds();
+            Enable();
+        }
+
+        private void SetupBinds()
+        {
+            for (int i = 0; i < DefaultBindings.Length; i++)
+            {
+                var (menuAction, key) = DefaultBindings[i];
+
+                var action = new InputAction(
+                    name: $"Menu_{menuAction}_{key}",
+                    type: InputActionType.Button,
+                    binding: $"<Keyboard>/{key}"
+                );
+
+                action.performed += _ => InputManager.OnMenuAction(menuAction, true);
+                action.canceled += _ => InputManager.OnMenuAction(menuAction, false);
+                _inputActions[i] = action;
+            }
+        }
+
+        public void Dispose()
+        {
+            foreach (var action in _inputActions)
+            {
+                action.Disable();
+                action.Dispose();
+            }
+        }
+
+        public void Enable()
+        {
+            foreach (var action in _inputActions)
+            {
+                action.Enable();
+            }
+        }
+
+        public void Disable()
+        {
+            foreach (var action in _inputActions)
+            {
+                action.Disable();
+            }
+        }
+    }
+}

--- a/Assets/Script/Input/Bindings/DefaultKeyboardMenuBindings.cs
+++ b/Assets/Script/Input/Bindings/DefaultKeyboardMenuBindings.cs
@@ -37,11 +37,12 @@ namespace YARG.Input
             for (int i = 0; i < DefaultBindings.Length; i++)
             {
                 var (menuAction, key) = DefaultBindings[i];
+                var keyPath = key.ToString().Replace("Digit", "");
 
                 var action = new InputAction(
                     name: $"Menu_{menuAction}_{key}",
                     type: InputActionType.Button,
-                    binding: $"<Keyboard>/{key}"
+                    binding: $"<Keyboard>/{keyPath}"
                 );
 
                 action.performed += _ => InputManager.OnMenuAction(menuAction, true);

--- a/Assets/Script/Input/Bindings/DefaultKeyboardMenuBindings.cs
+++ b/Assets/Script/Input/Bindings/DefaultKeyboardMenuBindings.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using UnityEngine.InputSystem;
 using YARG.Core.Input;
+using YARG.Player;
 
 namespace YARG.Input
 {

--- a/Assets/Script/Input/Bindings/DefaultKeyboardMenuBindings.cs.meta
+++ b/Assets/Script/Input/Bindings/DefaultKeyboardMenuBindings.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d3744af10cba40178df4871b1a04d2d6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Script/Input/InputManager.cs
+++ b/Assets/Script/Input/InputManager.cs
@@ -8,6 +8,7 @@ using UnityEngine.InputSystem.Layouts;
 using UnityEngine.InputSystem.LowLevel;
 using YARG.Core.Input;
 using YARG.Core.Logging;
+using YARG.Menu.Navigation;
 using YARG.Menu.Persistent;
 using YARG.Player;
 using YARG.Settings;
@@ -52,12 +53,22 @@ namespace YARG.Input
 
         private static HashSet<InputDevice> _registeredDevices = new();
 
+        private static DefaultKeyboardMenuBindings _defaultKeyboardMenuBindings;
+
         // We do this song and dance of tracking focus changes manually rather than setting
         // InputSettings.backgroundBehavior to IgnoreFocus, so that input is still (largely) disabled when unfocused
         // but devices are not removed only to be re-added when coming back into focus
         private static bool _gameFocused;
         private static bool _focusChanged;
         private static HashSet<InputDevice> _backgroundDisabledDevices = new();
+        public static bool HasRegisteredKeyboard
+        {
+            get
+            {
+                var keyboard = InputSystem.GetDevice<Keyboard>();
+                return keyboard != null && _registeredDevices.Contains(keyboard);
+            }
+        }
 
         public static void Initialize()
         {
@@ -71,6 +82,8 @@ namespace YARG.Input
             _gameFocused = Application.isFocused;
             Application.focusChanged += OnFocusChange;
             InputSystem.onDeviceChange += OnDeviceChange;
+
+            _defaultKeyboardMenuBindings = new DefaultKeyboardMenuBindings();
 
             // Notify of all current devices
             ToastManager.ToastInformation("Devices found: " + (Microphone.devices.Length + InputSystem.devices.Count));
@@ -98,6 +111,9 @@ namespace YARG.Input
 
         public static void Destroy()
         {
+            _defaultKeyboardMenuBindings?.Dispose();
+            _defaultKeyboardMenuBindings = null;
+
             InputSystem.onEvent -= OnEvent;
 
             InputSystem.onBeforeUpdate -= OnBeforeUpdate;
@@ -109,6 +125,9 @@ namespace YARG.Input
         public static void RegisterPlayer(YargPlayer player)
         {
             player.MenuInput += OnMenuInput;
+            player.Bindings.DeviceAdded += OnPlayerBindingDeviceAdded;
+            player.Bindings.DeviceRemoved += OnPlayerBindingDeviceRemoved;
+
             foreach (var device in player.Bindings.InputDevices)
             {
                 if (!_registeredDevices.Add(device))
@@ -121,6 +140,8 @@ namespace YARG.Input
         public static void UnregisterPlayer(YargPlayer player)
         {
             player.MenuInput -= OnMenuInput;
+            player.Bindings.DeviceAdded -= OnPlayerBindingDeviceAdded;
+            player.Bindings.DeviceRemoved -= OnPlayerBindingDeviceRemoved;
 
             foreach (var device in player.Bindings.InputDevices)
             {
@@ -129,6 +150,38 @@ namespace YARG.Input
                     YargLogger.LogFormatError("Player not registered with device: {0}", device);
                 }
             }
+        }
+
+        private static void OnPlayerBindingDeviceAdded(InputDevice device)
+        {
+            if (!_registeredDevices.Add(device))
+            {
+                YargLogger.LogFormatError("Device already registered when added to player bindings: {0}", device);
+            }
+
+            if (HasRegisteredKeyboard)
+            {
+                _defaultKeyboardMenuBindings.Disable();
+            }
+        }
+
+        private static void OnPlayerBindingDeviceRemoved(InputDevice device)
+        {
+            if (!_registeredDevices.Remove(device))
+            {
+                YargLogger.LogFormatError("Device not registered when removed from player bindings: {0}", device);
+            }
+
+            if (!HasRegisteredKeyboard)
+            {
+                _defaultKeyboardMenuBindings.Enable();
+            }
+        }
+
+        public static void OnMenuAction(MenuAction action, bool pressed)
+        {
+            var input = new GameInput(CurrentInputTime, (int)action, pressed);
+            MenuInput?.Invoke(null, ref input);
         }
 
         private static void OnMenuInput(YargPlayer player, ref GameInput input)

--- a/Assets/Script/Input/InputManager.cs
+++ b/Assets/Script/Input/InputManager.cs
@@ -63,7 +63,12 @@ namespace YARG.Input
         private static bool _focusChanged;
         private static HashSet<InputDevice> _backgroundDisabledDevices = new();
 
-        private static bool HasProfileWithKeyboard => _registeredDevices.Any(d => d is Keyboard);
+        private static bool HasProfileWithKeyboard =>
+            PlayerContainer.Players
+                .Where(p => p.InputsEnabled)
+                .SelectMany(p => p.Bindings.InputDevices)
+                .OfType<Keyboard>()
+                .Any();
 
         public static void Initialize()
         {
@@ -145,13 +150,15 @@ namespace YARG.Input
                     YargLogger.LogFormatError("Player not registered with device: {0}", device);
                 }
             }
+
+            if (!HasProfileWithKeyboard)
+            {
+                _defaultKeyboardMenuBindings.Enable();
+            }
         }
 
         private static void OnPlayerBindingDeviceAdded(InputDevice device)
         {
-            _registeredDevices.Add(device);
-            
-            if (HasRegisteredKeyboard)
             if (HasProfileWithKeyboard)
             {
                 _defaultKeyboardMenuBindings.Disable();
@@ -160,9 +167,6 @@ namespace YARG.Input
 
         private static void OnPlayerBindingDeviceRemoved(InputDevice device)
         {
-            _registeredDevices.Remove(device);
-            
-            if (!HasRegisteredKeyboard)
             if (!HasProfileWithKeyboard)
             {
                 _defaultKeyboardMenuBindings.Enable();

--- a/Assets/Script/Input/InputManager.cs
+++ b/Assets/Script/Input/InputManager.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Cysharp.Text;
 using UnityEngine;
 using UnityEngine.InputSystem;
@@ -61,14 +62,8 @@ namespace YARG.Input
         private static bool _gameFocused;
         private static bool _focusChanged;
         private static HashSet<InputDevice> _backgroundDisabledDevices = new();
-        public static bool HasRegisteredKeyboard
-        {
-            get
-            {
-                var keyboard = InputSystem.GetDevice<Keyboard>();
-                return keyboard != null && _registeredDevices.Contains(keyboard);
-            }
-        }
+
+        private static bool HasProfileWithKeyboard => _registeredDevices.Any(d => d is Keyboard);
 
         public static void Initialize()
         {
@@ -154,12 +149,10 @@ namespace YARG.Input
 
         private static void OnPlayerBindingDeviceAdded(InputDevice device)
         {
-            if (!_registeredDevices.Add(device))
-            {
-                YargLogger.LogFormatError("Device already registered when added to player bindings: {0}", device);
-            }
-
+            _registeredDevices.Add(device);
+            
             if (HasRegisteredKeyboard)
+            if (HasProfileWithKeyboard)
             {
                 _defaultKeyboardMenuBindings.Disable();
             }
@@ -167,12 +160,10 @@ namespace YARG.Input
 
         private static void OnPlayerBindingDeviceRemoved(InputDevice device)
         {
-            if (!_registeredDevices.Remove(device))
-            {
-                YargLogger.LogFormatError("Device not registered when removed from player bindings: {0}", device);
-            }
-
+            _registeredDevices.Remove(device);
+            
             if (!HasRegisteredKeyboard)
+            if (!HasProfileWithKeyboard)
             {
                 _defaultKeyboardMenuBindings.Enable();
             }

--- a/Assets/Script/Input/InputManager.cs
+++ b/Assets/Script/Input/InputManager.cs
@@ -134,6 +134,11 @@ namespace YARG.Input
                 {
                     YargLogger.LogFormatError("Player already registered with device: {0}", device);
                 }
+
+                if (device is Keyboard)
+                {
+                    _defaultKeyboardMenuBindings.Disable();
+                }
             }
         }
 

--- a/Assets/Script/Menu/Navigation/Navigator.cs
+++ b/Assets/Script/Menu/Navigation/Navigator.cs
@@ -143,6 +143,11 @@ namespace YARG.Menu.Navigation
             UpdateHelpBar().Forget();
         }
 
+        private void OnDestroy()
+        {
+            InputManager.MenuInput -= ProcessInput;
+        }
+
         private void Update()
         {
             if (ShouldBlockInputs())
@@ -175,9 +180,6 @@ namespace YARG.Menu.Navigation
                     InvokeNavigationEvent(repeat.Context.AsRepeat());
                 }
             }
-
-            // TODO: Keyboard inputs for menus
-            // UpdateKeyboardInput();
         }
 
         private void ProcessInput(YargPlayer player, ref GameInput input)
@@ -187,7 +189,7 @@ namespace YARG.Menu.Navigation
             var action = (MenuAction) input.Action;
 
             // Swap up and down for lefty flip
-            if (player.Profile.LeftyFlip)
+            if (player?.Profile.LeftyFlip == true)
             {
                 action = action switch
                 {

--- a/Assets/Script/Menu/Navigation/Navigator.cs
+++ b/Assets/Script/Menu/Navigation/Navigator.cs
@@ -143,11 +143,6 @@ namespace YARG.Menu.Navigation
             UpdateHelpBar().Forget();
         }
 
-        private void OnDestroy()
-        {
-            InputManager.MenuInput -= ProcessInput;
-        }
-
         private void Update()
         {
             if (ShouldBlockInputs())


### PR DESCRIPTION
The Problem:

- In order to use the keyboard to navigate the menus, you must attach a keyboard to a profile.  This is confusing for new players.  Additionally, if the user disconnects the profile which has the keyboard attached (which is not obvious) then menu binds stop working again, and now it's even more confusing.

This adds default keyboard bindings so the keyboard can always be used to navigate the UI.

If any connected profile has a keyboard device associated with it, the menu binds for that profile will override the default binds entirely.  That is, the default keyboard binds will be disabled completely in favor of the explicit menu binds on the profile.  If the profile has keyboard menu binds, but is disconnected, we use the default binds instead.

The default binds are: 

| Action | Key(s) |
|--------|--------|
| Green | 1, Enter |
| Red | 2, Escape |
| Yellow | 3 |
| Blue | 4 |
| Orange | 5 |
| Start | Space |
| Select | Backspace |
| Up/Down/Left/Right | Arrow keys |