### PR TITLE
Reduce memory allocations in a number of places

### DIFF
--- a/Assets/Script/Gameplay/HUD/CountdownDisplay.cs
+++ b/Assets/Script/Gameplay/HUD/CountdownDisplay.cs
@@ -4,7 +4,6 @@ using DG.Tweening;
 using UnityEngine;
 using UnityEngine.UI;
 using System;
-using Cysharp.Text;
 
 namespace YARG.Gameplay.HUD
 {
@@ -36,6 +35,7 @@ namespace YARG.Gameplay.HUD
         private Coroutine _currentCoroutine;
 
         private bool _displayActive;
+        private int _displayedCountdownValue = int.MinValue;
 
         public void UpdateCountdown(double countdownLength, double endTime)
         {
@@ -74,7 +74,7 @@ namespace YARG.Gameplay.HUD
             {
                 case CountdownDisplayMode.Seconds:
                 {
-                    _countdownText.SetText((int) Math.Ceiling(timeRemaining));
+                    SetCountdownValue((int) Math.Ceiling(timeRemaining));
                     break;
                 }
                 case CountdownDisplayMode.Measures:
@@ -84,7 +84,7 @@ namespace YARG.Gameplay.HUD
                     double endMeasure = Math.Floor(syncTrack.GetMeasurePosition(endTime));
                     double currentMeasure = syncTrack.GetMeasurePosition(currentTime);
                     int remainingMeasures = (int) Math.Ceiling(endMeasure - currentMeasure);
-                    _countdownText.SetText(remainingMeasures);
+                    SetCountdownValue(remainingMeasures);
                     break;
                 }
             }
@@ -99,6 +99,18 @@ namespace YARG.Gameplay.HUD
             _canvasGroup.alpha = 0f;
             gameObject.SetActive(true);
             _displayActive = false;
+            _displayedCountdownValue = int.MinValue;
+        }
+
+        private void SetCountdownValue(int value)
+        {
+            if (_displayedCountdownValue == value)
+            {
+                return;
+            }
+
+            _displayedCountdownValue = value;
+            _countdownText.SetText(value.ToString());
         }
 
         private void ToggleDisplay(bool isActive)

--- a/Assets/Script/Gameplay/HUD/FailMeter.cs
+++ b/Assets/Script/Gameplay/HUD/FailMeter.cs
@@ -188,10 +188,12 @@ namespace YARG.Gameplay.HUD
                 }
 
                 // The extra SPRITE_INITIAL_OFFSET is to get the whole group a bit farther from the meter itself
-                var xOffset =  SPRITE_INITIAL_OFFSET + (SPRITE_OVERLAP_OFFSET * overlap);
-                _xPosVectors[i].x = xOffset;
-
-                _xposTweeners[i].ChangeEndValue(_xPosVectors[i], 0.125f, true).Play();
+                var xOffset = SPRITE_INITIAL_OFFSET + (SPRITE_OVERLAP_OFFSET * overlap);
+                if (!Mathf.Approximately(_xPosVectors[i].x, xOffset))
+                {
+                    _xPosVectors[i].x = xOffset;
+                    _xposTweeners[i].ChangeEndValue(_xPosVectors[i], 0.125f, true).Play();
+                }
 
                 // This we can not do if the current player's happiness hasn't changed
                 if (_previousPlayerHappiness[i] != _players[i].Happiness)

--- a/Assets/Script/Gameplay/HUD/ScoreBox/ScoreBox.cs
+++ b/Assets/Script/Gameplay/HUD/ScoreBox/ScoreBox.cs
@@ -79,6 +79,8 @@ namespace YARG.Gameplay.HUD
         private bool _easterEggTriggered;
         private bool _vocalsOnly;
         private bool _singlePlayer;
+        private int _displayedCountUpSeconds = -1;
+        private int _displayedCountDownSeconds = -1;
 
         private Tween _multiplierShowTweener;
 
@@ -104,6 +106,8 @@ namespace YARG.Gameplay.HUD
             _scoreText.text = SCORE_PREFIX + "0";
             _bandComboText.text = SCORE_PREFIX + "0";
             _songTimer.text = string.Empty;
+            _displayedCountUpSeconds = -1;
+            _displayedCountDownSeconds = -1;
 
             _songProgressBar.SetProgress(0f);
         }
@@ -178,12 +182,21 @@ namespace YARG.Gameplay.HUD
             }
 
             // Skip if the song length has not been established yet, or if disabled
-            if (_songLengthTime == null) return;
+            if (_songLengthTime == null)
+            {
+                return;
+            }
 
-            var countUp = TimeSpan.FromSeconds(time);
-            var countDown = TimeSpan.FromSeconds(length - time);
-
-            _songTimer.SetTextFormat(_timeFormat, countUp, countDown, _songLengthTime);
+            var countUpSeconds = (int) time;
+            var countDownSeconds = (int) (length - time);
+            if (countUpSeconds != _displayedCountUpSeconds || countDownSeconds != _displayedCountDownSeconds)
+            {
+                var countUp = TimeSpan.FromSeconds(countUpSeconds);
+                var countDown = TimeSpan.FromSeconds(countDownSeconds);
+                _songTimer.SetTextFormat(_timeFormat, countUp, countDown, _songLengthTime);
+                _displayedCountUpSeconds = countUpSeconds;
+                _displayedCountDownSeconds = countDownSeconds;
+            }
         }
 
         private void UpdateBandMultiplier()

--- a/Assets/Script/Gameplay/HUD/VocalsPlayerHUD.cs
+++ b/Assets/Script/Gameplay/HUD/VocalsPlayerHUD.cs
@@ -36,11 +36,11 @@ namespace YARG.Gameplay.HUD
 
         private bool _shouldPulse;
         private bool _hudShowing = true;
-        private int _displayedMultiplier = int.MinValue;
+        private TextMeshProUGUI[] _textCache;
 
         public void Initialize(EnginePreset enginePreset)
         {
-            _displayedMultiplier = int.MinValue;
+            InitializeMultiplierTextCache(EnginePreset.DEFAULT_MAX_MULTIPLIER);
 
             if (enginePreset == EnginePreset.Default)
             {
@@ -61,6 +61,35 @@ namespace YARG.Gameplay.HUD
             }
 
             _starPowerFill.fillAmount = 0f;
+        }
+
+        private void InitializeMultiplierTextCache(int maxMultiplier)
+        {
+            if (_textCache != null)
+            {
+                foreach (var t in _textCache)
+                {
+                    t.enabled = false;
+                }
+
+                _multiplierText = _textCache[0];
+                return;
+            }
+
+            _textCache = new TextMeshProUGUI[maxMultiplier - 1];
+            for (int i = 0; i < _textCache.Length; i++)
+            {
+                var text = i == 0
+                    ? _multiplierText
+                    : Instantiate(_multiplierText, _multiplierText.transform.parent, true);
+
+                text.enabled = false;
+                text.text = string.Empty;
+                text.SetTextFormat("{0}<sub>x</sub>", i + 2);
+                _textCache[i] = text;
+            }
+
+            _multiplierText = _textCache[0];
         }
 
         private void Update()
@@ -94,18 +123,11 @@ namespace YARG.Gameplay.HUD
         {
             _comboMeterFillTarget = phrasePercent;
 
-            if (_displayedMultiplier != multiplier)
+            _multiplierText.enabled = false;
+            if (multiplier > 1)
             {
-                _displayedMultiplier = multiplier;
-
-                if (multiplier != 1)
-                {
-                    _multiplierText.SetTextFormat("{0}<sub>x</sub>", multiplier);
-                }
-                else
-                {
-                    _multiplierText.text = string.Empty;
-                }
+                _multiplierText = _textCache[multiplier - 2];
+                _multiplierText.enabled = true;
             }
 
             _starPowerFill.fillAmount = starPowerPercent;

--- a/Assets/Script/Gameplay/HUD/VocalsPlayerHUD.cs
+++ b/Assets/Script/Gameplay/HUD/VocalsPlayerHUD.cs
@@ -36,9 +36,12 @@ namespace YARG.Gameplay.HUD
 
         private bool _shouldPulse;
         private bool _hudShowing = true;
+        private int _displayedMultiplier = int.MinValue;
 
         public void Initialize(EnginePreset enginePreset)
         {
+            _displayedMultiplier = int.MinValue;
+
             if (enginePreset == EnginePreset.Default)
             {
                 // Don't change combo meter fill color if it's the default
@@ -91,13 +94,18 @@ namespace YARG.Gameplay.HUD
         {
             _comboMeterFillTarget = phrasePercent;
 
-            if (multiplier != 1)
+            if (_displayedMultiplier != multiplier)
             {
-                _multiplierText.SetTextFormat("{0}<sub>x</sub>", multiplier);
-            }
-            else
-            {
-                _multiplierText.text = string.Empty;
+                _displayedMultiplier = multiplier;
+
+                if (multiplier != 1)
+                {
+                    _multiplierText.SetTextFormat("{0}<sub>x</sub>", multiplier);
+                }
+                else
+                {
+                    _multiplierText.text = string.Empty;
+                }
             }
 
             _starPowerFill.fillAmount = starPowerPercent;

--- a/Assets/Script/Gameplay/Player/DrumsPlayer.cs
+++ b/Assets/Script/Gameplay/Player/DrumsPlayer.cs
@@ -24,6 +24,7 @@ namespace YARG.Gameplay.Player
     public class DrumsPlayer : TrackPlayer<DrumsEngine, DrumNote>
     {
         private const float DRUM_PAD_FLASH_HOLD_DURATION = 0.2f;
+        private static readonly Fret.AnimType[] AnimTypes = (Fret.AnimType[]) Enum.GetValues(typeof(Fret.AnimType));
 
         // Key is a FourLaneDrumPad or FiveLaneDrumPad
         private Dictionary<int, HighwayOrderingInfo> _highwayOrdering;
@@ -63,12 +64,12 @@ namespace YARG.Gameplay.Player
 
         public HighwayOrderingInfo GetHighwayOrderingInfo(int pad)
         {
-            if (_highwayOrdering.ContainsKey(pad))
+            if (_highwayOrdering.TryGetValue(pad, out var info))
             {
-                return _highwayOrdering[pad];
+                return info;
             }
 
-            return new(-1, pad);
+            return new HighwayOrderingInfo(-1, pad);
         }
 
 
@@ -672,7 +673,7 @@ namespace YARG.Gameplay.Player
 
         private void InitializeAnimTypes()
         {
-            foreach (Fret.AnimType animType in Enum.GetValues(typeof(Fret.AnimType)))
+            foreach (var animType in AnimTypes)
             {
                 _animTypeToFretToLastPressedDelta[animType] = new Dictionary<int, float>();
 
@@ -701,7 +702,7 @@ namespace YARG.Gameplay.Player
 
         private void UpdateAnimTimes()
         {
-            foreach (Fret.AnimType animType in Enum.GetValues(typeof(Fret.AnimType)))
+            foreach (var animType in AnimTypes)
             {
                 foreach (var fretIdx in _highwayOrdering.Keys)
                 {
@@ -936,7 +937,7 @@ namespace YARG.Gameplay.Player
             else
             {
                 LaneCount = 4;
-                _highwayOrdering = new()
+                _highwayOrdering = new Dictionary<int, HighwayOrderingInfo>
                 {
                     { (int)FourLaneDrumPad.RedDrum,       new(ApplyHandednessToPosition(0), ApplyHandednessToFourLaneColor(FourLaneDrumsFret.RedDrum)) },
                     { (int)FourLaneDrumPad.YellowCymbal,  new(ApplyHandednessToPosition(1), ApplyHandednessToFourLaneColor(FourLaneDrumsFret.YellowCymbal)) },

--- a/Assets/Script/Gameplay/Player/Vocals/VocalTrack.cs
+++ b/Assets/Script/Gameplay/Player/Vocals/VocalTrack.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using TMPro;
 using UnityEngine;
 using UnityEngine.Assertions;
@@ -518,7 +517,7 @@ namespace YARG.Gameplay.Player
             UpdateSpawning();
 
             // Fade on/off the starpower overlay
-            bool starpowerActive = _vocalPlayers.Any(player => player.Engine.EngineStats.IsStarPowerActive);
+            bool starpowerActive = IsAnyStarPowerActive();
             float currentStarpower = _starpowerMaterial.GetFloat(_alphaMultiplier);
             if (starpowerActive)
             {
@@ -530,6 +529,19 @@ namespace YARG.Gameplay.Player
                 _starpowerMaterial.SetFloat(_alphaMultiplier,
                     Mathf.Lerp(currentStarpower, 0f, Time.deltaTime * 4f));
             }
+        }
+
+        private bool IsAnyStarPowerActive()
+        {
+            for (int i = 0; i < _vocalPlayers.Count; i++)
+            {
+                if (_vocalPlayers[i].Engine.EngineStats.IsStarPowerActive)
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         private void UpdateHighwayGuidelines()

--- a/Assets/Script/Gameplay/Visuals/Fret/Fret.cs
+++ b/Assets/Script/Gameplay/Visuals/Fret/Fret.cs
@@ -110,13 +110,13 @@ namespace YARG.Gameplay.Visuals
 
         public void WhitenFretColor()
         {
-            foreach (var material in ThemeBind.GetColoredMaterials())
+            foreach (var material in _topMaterials)
             {
                 material.color = UnityEngine.Color.white;
                 material.SetColor(_emissionColor, UnityEngine.Color.white);
             }
 
-            foreach (var material in ThemeBind.GetInnerColoredMaterials())
+            foreach (var material in _innerMaterials)
             {
                 material.color = UnityEngine.Color.white;
                 material.SetColor(_emissionColor, UnityEngine.Color.white);
@@ -135,13 +135,13 @@ namespace YARG.Gameplay.Visuals
 
         public void RestoreFretColor()
         {
-            foreach (var material in ThemeBind.GetColoredMaterials())
+            foreach (var material in _topMaterials)
             {
                 material.color = _originalUnityTopColor;
                 material.SetColor(_emissionColor, _originalEmissionColor);
             }
 
-            foreach (var material in ThemeBind.GetInnerColoredMaterials())
+            foreach (var material in _innerMaterials)
             {
                 material.color = _originalUnityInnerColor;
                 material.SetColor(_emissionColor, _originalEmissionColor);


### PR DESCRIPTION
I did a bit of frame profiling in Unity and saw that there were some low hanging fruit with respect to memory allocations. Fewer allocations means less GC pressure and hopefully fewer GC collection cycles. I was seeing around 80 allocations per frame at 3.9KB on my test song. Now I'm seeing something closer to 23 allocations per frame at 1.4KB