### PR TITLE
Fix drum fill leadup effect on snare

### DIFF
--- a/Assets/Script/Gameplay/Visuals/TrackElements/TrackEffectElement.cs
+++ b/Assets/Script/Gameplay/Visuals/TrackElements/TrackEffectElement.cs
@@ -409,7 +409,7 @@ namespace YARG.Gameplay.Visuals
         private float GetXOffsetForLeadUp()
         {
             // Kick lead-ups and unknown indices should be centered
-            if (EffectRef.FillLanePosition <= 0 || EffectRef.FillLanePosition > EffectRef.TotalLanes)
+            if (EffectRef.FillLanePosition < 0 || EffectRef.FillLanePosition > EffectRef.TotalLanes)
             {
                 return 0f;
             }
@@ -429,7 +429,7 @@ namespace YARG.Gameplay.Visuals
             }
 
             // Kick lead-ups and unknown indices should not be shrunken
-            if (EffectRef.FillLanePosition <= 0 || EffectRef.FillLanePosition > EffectRef.TotalLanes)
+            if (EffectRef.FillLanePosition < 0 || EffectRef.FillLanePosition > EffectRef.TotalLanes)
             {
                 return 1f;
             }


### PR DESCRIPTION
The code to scale and offset the drum fill leadup effect was treating any position <=0 like a kick, but the red drum is position 0, causing the effect to be in the wrong place.

<img width="316" height="208" alt="image" src="https://github.com/user-attachments/assets/bc6f3a27-50e4-48f8-823f-1d23adbd7f1e" />

Demo chart:
[Snare Lane Demo.zip](https://github.com/user-attachments/files/26845171/Snare.Lane.Demo.zip)
