### PR TITLE
(Over)genrelizer adjustments

### DIFF
--- a/Assets/Script/Song/Genrelizer.Lists.cs
+++ b/Assets/Script/Song/Genrelizer.Lists.cs
@@ -87,10 +87,18 @@ namespace YARG.Song
         private const string POP_DANCE_ELECTRONIC = "pop/dance/electronic";
         private const string PROG = "prog";
         private const string REGGAE_SKA = "reggae/ska";
-        private const string REGGAE_SKA_RAW = "reggaeska"; // As rendered in raw CONs
         private const string URBAN = "urban";
 
+        // Raw DTA form
+        private const string HIP_HOP_RAP_RAW = "hiphoprap";
+        private const string INDIE_ROCK_RAW = "indierock";
+        private const string NEW_WAVE_RAW = "newwave";
+        private const string POP_DANCE_ELECTRONIC_RAW = "popdanceelectronic";
+        private const string POP_ROCK_RAW = "poprock";
+        private const string RNB_SOUL_FUNK_RAW = "rbsoulfunk";
+        private const string REGGAE_SKA_RAW = "reggaeska";
         
+
 
 
         // Mapping from official genre name to localization key
@@ -218,6 +226,14 @@ namespace YARG.Song
             { (INDIE_ROCK, "other"),                    (INDIE_ROCK, null) },
             //(INDIE_ROCK, "post rock")                 unchanged
             { (INDIE_ROCK, "postrock"),                 (INDIE_ROCK, "Post Rock") },
+            //(INDIE_ROCK_RAW, "lo-fi")                     unchanged
+            { (INDIE_ROCK_RAW, "lofi"),                     (INDIE_ROCK, "Lo-Fi") },
+            { (INDIE_ROCK_RAW, "math rock"),                (MATH_ROCK, null) },
+            { (INDIE_ROCK_RAW, "mathrock"),                 (MATH_ROCK, null) },
+            { (INDIE_ROCK_RAW, "noise"),                    (NOISE, "Noise Rock") },
+            { (INDIE_ROCK_RAW, "other"),                    (INDIE_ROCK, null) },
+            //(INDIE_ROCK_RAW, "post rock")                 unchanged
+            { (INDIE_ROCK_RAW, "postrock"),                 (INDIE_ROCK, "Post Rock") },
 
             //(JAZZ, "acid jazz")                       unchanged
             { (JAZZ, "acidjazz"),                       (JAZZ, "Acid Jazz") },
@@ -245,6 +261,11 @@ namespace YARG.Song
             //(NEW_WAVE, "electroclash)                 unchanged
             { (NEW_WAVE, "synthpop"),                   (SYNTHPOP_ELECTROPOP, "Synthpop") },
             { (NEW_WAVE, "other"),                      (NEW_WAVE, null) },
+            { (NEW_WAVE_RAW, "dark wave"),                  (NEW_WAVE, "Darkwave") },
+            //(NEW_WAVE_RAW, "darkwave"),                   unchanged
+            //(NEW_WAVE_RAW, "electroclash)                 unchanged
+            { (NEW_WAVE_RAW, "synthpop"),                   (SYNTHPOP_ELECTROPOP, "Synthpop") },
+            { (NEW_WAVE_RAW, "other"),                      (NEW_WAVE, null) },
 
             { (POP_DANCE_ELECTRONIC, "ambient"),        (AMBIENT_DRONE, "Ambient") },
             { (POP_DANCE_ELECTRONIC, "breakbeat"),      (DNB_BREAKBEAT_JUNGLE, "Breakbeat") },
@@ -263,6 +284,23 @@ namespace YARG.Song
             { (POP_DANCE_ELECTRONIC, "techno"),         (TECHNO, "") },
             { (POP_DANCE_ELECTRONIC, "trance"),         (TRANCE, "") },
             { (POP_DANCE_ELECTRONIC, "other"),          (ELECTRONIC, null) },
+            { (POP_DANCE_ELECTRONIC_RAW, "ambient"),        (AMBIENT_DRONE, "Ambient") },
+            { (POP_DANCE_ELECTRONIC_RAW, "breakbeat"),      (DNB_BREAKBEAT_JUNGLE, "Breakbeat") },
+            { (POP_DANCE_ELECTRONIC_RAW, "chiptune"),       (CHIPTUNE, null) },
+            { (POP_DANCE_ELECTRONIC_RAW, "dance"),          (DANCE, null) },
+            { (POP_DANCE_ELECTRONIC_RAW, "downtempo"),      (ELECTRONIC, "Downtempo") },
+            { (POP_DANCE_ELECTRONIC_RAW, "dub"),            (DUBSTEP, null) },
+            { (POP_DANCE_ELECTRONIC_RAW, "drum and bass"),  (DNB_BREAKBEAT_JUNGLE, "Drum and Bass") },
+            { (POP_DANCE_ELECTRONIC_RAW, "drumandbass"),    (DNB_BREAKBEAT_JUNGLE, "Drum and Bass") },
+            { (POP_DANCE_ELECTRONIC_RAW, "electronica"),    (ELECTRONIC, "Electronica") },
+            { (POP_DANCE_ELECTRONIC_RAW, "garage"),         (ELECTRONIC, "Garage") },
+            { (POP_DANCE_ELECTRONIC_RAW, "hardcore dance"), (HARDCORE_EDM, "Hardcore Dance") },
+            { (POP_DANCE_ELECTRONIC_RAW, "hardcoredance"),  (HARDCORE_EDM, "Hardcore Dance") },
+            { (POP_DANCE_ELECTRONIC_RAW, "house"),          (HOUSE, null) },
+            { (POP_DANCE_ELECTRONIC_RAW, "industrial"),     (INDUSTRIAL, null) },
+            { (POP_DANCE_ELECTRONIC_RAW, "techno"),         (TECHNO, "") },
+            { (POP_DANCE_ELECTRONIC_RAW, "trance"),         (TRANCE, "") },
+            { (POP_DANCE_ELECTRONIC_RAW, "other"),          (ELECTRONIC, null) },
 
             { (POP_ROCK, "contemporary"),               (POP_ROCK, "Contemporary Pop-Rock") },
             { (POP_ROCK, "disco"),                      (DISCO, null) },
@@ -275,12 +313,23 @@ namespace YARG.Song
             { (POP_ROCK, "soul"),                       (RNB_SOUL_FUNK, "Soul") },
             { (POP_ROCK, "teen"),                       (POP, "Teen Pop") },
             { (POP_ROCK, "other"),                      (POP_ROCK, null) },
+            { (POP_ROCK_RAW, "contemporary"),               (POP_ROCK, "Contemporary Pop-Rock") },
+            { (POP_ROCK_RAW, "disco"),                      (DISCO, null) },
+            { (POP_ROCK_RAW, "motown"),                     (RNB_SOUL_FUNK, "Motown") },
+            { (POP_ROCK_RAW, "pop"),                        (POP, "PopRock") },
+            { (POP_ROCK_RAW, "rhythm and blues"),           (RNB_SOUL_FUNK, "Rhythm and Blues") },
+            { (POP_ROCK_RAW, "rhythmandblues"),             (RNB_SOUL_FUNK, "Rhythm and Blues") },
+            //(POP_ROCK_RAW, "soft rock")                   unchanged
+            { (POP_ROCK_RAW, "softrock"),                   (POP_ROCK, "Soft Rock") },
+            { (POP_ROCK_RAW, "soul"),                       (RNB_SOUL_FUNK, "Soul") },
+            { (POP_ROCK_RAW, "teen"),                       (POP, "Teen Pop") },
+            { (POP_ROCK_RAW, "other"),                      (POP_ROCK, null) },
 
             { (PROG, "prog rock"),                      (PROGRESSIVE, null) }, // Without other Prog subgenres, this is effectively meaningless
             { (PROG, "progrock"),                       (PROGRESSIVE, null) },
 
-            { (PUNK, "alternative"),                    (PUNK, "Alternative Punk Rock") },
-            { (PUNK, "classic"),                        (PUNK, "Classic Punk Rock") },
+            { (PUNK, "alternative"),                    (PUNK, "Alternative Punk") },
+            { (PUNK, "classic"),                        (PUNK, "Classic Punk") },
             { (PUNK, "garage"),                         (PUNK, "Garage Punk") },
             { (PUNK, "hardcore"),                       (PUNK, "Hardcore Punk") },
             { (PUNK, "pop"),                            (POP_PUNK, null) },
@@ -292,10 +341,19 @@ namespace YARG.Song
             { (RNB_SOUL_FUNK, "other"),                 (RNB_SOUL_FUNK, null) },
             //(RNB_SOUL_FUNK, "rhythm and blues")       unchanged
             //(RNB_SOUL_FUNK, "soul")                   unchanged
+            { (RNB_SOUL_FUNK_RAW, "disco"),                 (DISCO, null) },
+            //(RNB_SOUL_FUNK_RAW, "funk")                   unchanged
+            //(RNB_SOUL_FUNK_RAW, "motown")                 unchanged
+            { (RNB_SOUL_FUNK_RAW, "other"),                 (RNB_SOUL_FUNK, null) },
+            //(RNB_SOUL_FUNK_RAW, "rhythm and blues")       unchanged
+            //(RNB_SOUL_FUNK_RAW, "soul")                   unchanged
 
             { (REGGAE_SKA, "reggae"),                   (REGGAE, null) },
             { (REGGAE_SKA, "ska"),                      (SKA, null) },
             { (REGGAE_SKA, "other"),                    (SKA, null) }, // Belt & suspenders; should've been caught earlier as a special case
+            { (REGGAE_SKA_RAW, "reggae"),               (REGGAE, null) },
+            { (REGGAE_SKA_RAW, "ska"),                  (SKA, null) },
+            { (REGGAE_SKA_RAW, "other"),                (SKA, null) }, // Belt & suspenders; should've been caught earlier as a special case
 
             { (ROCK, "arena"),                          (ROCK, "Arena Rock") },
             { (ROCK, "blues"),                          (ROCK, "Blues Rock") },
@@ -303,6 +361,7 @@ namespace YARG.Song
             { (ROCK, "folkrock"),                       (FOLK, "Folk Rock") },
             { (ROCK, "funk"),                           (RNB_SOUL_FUNK, "Funk") },
             { (ROCK, "garage"),                         (ROCK, "Garage Rock") },
+            { (ROCK, "psychadelic"),                    (ROCK, "Psychedelic Rock") },
             { (ROCK, "psychedelic"),                    (ROCK, "Psychedelic Rock") },
             { (ROCK, "reggae"),                         (REGGAE, null) },
             { (ROCK, "rockabilly"),                     (ROCK_AND_ROLL, "Rockabilly") },
@@ -333,6 +392,7 @@ namespace YARG.Song
             { (URBAN, "rap"),                           (HIP_HOP_RAP, "Rap") },
             { (URBAN, "trip hop"),                      (HIP_HOP_RAP, "Trip Hop") },
             { (URBAN, "underground rap"),               (HIP_HOP_RAP, "Underground Rap") },
+            { (URBAN, "undergroundrap"),                (HIP_HOP_RAP, "Underground Rap") },
             { (URBAN, "other"),                         (OTHER, "Urban") }, // Urban is deprecated as a genre
 
             //(OTHER, "a capella")                      unchanged

--- a/Assets/Script/Song/Genrelizer.Lists.cs
+++ b/Assets/Script/Song/Genrelizer.Lists.cs
@@ -79,6 +79,7 @@ namespace YARG.Song
         private const string SYNTHPOP_ELECTROPOP = "synthpop/electropop";
         private const string TECHNO = "techno";
         private const string THRASH_SPEED_METAL = "thrash/speed metal";
+        private const string TRADITIONAL = "traditional";
         private const string TRANCE = "trance";
         private const string TRAP = "trap";
         private const string WORLD = "world";
@@ -94,7 +95,7 @@ namespace YARG.Song
 
         // Overgenrelizer
         private static SortString OVER_ALTERNATIVE = new(Localize.Key("Menu.MusicLibrary.Genre.Broad.Alternative"));
-        private static SortString OVER_COUNTRY = new(Localize.Key("Menu.MusicLibrary.Genre.Broad.Country"));
+        private static SortString OVER_COUNTRY_FOLK = new(Localize.Key("Menu.MusicLibrary.Genre.Broad.CountryFolk"));
         private static SortString OVER_CLASSICAL_TRADITIONAL = new(Localize.Key("Menu.MusicLibrary.Genre.Broad.ClassicalTraditional"));
         private static SortString OVER_DANCE_ELECTRONIC = new(Localize.Key("Menu.MusicLibrary.Genre.Broad.DanceElectronic"));
         private static SortString OVER_HIP_HOP = new(Localize.Key("Menu.MusicLibrary.Genre.Broad.HipHop"));
@@ -179,6 +180,7 @@ namespace YARG.Song
             { SYNTHPOP_ELECTROPOP, "SynthpopElectropop"},
             { TECHNO, "Techno"},
             { THRASH_SPEED_METAL, "ThrashSpeedMetal"},
+            { TRADITIONAL, "Traditional" },
             { TRANCE, "Trance"},
             { TRAP, "Trap"},
             { WORLD, "World"},

--- a/Assets/Script/Song/Genrelizer.Lists.cs
+++ b/Assets/Script/Song/Genrelizer.Lists.cs
@@ -98,8 +98,8 @@ namespace YARG.Song
         private const string NEW_WAVE_RAW = "new_wave";
         private const string POP_DANCE_ELECTRONIC_RAW = "popdanceelectronic";
         private const string POP_ROCK_RAW = "poprock";
-        private const string RNB_SOUL_FUNK_RAW = "rbsoulfunk";
         private const string REGGAE_SKA_RAW = "reggaeska";
+        private const string RNB_SOUL_FUNK_RAW = "rbsoulfunk";
 
 
         // Overgenrelizer

--- a/Assets/Script/Song/Genrelizer.cs
+++ b/Assets/Script/Song/Genrelizer.cs
@@ -87,13 +87,14 @@ namespace YARG.Song
 
                 COUNTRY or
                 FOLK or
-                SOUTHERN_ROCK => OVER_COUNTRY,
+                SOUTHERN_ROCK => OVER_COUNTRY_FOLK,
 
                 CHILDRENS_MUSIC or
                 CLASSICAL or
                 HOLIDAY or
                 ORCHESTRAL or
-                SOUNDTRACK => OVER_CLASSICAL_TRADITIONAL,
+                SOUNDTRACK or
+                TRADITIONAL => OVER_CLASSICAL_TRADITIONAL,
 
                 AMBIENT_DRONE or
                 CHIPTUNE or

--- a/Assets/StreamingAssets/lang/en-US.json
+++ b/Assets/StreamingAssets/lang/en-US.json
@@ -444,6 +444,7 @@
                 "SynthpopElectropop": "Synthpop/Electropop",
                 "Techno": "Techno",
                 "ThrashSpeedMetal": "Thrash/Speed Metal",
+				"Traditional": "Traditional",
                 "Trance": "Trance",
                 "Trap": "Trap",
                 "World": "World",
@@ -451,7 +452,7 @@
                 "UnknownGenre": "Unknown Genre",
                 "Broad": {
                     "Alternative": "Alternative",
-                    "Country": "Country",
+                    "CountryFolk": "Country/Folk",
                     "ClassicalTraditional": "Classical/Traditional",
                     "DanceElectronic": "Dance/Electronic",
                     "HipHop": "Hip-Hop",


### PR DESCRIPTION
* Renames the `Country` overgenrelizer genre to `Country/Folk`
* Adds support for the new `Traditional` genre
* Fixes handling of various Magma value pairs, mostly by adding switch cases for the raw-in-DTA renderings in addition to the converted-to-INI versions

The new `Traditional` genre requires a Genrelizer repo update to fully take effect, so please ping me when this is merged or about to go live. It doesn't need to be tightly synchronized so don't worry about being super coordinated