### PR TITLE
Avoid calling Object.FindAnyObjectByType in stagekit stack

### DIFF
--- a/Assets/Script/Integration/MasterLightingController.cs
+++ b/Assets/Script/Integration/MasterLightingController.cs
@@ -5,6 +5,7 @@ using UnityEngine.SceneManagement;
 using YARG.Core.Chart;
 using YARG.Core.Logging;
 using YARG.Gameplay;
+using YARG.Playback;
 
 namespace YARG.Integration
 {
@@ -237,6 +238,13 @@ namespace YARG.Integration
         private static int _currentBassNote;
         private static PerformerEvent _currentPerformerEvent;
         private static int _currentKeysNote;
+
+        public static BeatEventController BeatVisual { get; private set; }
+
+        internal static void SetBeatVisual(BeatEventController beatVisual)
+        {
+            BeatVisual = beatVisual;
+        }
 
         public static void FireBonusFXEvent()
         {

--- a/Assets/Script/Integration/MasterLightingGameplayMonitor.cs
+++ b/Assets/Script/Integration/MasterLightingGameplayMonitor.cs
@@ -37,6 +37,16 @@ namespace YARG.Integration
         private int _drumEndCheckIndex = -1;
         private int _keysEndCheckIndex = -1;
 
+        protected override void GameplayAwake()
+        {
+            MasterLightingController.SetBeatVisual(GameManager.BeatEventHandler.Visual);
+        }
+
+        protected override void GameplayDestroy()
+        {
+            MasterLightingController.SetBeatVisual(null);
+        }
+
         protected override void OnChartLoaded(SongChart chart)
         {
             MasterLightingController.CurrentLightingCue = null;

--- a/Assets/Script/Integration/StageKit/StageKitLighting.Cues.cs
+++ b/Assets/Script/Integration/StageKit/StageKitLighting.Cues.cs
@@ -2,8 +2,6 @@ using System;
 using System.Collections.Generic;
 using PlasticBand.Haptics;
 using YARG.Core.Chart;
-using YARG.Gameplay;
-using Object = UnityEngine.Object;
 
 namespace YARG.Integration.StageKit
 {
@@ -802,7 +800,6 @@ namespace YARG.Integration.StageKit
 
     public class Dischord : StageKitLightingCue
     {
-        private GameManager _gameManager;
         private float _currentPitch;
         private bool _greenIsSpinning;
         private bool _blueOnTwo = true;
@@ -862,7 +859,6 @@ namespace YARG.Integration.StageKit
 
         public override void Enable()
         {
-            _gameManager = Object.FindAnyObjectByType<GameManager>();
             StageKitInterpreter.Instance.SetLed(RED, NONE);
             StageKitInterpreter.Instance.SetLed(BLUE, TWO | SIX);
 

--- a/Assets/Script/Integration/StageKit/StageKitLighting.Primitives.cs
+++ b/Assets/Script/Integration/StageKit/StageKitLighting.Primitives.cs
@@ -3,9 +3,8 @@ using System.Threading;
 using Cysharp.Threading.Tasks;
 using PlasticBand.Haptics;
 using YARG.Core.Chart;
-using YARG.Gameplay;
+using YARG.Integration;
 using YARG.Playback;
-using Object = UnityEngine.Object;
 
 namespace YARG.Integration.StageKit
 {
@@ -14,7 +13,6 @@ namespace YARG.Integration.StageKit
         private readonly bool _continuous;
         private int _patternIndex;
         private readonly (StageKitLedColor color, byte data)[] _patternList;
-        private GameManager _gameManager;
         private readonly float _beatsPerCycle;
 
         public BeatPattern((StageKitLedColor, byte)[] patternList, float beatsPerCycle, bool continuous = true)
@@ -27,9 +25,7 @@ namespace YARG.Integration.StageKit
         public override void Enable()
         {
             _patternIndex = 0;
-            // Brought to you by Hacky Hack and the Hacktones
-            _gameManager = Object.FindAnyObjectByType<GameManager>();
-            _gameManager.BeatEventHandler.Visual.Subscribe(OnBeat, BeatEventType.DenominatorBeat, division: _beatsPerCycle / _patternList.Length);
+            MasterLightingController.BeatVisual?.Subscribe(OnBeat, BeatEventType.DenominatorBeat, division: _beatsPerCycle / _patternList.Length);
         }
 
         private void OnBeat()
@@ -41,7 +37,7 @@ namespace YARG.Integration.StageKit
             // otherwise they pile up.
             if (!_continuous && _patternIndex == _patternList.Length)
             {
-                _gameManager.BeatEventHandler.Visual.Unsubscribe(OnBeat);
+                MasterLightingController.BeatVisual?.Unsubscribe(OnBeat);
                 KillSelf();
             }
 
@@ -53,10 +49,7 @@ namespace YARG.Integration.StageKit
 
         public override void KillSelf()
         {
-            if (_gameManager != null)
-            {
-                _gameManager.BeatEventHandler.Visual.Unsubscribe(OnBeat);
-            }
+            MasterLightingController.BeatVisual?.Unsubscribe(OnBeat);
         }
     }
 


### PR DESCRIPTION
These calls are very expensive to be called during gameplay