### PR TITLE
Create default keyboard bindings for MIDI Drumkit profiles

### DIFF
--- a/Assets/Script/Input/Bindings/Defaults/BindingCollection.Keyboard.cs
+++ b/Assets/Script/Input/Bindings/Defaults/BindingCollection.Keyboard.cs
@@ -15,6 +15,7 @@ namespace YARG.Input
 
                 GameMode.FourLaneDrums => SetDefaultFourLaneBindings(keyboard),
                 GameMode.FiveLaneDrums => SetDefaultFiveLaneBindings(keyboard),
+                GameMode.EliteDrums => SetDefaultEliteDrumsBindings(keyboard),
 
                 GameMode.ProGuitar => SetDefaultProGuitarBindings(keyboard),
                 GameMode.ProKeys => SetDefaultProKeysBindings(keyboard),
@@ -100,6 +101,34 @@ namespace YARG.Input
             AddBinding(DrumsAction.OrangeCymbal, keyboard.vKey);
 
             AddBinding(DrumsAction.Kick, keyboard.spaceKey);
+
+            return true;
+        }
+
+        private bool SetDefaultEliteDrumsBindings(Keyboard keyboard)
+        {
+            if (Mode != GameMode.EliteDrums)
+                return false;
+
+            AddBinding(EliteDrumsAction.Kick, keyboard.spaceKey);
+
+            /* 
+             * Actual ED-specific bindings go here
+             */
+
+            AddBinding(EliteDrumsAction.FourLaneRedDrum, keyboard.zKey);
+            AddBinding(EliteDrumsAction.FourLaneYellowDrum, keyboard.xKey);
+            AddBinding(EliteDrumsAction.FourLaneBlueDrum, keyboard.cKey);
+            AddBinding(EliteDrumsAction.FourLaneGreenDrum, keyboard.vKey);
+            AddBinding(EliteDrumsAction.FourLaneYellowCymbal, keyboard.sKey);
+            AddBinding(EliteDrumsAction.FourLaneBlueCymbal, keyboard.dKey);
+            AddBinding(EliteDrumsAction.FourLaneGreenCymbal, keyboard.fKey);
+
+            AddBinding(EliteDrumsAction.FiveLaneRedDrum, keyboard.zKey);
+            AddBinding(EliteDrumsAction.FiveLaneBlueDrum, keyboard.cKey);
+            AddBinding(EliteDrumsAction.FiveLaneGreenDrum, keyboard.bKey);
+            AddBinding(EliteDrumsAction.FiveLaneYellowCymbal, keyboard.xKey);
+            AddBinding(EliteDrumsAction.FiveLaneOrangeCymbal, keyboard.vKey);
 
             return true;
         }


### PR DESCRIPTION
Creates a default set of bindings for Keyboard devices on MIDI Drumkit profiles. The bindings are a straightforward copy and merge of the 4L and 5L defaults.