### PR TITLE
Update textures marked for dynamic scaling in venue rendering.

### DIFF
--- a/Assets/Script/Gameplay/VenueCameraRenderer.cs
+++ b/Assets/Script/Gameplay/VenueCameraRenderer.cs
@@ -119,6 +119,8 @@ namespace YARG.Gameplay
             var outputWidth = (int)(Screen.width * renderScale);
             var outputHeight = (int)(Screen.height * renderScale);
 
+            ScalableBufferManager.ResizeBuffers(renderScale, renderScale);
+            
             if (_trailsTexture != null)
             {
                 _trailsTexture.Release();


### PR DESCRIPTION
This will resize all render textures marked for dynamic scaling automatically to match venue's render scale factor.
This allows venue authors to mark custom render textures (for example to embed visualizer) for dynamic scaling and have them scaled down to follow venue's render scale