### PR TITLE
support song specific textures in custom characters

### DIFF
--- a/Assets/Script/Gameplay/BackgroundManager.cs
+++ b/Assets/Script/Gameplay/BackgroundManager.cs
@@ -200,22 +200,11 @@ namespace YARG.Gameplay
             // Breaks things for other platforms, because Unity
             var bg = (GameObject) await bundle.LoadAssetAsync<GameObject>(
                 BundleBackgroundManager.BACKGROUND_PREFAB_PATH.ToLowerInvariant());
-            var renderers = bg.GetComponentsInChildren<Renderer>(true);
 
             // Load Metal shaders, if necessary
             shaderBundle = await BackgroundHelper.LoadMetalShaders(bundle, bg, BackgroundHelper.ExportType.Background);
 
-            // Hookup song-specific textures
-            var textureManager = GetComponent<TextureManager>();
-            // Load SongBackground here to determine if textures need to be replaced
-            var songBackground = GameManager.Song.LoadBackground();
-            foreach (var renderer in renderers)
-            {
-                foreach (var material in renderer.sharedMaterials)
-                {
-                    textureManager.ProcessMaterial(material, songBackground?.Type);
-                }
-            }
+
 
             var bgInstance = Instantiate(bg);
             var bundleBackgroundManager = bgInstance.GetComponent<BundleBackgroundManager>();
@@ -232,12 +221,26 @@ namespace YARG.Gameplay
             // Destroy the default camera (venue has its own)
             Destroy(_videoPlayer.targetCamera.gameObject);
 
+            await LoadCustomCharacter(bgInstance);
+
+            var renderers = bgInstance.GetComponentsInChildren<Renderer>(true);
+
+            // Hookup song-specific textures
+            var textureManager = GetComponent<TextureManager>();
+            // Load SongBackground here to determine if textures need to be replaced
+            var songBackground = GameManager.Song.LoadBackground();
+            foreach (var renderer in renderers)
+            {
+                foreach (var material in renderer.sharedMaterials)
+                {
+                    textureManager.ProcessMaterial(material, songBackground?.Type);
+                }
+            }
+
             if (textureManager.VideoTexFound())
             {
                 SetUpVideoTexture(songBackground);
             }
-
-            await LoadCustomCharacter(bgInstance);
 
             // Initialize CharacterManager, if it exists
             var characterManager = bgInstance.GetComponentInChildren<CharacterManager>();


### PR DESCRIPTION
moved code around and use renderers from bgInstance instead of bg

this let's shaders on custom characters also use the song specific textures.
motivated by the character i posted  in #venue-artist

I've only tested on windows, and i don't know if this will have any effect on mac shader bundles.