### PR TITLE
Fix CS0649 warnings: Suppress warnings for fields assigned via Unity/JSON serialization

### DIFF
--- a/Assets/Script/Audio/Bass/BassAudioManager.cs
+++ b/Assets/Script/Audio/Bass/BassAudioManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using ManagedBass;
@@ -47,6 +47,7 @@ namespace YARG.Audio.BASS
         private          bool _disposed;
         public readonly  int  Stream;
 
+#pragma warning disable CS0649
         public int CompressorFX;
         public int PitchFX;
         public int ReverbFX;
@@ -54,6 +55,7 @@ namespace YARG.Audio.BASS
         public int LowEQ;
         public int MidEQ;
         public int HighEQ;
+#pragma warning restore CS0649
 
         private StreamHandle(int stream)
         {

--- a/Assets/Script/Input/Devices/UnsupportedXboxOneDevice.cs
+++ b/Assets/Script/Input/Devices/UnsupportedXboxOneDevice.cs
@@ -12,7 +12,9 @@ namespace YARG.Input.Devices
         public FourCC format => new('G', 'I', 'P');
 
         [InputControl(layout = "Integer")]
-        public byte dummy;
+#pragma warning disable CS0649
+        public byte dummy; // Required by InputSystem layout, never accessed in code
+#pragma warning restore CS0649
     }
 
     /// <summary>

--- a/Assets/Script/Menu/Common/Data/NavigationIcons.cs
+++ b/Assets/Script/Menu/Common/Data/NavigationIcons.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using UnityEngine;
 using YARG.Core.Input;
@@ -9,12 +9,14 @@ namespace YARG.Menu.Data
     public class NavigationIcons : ScriptableObject
     {
         [Serializable]
+#pragma warning disable CS0649
         private struct NavigationIcon
         {
             public MenuAction Action;
             public Sprite Sprite;
             public Color Color;
         }
+#pragma warning restore CS0649
 
         [SerializeField]
         private List<NavigationIcon> _menuIcons;

--- a/Assets/Script/Menu/Credits/CreditEntry.cs
+++ b/Assets/Script/Menu/Credits/CreditEntry.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using TMPro;
@@ -26,6 +26,7 @@ namespace YARG.Menu
             }
         };
 
+#pragma warning disable CS0649
         [Serializable]
         private struct SocialInfo
         {
@@ -33,6 +34,7 @@ namespace YARG.Menu
             public string Social;
             public GameObject Button;
         }
+#pragma warning restore CS0649
 
         [SerializeField]
         private TextMeshProUGUI _nameText;

--- a/Assets/Script/Settings/VenueAutoGenerationPreset.cs
+++ b/Assets/Script/Settings/VenueAutoGenerationPreset.cs
@@ -20,6 +20,7 @@ namespace YARG.Settings
         public static string DefaultPath =>
             Path.Combine(PathHelper.StreamingAssetsPath, "DefaultVenuePreset.json");
 
+#pragma warning disable CS0649
         private class VenueAutoGenerationFile
         {
             public string CameraPacing;
@@ -43,6 +44,7 @@ namespace YARG.Settings
 
             public string CameraPacingOverride;
         }
+#pragma warning restore CS0649
 
         private class AutoGenerationSectionPreset
         {

--- a/Assets/Script/Song/Genrelizer.Serialization.cs
+++ b/Assets/Script/Song/Genrelizer.Serialization.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
@@ -9,6 +9,7 @@ namespace YARG.Song
 {
     public static partial class Genrelizer
     {
+#pragma warning disable CS0649
         [Serializable]
         // This is a serialized class; naming conventions are JSON's, not C#'s
         [SuppressMessage("ReSharper", "All")]
@@ -37,5 +38,6 @@ namespace YARG.Song
             public Dictionary<string, List<string>> substitutions = new();
             public Dictionary<string, string> localizations = new();
         }
+#pragma warning restore CS0649
     }
 }


### PR DESCRIPTION
Just to reduce noise that may obscure real issues


- NavigationIcons.cs: Added #pragma disable CS0649 around NavigationIcon struct (fields assigned via Unity Inspector)
- VenueAutoGenerationPreset.cs: Added #pragma disable CS0649 around JSON deserialization classes VenueAutoGenerationFile and AutoGenerationSectionFile
- Genrelizer.Serialization.cs: Added #pragma disable CS0649 around JSON deserialization classes GenreMappingData and SubgenreMappingData
- CreditEntry.cs: Added #pragma disable CS0649 around SocialInfo struct (fields assigned via Unity Inspector)
- BassAudioManager.cs: Added #pragma disable CS0649 around FX fields (fields assigned in BassStemChannel.cs, not in constructor)
- UnsupportedXboxOneDevice.cs: Added #pragma disable CS0649 around dummy field (required by InputSystem layout but never accessed in code)
- YARG.Core: Fixed nullable reference and unused field warnings