### PR TITLE
Rework star and band star calculations

### DIFF
--- a/Assets/Script/Gameplay/GameManager.Debug.cs
+++ b/Assets/Script/Gameplay/GameManager.Debug.cs
@@ -293,7 +293,6 @@ namespace YARG.Gameplay
                 text.AppendFormat("- Committed score: {0}\n", stats.CommittedScore);
                 text.AppendFormat("- Pending score: {0}\n", stats.PendingScore);
                 text.AppendFormat("- Total score: {0}\n", stats.TotalScore);
-                text.AppendFormat("- Star score: {0}\n", stats.StarScore);
                 text.AppendFormat("- Stars: {0}\n", stats.Stars);
                 text.AppendLine();
                 text.AppendFormat("- Sustain score: {0}\n", stats.SustainScore);

--- a/Assets/Script/Gameplay/GameManager.Loading.cs
+++ b/Assets/Script/Gameplay/GameManager.Loading.cs
@@ -194,6 +194,9 @@ namespace YARG.Gameplay
             // Spawn players
             CreatePlayers();
 
+            EngineManager.PopulateStarScoreThresholds();
+
+
             // Set up the crowd stem so it can be restored after muting (if it exists)
             if (_stemStates.TryGetValue(SongStem.Crowd, out var state))
             {

--- a/Assets/Script/Gameplay/GameManager.Loading.cs
+++ b/Assets/Script/Gameplay/GameManager.Loading.cs
@@ -193,8 +193,9 @@ namespace YARG.Gameplay
 
             // Spawn players
             CreatePlayers();
-
-            EngineManager.PopulateStarScoreThresholds();
+            YargLogger.LogFormatDebug("Calculating star cutoffs for {0} players", YargPlayers.Count);
+            EngineManager.StarScoreThresholds = EngineManager.GetStarScoreCutoffs(YargPlayers.Count);
+            YargLogger.LogFormatDebug("Star score thresholds: {0}", string.Join(", ", EngineManager.StarScoreThresholds));
 
 
             // Set up the crowd stem so it can be restored after muting (if it exists)

--- a/Assets/Script/Gameplay/GameManager.Loading.cs
+++ b/Assets/Script/Gameplay/GameManager.Loading.cs
@@ -6,6 +6,7 @@ using UnityEngine;
 using YARG.Core;
 using YARG.Core.Audio;
 using YARG.Core.Chart;
+using YARG.Core.Engine;
 using YARG.Core.Logging;
 using YARG.Core.Replays;
 using YARG.Gameplay.Player;
@@ -194,7 +195,7 @@ namespace YARG.Gameplay
             // Spawn players
             CreatePlayers();
             YargLogger.LogFormatDebug("Calculating star cutoffs for {0} players", _players.Count);
-            EngineManager.StarScoreThresholds = EngineManager.GetStarScoreCutoffs(_players.Count);
+            EngineManager.StarScoreThresholds = EngineManager.GetStarScoreCutoffs(_players.ConvertAll(p => p.BaseEngine.StarScoreThresholds));
             YargLogger.LogFormatDebug("Star score thresholds: {0}", string.Join(", ", EngineManager.StarScoreThresholds));
 
 

--- a/Assets/Script/Gameplay/GameManager.Loading.cs
+++ b/Assets/Script/Gameplay/GameManager.Loading.cs
@@ -193,8 +193,8 @@ namespace YARG.Gameplay
 
             // Spawn players
             CreatePlayers();
-            YargLogger.LogFormatDebug("Calculating star cutoffs for {0} players", YargPlayers.Count);
-            EngineManager.StarScoreThresholds = EngineManager.GetStarScoreCutoffs(YargPlayers.Count);
+            YargLogger.LogFormatDebug("Calculating star cutoffs for {0} players", _players.Count);
+            EngineManager.StarScoreThresholds = EngineManager.GetStarScoreCutoffs(_players.Count);
             YargLogger.LogFormatDebug("Star score thresholds: {0}", string.Join(", ", EngineManager.StarScoreThresholds));
 
 

--- a/Assets/Script/Gameplay/GameManager.cs
+++ b/Assets/Script/Gameplay/GameManager.cs
@@ -641,7 +641,7 @@ namespace YARG.Gameplay
 
             // Get all of the individual player score entries
             var playerEntries = new List<PlayerScoreRecord>();
-
+            var starScoreCutoffsList = new List<int[]>();
             foreach (var player in _players)
             {
                 var profile = player.Player.Profile;
@@ -671,6 +671,8 @@ namespace YARG.Gameplay
 
                     Percent = player.BaseStats.Percent
                 });
+
+                starScoreCutoffsList.Add(player.StarScoreThresholds);
             }
 
             var validScoreCount = _players.Count(p => ScoreContainer.IsSoloScoreValid(SongSpeed, p.Player));
@@ -691,13 +693,11 @@ namespace YARG.Gameplay
                     return;
                 }
                 var results = ReplayAnalyzer.AnalyzeReplay(Chart, replayInfo, ReplayData);
-
                 foreach (var result in results)
                 {
                     humanBandScore += result.ResultStats.TotalScore + result.ResultStats.BandBonusScore;
                 }
-
-                var humanStarScoreCutoffs = EngineManager.GetStarScoreCutoffs(humanCount);
+                var humanStarScoreCutoffs = EngineManager.GetStarScoreCutoffs(starScoreCutoffsList);
                 // Determine where in the cutoffs humanBandScore is
                 // Iterating backwards is slightly faster assuming people are good at the game
                 for (int i = humanStarScoreCutoffs.Length - 1; i >= 0; i--)
@@ -707,6 +707,7 @@ namespace YARG.Gameplay
                         // This gives humanBandStars as an int, which is not exactly correct but should make no difference
                         // since it is converted into StarAmount by int anyway
                         humanBandStars = i + 1;
+                        YargLogger.LogFormatDebug("Star count: {0}", humanBandStars);
                         break;
                     }
                 }

--- a/Assets/Script/Gameplay/GameManager.cs
+++ b/Assets/Script/Gameplay/GameManager.cs
@@ -672,7 +672,7 @@ namespace YARG.Gameplay
                     Percent = player.BaseStats.Percent
                 });
 
-                starScoreCutoffsList.Add(player.StarScoreThresholds);
+                starScoreCutoffsList.Add(player.BaseEngine.StarScoreThresholds);
             }
 
             var validScoreCount = _players.Count(p => ScoreContainer.IsSoloScoreValid(SongSpeed, p.Player));

--- a/Assets/Script/Gameplay/GameManager.cs
+++ b/Assets/Script/Gameplay/GameManager.cs
@@ -680,7 +680,8 @@ namespace YARG.Gameplay
             }
 
             int humanBandScore = 0;
-            float humanBandStars = 0f;
+            float humanBandStars;
+            int humanCount = playerEntries.Count;
             if (HasBots && SaveScoresWithBots)
             {
                 // Simulate the replay with only human players to calculate the correct score.
@@ -689,12 +690,13 @@ namespace YARG.Gameplay
                 {
                     return;
                 }
-
+                var humanStarScoreCutoffs = EngineManager.GetStarScoreCutoffs(humanCount);
+                humanBandStars = humanStarScoreCutoffs.Count(cutoff => humanBandScore >= cutoff);
                 var results = ReplayAnalyzer.AnalyzeReplay(Chart, replayInfo, ReplayData);
+
                 foreach (var result in results)
                 {
                     humanBandScore += result.ResultStats.TotalScore + result.ResultStats.BandBonusScore;
-                    humanBandStars += result.ResultStats.Stars;
                 }
             }
             else
@@ -703,15 +705,12 @@ namespace YARG.Gameplay
                 foreach (var player in _players)
                 {
                     humanBandScore += player.Score + player.BaseStats.BandBonusScore;
-                    humanBandStars += player.Stars;
                 }
+                humanBandStars = EngineManager.Stars;
             }
 
-            // Calculate band stars by taking average stars for human players only
-            int humanCount = playerEntries.Count;
-            int averageStars = (int)(humanBandStars / humanCount);
             var bandStars = humanCount > 0
-                ? StarAmountHelper.GetStarsFromInt(averageStars)
+                ? StarAmountHelper.GetStarsFromInt(Mathf.FloorToInt(humanBandStars))
                 : StarAmount.None;
 
             ScoreContainer.RecordScore(new GameRecord
@@ -780,7 +779,7 @@ namespace YARG.Gameplay
             var cameraPresets = new Dictionary<Guid, CameraPreset>();
 
             int bandScore = 0;
-            float bandStars = 0f;
+            float bandStars = EngineManager.Stars;
             for (int i = 0; i < _players.Count; i++)
             {
                 var player = _players[i];
@@ -793,7 +792,6 @@ namespace YARG.Gameplay
                 frames.Add(frame);
                 replayStats.Add(stats);
                 bandScore += player.Score;
-                bandStars += player.Stars;
 
                 if (!player.Player.ColorProfile.DefaultPreset)
                 {
@@ -811,7 +809,7 @@ namespace YARG.Gameplay
                 return null;
             }
 
-            var stars = StarAmountHelper.GetStarsFromInt((int) (bandStars / frames.Count));
+            var stars = StarAmountHelper.GetStarsFromInt(Mathf.FloorToInt(bandStars));
             ReplayData = new ReplayData(colorProfiles, cameraPresets, frames.ToArray(), _frameTimes.ToArray());
 
             (bool success, var replayInfo) = ReplayIO.TrySerialize(directory, Song, SongSpeed, length, bandScore, stars, PauseInfo.ToArray(), replayStats.ToArray(), ReplayData);

--- a/Assets/Script/Gameplay/GameManager.cs
+++ b/Assets/Script/Gameplay/GameManager.cs
@@ -613,9 +613,10 @@ namespace YARG.Gameplay
                     IsHighScore = player.Score > player.LastHighScore,
                     Player = player.Player,
                     Stats = player.BaseStats,
-                    AverageMultiplier = player.BaseEngine.BaseScore == 0 ?
+                    AverageMultiplier = player.BaseEngine.BaseNoteScore == 0 ?
                         0 :
-                        (float) player.BaseStats.StarScore / player.BaseEngine.BaseScore
+                        // PendingScore should be 0 at this point, so no reason to add it
+                        (float) player.BaseStats.CommittedScore / player.BaseEngine.BaseNoteScore,
                 }).ToArray(),
                 BandScore = BandScore,
                 BandStars = (int) BandStars,

--- a/Assets/Script/Gameplay/GameManager.cs
+++ b/Assets/Script/Gameplay/GameManager.cs
@@ -43,6 +43,7 @@ namespace YARG.Gameplay
 
         public const float TRACK_SPACING_X = 100f;
 
+
         public bool IsSeekingReplay;
 
         [Header("References")]
@@ -142,11 +143,7 @@ namespace YARG.Gameplay
             set => EngineManager.Combo = value;
         }
 
-        public float BandStars
-        {
-            get => EngineManager.Stars;
-            set => EngineManager.Stars = value;
-        }
+        public float BandStars => EngineManager.Stars;
 
         public int BandMultiplier => EngineManager.BandMultiplier;
 
@@ -294,14 +291,12 @@ namespace YARG.Gameplay
 
             // Update players
             int totalScore = 0;
-            float totalStars = 0f;
             foreach (var player in _players)
             {
                 player.GameplayUpdate();
 
                 totalScore += player.Score;
                 totalScore += player.BandBonusScore;
-                totalStars += player.Stars;
             }
 
             if (GlobalVariables.VerboseReplays)
@@ -310,7 +305,7 @@ namespace YARG.Gameplay
             }
 
             BandScore = totalScore;
-            BandStars = totalStars / _players.Count;
+            EngineManager.UpdateStars();
 
             // End song if needed (required for the [end] event)
             if (_songRunner.SongTime >= SongLength)
@@ -321,6 +316,7 @@ namespace YARG.Gameplay
                 }
             }
         }
+
 
         public void SetSongTime(double time, double delayTime = SONG_START_DELAY)
         {

--- a/Assets/Script/Gameplay/GameManager.cs
+++ b/Assets/Script/Gameplay/GameManager.cs
@@ -680,7 +680,7 @@ namespace YARG.Gameplay
             }
 
             int humanBandScore = 0;
-            float humanBandStars;
+            float humanBandStars = 0;
             int humanCount = playerEntries.Count;
             if (HasBots && SaveScoresWithBots)
             {
@@ -690,13 +690,25 @@ namespace YARG.Gameplay
                 {
                     return;
                 }
-                var humanStarScoreCutoffs = EngineManager.GetStarScoreCutoffs(humanCount);
-                humanBandStars = humanStarScoreCutoffs.Count(cutoff => humanBandScore >= cutoff);
                 var results = ReplayAnalyzer.AnalyzeReplay(Chart, replayInfo, ReplayData);
 
                 foreach (var result in results)
                 {
                     humanBandScore += result.ResultStats.TotalScore + result.ResultStats.BandBonusScore;
+                }
+
+                var humanStarScoreCutoffs = EngineManager.GetStarScoreCutoffs(humanCount);
+                // Determine where in the cutoffs humanBandScore is
+                // Iterating backwards is slightly faster assuming people are good at the game
+                for (int i = humanStarScoreCutoffs.Length - 1; i >= 0; i--)
+                {
+                    if (humanBandScore >= humanStarScoreCutoffs[i])
+                    {
+                        // This gives humanBandStars as an int, which is not exactly correct but should make no difference
+                        // since it is converted into StarAmount by int anyway
+                        humanBandStars = i + 1;
+                        break;
+                    }
                 }
             }
             else

--- a/Assets/Script/Gameplay/Player/BasePlayer.cs
+++ b/Assets/Script/Gameplay/Player/BasePlayer.cs
@@ -61,7 +61,7 @@ namespace YARG.Gameplay.Player
         public BaseStats BaseStats => BaseEngine.BaseStats;
         public BaseEngineParameters BaseParameters => BaseEngine.BaseParameters;
 
-        public abstract float[] StarMultiplierThresholds { get; protected set; }
+        protected abstract float[] StarMultiplierThresholds { get; set; }
 
         protected readonly float[] SoloBonusStarMultiplierThresholds = {
             0.05f, 0.1f, 0.2f, 0.35f, 0.65f, 0.95f

--- a/Assets/Script/Gameplay/Player/BasePlayer.cs
+++ b/Assets/Script/Gameplay/Player/BasePlayer.cs
@@ -61,11 +61,21 @@ namespace YARG.Gameplay.Player
         public BaseStats BaseStats => BaseEngine.BaseStats;
         public BaseEngineParameters BaseParameters => BaseEngine.BaseParameters;
 
+        /// <summary>
+        /// <p> Star thresholds, from 1 to 5 stars, then gold stars. </p>
+        /// <p> These values represent multiples of the score if you were to FC, hold all sustains fully, hit no dynamics, and use no star power. </p>
+        /// <p> Multiplying these by the max multiplier of the instrument will also roughly give you the average multiplier needed for that star. </p>
+        /// </summary>
         protected abstract float[] StarMultiplierThresholds { get; set; }
 
+        /// <summary>
+        /// Multiples of the maximum points it is possible to get from a solo, which is then added to each star point threshold (1 to 5, then gold stars).
+        /// <seealso cref="StarMultiplierThresholds"/>
+        /// </summary>
         protected readonly float[] SoloBonusStarMultiplierThresholds = {
             0.05f, 0.1f, 0.2f, 0.35f, 0.65f, 0.95f
         };
+
         public abstract bool ShouldUpdateInputsOnResume { get; }
 
         public HitWindowSettings HitWindow { get; protected set; }

--- a/Assets/Script/Gameplay/Player/BasePlayer.cs
+++ b/Assets/Script/Gameplay/Player/BasePlayer.cs
@@ -62,8 +62,10 @@ namespace YARG.Gameplay.Player
         public BaseEngineParameters BaseParameters => BaseEngine.BaseParameters;
 
         public abstract float[] StarMultiplierThresholds { get; protected set; }
-        public abstract int[] StarScoreThresholds { get; protected set; }
 
+        protected readonly float[] SoloBonusStarMultiplierThresholds = {
+            0.05f, 0.1f, 0.2f, 0.35f, 0.65f, 0.95f
+        };
         public abstract bool ShouldUpdateInputsOnResume { get; }
 
         public HitWindowSettings HitWindow { get; protected set; }

--- a/Assets/Script/Gameplay/Player/BasePlayer.cs
+++ b/Assets/Script/Gameplay/Player/BasePlayer.cs
@@ -412,18 +412,6 @@ namespace YARG.Gameplay.Player
             GameManager.ResetBandCombo();
         }
 
-        protected static int[] PopulateStarScoreThresholds(float[] multiplierThresh, int baseScore)
-        {
-            var starScoreThresh = new int[multiplierThresh.Length];
-
-            for (int i = 0; i < multiplierThresh.Length; i++)
-            {
-                starScoreThresh[i] = Mathf.FloorToInt(baseScore * multiplierThresh[i]);
-            }
-
-            return starScoreThresh;
-        }
-
         public abstract (ReplayFrame Frame, ReplayStats Stats) ConstructReplayData();
     }
 }

--- a/Assets/Script/Gameplay/Player/DrumsPlayer.cs
+++ b/Assets/Script/Gameplay/Player/DrumsPlayer.cs
@@ -104,7 +104,7 @@ namespace YARG.Gameplay.Player
 
         public override float[] StarMultiplierThresholds { get; protected set; } =
         {
-            0.21f, 0.46f, 0.77f, 1.85f, 3.08f, 4.29f
+            0.06f, 0.12f, 0.2f, 0.45f, 0.75f, 1.09f
         };
 
         public override int[] StarScoreThresholds { get; protected set; }
@@ -195,7 +195,7 @@ namespace YARG.Gameplay.Player
 
         protected override void FinishInitialization()
         {
-            StarScoreThresholds = PopulateStarScoreThresholds(StarMultiplierThresholds, Engine.BaseScore);
+            StarScoreThresholds = Engine.StarScoreThresholds;
 
             // Get the proper info for four/five lane
             IFretColorProvider colors = !_fiveLaneMode

--- a/Assets/Script/Gameplay/Player/DrumsPlayer.cs
+++ b/Assets/Script/Gameplay/Player/DrumsPlayer.cs
@@ -102,7 +102,7 @@ namespace YARG.Gameplay.Player
 
         public override bool ShouldUpdateInputsOnResume => false;
 
-        public override float[] StarMultiplierThresholds { get; protected set; } =
+        protected override float[] StarMultiplierThresholds { get; set; } =
         {
             0.06f, 0.12f, 0.2f, 0.45f, 0.75f, 1.09f
         };

--- a/Assets/Script/Gameplay/Player/DrumsPlayer.cs
+++ b/Assets/Script/Gameplay/Player/DrumsPlayer.cs
@@ -107,8 +107,6 @@ namespace YARG.Gameplay.Player
             0.06f, 0.12f, 0.2f, 0.45f, 0.75f, 1.09f
         };
 
-        public override int[] StarScoreThresholds { get; protected set; }
-
         private int[] _drumSoundEffectRoundRobin = new int[8];
         private float _drumSoundEffectAccentThreshold;
 
@@ -146,7 +144,7 @@ namespace YARG.Gameplay.Player
             if (!Player.IsReplay)
             {
                 // Create the engine params from the engine preset
-                EngineParams = Player.EnginePreset.Drums.Create(StarMultiplierThresholds, mode);
+                EngineParams = Player.EnginePreset.Drums.Create(StarMultiplierThresholds, SoloBonusStarMultiplierThresholds, mode);
             }
             else
             {
@@ -195,8 +193,6 @@ namespace YARG.Gameplay.Player
 
         protected override void FinishInitialization()
         {
-            StarScoreThresholds = Engine.StarScoreThresholds;
-
             // Get the proper info for four/five lane
             IFretColorProvider colors = !_fiveLaneMode
                 ? Player.ColorProfile.FourLaneDrums

--- a/Assets/Script/Gameplay/Player/FiveFretGuitarPlayer.cs
+++ b/Assets/Script/Gameplay/Player/FiveFretGuitarPlayer.cs
@@ -118,8 +118,6 @@ namespace YARG.Gameplay.Player
         public override float[] StarMultiplierThresholds { get; protected set; } =
             GuitarStarMultiplierThresholds;
 
-        public override int[] StarScoreThresholds { get; protected set; }
-
         public float WhammyFactor { get; private set; }
 
         private int _sustainCount;
@@ -159,7 +157,7 @@ namespace YARG.Gameplay.Player
             if (!Player.IsReplay)
             {
                 // Create the engine params from the engine preset
-                EngineParams = Player.EnginePreset.FiveFretGuitar.Create(StarMultiplierThresholds, isBass);
+                EngineParams = Player.EnginePreset.FiveFretGuitar.Create(StarMultiplierThresholds, SoloBonusStarMultiplierThresholds, isBass);
                 //EngineParams = EnginePreset.Precision.FiveFretGuitar.Create(StarMultiplierThresholds, isBass);
             }
             else
@@ -208,8 +206,6 @@ namespace YARG.Gameplay.Player
             base.FinishInitialization();
 
             MakeHighwayOrdering();
-
-            StarScoreThresholds = Engine.StarScoreThresholds;
 
             IndicatorStripes.Initialize(Player.EnginePreset.FiveFretGuitar);
 

--- a/Assets/Script/Gameplay/Player/FiveFretGuitarPlayer.cs
+++ b/Assets/Script/Gameplay/Player/FiveFretGuitarPlayer.cs
@@ -77,12 +77,12 @@ namespace YARG.Gameplay.Player
 
         private static float[] GuitarStarMultiplierThresholds => new[]
         {
-            0.21f, 0.46f, 0.77f, 1.85f, 3.08f, 4.52f
+            0.06f, 0.12f, 0.2f, 0.47f, 0.78f, 1.15f
         };
 
         private static float[] BassStarMultiplierThresholds => new[]
         {
-            0.21f, 0.50f, 0.90f, 2.77f, 4.62f, 6.78f
+            0.05f, 0.1f, 0.19f, 0.47f, 0.78f, 1.15f
         };
 
         public GuitarEngineParameters EngineParams { get; private set; }
@@ -209,7 +209,7 @@ namespace YARG.Gameplay.Player
 
             MakeHighwayOrdering();
 
-            StarScoreThresholds = PopulateStarScoreThresholds(StarMultiplierThresholds, Engine.BaseScore);
+            StarScoreThresholds = Engine.StarScoreThresholds;
 
             IndicatorStripes.Initialize(Player.EnginePreset.FiveFretGuitar);
 

--- a/Assets/Script/Gameplay/Player/FiveFretGuitarPlayer.cs
+++ b/Assets/Script/Gameplay/Player/FiveFretGuitarPlayer.cs
@@ -115,7 +115,7 @@ namespace YARG.Gameplay.Player
         [SerializeField]
         private Pool _rangeIndicatorPool;
 
-        public override float[] StarMultiplierThresholds { get; protected set; } =
+        protected override float[] StarMultiplierThresholds { get; set; } =
             GuitarStarMultiplierThresholds;
 
         public float WhammyFactor { get; private set; }

--- a/Assets/Script/Gameplay/Player/FiveFretGuitarPlayer.cs
+++ b/Assets/Script/Gameplay/Player/FiveFretGuitarPlayer.cs
@@ -75,11 +75,13 @@ namespace YARG.Gameplay.Player
 
         public override bool ShouldUpdateInputsOnResume => true;
 
+        /// See <see cref="StarMultiplierThresholds"/>
         private static float[] GuitarStarMultiplierThresholds => new[]
         {
             0.06f, 0.12f, 0.2f, 0.47f, 0.78f, 1.15f
         };
 
+        /// See <see cref="StarMultiplierThresholds"/>
         private static float[] BassStarMultiplierThresholds => new[]
         {
             0.05f, 0.1f, 0.19f, 0.47f, 0.78f, 1.15f

--- a/Assets/Script/Gameplay/Player/FiveLaneKeysPlayer.cs
+++ b/Assets/Script/Gameplay/Player/FiveLaneKeysPlayer.cs
@@ -111,8 +111,6 @@ public override bool ShouldUpdateInputsOnResume => true;
         public override float[] StarMultiplierThresholds { get; protected set; } =
             GuitarStarMultiplierThresholds;
 
-        public override int[] StarScoreThresholds { get; protected set; }
-
         public float WhammyFactor { get; private set; }
 
         private int _sustainCount;
@@ -149,7 +147,7 @@ public override bool ShouldUpdateInputsOnResume => true;
             if (!Player.IsReplay)
             {
                 // Create the engine params from the engine preset
-                EngineParams = Player.EnginePreset.ProKeys.Create(StarMultiplierThresholds, isBass);
+                EngineParams = Player.EnginePreset.ProKeys.Create(StarMultiplierThresholds, SoloBonusStarMultiplierThresholds, isBass);
                 //EngineParams = EnginePreset.Precision.FiveFretGuitar.Create(StarMultiplierThresholds, isBass);
             }
             else
@@ -196,8 +194,6 @@ public override bool ShouldUpdateInputsOnResume => true;
         protected override void FinishInitialization()
         {
             base.FinishInitialization();
-
-            StarScoreThresholds = Engine.StarScoreThresholds;
 
             IndicatorStripes.Initialize(Player.EnginePreset.FiveFretGuitar);
 

--- a/Assets/Script/Gameplay/Player/FiveLaneKeysPlayer.cs
+++ b/Assets/Script/Gameplay/Player/FiveLaneKeysPlayer.cs
@@ -80,12 +80,12 @@ public override bool ShouldUpdateInputsOnResume => true;
 
         private static float[] GuitarStarMultiplierThresholds => new[]
         {
-            0.21f, 0.46f, 0.77f, 1.85f, 3.08f, 4.52f
+            0.06f, 0.12f, 0.2f, 0.47f, 0.78f, 1.15f
         };
 
         private static float[] BassStarMultiplierThresholds => new[]
         {
-            0.21f, 0.50f, 0.90f, 2.77f, 4.62f, 6.78f
+            0.05f, 0.1f, 0.19f, 0.47f, 0.78f, 1.15f
         };
 
         public KeysEngineParameters EngineParams { get; private set; }
@@ -197,7 +197,7 @@ public override bool ShouldUpdateInputsOnResume => true;
         {
             base.FinishInitialization();
 
-            StarScoreThresholds = PopulateStarScoreThresholds(StarMultiplierThresholds, Engine.BaseScore);
+            StarScoreThresholds = Engine.StarScoreThresholds;
 
             IndicatorStripes.Initialize(Player.EnginePreset.FiveFretGuitar);
 

--- a/Assets/Script/Gameplay/Player/FiveLaneKeysPlayer.cs
+++ b/Assets/Script/Gameplay/Player/FiveLaneKeysPlayer.cs
@@ -108,7 +108,7 @@ public override bool ShouldUpdateInputsOnResume => true;
         [SerializeField]
         private Pool _rangeIndicatorPool;
 
-        public override float[] StarMultiplierThresholds { get; protected set; } =
+        protected override float[] StarMultiplierThresholds { get; set; } =
             GuitarStarMultiplierThresholds;
 
         public float WhammyFactor { get; private set; }

--- a/Assets/Script/Gameplay/Player/FiveLaneKeysPlayer.cs
+++ b/Assets/Script/Gameplay/Player/FiveLaneKeysPlayer.cs
@@ -78,11 +78,13 @@ namespace YARG.Assets.Script.Gameplay.Player
 
 public override bool ShouldUpdateInputsOnResume => true;
 
+        /// See <see cref="StarMultiplierThresholds"/>
         private static float[] GuitarStarMultiplierThresholds => new[]
         {
             0.06f, 0.12f, 0.2f, 0.47f, 0.78f, 1.15f
         };
 
+        /// See <see cref="StarMultiplierThresholds"/>
         private static float[] BassStarMultiplierThresholds => new[]
         {
             0.05f, 0.1f, 0.19f, 0.47f, 0.78f, 1.15f

--- a/Assets/Script/Gameplay/Player/ProKeysPlayer.cs
+++ b/Assets/Script/Gameplay/Player/ProKeysPlayer.cs
@@ -52,7 +52,7 @@ namespace YARG.Gameplay.Player
 
         public override float[] StarMultiplierThresholds { get; protected set; } =
         {
-            0.21f, 0.46f, 0.77f, 1.85f, 3.08f, 4.52f
+            0.06f, 0.12f, 0.2f, 0.47f, 0.78f, 1.15f
         };
 
         public override int[] StarScoreThresholds { get; protected set; }

--- a/Assets/Script/Gameplay/Player/ProKeysPlayer.cs
+++ b/Assets/Script/Gameplay/Player/ProKeysPlayer.cs
@@ -50,7 +50,7 @@ namespace YARG.Gameplay.Player
 
         private const int SHIFT_INDICATOR_MEASURES_BEFORE = 4;
 
-        public override float[] StarMultiplierThresholds { get; protected set; } =
+        protected override float[] StarMultiplierThresholds { get; set; } =
         {
             0.06f, 0.12f, 0.2f, 0.47f, 0.78f, 1.15f
         };

--- a/Assets/Script/Gameplay/Player/ProKeysPlayer.cs
+++ b/Assets/Script/Gameplay/Player/ProKeysPlayer.cs
@@ -55,8 +55,6 @@ namespace YARG.Gameplay.Player
             0.06f, 0.12f, 0.2f, 0.47f, 0.78f, 1.15f
         };
 
-        public override int[] StarScoreThresholds { get; protected set; }
-
         public KeysEngineParameters EngineParams { get; private set; }
 
         public override bool ShouldUpdateInputsOnResume => true;
@@ -116,7 +114,7 @@ namespace YARG.Gameplay.Player
             if (!Player.IsReplay)
             {
                 // Create the engine params from the engine preset
-                EngineParams = Player.EnginePreset.ProKeys.Create(StarMultiplierThresholds, false);
+                EngineParams = Player.EnginePreset.ProKeys.Create(StarMultiplierThresholds, SoloBonusStarMultiplierThresholds, false);
             }
             else
             {

--- a/Assets/Script/Gameplay/Player/VocalsPlayer.cs
+++ b/Assets/Script/Gameplay/Player/VocalsPlayer.cs
@@ -35,7 +35,7 @@ namespace YARG.Gameplay.Player
 
         public override bool ShouldUpdateInputsOnResume => false;
 
-        public override float[] StarMultiplierThresholds { get; protected set; } =
+        protected override float[] StarMultiplierThresholds { get; set; } =
         {
             0.05f, 0.11f, 0.19f, 0.46f, 0.77f, 1.06f
         };

--- a/Assets/Script/Gameplay/Player/VocalsPlayer.cs
+++ b/Assets/Script/Gameplay/Player/VocalsPlayer.cs
@@ -37,7 +37,7 @@ namespace YARG.Gameplay.Player
 
         public override float[] StarMultiplierThresholds { get; protected set; } =
         {
-            0.21f, 0.46f, 0.77f, 1.85f, 3.08f, 4.18f
+            0.05f, 0.11f, 0.19f, 0.46f, 0.77f, 1.06f
         };
 
         public override int[] StarScoreThresholds { get; protected set; }
@@ -157,7 +157,7 @@ namespace YARG.Gameplay.Player
                 Engine.SetSpeed(GameManager.SongSpeed);
             }
 
-            StarScoreThresholds = PopulateStarScoreThresholds(StarMultiplierThresholds, Engine.BaseScore);
+            StarScoreThresholds = Engine.StarScoreThresholds;
         }
 
         protected override void FinishDestruction()

--- a/Assets/Script/Gameplay/Player/VocalsPlayer.cs
+++ b/Assets/Script/Gameplay/Player/VocalsPlayer.cs
@@ -40,8 +40,6 @@ namespace YARG.Gameplay.Player
             0.05f, 0.11f, 0.19f, 0.46f, 0.77f, 1.06f
         };
 
-        public override int[] StarScoreThresholds { get; protected set; }
-
         private InstrumentDifficulty<VocalNote> NoteTrack { get; set; }
         private InstrumentDifficulty<VocalNote> OriginalNoteTrack { get; set; }
 
@@ -157,7 +155,6 @@ namespace YARG.Gameplay.Player
                 Engine.SetSpeed(GameManager.SongSpeed);
             }
 
-            StarScoreThresholds = Engine.StarScoreThresholds;
         }
 
         protected override void FinishDestruction()
@@ -172,7 +169,7 @@ namespace YARG.Gameplay.Player
                 var singToActivateStarPower = SettingsManager.Settings.VoiceActivatedVocalStarPower.Value;
 
                 // Create the engine params from the engine preset
-                EngineParams = Player.EnginePreset.Vocals.Create(StarMultiplierThresholds,
+                EngineParams = Player.EnginePreset.Vocals.Create(StarMultiplierThresholds, SoloBonusStarMultiplierThresholds,
                     Player.Profile.CurrentDifficulty, MicDevice.UPDATES_PER_SECOND, singToActivateStarPower);
             }
             else


### PR DESCRIPTION
See YARC-Official/YARG.Core#346

Most of the code here is just to deal with the changes in the Core PR, and to fix replay saving when playing with bots, and adjusting the star cutoff multipliers to match the `BaseScore` calculation changes.