### PR TITLE
Remove more memory allocations

### DIFF
--- a/Assets/Script/Gameplay/HUD/ScoreBox/ScoreBox.cs
+++ b/Assets/Script/Gameplay/HUD/ScoreBox/ScoreBox.cs
@@ -79,6 +79,8 @@ namespace YARG.Gameplay.HUD
         private bool _easterEggTriggered;
         private bool _vocalsOnly;
         private bool _singlePlayer;
+        private int _displayedCountUpSeconds = -1;
+        private int _displayedCountDownSeconds = -1;
 
         private Tween _multiplierShowTweener;
 
@@ -104,6 +106,8 @@ namespace YARG.Gameplay.HUD
             _scoreText.text = SCORE_PREFIX + "0";
             _bandComboText.text = SCORE_PREFIX + "0";
             _songTimer.text = string.Empty;
+            _displayedCountUpSeconds = -1;
+            _displayedCountDownSeconds = -1;
 
             _songProgressBar.SetProgress(0f);
         }
@@ -178,13 +182,21 @@ namespace YARG.Gameplay.HUD
             }
 
             // Skip if the song length has not been established yet, or if disabled
-            // Skip if the song length has not been established yet, or if disabled
-            if (_songLengthTime == null) return;
+            if (_songLengthTime == null)
+            {
+                return;
+            }
 
-            var countUp = TimeSpan.FromSeconds(time);
-            var countDown = TimeSpan.FromSeconds(length - time);
-
-            _songTimer.SetTextFormat(_timeFormat, countUp, countDown, _songLengthTime);
+            var countUpSeconds = (int) time;
+            var countDownSeconds = (int) (length - time);
+            if (countUpSeconds != _displayedCountUpSeconds || countDownSeconds != _displayedCountDownSeconds)
+            {
+                var countUp = TimeSpan.FromSeconds(countUpSeconds);
+                var countDown = TimeSpan.FromSeconds(countDownSeconds);
+                _songTimer.SetTextFormat(_timeFormat, countUp, countDown, _songLengthTime);
+                _displayedCountUpSeconds = countUpSeconds;
+                _displayedCountDownSeconds = countDownSeconds;
+            }
         }
 
         private void UpdateBandMultiplier()

--- a/Assets/Script/Gameplay/HUD/ScoreBox/ScoreBox.cs
+++ b/Assets/Script/Gameplay/HUD/ScoreBox/ScoreBox.cs
@@ -26,8 +26,6 @@ namespace YARG.Gameplay.HUD
     public class ScoreBox : GameplayBehaviour
     {
         private const string SCORE_PREFIX = "<mspace=0.538em>";
-        private const string SCORE_TEXT_FORMAT = SCORE_PREFIX + "{0:0,0}";
-        private const string MULTIPLIER_TEXT_FORMAT = "{0:0}x";
 
         private const string TIME_FORMAT       = @"m\:ss";
         private const string TIME_FORMAT_HOURS = @"h\:mm\:ss";
@@ -81,8 +79,6 @@ namespace YARG.Gameplay.HUD
         private bool _easterEggTriggered;
         private bool _vocalsOnly;
         private bool _singlePlayer;
-        private int _displayedCountUpSeconds = -1;
-        private int _displayedCountDownSeconds = -1;
 
         private Tween _multiplierShowTweener;
 
@@ -108,8 +104,6 @@ namespace YARG.Gameplay.HUD
             _scoreText.text = SCORE_PREFIX + "0";
             _bandComboText.text = SCORE_PREFIX + "0";
             _songTimer.text = string.Empty;
-            _displayedCountUpSeconds = -1;
-            _displayedCountDownSeconds = -1;
 
             _songProgressBar.SetProgress(0f);
         }
@@ -147,7 +141,7 @@ namespace YARG.Gameplay.HUD
             if (GameManager.BandScore != _bandScore)
             {
                 _bandScore = GameManager.BandScore;
-                _scoreText.SetText(SCORE_TEXT_FORMAT, _bandScore);
+                _scoreText.SetTextFormat("{0}{1:N0}", SCORE_PREFIX, _bandScore);
 
                 var scoreTextLength = _bandScore == 0 ? 1 : Math.Floor(Math.Log10(_bandScore) + 1);
                 scoreTextLength += Math.Floor((scoreTextLength - 1) / 3); // thousand coma separators
@@ -169,7 +163,7 @@ namespace YARG.Gameplay.HUD
             {
                 _bandCombo = GameManager.BandCombo;
                 var modifier = _vocalsOnly ? 10 : 1;
-                _bandComboText.SetText(SCORE_TEXT_FORMAT, _bandCombo / (float) modifier);
+                _bandComboText.SetTextFormat("{0}{1:N0}", SCORE_PREFIX, _bandCombo / modifier);
             }
 
             UpdateBandMultiplier();
@@ -184,21 +178,13 @@ namespace YARG.Gameplay.HUD
             }
 
             // Skip if the song length has not been established yet, or if disabled
-            if (_songLengthTime == null)
-            {
-                return;
-            }
+            // Skip if the song length has not been established yet, or if disabled
+            if (_songLengthTime == null) return;
 
-            var countUpSeconds = (int) time;
-            var countDownSeconds = (int) (length - time);
-            if (countUpSeconds != _displayedCountUpSeconds || countDownSeconds != _displayedCountDownSeconds)
-            {
-                var countUp = TimeSpan.FromSeconds(countUpSeconds);
-                var countDown = TimeSpan.FromSeconds(countDownSeconds);
-                _songTimer.SetTextFormat(_timeFormat, countUp, countDown, _songLengthTime);
-                _displayedCountUpSeconds = countUpSeconds;
-                _displayedCountDownSeconds = countDownSeconds;
-            }
+            var countUp = TimeSpan.FromSeconds(time);
+            var countDown = TimeSpan.FromSeconds(length - time);
+
+            _songTimer.SetTextFormat(_timeFormat, countUp, countDown, _songLengthTime);
         }
 
         private void UpdateBandMultiplier()
@@ -210,7 +196,7 @@ namespace YARG.Gameplay.HUD
 
             var show = GameManager.BandMultiplier > 1 && !_singlePlayer;
             _bandMultiplier = GameManager.BandMultiplier;
-            _bandMultiplierText.SetText(MULTIPLIER_TEXT_FORMAT, GameManager.BandMultiplier);
+            _bandMultiplierText.SetTextFormat("{0}x", GameManager.BandMultiplier);
 
             if (show)
             {

--- a/Assets/Script/Gameplay/HUD/ScoreBox/ScoreBox.cs
+++ b/Assets/Script/Gameplay/HUD/ScoreBox/ScoreBox.cs
@@ -26,6 +26,8 @@ namespace YARG.Gameplay.HUD
     public class ScoreBox : GameplayBehaviour
     {
         private const string SCORE_PREFIX = "<mspace=0.538em>";
+        private const string SCORE_TEXT_FORMAT = SCORE_PREFIX + "{0:0,0}";
+        private const string MULTIPLIER_TEXT_FORMAT = "{0:0}x";
 
         private const string TIME_FORMAT       = @"m\:ss";
         private const string TIME_FORMAT_HOURS = @"h\:mm\:ss";
@@ -145,7 +147,7 @@ namespace YARG.Gameplay.HUD
             if (GameManager.BandScore != _bandScore)
             {
                 _bandScore = GameManager.BandScore;
-                _scoreText.SetTextFormat("{0}{1:N0}", SCORE_PREFIX, _bandScore);
+                _scoreText.SetText(SCORE_TEXT_FORMAT, _bandScore);
 
                 var scoreTextLength = _bandScore == 0 ? 1 : Math.Floor(Math.Log10(_bandScore) + 1);
                 scoreTextLength += Math.Floor((scoreTextLength - 1) / 3); // thousand coma separators
@@ -167,7 +169,7 @@ namespace YARG.Gameplay.HUD
             {
                 _bandCombo = GameManager.BandCombo;
                 var modifier = _vocalsOnly ? 10 : 1;
-                _bandComboText.SetTextFormat("{0}{1:N0}", SCORE_PREFIX, _bandCombo / modifier);
+                _bandComboText.SetText(SCORE_TEXT_FORMAT, _bandCombo / (float) modifier);
             }
 
             UpdateBandMultiplier();
@@ -208,7 +210,7 @@ namespace YARG.Gameplay.HUD
 
             var show = GameManager.BandMultiplier > 1 && !_singlePlayer;
             _bandMultiplier = GameManager.BandMultiplier;
-            _bandMultiplierText.SetTextFormat("{0}x", GameManager.BandMultiplier);
+            _bandMultiplierText.SetText(MULTIPLIER_TEXT_FORMAT, GameManager.BandMultiplier);
 
             if (show)
             {

--- a/Assets/Script/Gameplay/HUD/SoloBox.cs
+++ b/Assets/Script/Gameplay/HUD/SoloBox.cs
@@ -42,6 +42,9 @@ namespace YARG.Gameplay.HUD
         private SoloSection _solo;
 
         private bool _showingForPreview;
+        private int _displayedHitPercent = int.MinValue;
+        private int _displayedNotesHit = int.MinValue;
+        private int _displayedNoteCount = int.MinValue;
 
         private int HitPercent => Mathf.FloorToInt((float) _solo.NotesHit / _solo.NoteCount * 100f);
 
@@ -54,6 +57,9 @@ namespace YARG.Gameplay.HUD
 
             _solo = solo;
             _soloEnded = false;
+            _displayedHitPercent = int.MinValue;
+            _displayedNotesHit = int.MinValue;
+            _displayedNoteCount = int.MinValue;
             gameObject.SetActive(true);
 
             StopCurrentCoroutine();
@@ -80,8 +86,19 @@ namespace YARG.Gameplay.HUD
         {
             if (_soloEnded || _showingForPreview) return;
 
-            _soloTopText.SetTextFormat("{0}%", HitPercent);
-            _soloBottomText.SetTextFormat("{0}/{1}", _solo.NotesHit, _solo.NoteCount);
+            var hitPercent = HitPercent;
+            if (_displayedHitPercent != hitPercent)
+            {
+                _displayedHitPercent = hitPercent;
+                _soloTopText.SetTextFormat("{0}%", hitPercent);
+            }
+
+            if (_displayedNotesHit != _solo.NotesHit || _displayedNoteCount != _solo.NoteCount)
+            {
+                _displayedNotesHit = _solo.NotesHit;
+                _displayedNoteCount = _solo.NoteCount;
+                _soloBottomText.SetTextFormat("{0}/{1}", _displayedNotesHit, _displayedNoteCount);
+            }
         }
 
         public void EndSolo(int soloBonus, Action endCallback)

--- a/Assets/Script/Gameplay/VenueCameraRenderer.cs
+++ b/Assets/Script/Gameplay/VenueCameraRenderer.cs
@@ -26,6 +26,7 @@ namespace YARG.Gameplay
         private static RawImage _venueOutput;
         private static RenderTexture _venueTexture;
         private static RenderTexture _trailsTexture;
+        private static RTHandle _trailsTextureHandle;
 
         private static readonly int _IsVenueId = Shader.PropertyToID("_YargIsVenue");
         private static readonly int _trailsLengthId = Shader.PropertyToID("_YargTrailLength");
@@ -123,6 +124,8 @@ namespace YARG.Gameplay
             
             if (_trailsTexture != null)
             {
+                _trailsTextureHandle?.Release();
+                _trailsTextureHandle = null;
                 _trailsTexture.Release();
                 _trailsTexture.DiscardContents();
             }
@@ -137,6 +140,7 @@ namespace YARG.Gameplay
             _trailsTexture.filterMode = FilterMode.Bilinear;
             _trailsTexture.wrapMode = TextureWrapMode.Clamp;
             _trailsTexture.Create();
+            _trailsTextureHandle = RTHandles.Alloc(_trailsTexture);
             Shader.SetGlobalTexture(_trailsTextureId, _trailsTexture);
             Graphics.Blit(Texture2D.blackTexture, _trailsTexture);
         }
@@ -168,6 +172,8 @@ namespace YARG.Gameplay
 
             if (_trailsTexture != null)
             {
+                _trailsTextureHandle?.Release();
+                _trailsTextureHandle = null;
                 _trailsTexture.Release();
                 Destroy(_trailsTexture);
                 _trailsTexture = null;
@@ -188,6 +194,8 @@ namespace YARG.Gameplay
 
             if (_trailsTexture != null)
             {
+                _trailsTextureHandle?.Release();
+                _trailsTextureHandle = null;
                 _trailsTexture.Release();
                 Destroy(_trailsTexture);
                 _trailsTexture = null;
@@ -366,7 +374,7 @@ namespace YARG.Gameplay
             public override void RecordRenderGraph(RenderGraph renderGraph, ContextContainer frameData)
             {
                 UniversalResourceData resourceData = frameData.Get<UniversalResourceData>();
-                TextureHandle trailsTexture = renderGraph.ImportTexture(RTHandles.Alloc(_trailsTexture));
+                TextureHandle trailsTexture = renderGraph.ImportTexture(_trailsTextureHandle);
                 renderGraph.AddCopyPass(resourceData.activeColorTexture, trailsTexture, "Store frame for trail");
             }
         }

--- a/Assets/Script/Gameplay/VenueCameraRenderer.cs
+++ b/Assets/Script/Gameplay/VenueCameraRenderer.cs
@@ -22,6 +22,8 @@ namespace YARG.Gameplay
         private Camera _renderCamera;
         private float _originalFactor;
         private UniversalRenderPipelineAsset UniversalRenderPipelineAsset;
+        private readonly RenderPipeline.StandardRequest _renderRequest = new();
+        private bool _supportsRenderRequest;
 
         private static RawImage _venueOutput;
         private static RenderTexture _venueTexture;
@@ -98,6 +100,7 @@ namespace YARG.Gameplay
             }
             UniversalRenderPipelineAsset = GraphicsSettings.currentRenderPipeline as UniversalRenderPipelineAsset;
             _originalFactor = UniversalRenderPipelineAsset.renderScale;
+            _supportsRenderRequest = RenderPipeline.SupportsRenderRequest(_renderCamera, _renderRequest);
 
             FPS = SettingsManager.Settings.VenueFpsCap.Value;
             _venueLayerMask = LayerMask.GetMask("Venue");
@@ -121,7 +124,7 @@ namespace YARG.Gameplay
             var outputHeight = (int)(Screen.height * renderScale);
 
             ScalableBufferManager.ResizeBuffers(renderScale, renderScale);
-            
+
             if (_trailsTexture != null)
             {
                 _trailsTextureHandle?.Release();
@@ -335,20 +338,18 @@ namespace YARG.Gameplay
 
         private void Render()
         {
-            // Create a standard request
-            var request = new RenderPipeline.StandardRequest();
-
-            // Check if the request is supported by the active render pipeline
-            if (RenderPipeline.SupportsRenderRequest(_renderCamera, request))
+            if (!_supportsRenderRequest)
             {
-                request.destination = _venueTexture;
-                // Render camera and fill texture2D with its view
-                RenderPipeline.SubmitRenderRequest(_renderCamera, request);
+                return;
+            }
 
-                if (!IsRendered)
-                {
-                    IsRendered = true;
-                }
+            _renderRequest.destination = _venueTexture;
+            // Render camera and fill texture2D with its view
+            RenderPipeline.SubmitRenderRequest(_renderCamera, _renderRequest);
+
+            if (!IsRendered)
+            {
+                IsRendered = true;
             }
         }
 

--- a/Assets/Script/Gameplay/Visuals/HighwayCameraRendering.cs
+++ b/Assets/Script/Gameplay/Visuals/HighwayCameraRendering.cs
@@ -45,6 +45,7 @@ namespace YARG.Gameplay.Visuals
         public  RenderTexture              HighwaysOutputTexture { get; private set; }
         public event Action<RenderTexture> OnHighwaysTextureCreated;
         private RenderTexture              _highwaysAlphaTexture;
+        private RTHandle                   _highwaysAlphaTextureHandle;
         private ScriptableRenderPass       _fadeCalcPass;
         private bool                       _allowTextureRecreation = true;
         private bool                       _needsInitialization    = true;
@@ -315,6 +316,12 @@ namespace YARG.Gameplay.Visuals
 
         private void ResetHighwayAlphaTexture()
         {
+            if (_highwaysAlphaTextureHandle != null)
+            {
+                _highwaysAlphaTextureHandle.Release();
+                _highwaysAlphaTextureHandle = null;
+            }
+
             if (_highwaysAlphaTexture != null)
             {
                 _highwaysAlphaTexture.Release();
@@ -328,6 +335,7 @@ namespace YARG.Gameplay.Visuals
                 mipCount = 0,
             };
             _highwaysAlphaTexture = new RenderTexture(descriptor);
+            _highwaysAlphaTextureHandle = RTHandles.Alloc(_highwaysAlphaTexture);
             Shader.SetGlobalTexture(YargHighwaysAlphaTextureID, _highwaysAlphaTexture);
         }
 
@@ -344,6 +352,8 @@ namespace YARG.Gameplay.Visuals
             }
             if (_highwaysAlphaTexture != null)
             {
+                _highwaysAlphaTextureHandle?.Release();
+                _highwaysAlphaTextureHandle = null;
                 _highwaysAlphaTexture.Release();
                 _highwaysAlphaTexture = null;
             }
@@ -495,7 +505,7 @@ namespace YARG.Gameplay.Visuals
 
                     passData.material = _material;
 
-                    var alphaTextureHandle = renderGraph.ImportTexture(RTHandles.Alloc(_highwayCameraRendering._highwaysAlphaTexture));
+                    var alphaTextureHandle = renderGraph.ImportTexture(_highwayCameraRendering._highwaysAlphaTextureHandle);
 
                     builder.SetRenderAttachment(alphaTextureHandle, 0, AccessFlags.WriteAll);
                     // We could allocate a different depth texture, however at this point

--- a/Assets/Script/Gameplay/Visuals/HighwayCameraRendering.cs
+++ b/Assets/Script/Gameplay/Visuals/HighwayCameraRendering.cs
@@ -485,6 +485,7 @@ namespace YARG.Gameplay.Visuals
             private readonly ProfilingSampler       _profilingSampler = new ProfilingSampler("CalcFadeAlphaMask");
             private readonly HighwayCameraRendering _highwayCameraRendering;
             private readonly Material               _material;
+            private readonly ShaderTagId[]          _shaderTagIds = { new ShaderTagId("UniversalForward") };
 
             public static readonly int LayerMask = ~(1 << UnityEngine.LayerMask.NameToLayer("FadeExclude"));
 
@@ -514,10 +515,8 @@ namespace YARG.Gameplay.Visuals
 
                     builder.AllowPassCulling(false);
 
-                    var shaderTagIds = new[] { new ShaderTagId("UniversalForward") };
-
                     // Create renderer list for transparents
-                    var transparentDesc = new RendererListDesc(shaderTagIds, renderingData.cullResults, cameraData.camera)
+                    var transparentDesc = new RendererListDesc(_shaderTagIds, renderingData.cullResults, cameraData.camera)
                     {
                         renderQueueRange = RenderQueueRange.transparent,
                         overrideMaterial = passData.material,
@@ -527,7 +526,7 @@ namespace YARG.Gameplay.Visuals
                     builder.UseRendererList(passData.transparentRendererList);
 
                     // Create renderer list for opaques
-                    var opaqueDesc = new RendererListDesc(shaderTagIds, renderingData.cullResults, cameraData.camera)
+                    var opaqueDesc = new RendererListDesc(_shaderTagIds, renderingData.cullResults, cameraData.camera)
                     {
                         renderQueueRange = RenderQueueRange.opaque,
                         overrideMaterial = passData.material,

--- a/Assets/Script/Gameplay/Visuals/TrackElements/SustainLine.cs
+++ b/Assets/Script/Gameplay/Visuals/TrackElements/SustainLine.cs
@@ -34,6 +34,9 @@ namespace YARG.Gameplay.Visuals
         private Mesh _sustainMesh;
         private Material _materialInstance;
         private TrackPlayer _player;
+        private Vector3[] _vertices;
+        private Vector3[] _normals;
+        private Vector2[] _uvs;
 
         private SustainState _hitState = SustainState.Waiting;
         private float _whammyFactor;
@@ -80,37 +83,31 @@ namespace YARG.Gameplay.Visuals
 
             // Ensure subdivisions is at least 1
             int subdivisions = Mathf.Max(1, _subdivisions);
-
-            // Calculate vertex count: (subdivisions + 1) vertices on each end edge
-            int verticesPerEdge = subdivisions + 1;
-            int totalVertices = verticesPerEdge * 2; // Start edge + end edge
-
-            Vector3[] vertices = new Vector3[totalVertices];
-            Vector3[] normals = new Vector3[totalVertices];
-            Vector2[] uvs = new Vector2[totalVertices];
+            EnsureMeshBuffers(subdivisions);
 
             // Calculate triangle count: subdivisions * 2 triangles per subdivision
             int triangleCount = subdivisions * 2;
             int[] triangles = new int[triangleCount * 3];
 
             // Set up UVs and normals
-            for (int i = 0; i < totalVertices; i++)
+            for (int i = 0; i < _vertices.Length; i++)
             {
-                normals[i] = Vector3.up;
+                _normals[i] = Vector3.up;
             }
 
             // Set up UVs for start edge (right side in UV space)
+            int verticesPerEdge = subdivisions + 1;
             for (int i = 0; i < verticesPerEdge; i++)
             {
                 float t = (float)i / subdivisions; // 0 to 1 across the width
-                uvs[i] = new Vector2(1f, 1f - t); // Right side, top to bottom
+                _uvs[i] = new Vector2(1f, 1f - t); // Right side, top to bottom
             }
 
             // Set up UVs for end edge (left side in UV space)
             for (int i = 0; i < verticesPerEdge; i++)
             {
                 float t = (float)i / subdivisions; // 0 to 1 across the width
-                uvs[verticesPerEdge + i] = new Vector2(0f, 1f - t); // Left side, top to bottom
+                _uvs[verticesPerEdge + i] = new Vector2(0f, 1f - t); // Left side, top to bottom
             }
 
             // Set up triangles with consistent winding
@@ -134,9 +131,9 @@ namespace YARG.Gameplay.Visuals
                 triangles[triangleIndex++] = topRight;
             }
 
-            _sustainMesh.vertices = vertices;
-            _sustainMesh.normals = normals;
-            _sustainMesh.uv = uvs;
+            _sustainMesh.vertices = _vertices;
+            _sustainMesh.normals = _normals;
+            _sustainMesh.uv = _uvs;
             _sustainMesh.triangles = triangles;
 
             // Ensure proper bounds and validate mesh
@@ -151,6 +148,21 @@ namespace YARG.Gameplay.Visuals
             }
 
             _meshFilter.mesh = _sustainMesh;
+        }
+
+        private void EnsureMeshBuffers(int subdivisions)
+        {
+            int verticesPerEdge = subdivisions + 1;
+            int totalVertices = verticesPerEdge * 2;
+
+            if (_vertices is { Length: var length } && length == totalVertices)
+            {
+                return;
+            }
+
+            _vertices = new Vector3[totalVertices];
+            _normals = new Vector3[totalVertices];
+            _uvs = new Vector2[totalVertices];
         }
 
         public void Initialize(float len)
@@ -252,12 +264,8 @@ namespace YARG.Gameplay.Visuals
 
             // Ensure subdivisions is at least 1
             int subdivisions = Mathf.Max(1, _subdivisions);
+            EnsureMeshBuffers(subdivisions);
             int verticesPerEdge = subdivisions + 1;
-            int totalVertices = verticesPerEdge * 2;
-
-            Vector3[] vertices = new Vector3[totalVertices];
-            Vector3[] normals = new Vector3[totalVertices];
-            Vector2[] uvs = new Vector2[totalVertices];
             float halfWidth = _sustainWidth * 0.5f;
 
             // Create start edge vertices (at _currentStartZ)
@@ -265,9 +273,9 @@ namespace YARG.Gameplay.Visuals
             {
                 float t = (float)i / subdivisions; // 0 to 1 across the width
                 float x = Mathf.Lerp(-halfWidth, halfWidth, t);
-                vertices[i] = new Vector3(x, 0f, _currentStartZ);
-                normals[i] = Vector3.up;
-                uvs[i] = new Vector2(_currentLength - _currentStartZ, 1f - t);
+                _vertices[i] = new Vector3(x, 0f, _currentStartZ);
+                _normals[i] = Vector3.up;
+                _uvs[i] = new Vector2(_currentLength - _currentStartZ, 1f - t);
             }
 
             // Create end edge vertices (at _currentLength)
@@ -275,14 +283,14 @@ namespace YARG.Gameplay.Visuals
             {
                 float t = (float)i / subdivisions; // 0 to 1 across the width
                 float x = Mathf.Lerp(-halfWidth, halfWidth, t);
-                vertices[verticesPerEdge + i] = new Vector3(x, 0.01f, _currentLength); // Slightly elevated
-                normals[verticesPerEdge + i] = Vector3.up;
-                uvs[verticesPerEdge + i] = new Vector2(0f, 1f - t);
+                _vertices[verticesPerEdge + i] = new Vector3(x, 0.01f, _currentLength); // Slightly elevated
+                _normals[verticesPerEdge + i] = Vector3.up;
+                _uvs[verticesPerEdge + i] = new Vector2(0f, 1f - t);
             }
 
-            _sustainMesh.vertices = vertices;
-            _sustainMesh.normals = normals;
-            _sustainMesh.uv = uvs;
+            _sustainMesh.vertices = _vertices;
+            _sustainMesh.normals = _normals;
+            _sustainMesh.uv = _uvs;
             _sustainMesh.RecalculateNormals();
             _sustainMesh.RecalculateBounds();
         }

--- a/Assets/Script/Menu/Calibrator/Calibrator.cs
+++ b/Assets/Script/Menu/Calibrator/Calibrator.cs
@@ -54,7 +54,7 @@ namespace YARG.Menu.Calibrator
 
         private void Awake()
         {
-            _wasWhammyEnabled = SettingsManager.Settings?.UseWhammyFx?.Value ?? false;
+            _wasWhammyEnabled = SettingsManager.Settings.UseWhammyFx.Value;
         }
 
         private void Start()

--- a/Assets/Script/Menu/Calibrator/Calibrator.cs
+++ b/Assets/Script/Menu/Calibrator/Calibrator.cs
@@ -50,7 +50,12 @@ namespace YARG.Menu.Calibrator
         private double _time;
 #nullable disable
 
-        private bool wasWhammyEnabled = SettingsManager.Settings.UseWhammyFx.Value;
+        private bool _wasWhammyEnabled;
+
+        private void Awake()
+        {
+            _wasWhammyEnabled = SettingsManager.Settings?.UseWhammyFx?.Value ?? false;
+        }
 
         private void Start()
         {
@@ -152,7 +157,7 @@ namespace YARG.Menu.Calibrator
                     break;
                 case State.AudioDone:
                     //Restore whammy settings
-                    SettingsManager.Settings.UseWhammyFx.Value = wasWhammyEnabled;
+                    SettingsManager.Settings.UseWhammyFx.Value = _wasWhammyEnabled;
 
                     _audioCalibrateContainer.SetActive(true);
                     CalculateAudioLatency();


### PR DESCRIPTION
I think this is the remaining low hanging fruit w.r.t. needless allocation every frame. I'm only seeing around 100 bytes a frame now for the "typical frame" in the VenueCameraRender which I believe is happening inside of Unity library code. It's a far cry from the 4k per frame we were seeing originally. Unfortunately, there are still burst-y allocations as songs play but those can be tackled in a future PR.