### PR TITLE
fix: MusicPlayer using gameplay mix

### DIFF
--- a/Assets/Script/Menu/Persistent/MusicPlayer.cs
+++ b/Assets/Script/Menu/Persistent/MusicPlayer.cs
@@ -46,11 +46,13 @@ namespace YARG.Menu.Persistent
                 gameObject.SetActive(false);
                 return;
             }
+            StemSettings.ApplySettings = false; // ensure that MusicPlayer uses the full-volume mix
             NextSong();
         }
 
         private void OnDisable()
         {
+            StemSettings.ApplySettings = true; // reset to default value
             lock (_lock)
             {
                 _mixer?.Dispose();


### PR DESCRIPTION
**Code fix:** `MusicPlayer` silently inherits the default value of `StemSettings.ApplySettings`, resulting in the background music potentially missing out some stems, e.g., muted drums. Now setting `ApplySettings = false` in `OnEnable()` and `ApplySettings = true` in `OnDisable()`, relying on `MusicPlayer`'s lifecycle, where it is only active during menu navigation and not gameplay or the library preview.

## Background
YARG has per-stem instrument volume for use during gameplay. `ApplyVolumesInMusicLibrary` controls whether these are also applied to song previews in the music library.

`MusicPlayer` plays random songs while the user navigates menus and settings. This music uses the gameplay mix instead of the original (full) mix.

## Audio Mix System (YARG.Core)

- **`StemSettings`:** Global singleton instance per `SongStem` value, stored in `GlobalAudioHandler.StemSettings`. Holds per-stem volume/effects settings.
- **`StemSettings.ApplySettings`:** `static bool` (line 7). Default `true`.
- **`TrueVolume`:**  Sent to audio channels. If `ApplySettings = false`, all stems play at full volume.
- **`StemChannel`:** subscribes to `GlobalAudioHandler.StemSettings[stem].OnVolumeChange` on construction. When the event fires, it calls `SetVolume_Internal` with whatever `TrueVolume` was at the moment the event fired, so `ApplySettings` is read at volume-change events.

## Issue
### Song preview — works correctly
**`Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs`**
- Line 180 (`OnEnable`): `StemSettings.ApplySettings = SettingsManager.Settings.ApplyVolumesInMusicLibrary.Value;`
- Line 586 (`ExitLibrary`): resets to `true`
- Line 928 (`OnDestroy`): resets to `true`

The global static is explicitly managed around the lifetime of the music library screen.

### Background menu music
**`Assets/Script/Menu/Persistent/MusicPlayer.cs`**
- Line 78 (`NextSong`): `entry.LoadAudio(SPEED, SettingsManager.Settings.MusicPlayerVolume.Value, SongStem.Crowd)`
- `SPEED` is hardcoded to `1f` so that music player is always at "normal" speed.
- `MusicPlayer` never touches `StemSettings.ApplySettings`. Since the static defaults to `true`, and nothing sets it to `false` outside of `MusicLibraryMenu`, so it always plays with the gameplay mix.

## Why not modify `ApplySettings` in `NextSong()` ?
- `NextSong()` is called each time a new song starts, but changing `ApplySettings` there adds an implicit ordering dependency on song boundaries rather than on the actual playback context lifetime.

Note: since only one `StemMixer` is active at a time in practice (each caller disposes the previous before creating a new one). The concern is not concurrent mixers, it's that the global flag is never explicitly set for the `MusicPlayer` context, so it silently inherits whatever was last written by `MusicLibraryMenu` (since exiting the gameplay loop returns to the music library).

## Root Cause
- Given the observed behavior, it seems like the original design of the system was just two states: "playing a song" or "browsing the song library", with the gameplay being the assumed "normal" state, resulting in the library view implicitly being left to change the state of the system away from and then back to the default.
- `ApplySettings` is a `static bool` on `StemSettings`. It represents per-context state (should this playback session apply user volume settings?) implemented as global mutable state. There is no mechanism to scope it to a particular playback context, it depends entirely on call-site discipline around when it's set / reset, which would have only been one place (the library browser) before the music player was added.

### Gameplay never sets `ApplySettings`
`GameManager.Audio.cs` never sets `StemSettings.ApplySettings`. It relies on the default value of `true` to apply per-stem volumes during gameplay, this supports the idea that the gameplay loop is the assumed normal state of the system, and makes it vulnerable to side effects.

### Near-term: YARG-only fix (this PR)
This is fragile but not any more than the existing code. It uses the same global static mutation pattern already present in `MusicLibraryMenu`, but MusicPlayer lifecycle is well-bounded:
- `OnEnable()` only fires in the main menu context
- `OnDisable()` fires when `MusicPlayer` is explicitly stopped: either `MusicLibraryMenu` sets `allowsMusicPlayer: false`, or a scene change to gameplay forces it off
- All paths to the library route through `PushMenu(MusicLibrary)`, which triggers `allowsMusicPlayer: false`

Key assumptions:
1. `MusicPlayer` is only ever active during main / settings menu navigation
2. Every path that stops `MusicPlayer` goes through `OnDisable()`
3. `MusicLibraryMenu` sets `ApplySettings = true` on exit, `MusicPlayer.OnEnable` will set it to `false` again when the main menu re-enables it. (It actually waits until after checking song count > 0, so if there are no songs it never sets it to `false`, but it will set it to `true` in `OnDisable()` regardless)

### Long-term: Possible `YARG.Core` change
Move `ApplySettings` from a `static bool` on `StemSettings` to a per-instance `bool` on `StemMixer`, passed in at construction via `CreateMixer`.

**`StemMixer`** (`YARG.Core/Audio/StemMixer.cs`):
- Add `bool _applySettings` field, set via constructor/`CreateMixer`
- `StemMixer` (not `StemChannel`) subscribes to `GlobalAudioHandler.StemSettings[stem].OnVolumeChange`
- When the event fires, the mixer decides whether to forward `TrueVolume` or `VolumeSetting` to its channels based on its own `_applySettings`

**`StemSettings`** (`YARG.Core/Audio/StemSettings.cs`):
- Remove `static bool ApplySettings`
- Remove `TrueVolume` (or simplify to just return `_volume`)
- The "apply or not" decision would no longer be the settings object's concern

**`GlobalAudioHandler.CreateMixer`** (`YARG.Core/Audio/GlobalAudioHandler.cs`):
- Add `bool applySettings = true` parameter, thread it through to `StemMixer` constructor

**Call sites in YARG:**
- `GameManager.Audio.cs` gameplay: `applySettings: true`
- `MusicPlayer.cs` background music: `applySettings: false` by default, with three options:
  1. **Always use full mix:** Hardcode `false`. Background music always plays with all stems at full volume, regardless of any user setting, would align with forced `SPEED` of `1f`.
  2. **Reuse the existing toggle:** Pass `ApplyVolumesInMusicLibrary.Value`. The `MusicPlayer` would respect the same toggle as the library preview, giving users one setting that controls both contexts. (But, the name would be slightly misleading)
  3. **Add a dedicated toggle:** Create `ApplyVolumesInMusicPlayer` (defaulting to `false`). Gives users independent control over the `MusicPlayer` mix. (But, requires UI support)
- `MusicLibraryMenu.cs`: pass `ApplyVolumesInMusicLibrary` toggle value explicitly at mixer creation, remove the `StemSettings.ApplySettings = ...` changes

This eliminates the global static, makes the intent explicit at each call site, and removes the lifecycle assumptions the near-term fix depends on.

(An even more elaborate change would be to generalize the mixer settings into a reusable object and have separate gameplay/song library/music player mixes, which would either be a giant pain in the ass or trivial, depending on how composable the interface is)