### PR TITLE
Add ability to show fail meter with no fail on

### DIFF
--- a/Assets/Script/Gameplay/GameManager.Loading.cs
+++ b/Assets/Script/Gameplay/GameManager.Loading.cs
@@ -8,6 +8,7 @@ using YARG.Core.Audio;
 using YARG.Core.Chart;
 using YARG.Core.Logging;
 using YARG.Core.Replays;
+using YARG.Gameplay.HUD;
 using YARG.Gameplay.Player;
 using YARG.Menu;
 using YARG.Menu.Navigation;
@@ -230,7 +231,7 @@ namespace YARG.Gameplay
 
             _failMeter.Initialize(EngineManager, this);
 
-            if (SettingsManager.Settings.NoFailMode.Value || IsPractice)
+            if (SettingsManager.Settings.NoFail.Value == NoFailMode.NoMeter || IsPractice)
             {
                 _failMeter.SetActive(false);
             }
@@ -243,7 +244,7 @@ namespace YARG.Gameplay
 
                 EngineManager.InitializeHappiness();
 
-                SettingsManager.Settings.NoFailMode.OnChange += OnNoFailModeChanged;
+                SettingsManager.Settings.NoFail.OnChange += OnNoFailModeChanged;
                 SettingsManager.Settings.AutoCalibrateAudio.Value = false;
                 SettingsManager.Settings.AutoCalibrateVideo.Value = false;
             }

--- a/Assets/Script/Gameplay/GameManager.cs
+++ b/Assets/Script/Gameplay/GameManager.cs
@@ -232,7 +232,7 @@ namespace YARG.Gameplay
             }
 
             // Unsubscribe from other events
-            SettingsManager.Settings.NoFailMode.OnChange -= OnNoFailModeChanged;
+            SettingsManager.Settings.NoFail.OnChange -= OnNoFailModeChanged;
             EngineManager.OnSongFailed -= OnSongFailed;
             EngineManager.OnCodaStart -= StartCoda;
             EngineManager.OnCodaEnd -= EndCoda;
@@ -876,7 +876,7 @@ namespace YARG.Gameplay
 
         private async void OnSongFailed()
         {
-            if (SettingsManager.Settings.NoFailMode.Value || IsPractice)
+            if (SettingsManager.Settings.NoFail.Value != NoFailMode.Off || IsPractice)
             {
                 return;
             }
@@ -893,16 +893,16 @@ namespace YARG.Gameplay
 
         // If we go from no fail to fail, we need to reinitialize the happiness state so we avoid
         // the possibility of an instant fail. Yes, this is cheeseable since toggling no fail resets happiness.
-        private void OnNoFailModeChanged(bool noFail)
+        private void OnNoFailModeChanged(NoFailMode mode)
         {
             // If we're going from no fail to fail and happiness would result in an insta-fail, reset happiness,
             // but also inhibit score saving to avoid cheesing
-            if (!noFail && EngineManager.Happiness <= 0f)
+            if (mode == NoFailMode.Off && EngineManager.Happiness <= 0f)
             {
                 InvalidateScores("Menu.Toast.NoFailScore");
-
                 EngineManager.InitializeHappiness();
             }
+            _failMeter.SetActive(mode != NoFailMode.NoMeter);
         }
 
         internal void InvalidateScores(string toastKey)

--- a/Assets/Script/Gameplay/HUD/FailMeter.cs
+++ b/Assets/Script/Gameplay/HUD/FailMeter.cs
@@ -13,6 +13,12 @@ using YARG.Settings;
 
 namespace YARG.Gameplay.HUD
 {
+    public enum NoFailMode
+    {
+        Off,
+        On,
+        NoMeter
+    }
     public class FailMeter : MonoBehaviour
     {
         [SerializeField]
@@ -51,7 +57,7 @@ namespace YARG.Gameplay.HUD
 
         private void Awake()
         {
-            if (SettingsManager.Settings.NoFailMode.Value)
+            if (SettingsManager.Settings.NoFail.Value == NoFailMode.NoMeter)
             {
                 _meterContainer.transform.position = new Vector3(
                     _meterContainer.transform.position.x,

--- a/Assets/Script/Gameplay/HUD/Pause/FailPause.cs
+++ b/Assets/Script/Gameplay/HUD/Pause/FailPause.cs
@@ -31,7 +31,7 @@ namespace YARG.Gameplay.HUD
         public void EnableNoFail()
         {
             // It feels a bit icky reaching down into the settings like this
-            SettingsManager.Settings.NoFailMode.SetValueWithoutNotify(true);
+            SettingsManager.Settings.NoFail.SetValueWithoutNotify(NoFailMode.On);
             Restart();
         }
     }

--- a/Assets/Script/Gameplay/HUD/Pause/QuickSettings.cs
+++ b/Assets/Script/Gameplay/HUD/Pause/QuickSettings.cs
@@ -68,7 +68,7 @@ namespace YARG.Gameplay.HUD
             _quickSettingsContainer.gameObject.SetActive(true);
             _subSettingsObject.SetActive(false);
             // _noFailButton.SetActive(!SettingsManager.Settings.NoFailMode.Value);
-            _noFailText.text = SettingsManager.Settings.NoFailMode.Value ? "Disable No Fail" : "Enable No Fail";
+            _noFailText.text = SettingsManager.Settings.NoFail.Value != NoFailMode.Off ? "Disable No Fail" : "Enable No Fail";
             _venuePostProcessingText.text = SettingsManager.Settings.VenuePostProcessing.Value
                 ? "Disable Venue Post Processing"
                 : "Enable Venue Post Processing";
@@ -104,11 +104,15 @@ namespace YARG.Gameplay.HUD
 
         public void ToggleNoFail()
         {
-            SettingsManager.Settings.NoFailMode.Value = !SettingsManager.Settings.NoFailMode.Value;
-            _noFailText.text = SettingsManager.Settings.NoFailMode.Value ? "Disable No Fail" : "Enable No Fail";
-
-            // Disappear the fail meter
-            _failMeter.SetActive(!SettingsManager.Settings.NoFailMode.Value);
+            if (SettingsManager.Settings.NoFail.Value == NoFailMode.Off)
+            {
+                SettingsManager.Settings.NoFail.Value = NoFailMode.On;
+            }
+            else
+            {
+                SettingsManager.Settings.NoFail.Value = NoFailMode.Off;
+            }
+            _noFailText.text = SettingsManager.Settings.NoFail.Value != NoFailMode.Off ? "Disable No Fail" : "Enable No Fail";
         }
 
         public void ToggleVenuePostProcessing()

--- a/Assets/Script/Menu/ScoreScreen/ScoreCards/ScoreCard.cs
+++ b/Assets/Script/Menu/ScoreScreen/ScoreCards/ScoreCard.cs
@@ -8,6 +8,7 @@ using YARG.Helpers.Extensions;
 using YARG.Core.Engine;
 using YARG.Core.Extensions;
 using YARG.Core.Game;
+using YARG.Gameplay.HUD;
 using YARG.Localization;
 using YARG.Menu.MusicLibrary;
 using YARG.Player;
@@ -189,7 +190,7 @@ namespace YARG.Menu.ScoreScreen
             else
             {
                 _colorizer.SetCardColor(ScoreCardColorizer.ScoreCardColor.Blue);
-                ShowTag(SettingsManager.Settings.NoFailMode.Value ? "Completed" : "Cleared");
+                ShowTag(SettingsManager.Settings.NoFail.Value != NoFailMode.Off ? "Completed" : "Cleared");
             }
 
             _score.text = Stats.TotalScore.ToString("N0");

--- a/Assets/Script/Playback/CrowdEventHandler.cs
+++ b/Assets/Script/Playback/CrowdEventHandler.cs
@@ -5,6 +5,7 @@ using YARG.Core.Chart;
 using YARG.Core.Engine;
 using YARG.Core.Parsing;
 using YARG.Gameplay;
+using YARG.Gameplay.HUD;
 using YARG.Settings;
 
 namespace YARG.Playback
@@ -101,7 +102,7 @@ namespace YARG.Playback
                 }
             }
 
-            if (SettingsManager.Settings.NoFailMode.Value || GlobalVariables.State.IsPractice)
+            if (SettingsManager.Settings.NoFail.Value == NoFailMode.NoMeter || GlobalVariables.State.IsPractice)
             {
                 return;
             }

--- a/Assets/Script/Settings/SettingsManager.Settings.cs
+++ b/Assets/Script/Settings/SettingsManager.Settings.cs
@@ -110,7 +110,12 @@ namespace YARG.Settings
                 FileExplorerHelper.OpenFolder(VenueLoader.VenueFolder);
             }
 
-            public ToggleSetting NoFailMode { get; } = new(false);
+            public DropdownSetting<NoFailMode> NoFail { get; } = new(NoFailMode.Off)
+            {
+                NoFailMode.Off,
+                NoFailMode.On,
+                NoFailMode.NoMeter
+            };
 
             public ToggleSetting DisableDefaultBackground  { get; } = new(false);
             public ToggleSetting DisableGlobalBackgrounds  { get; } = new(false);

--- a/Assets/Script/Settings/SettingsManager.cs
+++ b/Assets/Script/Settings/SettingsManager.cs
@@ -48,7 +48,7 @@ namespace YARG.Settings
                 nameof(Settings.VoiceActivatedVocalStarPower),
                 new FieldMetadata(nameof(Settings.EnablePracticeSP), isAdvanced: true),
                 new FieldMetadata(nameof(Settings.PracticeRestartDelay), isAdvanced: true),
-                nameof(Settings.NoFailMode),
+                nameof(Settings.NoFail),
                 nameof(Settings.LearningGuides),
                 new FieldMetadata(nameof(Settings.ReduceNoteSpeedByDifficulty)),
 

--- a/Assets/StreamingAssets/lang/en-US.json
+++ b/Assets/StreamingAssets/lang/en-US.json
@@ -1258,9 +1258,14 @@
                 "Name": "No Kicks",
                 "Description": "Removes all kick notes (drums only)."
             },
-            "NoFailMode": {
+            "NoFail": {
                 "Name": "No Fail Mode",
-                "Description": "Disables ending a song early when crowd happiness is too low."
+                "Description": "Disables ending a song early when crowd happiness is too low.",
+                "Dropdown": {
+                    "Off": "Off",
+                    "On": "On",
+                    "NoMeter": "On + No Meter"
+                }
             },
             "NoteStreakFrequency": {
                 "Name": "Note Streak Frequency",


### PR DESCRIPTION
The no fail option in settings has become a 3-state dropdown menu, and quick settings (and the fail screen) as a toggle off/on, which always leaves the fail meter on screen. If you want it offscreen, you need to set it manually in settings.

This also means there is no way to disable the fail meter within a song, once it's enabled, but I left the code to do it in there, in case we ever want the dropdown in quick settings instead of a toggle, for example.

I don't think there's a way to migrate settings, so this will unfortunately reset everyone's no fail setting to Off.