### PR TITLE
Reduce flicker on gameplay start

### DIFF
--- a/Assets/Scenes/Gameplay.unity
+++ b/Assets/Scenes/Gameplay.unity
@@ -1450,6 +1450,7 @@ MonoBehaviour:
   _backgroundImage: {fileID: 1773048783}
   _backgroundDimmer: {fileID: 1038164713}
   _venueOutput: {fileID: 879254558}
+  _venueStartupFadeOverlay: {fileID: 879254562}
 --- !u!114 &318454377
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -4654,7 +4655,8 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children: []
+  m_Children:
+  - {fileID: 879254561}
   m_Father: {fileID: 1212139298}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -4696,6 +4698,81 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 879254556}
+  m_CullTransparentMesh: 1
+--- !u!1 &879254560
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 879254561}
+  - component: {fileID: 879254563}
+  - component: {fileID: 879254562}
+  m_Layer: 5
+  m_Name: Venue Fade Overlay
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &879254561
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 879254560}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 879254557}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &879254562
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 879254560}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &879254563
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 879254560}
   m_CullTransparentMesh: 1
 --- !u!84 &906685306
 RenderTexture:

--- a/Assets/Scenes/Gameplay.unity
+++ b/Assets/Scenes/Gameplay.unity
@@ -1450,7 +1450,7 @@ MonoBehaviour:
   _backgroundImage: {fileID: 1773048783}
   _backgroundDimmer: {fileID: 1038164713}
   _venueOutput: {fileID: 879254558}
-  _venueStartupFadeOverlay: {fileID: 879254562}
+  _venueFadeOverlay: {fileID: 879254562}
 --- !u!114 &318454377
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -3314,7 +3314,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Texture: {fileID: 906685306}
+  m_Texture: {fileID: 552703397}
   m_UVRect:
     serializedVersion: 2
     x: 0
@@ -3876,6 +3876,43 @@ MonoBehaviour:
   m_ChildScaleWidth: 0
   m_ChildScaleHeight: 0
   m_ReverseArrangement: 0
+--- !u!84 &552703397
+RenderTexture:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_ImageContentsHash:
+    serializedVersion: 2
+    Hash: 00000000000000000000000000000000
+  m_IsAlphaChannelOptional: 0
+  serializedVersion: 6
+  m_Width: 1945
+  m_Height: 1209
+  m_AntiAliasing: 1
+  m_MipCount: -1
+  m_DepthStencilFormat: 94
+  m_ColorFormat: 48
+  m_MipMap: 0
+  m_GenerateMips: 1
+  m_SRGB: 0
+  m_UseDynamicScale: 0
+  m_UseDynamicScaleExplicit: 0
+  m_BindMS: 0
+  m_EnableCompatibleFormat: 1
+  m_EnableRandomWrite: 0
+  m_TextureSettings:
+    serializedVersion: 2
+    m_FilterMode: 1
+    m_Aniso: 1
+    m_MipBias: 0
+    m_WrapU: 1
+    m_WrapV: 1
+    m_WrapW: 1
+  m_Dimension: 2
+  m_VolumeDepth: 1
+  m_ShadowSamplingMode: 2
 --- !u!1 &626807277
 GameObject:
   m_ObjectHideFlags: 0
@@ -4774,43 +4811,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 879254560}
   m_CullTransparentMesh: 1
---- !u!84 &906685306
-RenderTexture:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: 
-  m_ImageContentsHash:
-    serializedVersion: 2
-    Hash: 00000000000000000000000000000000
-  m_IsAlphaChannelOptional: 0
-  serializedVersion: 6
-  m_Width: 1920
-  m_Height: 1080
-  m_AntiAliasing: 1
-  m_MipCount: -1
-  m_DepthStencilFormat: 94
-  m_ColorFormat: 48
-  m_MipMap: 0
-  m_GenerateMips: 1
-  m_SRGB: 0
-  m_UseDynamicScale: 0
-  m_UseDynamicScaleExplicit: 0
-  m_BindMS: 0
-  m_EnableCompatibleFormat: 1
-  m_EnableRandomWrite: 0
-  m_TextureSettings:
-    serializedVersion: 2
-    m_FilterMode: 1
-    m_Aniso: 1
-    m_MipBias: 0
-    m_WrapU: 1
-    m_WrapV: 1
-    m_WrapW: 1
-  m_Dimension: 2
-  m_VolumeDepth: 1
-  m_ShadowSamplingMode: 2
 --- !u!1001 &922548496
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -7060,7 +7060,7 @@ Camera:
     serializedVersion: 2
     m_Bits: 511
   m_RenderingPath: -1
-  m_TargetTexture: {fileID: 906685306}
+  m_TargetTexture: {fileID: 552703397}
   m_TargetDisplay: 0
   m_TargetEye: 3
   m_HDR: 1

--- a/Assets/Script/Gameplay/BackgroundManager.cs
+++ b/Assets/Script/Gameplay/BackgroundManager.cs
@@ -49,11 +49,16 @@ namespace YARG.Gameplay
         [SerializeField]
         private RawImage _venueOutput;
 
+        [SerializeField]
+        private Image _venueFadeOverlay;
+
         private BackgroundType _type;
         private VenueSource _source;
 
         private bool _videoStarted = false;
         private bool _videoSeeking = false;
+
+        private const float FADE_DURATION = 0.5f;
 
         private float YARGROUND_OFFSET = 50f;
 
@@ -125,7 +130,7 @@ namespace YARG.Gameplay
 
                 _usingEditorVenue = true;
 
-                _venueOutput.gameObject.SetActive(true);
+                ShowVenue();
 
                 var editorRenderers = editorBg.GetComponentsInChildren<Renderer>(true);
 
@@ -190,7 +195,7 @@ namespace YARG.Gameplay
             var bundle = AssetBundle.LoadFromStream(result.Stream);
             AssetBundle shaderBundle = null;
 
-            _venueOutput.gameObject.SetActive(true);
+            ShowVenue();
             // KEEP THIS PATH LOWERCASE
             // Breaks things for other platforms, because Unity
             var bg = (GameObject) await bundle.LoadAssetAsync<GameObject>(
@@ -269,6 +274,25 @@ namespace YARG.Gameplay
                     Destroy(songTex);
                     return;
             }
+        }
+
+        private void ShowVenue()
+        {
+            _venueOutput.gameObject.SetActive(true);
+            FadeInVenue().Forget();
+        }
+
+        private async UniTaskVoid FadeInVenue()
+        {
+            // Wait for the venue to be rendered, otherwise we will see a gray screen
+            var token = this.GetCancellationTokenOnDestroy();
+            await UniTask
+                .WaitUntil(
+                    () => VenueCameraRenderer.IsRendered,
+                    cancellationToken: token
+                )
+                .SuppressCancellationThrow();
+            _venueFadeOverlay.CrossFadeAlpha(0f, FADE_DURATION, true);
         }
 
         private void LoadVideoBackground(BackgroundResult bg)

--- a/Assets/Script/Gameplay/HUD/FailMeter.cs
+++ b/Assets/Script/Gameplay/HUD/FailMeter.cs
@@ -9,6 +9,7 @@ using YARG.Core.Engine;
 using YARG.Core.Game;
 using YARG.Core.Logging;
 using YARG.Helpers.Extensions;
+using YARG.Settings;
 
 namespace YARG.Gameplay.HUD
 {
@@ -46,8 +47,18 @@ namespace YARG.Gameplay.HUD
 
         private Vector2[] _xPosVectors;
 
-        private bool _intendedActive;
+        private const float OFFSCREEN_Y = -400f;
 
+        private void Awake()
+        {
+            if (SettingsManager.Settings.NoFailMode.Value)
+            {
+                _meterContainer.transform.position = new Vector3(
+                    _meterContainer.transform.position.x,
+                    OFFSCREEN_Y,
+                    _meterContainer.transform.position.z);
+            }
+        }
 
         // TODO: Should probably make a more specific class we can reference here
         private EngineManager _engineManager;
@@ -99,7 +110,7 @@ namespace YARG.Gameplay.HUD
                 SetLink(_fillImage.gameObject);
 
             // This is set up to move the container offscreen, but may later be used to move it back on
-            _meterPositionTweener = _meterContainer.transform.DOMoveY(-400f, 0.5f).
+            _meterPositionTweener = _meterContainer.transform.DOMoveY(OFFSCREEN_Y, 0.5f).
                 SetAutoKill(false).
                 Pause().
                 SetLink(_meterContainer);

--- a/Assets/Script/Gameplay/HUD/TrackView.cs
+++ b/Assets/Script/Gameplay/HUD/TrackView.cs
@@ -57,6 +57,8 @@ namespace YARG.Gameplay.HUD
             _highwayDraggable.PositionChanged += OnHighwayDraggablePositionChanged;
             _highwayDraggable.ScaleChanged += OnHighwayDraggableScaleChanged;
             _highwayRenderer.SetScaleMultiplier(_highwayDraggable.CurrentScale);
+
+            _centerElementContainer.position = _hiddenPosition;
         }
 
         public void UpdateHUDPosition(int highwayIndex, int highwayCount)

--- a/Assets/Script/Gameplay/HUD/VocalsPlayerHUD.cs
+++ b/Assets/Script/Gameplay/HUD/VocalsPlayerHUD.cs
@@ -56,6 +56,8 @@ namespace YARG.Gameplay.HUD
                 // Otherwise, it must be a custom preset
                 _comboMeterFill.color = new Color(1.0f, 0.25f, 0.25f);
             }
+
+            _starPowerFill.fillAmount = 0f;
         }
 
         private void Update()

--- a/Assets/Script/Gameplay/VenueCameraRenderer.cs
+++ b/Assets/Script/Gameplay/VenueCameraRenderer.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Threading;
 using UnityEngine;
 using UnityEngine.Rendering;
 using UnityEngine.Rendering.RenderGraphModule;
@@ -29,8 +27,6 @@ namespace YARG.Gameplay
         private static RenderTexture _venueTexture;
         private static RenderTexture _trailsTexture;
 
-        private static CancellationTokenSource _cts;
-
         private static readonly int _trailsLengthId = Shader.PropertyToID("_YargTrailLength");
         private static readonly int _trailsTextureId = Shader.PropertyToID("_YargPrevFrame");
         private static readonly int _posterizeStepsId = Shader.PropertyToID("_YargPosterizeSteps");
@@ -47,6 +43,7 @@ namespace YARG.Gameplay
 
         public static float ActualFPS;
         public static float TargetFPS;
+        public static bool IsRendered { get; private set; }
 
         private int _fps;
         private int FPS
@@ -62,12 +59,9 @@ namespace YARG.Gameplay
 
         private int _venueLayerMask;
 
-        private bool _didRender;
-
         private int _frameCount;
         private float _elapsedTime;
         private static float _timeSinceLastRender;
-
         private bool _needsInitialization = true;
 
         private void Awake()
@@ -124,15 +118,16 @@ namespace YARG.Gameplay
             var outputWidth = (int)(Screen.width * renderScale);
             var outputHeight = (int)(Screen.height * renderScale);
 
+            var descriptor = new RenderTextureDescriptor(outputWidth, outputHeight, RenderTextureFormat.DefaultHDR, 16, 0);
+            _venueTexture = new RenderTexture(descriptor);
+            _venueTexture.Create();
+            _venueOutput.texture = _venueTexture;
+
             if (_trailsTexture != null)
             {
                 _trailsTexture.Release();
                 _trailsTexture.DiscardContents();
             }
-
-            var descriptor = new RenderTextureDescriptor(outputWidth, outputHeight, RenderTextureFormat.DefaultHDR, 16, 0);
-            _venueTexture = new RenderTexture(descriptor);
-            _venueOutput.texture = _venueTexture;
 
             descriptor.depthBufferBits = 0;
             _trailsTexture = new RenderTexture(descriptor);
@@ -147,6 +142,7 @@ namespace YARG.Gameplay
         {
             FPS = SettingsManager.Settings.VenueFpsCap.Value;
             _timeSinceLastRender = 0f;
+            _needsInitialization = true;
             RenderPipelineManager.beginCameraRendering += OnPreCameraRender;
             RenderPipelineManager.endCameraRendering += OnEndCameraRender;
             SceneManager.sceneUnloaded += OnSceneUnloaded;
@@ -176,6 +172,7 @@ namespace YARG.Gameplay
             }
 
             _venueOutput = null;
+            IsRendered = false;
         }
 
         private void OnSceneUnloaded(Scene scene)
@@ -334,6 +331,11 @@ namespace YARG.Gameplay
                 request.destination = _venueTexture;
                 // Render camera and fill texture2D with its view
                 RenderPipeline.SubmitRenderRequest(_renderCamera, request);
+
+                if (!IsRendered)
+                {
+                    IsRendered = true;
+                }
             }
         }
 

--- a/Assets/Script/Gameplay/VenueCameraRenderer.cs
+++ b/Assets/Script/Gameplay/VenueCameraRenderer.cs
@@ -118,16 +118,16 @@ namespace YARG.Gameplay
             var outputWidth = (int)(Screen.width * renderScale);
             var outputHeight = (int)(Screen.height * renderScale);
 
-            var descriptor = new RenderTextureDescriptor(outputWidth, outputHeight, RenderTextureFormat.DefaultHDR, 16, 0);
-            _venueTexture = new RenderTexture(descriptor);
-            _venueTexture.Create();
-            _venueOutput.texture = _venueTexture;
-
             if (_trailsTexture != null)
             {
                 _trailsTexture.Release();
                 _trailsTexture.DiscardContents();
             }
+
+            var descriptor = new RenderTextureDescriptor(outputWidth, outputHeight, RenderTextureFormat.DefaultHDR, 16, 0);
+            _venueTexture = new RenderTexture(descriptor);
+            _venueTexture.Create();
+            _venueOutput.texture = _venueTexture;
 
             descriptor.depthBufferBits = 0;
             _trailsTexture = new RenderTexture(descriptor);
@@ -142,7 +142,6 @@ namespace YARG.Gameplay
         {
             FPS = SettingsManager.Settings.VenueFpsCap.Value;
             _timeSinceLastRender = 0f;
-            _needsInitialization = true;
             RenderPipelineManager.beginCameraRendering += OnPreCameraRender;
             RenderPipelineManager.endCameraRendering += OnEndCameraRender;
             SceneManager.sceneUnloaded += OnSceneUnloaded;


### PR DESCRIPTION
Currently there's a few things that make gameplay look janky on start

1. Gray screen before venue pops in
2. HUD elements flicker

This PR fixes these issues by positioning HUD elements correctly, and also fading in the venue once it is loaded

Before:

https://github.com/user-attachments/assets/e3336532-c2eb-41ea-b014-2991b209b201

After:

https://github.com/user-attachments/assets/3c64fcad-2e8c-4c48-93ba-deb5c94f9d49

