### PR TITLE
Revert drum BREs to single-zone, move visual BRE logic out of Core

### DIFF
--- a/Assets/Script/Gameplay/Player/DrumsPlayer.cs
+++ b/Assets/Script/Gameplay/Player/DrumsPlayer.cs
@@ -28,7 +28,16 @@ namespace YARG.Gameplay.Player
 
         // Key is a FourLaneDrumPad or FiveLaneDrumPad
         private Dictionary<int, HighwayOrderingInfo> _highwayOrdering;
-        private Dictionary<int, int>                 _actionToBreScoringZoneIndex;
+
+        // When an action happens, we'll use this to determine which _actionToMostRecentTime entry to update
+        // This is often 1:1, but non-split 4L maps multiple actions to the shared lanes
+        private Dictionary<DrumsAction, DrumsBreLaneIndex> _actionToBreLaneIndex;
+
+        // When a BRE lane element needs to know how bright it should be, it'll use this table to get the right BRE lane index
+        private Dictionary<int, DrumsBreLaneIndex> _highwayOrderingIndexToBreLaneIndex;
+
+        // Record of the most recent time that each BRE lane has been lit up by any of the actions that map to it
+        private Dictionary<DrumsBreLaneIndex, double> _breLaneIndexToMostRecentTime = new();
 
         private int DrumsActionToHighwayIndex(DrumsAction action)
         {
@@ -117,7 +126,6 @@ namespace YARG.Gameplay.Player
 
         private Dictionary<int, float>                            _fretToLastPressedTimeDelta       = new();
         private Dictionary<Fret.AnimType, Dictionary<int, float>> _animTypeToFretToLastPressedDelta = new();
-        private Dictionary<int, int>                              _highwayOrderingIndexToBreScoringZoneIndex;
 
         private bool IsSplitMode => Player.Profile.CurrentInstrument is Instrument.ProDrums && Player.Profile.SplitProTomsAndCymbals;
 
@@ -509,6 +517,9 @@ namespace YARG.Gameplay.Player
             if (Engine.IsCodaActive)
             {
                 CurrentCoda.HitLane(GameManager.VisualTime, (int) action);
+
+                var breLaneIndex = _actionToBreLaneIndex[action];
+                _breLaneIndexToMostRecentTime[breLaneIndex] = GameManager.VisualTime;
             }
 
             // Update last hit times for fret flashing animation
@@ -654,9 +665,11 @@ namespace YARG.Gameplay.Player
             {
                 // Set emission color of BRE lanes depending on time since last hit
 
-                foreach (var (k, v) in _highwayOrderingIndexToBreScoringZoneIndex)
+                foreach (var (highwayOrderingIndex, breLaneIndex) in _highwayOrderingIndexToBreLaneIndex)
                 {
-                    BRELanes[k].SetEmissionColor(CurrentCoda.GetNormalizedTimeSinceLastHit(v, visualTime));
+                    var mostRecentTime = _breLaneIndexToMostRecentTime[breLaneIndex];
+                    var normalizedTimeSinceLastHit = CodaSection.GetNormalizedTimeSinceLastHit(visualTime, mostRecentTime);
+                    BRELanes[highwayOrderingIndex].SetEmissionColor(normalizedTimeSinceLastHit);
                 }
             }
 
@@ -881,23 +894,23 @@ namespace YARG.Gameplay.Player
                     { (int)FiveLaneDrumPad.Green,  new(ApplyHandednessToPosition(4),                                        ApplyHandednessToFiveLaneColor(FiveLaneDrumsFret.Green) ) }
                 };
 
-                _actionToBreScoringZoneIndex = new Dictionary<int, int>
+                _actionToBreLaneIndex = new()
                 {
-                    { (int)DrumsAction.RedDrum, 0 },
-                    { (int)DrumsAction.YellowCymbal, 1 },
-                    { (int)DrumsAction.BlueDrum, 2 },
-                    { (int)DrumsAction.OrangeCymbal, 3 },
-                    { (int)DrumsAction.GreenDrum, 4 },
-                    { (int)DrumsAction.Kick, 5 }
+                    { DrumsAction.RedDrum,         DrumsBreLaneIndex.Red },
+                    { DrumsAction.YellowCymbal,    DrumsBreLaneIndex.Yellow },
+                    { DrumsAction.BlueDrum,        DrumsBreLaneIndex.Blue },
+                    { DrumsAction.OrangeCymbal,    DrumsBreLaneIndex.Orange },
+                    { DrumsAction.GreenDrum,       DrumsBreLaneIndex.Green },
+                    { DrumsAction.Kick,            DrumsBreLaneIndex.Kick }
                 };
 
-                _highwayOrderingIndexToBreScoringZoneIndex = new Dictionary<int, int>
+                _highwayOrderingIndexToBreLaneIndex = new()
                 {
-                    { _highwayOrdering[(int)FiveLaneDrumPad.Red].Position, 0 },
-                    { _highwayOrdering[(int)FiveLaneDrumPad.Yellow].Position, 1 },
-                    { _highwayOrdering[(int)FiveLaneDrumPad.Blue].Position, 2 },
-                    { _highwayOrdering[(int)FiveLaneDrumPad.Orange].Position, 3 },
-                    { _highwayOrdering[(int)FiveLaneDrumPad.Green].Position, 4 },
+                    { _highwayOrdering[(int)FiveLaneDrumPad.Red].Position,      DrumsBreLaneIndex.Red },
+                    { _highwayOrdering[(int)FiveLaneDrumPad.Yellow].Position,   DrumsBreLaneIndex.Yellow },
+                    { _highwayOrdering[(int)FiveLaneDrumPad.Blue].Position,     DrumsBreLaneIndex.Blue },
+                    { _highwayOrdering[(int)FiveLaneDrumPad.Orange].Position,   DrumsBreLaneIndex.Orange },
+                    { _highwayOrdering[(int)FiveLaneDrumPad.Green].Position,    DrumsBreLaneIndex.Green },
                 };
             }
             else if (Player.Profile.SplitProTomsAndCymbals && Player.Profile.CurrentInstrument is Instrument.ProDrums)
@@ -914,26 +927,26 @@ namespace YARG.Gameplay.Player
                     { (int)FourLaneDrumPad.GreenDrum,     new(ApplyHandednessToPosition(6),                                          ApplyHandednessToFourLaneColor(FourLaneDrumsFret.GreenDrum)) },
                 };
 
-                _actionToBreScoringZoneIndex = new Dictionary<int, int>
+                _actionToBreLaneIndex = new()
                 {
-                    { (int)DrumsAction.RedDrum, 0 },
-                    { (int)DrumsAction.YellowDrum, 1 },
-                    { (int)DrumsAction.BlueDrum, 2 },
-                    { (int)DrumsAction.GreenDrum, 3 },
-                    { (int)DrumsAction.YellowCymbal, 1 },
-                    { (int)DrumsAction.BlueCymbal, 2 },
-                    { (int)DrumsAction.GreenCymbal, 3 },
-                    { (int)DrumsAction.Kick, 4 },
+                    { DrumsAction.RedDrum,         DrumsBreLaneIndex.Red },
+                    { DrumsAction.YellowDrum,      DrumsBreLaneIndex.YellowDrum },
+                    { DrumsAction.BlueDrum,        DrumsBreLaneIndex.BlueDrum },
+                    { DrumsAction.GreenDrum,       DrumsBreLaneIndex.GreenDrum },
+                    { DrumsAction.YellowCymbal,    DrumsBreLaneIndex.YellowCymbal },
+                    { DrumsAction.BlueCymbal,      DrumsBreLaneIndex.BlueCymbal },
+                    { DrumsAction.GreenCymbal,     DrumsBreLaneIndex.GreenCymbal },
+                    { DrumsAction.Kick,            DrumsBreLaneIndex.Kick },
                 };
 
-                _highwayOrderingIndexToBreScoringZoneIndex = new Dictionary<int, int> {
-                    { _highwayOrdering[(int)FourLaneDrumPad.RedDrum].Position, 0 },
-                    { _highwayOrdering[(int)FourLaneDrumPad.YellowDrum].Position, 1 },
-                    { _highwayOrdering[(int)FourLaneDrumPad.BlueDrum].Position, 2 },
-                    { _highwayOrdering[(int)FourLaneDrumPad.GreenDrum].Position, 3 },
-                    { _highwayOrdering[(int)FourLaneDrumPad.YellowCymbal].Position, 1 },
-                    { _highwayOrdering[(int)FourLaneDrumPad.BlueCymbal].Position, 2 },
-                    { _highwayOrdering[(int)FourLaneDrumPad.GreenCymbal].Position, 3 }
+                _highwayOrderingIndexToBreLaneIndex = new() {
+                    { _highwayOrdering[(int)FourLaneDrumPad.RedDrum].Position,      DrumsBreLaneIndex.Red },
+                    { _highwayOrdering[(int)FourLaneDrumPad.YellowDrum].Position,   DrumsBreLaneIndex.YellowDrum },
+                    { _highwayOrdering[(int)FourLaneDrumPad.BlueDrum].Position,     DrumsBreLaneIndex.BlueDrum },
+                    { _highwayOrdering[(int)FourLaneDrumPad.GreenDrum].Position,    DrumsBreLaneIndex.GreenDrum },
+                    { _highwayOrdering[(int)FourLaneDrumPad.YellowCymbal].Position, DrumsBreLaneIndex.YellowCymbal },
+                    { _highwayOrdering[(int)FourLaneDrumPad.BlueCymbal].Position,   DrumsBreLaneIndex.BlueCymbal },
+                    { _highwayOrdering[(int)FourLaneDrumPad.GreenCymbal].Position,  DrumsBreLaneIndex.GreenCymbal },
                 };
             }
             else
@@ -950,27 +963,51 @@ namespace YARG.Gameplay.Player
                     { (int)FourLaneDrumPad.GreenDrum,     new(ApplyHandednessToPosition(3), ApplyHandednessToFourLaneColor(FourLaneDrumsFret.GreenDrum)) },
                 };
 
-                _actionToBreScoringZoneIndex = new Dictionary<int, int>
+                _actionToBreLaneIndex = new()
                 {
-                    { (int)DrumsAction.RedDrum, 0 },
-                    { (int)DrumsAction.YellowDrum, 1 },
-                    { (int)DrumsAction.BlueDrum, 2 },
-                    { (int)DrumsAction.GreenDrum, 3 },
-                    { (int)DrumsAction.YellowCymbal, 1 },
-                    { (int)DrumsAction.BlueCymbal, 2 },
-                    { (int)DrumsAction.GreenCymbal, 3 },
-                    { (int)DrumsAction.Kick, 4 },
+                    { DrumsAction.RedDrum,      DrumsBreLaneIndex.Red },
+                    { DrumsAction.YellowDrum,   DrumsBreLaneIndex.Yellow },
+                    { DrumsAction.BlueDrum,     DrumsBreLaneIndex.Blue },
+                    { DrumsAction.GreenDrum,    DrumsBreLaneIndex.Green },
+                    { DrumsAction.YellowCymbal, DrumsBreLaneIndex.Yellow },
+                    { DrumsAction.BlueCymbal,   DrumsBreLaneIndex.Blue },
+                    { DrumsAction.GreenCymbal,  DrumsBreLaneIndex.Green },
+                    { DrumsAction.Kick,         DrumsBreLaneIndex.Kick },
                 };
 
-                _highwayOrderingIndexToBreScoringZoneIndex = new Dictionary<int, int> {
-                    { _highwayOrdering[(int)FourLaneDrumPad.RedDrum].Position, 0 }, // RedDrum
-                    { _highwayOrdering[(int)FourLaneDrumPad.YellowDrum].Position, 1 }, // YellowDrum and YellowCymbal
-                    { _highwayOrdering[(int)FourLaneDrumPad.BlueDrum].Position, 2 }, // BlueDrum and BlueCymbal
-                    { _highwayOrdering[(int)FourLaneDrumPad.GreenDrum].Position, 3 }, // GreenDrum and GreenCymbal
+                _highwayOrderingIndexToBreLaneIndex = new() {
+                    { _highwayOrdering[(int)FourLaneDrumPad.RedDrum].Position,      DrumsBreLaneIndex.Red },
+                    { _highwayOrdering[(int)FourLaneDrumPad.YellowDrum].Position,   DrumsBreLaneIndex.Yellow },
+                    { _highwayOrdering[(int)FourLaneDrumPad.BlueDrum].Position,     DrumsBreLaneIndex.Blue },
+                    { _highwayOrdering[(int)FourLaneDrumPad.GreenDrum].Position,    DrumsBreLaneIndex.Green },
                 };
+            }
+
+            foreach (var breLaneIndex in _highwayOrderingIndexToBreLaneIndex.Values)
+            {
+                _breLaneIndexToMostRecentTime[breLaneIndex] = 0;
             }
         }
 
-        protected override Dictionary<int, int> GetLaneIndexes() => _actionToBreScoringZoneIndex;
+        private enum DrumsBreLaneIndex
+        {
+            Kick,
+
+            Red,
+
+            Yellow,
+            YellowDrum,
+            YellowCymbal,
+
+            Blue,
+            BlueDrum,
+            BlueCymbal,
+
+            Green,
+            GreenDrum,
+            GreenCymbal,
+
+            Orange
+        }
     }
 }

--- a/Assets/Script/Gameplay/Player/FiveFretGuitarPlayer.cs
+++ b/Assets/Script/Gameplay/Player/FiveFretGuitarPlayer.cs
@@ -41,7 +41,7 @@ namespace YARG.Gameplay.Player
         };
 
         // Record of the most recent time that each BRE lane has been lit up by any of the actions that map to it
-        private static Dictionary<FiveFretGuitarFret, double> _fretToMostRecentTime = new()
+        private Dictionary<FiveFretGuitarFret, double> _fretToMostRecentTime = new()
         {
             { FiveFretGuitarFret.Green,     0 },
             { FiveFretGuitarFret.Red,       0 },

--- a/Assets/Script/Gameplay/Player/FiveFretGuitarPlayer.cs
+++ b/Assets/Script/Gameplay/Player/FiveFretGuitarPlayer.cs
@@ -32,6 +32,25 @@ namespace YARG.Gameplay.Player
 
         public const int LANE_COUNT = 5;
 
+        private static Dictionary<GuitarAction, FiveFretGuitarFret> _actionToFret = new() {
+            { GuitarAction.Fret1,    FiveFretGuitarFret.Green},
+            { GuitarAction.Fret2,     FiveFretGuitarFret.Red},
+            { GuitarAction.Fret3,   FiveFretGuitarFret.Yellow},
+            { GuitarAction.Fret4,     FiveFretGuitarFret.Blue},
+            { GuitarAction.Fret5,   FiveFretGuitarFret.Orange},
+        };
+
+        // Record of the most recent time that each BRE lane has been lit up by any of the actions that map to it
+        private static Dictionary<FiveFretGuitarFret, double> _fretToMostRecentTime = new()
+        {
+            { FiveFretGuitarFret.Green,     0 },
+            { FiveFretGuitarFret.Red,       0 },
+            { FiveFretGuitarFret.Yellow,    0 },
+            { FiveFretGuitarFret.Blue,      0 },
+            { FiveFretGuitarFret.Orange,    0 },
+        };
+
+
         // Key is a FiveFretGuitarFret
         // Value is the fret's lateral position on the fret array
         private Dictionary<int, int> _lanePositions;
@@ -263,15 +282,11 @@ namespace YARG.Gameplay.Player
             if (Engine.IsCodaActive)
             {
                 // Set emission color of BRE lanes depending on currently available score value
-                for (int i = 0; i < CurrentCoda.ScoringZones; i++)
+                foreach (var (breLaneIndex, highwayOrderingIndex) in DEFAULT_HIGHWAY_ORDERING)
                 {
-                    // var intensity = CurrentCoda.GetNormalizedTimeSinceLastHit(i, visualTime);
-                    // intensity = (float) Math.Clamp(Math.Cos(Math.PI * intensity), 0f, 1f);
-                    // intensity = (float) Math.Clamp((Math.Tan(intensity) * -1) + 1, 0f, 1f);
-                    // intensity = (float) Math.Clamp((Math.Atan(intensity * 3) * -1.8) + 2, 0f, 2f);
-                    // intensity = 1 - Mathf.Sin(Mathf.Pow(intensity, 1f / 2.4f) * 2);
-                    // intensity = 1 - Mathf.Sin(Mathf.Pow(intensity, 0.5f) * 1.6f);
-                    BRELanes[i].SetEmissionColor(CurrentCoda.GetNormalizedTimeSinceLastHit(i, visualTime));
+                    var mostRecentTime = _fretToMostRecentTime[(FiveFretGuitarFret)breLaneIndex];
+                    var normalizedTimeSinceLastHit = CodaSection.GetNormalizedTimeSinceLastHit(visualTime, mostRecentTime);
+                    BRELanes[highwayOrderingIndex].SetEmissionColor(normalizedTimeSinceLastHit);
                 }
             }
 
@@ -458,9 +473,12 @@ namespace YARG.Gameplay.Player
             LaneElement.DefineLaneScale(Player.Profile.CurrentInstrument, 5, true);
         }
 
-        private void OnLaneHit(int fret)
+        private void OnLaneHit(int action)
         {
-            _fretArray.PlayCodaHitAnimation(fret + 1);
+            var asFret = _actionToFret[(GuitarAction)action];
+
+            _fretToMostRecentTime[asFret] = GameManager.VisualTime;
+            _fretArray.PlayCodaHitAnimation((int)asFret);
         }
 
         protected override void OnCodaStart(CodaSection coda)

--- a/Assets/Script/Gameplay/Player/FiveLaneKeysPlayer.cs
+++ b/Assets/Script/Gameplay/Player/FiveLaneKeysPlayer.cs
@@ -33,13 +33,26 @@ namespace YARG.Assets.Script.Gameplay.Player
 
         // Key is a FiveFretGuitarFret
         // Value is the fret's lateral position on the fret array
-        private Dictionary<int, int> _lanePositions;
+        private Dictionary<int, int> _highwayOrdering;
+
+
+        // When an action happens, we'll use this to determine which _actionToMostRecentTime entry to update
+        // This is usually 1:1, but if there's no dedicated open lane enabled, then we'll redirect open note inputs to the
+        // green lane visuals because they share a notional scoring zone behind the scenes
+        private Dictionary<FiveLaneKeysAction, FiveLaneKeysBreLaneIndex> _actionToBreLaneIndex;
+
+        // When a BRE lane element needs to know how bright it should be, it'll use this table to get the right BRE lane index
+        private Dictionary<int, FiveLaneKeysBreLaneIndex> _highwayOrderingIndexToBreLaneIndex;
+
+        // Record of the most recent time that each BRE lane has been lit up by any of the actions that map to it
+        private Dictionary<FiveLaneKeysBreLaneIndex, double> _breLaneIndexToMostRecentTime = new();
+
 
         private float GetLanePositionOrCentered(int fret)
         {
-            if (_lanePositions.ContainsKey(fret))
+            if (_highwayOrdering.ContainsKey(fret))
             {
-                return _lanePositions[fret];
+                return _highwayOrdering[fret];
             }
 
             return (LaneCount - 1) / 2;
@@ -63,7 +76,7 @@ namespace YARG.Assets.Script.Gameplay.Player
 
         public int GetLanePosition(FiveFretGuitarFret fret)
         {
-            return _lanePositions[(int) fret];
+            return _highwayOrdering[(int) fret];
         }
 
         public bool IsNormalNote(GuitarNote note)
@@ -210,7 +223,7 @@ public override bool ShouldUpdateInputsOnResume => true;
             MakeHighwayOrdering();
 
             _fretArray.Initialize(
-                _lanePositions,
+                _highwayOrdering,
                 LaneCount,
                 null,
                 Player.ColorProfile.FiveFretGuitar,
@@ -259,22 +272,12 @@ public override bool ShouldUpdateInputsOnResume => true;
         {
             if (Engine.IsCodaActive)
             {
-                // Open lane requires stupidity
-                if (UsingOpenLane)
+                // Set emission color of BRE lanes depending on time since last hit
+                foreach (var (highwayOrderingIndex, breLaneIndex) in _highwayOrderingIndexToBreLaneIndex)
                 {
-                    for (int i = 0; i < (int)FiveLaneKeysAction.OrangeKey + 1; i++)
-                    {
-                        BRELanes[i + 1].SetEmissionColor(CurrentCoda.GetNormalizedTimeSinceLastHit(i, visualTime));
-                    }
-
-                    BRELanes[0].SetEmissionColor(CurrentCoda.GetNormalizedTimeSinceLastHit(6, visualTime));
-                }
-                else
-                {
-                    for (int i = 0; i < BRELanes.Length; i++)
-                    {
-                        BRELanes[i].SetEmissionColor(CurrentCoda.GetNormalizedTimeSinceLastHit(i, visualTime));
-                    }
+                    var mostRecentTime = _breLaneIndexToMostRecentTime[breLaneIndex];
+                    var normalizedTimeSinceLastHit = CodaSection.GetNormalizedTimeSinceLastHit(visualTime, mostRecentTime);
+                    BRELanes[highwayOrderingIndex].SetEmissionColor(normalizedTimeSinceLastHit);
                 }
             }
 
@@ -344,7 +347,7 @@ public override bool ShouldUpdateInputsOnResume => true;
             if (nextShift.Time <= visualTime)
             {
                 _rangeShiftEventQueue.Dequeue();
-                foreach (var fretIndex in _lanePositions.Keys)
+                foreach (var fretIndex in _highwayOrdering.Keys)
                 {
                     _fretArray.SetFretColorPulse(fretIndex, false, (float) nextShift.BeatDuration);
                 }
@@ -482,16 +485,13 @@ public override bool ShouldUpdateInputsOnResume => true;
             LaneElement.DefineLaneScale(Player.Profile.CurrentInstrument, LaneCount, true);
         }
 
-        private void OnLaneHit(int fret)
+        private void OnLaneHit(int action)
         {
-            // Adjustment for open lane
-            if (fret == 5)
-            {
-                fret++;
-            }
+            var breIndex = _actionToBreLaneIndex[(FiveLaneKeysAction)action];
 
-            var index = GetFretIndex((FiveLaneKeysAction)fret).Convert();
-            _fretArray.PlayCodaHitAnimation(index);
+            _breLaneIndexToMostRecentTime[breIndex] = GameManager.VisualTime;
+            _fretArray.PlayCodaHitAnimation((int)breIndex);
+
         }
 
         protected override void OnCodaStart(CodaSection coda)
@@ -790,7 +790,7 @@ public override bool ShouldUpdateInputsOnResume => true;
         private void SetDefaultActiveFrets()
         {
             var newFrets = new List<int>();
-            foreach (var fretIdx in _lanePositions.Keys)
+            foreach (var fretIdx in _highwayOrdering.Keys)
             {
                 newFrets.Add(fretIdx);
             }
@@ -809,12 +809,59 @@ public override bool ShouldUpdateInputsOnResume => true;
             if (UsingOpenLane)
             {
                 LaneCount = 6;
-                _lanePositions = OPEN_LANE_HIGHWAY_ORDERING;
+
+                _highwayOrdering = OPEN_LANE_HIGHWAY_ORDERING;
+
+                _actionToBreLaneIndex = new()
+                {
+                    { FiveLaneKeysAction.OpenNote,  FiveLaneKeysBreLaneIndex.Open },
+                    { FiveLaneKeysAction.GreenKey,  FiveLaneKeysBreLaneIndex.Green },
+                    { FiveLaneKeysAction.RedKey,  FiveLaneKeysBreLaneIndex.Red },
+                    { FiveLaneKeysAction.YellowKey,  FiveLaneKeysBreLaneIndex.Yellow },
+                    { FiveLaneKeysAction.BlueKey,  FiveLaneKeysBreLaneIndex.Blue },
+                    { FiveLaneKeysAction.OrangeKey,  FiveLaneKeysBreLaneIndex.Orange },
+                };
+
+                _highwayOrderingIndexToBreLaneIndex = new()
+                {
+                    { _highwayOrdering[(int)FiveFretGuitarFret.Open],   FiveLaneKeysBreLaneIndex.Open },
+                    { _highwayOrdering[(int)FiveFretGuitarFret.Green],  FiveLaneKeysBreLaneIndex.Green },
+                    { _highwayOrdering[(int)FiveFretGuitarFret.Red],    FiveLaneKeysBreLaneIndex.Red },
+                    { _highwayOrdering[(int)FiveFretGuitarFret.Yellow], FiveLaneKeysBreLaneIndex.Yellow },
+                    { _highwayOrdering[(int)FiveFretGuitarFret.Blue],   FiveLaneKeysBreLaneIndex.Blue },
+                    { _highwayOrdering[(int)FiveFretGuitarFret.Orange], FiveLaneKeysBreLaneIndex.Orange },
+                };
             }
             else
             {
                 LaneCount = 5;
-                _lanePositions = FiveFretGuitarPlayer.DEFAULT_HIGHWAY_ORDERING;
+                _highwayOrdering = FiveFretGuitarPlayer.DEFAULT_HIGHWAY_ORDERING;
+
+                _actionToBreLaneIndex = new()
+                {
+                    // Open has no dedicated lane, so map its inputs to Green since they share a notional scoring zone
+                    { FiveLaneKeysAction.OpenNote,  FiveLaneKeysBreLaneIndex.Green },
+                    { FiveLaneKeysAction.GreenKey,  FiveLaneKeysBreLaneIndex.Green },
+                    { FiveLaneKeysAction.RedKey,  FiveLaneKeysBreLaneIndex.Red },
+                    { FiveLaneKeysAction.YellowKey,  FiveLaneKeysBreLaneIndex.Yellow },
+                    { FiveLaneKeysAction.BlueKey,  FiveLaneKeysBreLaneIndex.Blue },
+                    { FiveLaneKeysAction.OrangeKey,  FiveLaneKeysBreLaneIndex.Orange },
+                };
+
+                _highwayOrderingIndexToBreLaneIndex = new()
+                {
+                    // Open has no dedicated lane, so we'll never query this for the open lane
+                    { _highwayOrdering[(int)FiveFretGuitarFret.Green],  FiveLaneKeysBreLaneIndex.Green },
+                    { _highwayOrdering[(int)FiveFretGuitarFret.Red],    FiveLaneKeysBreLaneIndex.Red },
+                    { _highwayOrdering[(int)FiveFretGuitarFret.Yellow], FiveLaneKeysBreLaneIndex.Yellow },
+                    { _highwayOrdering[(int)FiveFretGuitarFret.Blue],   FiveLaneKeysBreLaneIndex.Blue },
+                    { _highwayOrdering[(int)FiveFretGuitarFret.Orange], FiveLaneKeysBreLaneIndex.Orange },
+                };
+            }
+
+            foreach (var breLaneIndex in _highwayOrderingIndexToBreLaneIndex.Values)
+            {
+                _breLaneIndexToMostRecentTime[breLaneIndex] = 0;
             }
         }
 
@@ -843,7 +890,7 @@ public override bool ShouldUpdateInputsOnResume => true;
             }
         }
 
-        protected override Dictionary<int, int> GetLaneIndexes()
+        protected Dictionary<int, int> GetLaneIndexes()
         {
             if (UsingOpenLane)
             {
@@ -866,6 +913,16 @@ public override bool ShouldUpdateInputsOnResume => true;
                 { (int) FiveLaneKeysAction.BlueKey, 3 },
                 { (int) FiveLaneKeysAction.OrangeKey, 4 }
             };
+        }
+
+        private enum FiveLaneKeysBreLaneIndex
+        {
+            Open, // Only exists if the Dedicated Open Lane setting is enabled
+            Green,
+            Red,
+            Yellow,
+            Blue,
+            Orange
         }
     }
 }

--- a/Assets/Script/Gameplay/Player/FiveLaneKeysPlayer.cs
+++ b/Assets/Script/Gameplay/Player/FiveLaneKeysPlayer.cs
@@ -888,32 +888,6 @@ public override bool ShouldUpdateInputsOnResume => true;
                     throw new ArgumentOutOfRangeException("Unrecognized OpenLaneDisplayType");
             }
         }
-
-        protected Dictionary<int, int> GetLaneIndexes()
-        {
-            if (UsingOpenLane)
-            {
-                return new Dictionary<int, int>
-                {
-                    { (int) FiveLaneKeysAction.GreenKey, 0 },
-                    { (int) FiveLaneKeysAction.RedKey, 1 },
-                    { (int) FiveLaneKeysAction.YellowKey, 2 },
-                    { (int) FiveLaneKeysAction.BlueKey, 3 },
-                    { (int) FiveLaneKeysAction.OrangeKey, 4 },
-                    { (int) FiveLaneKeysAction.OpenNote, 5 }
-                };
-            }
-
-            return new Dictionary<int, int>
-            {
-                { (int) FiveLaneKeysAction.GreenKey, 0 },
-                { (int) FiveLaneKeysAction.RedKey, 1 },
-                { (int) FiveLaneKeysAction.YellowKey, 2 },
-                { (int) FiveLaneKeysAction.BlueKey, 3 },
-                { (int) FiveLaneKeysAction.OrangeKey, 4 }
-            };
-        }
-
         private enum FiveLaneKeysBreLaneIndex
         {
             Open, // Only exists if the Dedicated Open Lane setting is enabled

--- a/Assets/Script/Gameplay/Player/FiveLaneKeysPlayer.cs
+++ b/Assets/Script/Gameplay/Player/FiveLaneKeysPlayer.cs
@@ -47,7 +47,6 @@ namespace YARG.Assets.Script.Gameplay.Player
         // Record of the most recent time that each BRE lane has been lit up by any of the actions that map to it
         private Dictionary<FiveLaneKeysBreLaneIndex, double> _breLaneIndexToMostRecentTime = new();
 
-
         private float GetLanePositionOrCentered(int fret)
         {
             if (_highwayOrdering.ContainsKey(fret))
@@ -490,8 +489,8 @@ public override bool ShouldUpdateInputsOnResume => true;
             var breIndex = _actionToBreLaneIndex[(FiveLaneKeysAction)action];
 
             _breLaneIndexToMostRecentTime[breIndex] = GameManager.VisualTime;
-            _fretArray.PlayCodaHitAnimation((int)breIndex);
 
+            _fretArray.PlayCodaHitAnimation((int)((FiveLaneKeysAction)action).ToFret());
         }
 
         protected override void OnCodaStart(CodaSection coda)

--- a/Assets/Script/Gameplay/Player/ProKeysPlayer.cs
+++ b/Assets/Script/Gameplay/Player/ProKeysPlayer.cs
@@ -45,10 +45,8 @@ namespace YARG.Gameplay.Player
             public bool LeftSide;
         }
 
-        // When an action happens, we'll use this to determine which _actionToMostRecentTime entry to update
-        // This is often 1:1, but non-split 4L maps multiple actions to the shared lanes
         // The key is really a ProKeysAction, but we have to store it as a regular int because - unlike any other instrument
-        // currently - Pro Keys' BRE lanes can change from one BRE to the next within the same song (due ro range shifts),
+        // currently - Pro Keys' BRE lanes can change from one BRE to the next within the same song (due to range shifts),
         // meaning we have to pass the indexes to CurrentCoda.
         private Dictionary<int, int> _actionToBreLaneIndex;
 

--- a/Assets/Script/Gameplay/Player/ProKeysPlayer.cs
+++ b/Assets/Script/Gameplay/Player/ProKeysPlayer.cs
@@ -375,7 +375,7 @@ namespace YARG.Gameplay.Player
                         continue;
                     }
 
-                    BRELanes[i].SetEmissionColor(CurrentCoda.GetNormalizedTimeSinceLastHit(i, visualTime));
+                    //BRELanes[i].SetEmissionColor(CurrentCoda.GetNormalizedTimeSinceLastHit(i, visualTime));
                 }
             }
         }
@@ -561,7 +561,7 @@ namespace YARG.Gameplay.Player
             _keysArray.PlayHitAnimation(key);
         }
 
-        protected override Dictionary<int,int> GetLaneIndexes()
+        protected Dictionary<int,int> GetLaneIndexes()
         {
             return _currentIndex switch
             {

--- a/Assets/Script/Gameplay/Player/ProKeysPlayer.cs
+++ b/Assets/Script/Gameplay/Player/ProKeysPlayer.cs
@@ -45,10 +45,21 @@ namespace YARG.Gameplay.Player
             public bool LeftSide;
         }
 
+        // When an action happens, we'll use this to determine which _actionToMostRecentTime entry to update
+        // This is often 1:1, but non-split 4L maps multiple actions to the shared lanes
+        // The key is really a ProKeysAction, but we have to store it as a regular int because - unlike any other instrument
+        // currently - Pro Keys' BRE lanes can change from one BRE to the next within the same song (due ro range shifts),
+        // meaning we have to pass the indexes to CurrentCoda.
+        private Dictionary<int, int> _actionToBreLaneIndex;
+
+        // Record of the most recent time that each BRE lane has been lit up by any of the actions that map to it
+        private Dictionary<int, double> _breLaneIndexToMostRecentTime = new();
+
         public const int WHITE_KEY_VISIBLE_COUNT = 10;
         public const int TOTAL_KEY_COUNT = 25;
 
         private const int SHIFT_INDICATOR_MEASURES_BEFORE = 4;
+        private const int MAX_TOTAL_BRE_LANES = 4;
 
         public override float[] StarMultiplierThresholds { get; protected set; } =
         {
@@ -95,7 +106,18 @@ namespace YARG.Gameplay.Player
 
         private List<LaneParameters> _breLaneParameters;
 
-        private Tween _leftOutOfRangeTween => DOTween.Sequence(_leftOutOfRangeFlasher.material)
+        private (int minimumKeyInRange, int maximumKeyInRange) _minAndMaxKeysInRange => _rangeShifts[_rangeShiftIndex - 1].Key switch
+            {
+                ProKeysUtilities.LOW_C => (ProKeysUtilities.LOW_C, ProKeysUtilities.HIGH_E),
+                ProKeysUtilities.LOW_D => (ProKeysUtilities.LOW_C_SHARP, ProKeysUtilities.HIGH_F_SHARP),
+                ProKeysUtilities.LOW_E => (ProKeysUtilities.LOW_D_SHARP, ProKeysUtilities.HIGH_G_SHARP),
+                ProKeysUtilities.LOW_F => (ProKeysUtilities.LOW_F, ProKeysUtilities.HIGH_A_SHARP),
+                ProKeysUtilities.LOW_G => (ProKeysUtilities.LOW_F_SHARP, ProKeysUtilities.HIGH_B),
+                ProKeysUtilities.LOW_A => (ProKeysUtilities.LOW_G_SHARP, ProKeysUtilities.HIGH_C),
+                _ => throw new ArgumentOutOfRangeException("Unexpected Pro Keys range")
+            };
+
+    private Tween _leftOutOfRangeTween => DOTween.Sequence(_leftOutOfRangeFlasher.material)
             .Append(_leftOutOfRangeFlasher.material.DOFade(1.0f, 0.05f))
             .Append(_leftOutOfRangeFlasher.material.DOFade(0.0f, 0.6f))
             .SetAutoKill(false).Pause().SetEase(Ease.Linear);
@@ -309,25 +331,19 @@ namespace YARG.Gameplay.Player
         {
             var currentRange = _rangeShifts[_rangeShiftIndex-1];
 
-            var (minimumKeyInRange, maximumKeyInRange) = currentRange.Key switch
-            {
-                ProKeysUtilities.LOW_C => (ProKeysUtilities.LOW_C, ProKeysUtilities.HIGH_E),
-                ProKeysUtilities.LOW_D => (ProKeysUtilities.LOW_C_SHARP, ProKeysUtilities.HIGH_F_SHARP),
-                ProKeysUtilities.LOW_E => (ProKeysUtilities.LOW_D_SHARP, ProKeysUtilities.HIGH_G_SHARP),
-                ProKeysUtilities.LOW_F => (ProKeysUtilities.LOW_F, ProKeysUtilities.HIGH_A_SHARP),
-                ProKeysUtilities.LOW_G => (ProKeysUtilities.LOW_F_SHARP, ProKeysUtilities.HIGH_B),
-                ProKeysUtilities.LOW_A => (ProKeysUtilities.LOW_G_SHARP, ProKeysUtilities.HIGH_C),
-                _ => (currentRange.Key, currentRange.Key + 16) // Should never happen, but might as well have a naive fallback
-            };
+            var (minimumKeyInRange, maximumKeyInRange) = _minAndMaxKeysInRange;
 
-            if (key < minimumKeyInRange)
+            if (!Engine.IsCodaActive) // We still award points for out-of-range hits during a BRE, so don't discourage them
             {
-                _leftOutOfRangeTween.Restart();
-            }
-            else if (key > maximumKeyInRange)
-            {
+                if (key < minimumKeyInRange)
+                {
+                    _leftOutOfRangeTween.Restart();
+                }
+                else if (key > maximumKeyInRange)
+                {
 
-                _rightOutOfRangeTween.Restart();
+                    _rightOutOfRangeTween.Restart();
+                }
             }
         }
 
@@ -368,14 +384,11 @@ namespace YARG.Gameplay.Player
         {
             if (Engine.IsCodaActive)
             {
-                for (int i = 0; i < CurrentCoda.ScoringZones; i++)
+                for (var i = 0; i < BRELanes.Length; i++)
                 {
-                    if (i >= BRELanes.Length)
-                    {
-                        continue;
-                    }
-
-                    //BRELanes[i].SetEmissionColor(CurrentCoda.GetNormalizedTimeSinceLastHit(i, visualTime));
+                    var mostRecentTime = _breLaneIndexToMostRecentTime[i];
+                    var normalizedTimeSinceLastHit = CodaSection.GetNormalizedTimeSinceLastHit(visualTime, mostRecentTime);
+                    BRELanes[i].SetEmissionColor(normalizedTimeSinceLastHit);
                 }
             }
         }
@@ -558,10 +571,18 @@ namespace YARG.Gameplay.Player
 
         private void OnLaneHit(int key)
         {
-            _keysArray.PlayHitAnimation(key);
+            var (minimumKeyInRange, maximumKeyInRange) = _minAndMaxKeysInRange;
+
+            if (minimumKeyInRange <= key && key <= maximumKeyInRange)
+            {
+                _keysArray.PlayHitAnimation(key);
+            }
+
+            var breLaneIndex = _actionToBreLaneIndex[key];
+            _breLaneIndexToMostRecentTime[breLaneIndex] = GameManager.VisualTime;
         }
 
-        protected Dictionary<int,int> GetLaneIndexes()
+        protected Dictionary<int, int> GetLaneIndexes()
         {
             return _currentIndex switch
             {
@@ -580,6 +601,14 @@ namespace YARG.Gameplay.Player
             base.OnCodaStart(coda);
             CurrentCoda.OnLaneHit += OnLaneHit;
             CurrentCoda.SetLaneIndexes(GetLaneIndexes());
+
+            _actionToBreLaneIndex = GetLaneIndexes();
+
+            for (var i = 0; i < MAX_TOTAL_BRE_LANES; i++)
+            {
+                _breLaneIndexToMostRecentTime[i] = 0;
+            }
+
             _keysArray.SetBreMode(true);
         }
 

--- a/Assets/Script/Gameplay/Player/ProKeysPlayer.cs
+++ b/Assets/Script/Gameplay/Player/ProKeysPlayer.cs
@@ -582,9 +582,9 @@ namespace YARG.Gameplay.Player
             _breLaneIndexToMostRecentTime[breLaneIndex] = GameManager.VisualTime;
         }
 
-        protected Dictionary<int, int> GetLaneIndexes()
+        protected Dictionary<int, int> GetLaneIndexes(int leftmostKey)
         {
-            return _currentIndex switch
+            return leftmostKey switch
             {
                 ProKeysUtilities.LOW_C => LANE_INDEXES_C3_TO_E4,
                 ProKeysUtilities.LOW_D => LANE_INDEXES_D3_TO_F4,
@@ -600,9 +600,7 @@ namespace YARG.Gameplay.Player
         {
             base.OnCodaStart(coda);
             CurrentCoda.OnLaneHit += OnLaneHit;
-            CurrentCoda.SetLaneIndexes(GetLaneIndexes());
-
-            _actionToBreLaneIndex = GetLaneIndexes();
+            CurrentCoda.SetLaneIndexes(GetLaneIndexes(_currentIndex));
 
             for (var i = 0; i < MAX_TOTAL_BRE_LANES; i++)
             {
@@ -623,6 +621,8 @@ namespace YARG.Gameplay.Player
         {
             _breLaneParameters = GetLaneParameters(timeStart);
             BRELanes = new LaneElement[_breLaneParameters.Count];
+
+            _actionToBreLaneIndex = GetLaneIndexes(GetLeftmostWhiteKeyAtTime(timeStart));
 
             if (!LanePool.CanSpawnAmount(BRELanes.Length))
             {

--- a/Assets/Script/Gameplay/Player/TrackPlayer.cs
+++ b/Assets/Script/Gameplay/Player/TrackPlayer.cs
@@ -1063,7 +1063,6 @@ namespace YARG.Gameplay.Player
         protected virtual void OnCodaStart(CodaSection coda)
         {
             CurrentCoda = coda;
-            CurrentCoda.SetLaneIndexes(GetLaneIndexes());
             SetStemMuteState(false);
         }
 
@@ -1112,17 +1111,6 @@ namespace YARG.Gameplay.Player
         public void MetronomeTock()
         {
             GlobalAudioHandler.PlayMetronomeSoundEffect(SettingsManager.Settings.MetronomeSound.Value, MetronomePitch.Lo);
-        }
-
-        protected virtual Dictionary<int, int> GetLaneIndexes()
-        {
-            var indexDict = new Dictionary<int, int>();
-            for (int i = 0; i < LaneCount; i++)
-            {
-                indexDict[i] = i;
-            }
-
-            return indexDict;
         }
     }
 }


### PR DESCRIPTION
[Corresponding YARG.Core PR](https://github.com/YARC-Official/YARG.Core/pull/360)

Reverts drums to their previous behavior where they functionally have just one big scoring zone. This encourages players to play something musical, since drum BREs actually produce sound - it's also what RB does, I suspect for the same reason.

This also takes the visual "last hit" logic entirely out of YARG.Core and lets each Player class handle it. Each instrument can define arbitrary sets of scoring zones (just one for drums, five for guitar/5LK, three or four for PK depending on the current range), and can then arbitrarily map actions to those zones.

BRE visuals now prioritize visual feedback on the player's actions rather than trying to convey 1:1 information about the scoring system. This means that each drum hit will always light up only its own lane, even in split view, because there are no separate scoring zones to notate anyway. 5LK also separately flashes the Open and Green lanes if the dedicated open lane is enabled, despite them sharing a scoring zone under the hood. It does still flash the Green lane for Open inputs when there _isn't_ an open lane, to explain why they're still gaining points from the open inputs.