### PR TITLE
Fix drum fret animations on non-split 4L and Pro

### DIFF
--- a/Assets/Script/Gameplay/Player/DrumsPlayer.cs
+++ b/Assets/Script/Gameplay/Player/DrumsPlayer.cs
@@ -54,9 +54,9 @@ namespace YARG.Gameplay.Player
                 DrumsAction.YellowDrum =>   (int) FourLaneDrumPad.YellowDrum,
                 DrumsAction.BlueDrum =>     (int) FourLaneDrumPad.BlueDrum,
                 DrumsAction.GreenDrum =>    (int) FourLaneDrumPad.GreenDrum,
-                DrumsAction.YellowCymbal => (int) (Player.Profile.SplitProTomsAndCymbals ? FourLaneDrumPad.YellowCymbal : FourLaneDrumPad.YellowDrum),
-                DrumsAction.BlueCymbal =>   (int) (Player.Profile.SplitProTomsAndCymbals ? FourLaneDrumPad.BlueCymbal : FourLaneDrumPad.BlueDrum),
-                DrumsAction.GreenCymbal =>  (int) (Player.Profile.SplitProTomsAndCymbals ? FourLaneDrumPad.GreenCymbal : FourLaneDrumPad.GreenDrum),
+                DrumsAction.YellowCymbal => (int) FourLaneDrumPad.YellowCymbal,
+                DrumsAction.BlueCymbal =>   (int) FourLaneDrumPad.BlueCymbal,
+                DrumsAction.GreenCymbal =>  (int) FourLaneDrumPad.GreenCymbal,
                 DrumsAction.WildcardPad =>  (int) FourLaneDrumPad.Kick,
                 _ => throw new ArgumentOutOfRangeException(nameof(action))
             };

--- a/Assets/Script/Gameplay/Visuals/Fret/FretArray.cs
+++ b/Assets/Script/Gameplay/Visuals/Fret/FretArray.cs
@@ -36,6 +36,10 @@ namespace YARG.Gameplay.Visuals
         private Transform _rightKickFretPosition;
 
         private readonly Dictionary<int, Fret> _frets = new();
+        // These will be empty on anything that does not have stacked frets, which is only 4L and Pro Drums right now.
+        private readonly Dictionary<int, int>       _stackedFretIndices        = new();
+        private readonly HashSet<int>               _enabledStackedFretIndices = new();
+
         private readonly List<KickFret> _kickFrets = new();
 
         private readonly List<int> _activeFrets  = new();
@@ -90,6 +94,16 @@ namespace YARG.Gameplay.Visuals
                     fretColorProvider.GetParticleColor((int)FiveFretGuitarFret.Open)
                 );
 
+                foreach (var f in _frets)
+                {
+                    if (Mathf.Approximately(f.Value.transform.localPosition.x, x))
+                    {
+                        // We add both ways because we want to be able to look up either fret and find the other one
+                        _stackedFretIndices.Add(noteType, f.Key);
+                        _stackedFretIndices.Add(f.Key, noteType);
+                        break;
+                    }
+                }
                 _frets[noteType] = fretComp;
             }
 
@@ -127,6 +141,22 @@ namespace YARG.Gameplay.Visuals
             }
         }
         #nullable restore
+        private void SetActiveStackedFret(int index)
+        {
+            if (_stackedFretIndices.Count == 0 || _enabledStackedFretIndices.Contains(index) || !_stackedFretIndices.TryGetValue(index, out int otherFretIndex))
+            {
+                return;
+            }
+            var fretTransform = _frets[index].transform;
+            var otherFretTransform = _frets[otherFretIndex].transform;
+
+            // Disabling the gameObject can cause the animation to get stuck in a weird spot, so just set the Z scale to 0
+            fretTransform.localScale = fretTransform.localScale.WithZ(1f);
+            otherFretTransform.localScale = otherFretTransform.localScale.WithZ(0f);
+
+            _enabledStackedFretIndices.Remove(otherFretIndex);
+            _enabledStackedFretIndices.Add(index);
+        }
 
         public void SetPressed(int index, bool pressed)
         {
@@ -145,6 +175,7 @@ namespace YARG.Gameplay.Visuals
 
         public void PlayHitAnimation(int index)
         {
+            SetActiveStackedFret(index);
             _frets[index].PlayHitAnimation();
             _frets[index].PlayHitParticles();
         }
@@ -155,13 +186,14 @@ namespace YARG.Gameplay.Visuals
             {
                 return;
             }
-
+            SetActiveStackedFret(index);
             fret.PlayHitAnimation();
             fret.PlayHitParticles();
         }
 
         public void PlayCymbalHitAnimation(int index)
         {
+            SetActiveStackedFret(index);
             _frets[index].PlayCymbalHitAnimation();
             _frets[index].PlayHitParticles();
         }
@@ -179,6 +211,7 @@ namespace YARG.Gameplay.Visuals
         {
             if (_frets.ContainsKey(index))
             {
+                SetActiveStackedFret(index);
                 _frets[index].PlayMissAnimation();
                 _frets[index].PlayMissParticles();
             }


### PR DESCRIPTION
The reason the animations were messed up (see [here](https://discord.com/channels/1086048856678084609/1482102039184933079) for details) was because there were essentially two frets inside of each other, one for cymbals, and one for toms, which caused some animations, especially the overhit and cymbal hit animations, to look weird since you could see both frets.

This change hides whichever fret is not the one being hit on any hit, allowing the animations to play properly.