### PR TITLE
Song library enhancements

### DIFF
--- a/Assets/Script/Menu/MusicLibrary/DifficultyRing.cs
+++ b/Assets/Script/Menu/MusicLibrary/DifficultyRing.cs
@@ -1,4 +1,5 @@
-﻿using TMPro;
+﻿using System.Collections.Generic;
+using TMPro;
 using UnityEngine;
 using UnityEngine.AddressableAssets;
 using UnityEngine.EventSystems;
@@ -18,6 +19,8 @@ namespace YARG.Menu.MusicLibrary
 
     public class DifficultyRing : MonoBehaviour, IPointerClickHandler
     {
+        private static readonly Dictionary<string, Sprite> ICON_CACHE = new();
+
         [SerializeField]
         private Image _instrumentIcon;
 
@@ -59,7 +62,7 @@ namespace YARG.Menu.MusicLibrary
         public void SetInfo(string assetName, Instrument instrument, PartValues values)
         {
             // Set instrument icon
-            var icon = Addressables.LoadAssetAsync<Sprite>($"InstrumentIcons[{assetName}]").WaitForCompletion();
+            var icon = GetIcon(assetName);
             _instrumentIcon.sprite = icon;
             _instrument = instrument;
             _intensity = values.Intensity;
@@ -158,6 +161,17 @@ namespace YARG.Menu.MusicLibrary
             }
 
             UpdateIconColor();
+        }
+
+        private static Sprite GetIcon(string assetName)
+        {
+            string assetKey = $"InstrumentIcons[{assetName}]";
+            if (!ICON_CACHE.TryGetValue(assetKey, out var icon))
+            {
+                ICON_CACHE[assetKey] = icon = Addressables.LoadAssetAsync<Sprite>(assetKey).WaitForCompletion();
+            }
+
+            return icon;
         }
 
         private void UpdateIconColor()

--- a/Assets/Script/Menu/MusicLibrary/InstrumentDifficultyView.cs
+++ b/Assets/Script/Menu/MusicLibrary/InstrumentDifficultyView.cs
@@ -1,4 +1,4 @@
-using System;
+using System.Collections.Generic;
 using TMPro;
 using UnityEngine;
 using UnityEngine.AddressableAssets;
@@ -6,11 +6,12 @@ using UnityEngine.UI;
 using YARG.Helpers.Extensions;
 using YARG.Settings;
 
-
 namespace YARG.Menu.MusicLibrary
 {
     public class InstrumentDifficultyView : MonoBehaviour
     {
+        private static readonly Dictionary<string, Sprite> SpriteCache = new();
+
         [SerializeField]
         private Image _instrumentIcon;
 
@@ -20,7 +21,7 @@ namespace YARG.Menu.MusicLibrary
         [SerializeField]
         private TextMeshProUGUI _percentText;
 
-        private static Color _fcGold = new(1, 208 / 255f, 41 / 255f);
+        private static readonly Color FcGold = new(1, 208 / 255f, 41 / 255f);
 
 
         public void SetInfo(ViewType.ScoreInfo scoreInfo)
@@ -31,12 +32,10 @@ namespace YARG.Menu.MusicLibrary
             GetComponent<RectTransform>().sizeDelta = new Vector2(length, rect.sizeDelta.y);
 
             // Set instrument icon
-            var icon = Addressables.LoadAssetAsync<Sprite>($"InstrumentIcons[{scoreInfo.Instrument.ToResourceName()}]").WaitForCompletion();
-            _instrumentIcon.sprite = icon;
+            _instrumentIcon.sprite = GetSprite($"InstrumentIcons[{scoreInfo.Instrument.ToResourceName()}]");
 
             // Set difficulty icon
-            var difficultyIcon = Addressables.LoadAssetAsync<Sprite>($"DifficultyIcons[{scoreInfo.Difficulty.ToString()}]").WaitForCompletion();
-            _difficultyIcon.sprite = difficultyIcon;
+            _difficultyIcon.sprite = GetSprite($"DifficultyIcons[{scoreInfo.Difficulty.ToString()}]");
 
             // Set percent value
             if (SettingsManager.Settings.ShowPercentDecimals.Value)
@@ -49,7 +48,17 @@ namespace YARG.Menu.MusicLibrary
                 _percentText.text = $"{Mathf.FloorToInt(scoreInfo.Percent * 100f)}%";
             }
 
-            _percentText.color = scoreInfo.IsFc ? _fcGold : Color.white;
+            _percentText.color = scoreInfo.IsFc ? FcGold : Color.white;
+        }
+
+        private static Sprite GetSprite(string assetKey)
+        {
+            if (!SpriteCache.TryGetValue(assetKey, out var sprite))
+            {
+                SpriteCache[assetKey] = sprite = Addressables.LoadAssetAsync<Sprite>(assetKey).WaitForCompletion();
+            }
+
+            return sprite;
         }
     }
 }

--- a/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.SortFilter.cs
+++ b/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.SortFilter.cs
@@ -507,9 +507,7 @@ namespace YARG.Menu.MusicLibrary
         private void OpenFilters()
         {
             // Stop any library preview audio so the Filters menu doesn't inherit it
-            _previewCanceller?.Cancel();
-            _previewContext?.Stop();
-            _previewContext = null;
+            StopPreview();
 
             var menu = YARG.Menu.Filters.FiltersMenu.Instance;
             if (menu == null)

--- a/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
+++ b/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using TMPro;
 using UnityEngine;
 using YARG.Core;
@@ -377,10 +378,8 @@ namespace YARG.Menu.MusicLibrary
                 _currentSong = null;
             }
 
-            _previewCanceller?.Cancel();
+            StopPreview();
             _previewCanceller = new CancellationTokenSource();
-            _previewContext?.Stop();
-            _previewContext = null;
             StartPreview(_previewDelay, _previewCanceller);
 
             _previewDelay = PREVIEW_SCROLL_DELAY;
@@ -660,10 +659,48 @@ namespace YARG.Menu.MusicLibrary
 
         private void ClearPreview()
         {
-            _currentSong = null;
-            _previewCanceller?.Cancel();
-            _previewContext?.Stop();
+            StopPreview(clearCurrentSong: true);
+        }
+
+        private void StopPreview(bool clearCurrentSong = false)
+        {
+            _ = StopPreviewAsync(clearCurrentSong);
+        }
+
+        private async Task StopPreviewAsync(bool clearCurrentSong = false)
+        {
+            if (clearCurrentSong)
+            {
+                _currentSong = null;
+            }
+
+            var previewCanceller = _previewCanceller;
+            var previewContext = _previewContext;
+
+            _previewCanceller = null;
             _previewContext = null;
+
+            previewCanceller?.Cancel();
+            if (previewContext != null)
+            {
+                await previewContext.WaitForCompletionAsync();
+            }
+
+            previewCanceller?.Dispose();
+        }
+
+        private void DisposePreview()
+        {
+            var previewCanceller = _previewCanceller;
+            var previewContext = _previewContext;
+
+            _previewCanceller = null;
+            _previewContext = null;
+            _currentSong = null;
+
+            previewCanceller?.Cancel();
+            previewContext?.Dispose();
+            previewCanceller?.Dispose();
         }
 
         private void EnterPlaylistSelectFromLibrary()
@@ -714,11 +751,23 @@ namespace YARG.Menu.MusicLibrary
                 return;
             }
 
-            var context = await PreviewContext.Create(_currentSong, previewVolume, GlobalVariables.State.SongSpeed,
-                delay, FADE_DURATION, canceller);
+            var context = await PreviewContext.Create(
+                _currentSong,
+                previewVolume,
+                GlobalVariables.State.SongSpeed,
+                delay,
+                FADE_DURATION,
+                canceller.Token);
             if (context != null)
             {
-                _previewContext = context;
+                if (_previewCanceller == canceller && !canceller.IsCancellationRequested)
+                {
+                    _previewContext = context;
+                }
+                else
+                {
+                    context.Dispose();
+                }
             }
         }
 
@@ -746,8 +795,7 @@ namespace YARG.Menu.MusicLibrary
 
             Navigator.Instance.PopScheme();
 
-            _previewCanceller?.Cancel();
-            _previewContext?.Stop();
+            StopPreview();
             _searchField.OnSearchQueryUpdated -= UpdateSearch;
 
             PlayerContainer.PlayerAdded -= OnPlayerAdded;
@@ -756,8 +804,7 @@ namespace YARG.Menu.MusicLibrary
 
         private void OnDestroy()
         {
-            _previewCanceller?.Cancel();
-            _previewContext?.Dispose();
+            DisposePreview();
             _reloadState = MusicLibraryReloadState.Partial;
             StemSettings.ApplySettings = true;
         }
@@ -1169,9 +1216,7 @@ namespace YARG.Menu.MusicLibrary
         public async void RefreshSongs()
         {
             // Stop any library preview audio so the loading screen doesn't inherit it
-            _previewCanceller?.Cancel();
-            _previewContext?.Stop();
-            _previewContext = null;
+            await StopPreviewAsync();
 
             SetSidebarDifficultiesVisible(false);
             using var context = new LoadingContext();

--- a/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
+++ b/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
@@ -674,6 +674,8 @@ namespace YARG.Menu.MusicLibrary
                 _currentSong = null;
             }
 
+            // Snapshot the current preview before awaiting so a newer preview started in the meantime
+            // cannot be canceled, disposed, or cleared by this older shutdown path.
             var previewCanceller = _previewCanceller;
             var previewContext = _previewContext;
 

--- a/Assets/Script/Menu/MusicLibrary/Sidebar.cs
+++ b/Assets/Script/Menu/MusicLibrary/Sidebar.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading;
+using Cysharp.Threading.Tasks;
 using TMPro;
 using UnityEngine;
 using UnityEngine.Serialization;
@@ -150,13 +151,7 @@ namespace YARG.Menu.MusicLibrary
 
             _currentView = selected;
 
-            // Cancel album art
-            if (_cancellationToken != null)
-            {
-                _cancellationToken.Cancel();
-                _cancellationToken.Dispose();
-                _cancellationToken = null;
-            }
+            CancelAlbumLoad();
 
             switch (selected)
             {
@@ -198,11 +193,7 @@ namespace YARG.Menu.MusicLibrary
 
         private void ClearSidebar()
         {
-            // Hide album art
-            _albumCover.texture = null;
-            _albumCover.color = Color.clear;
-            _albumCoverSmall.texture = null;
-            _albumCoverSmall.color = Color.clear;
+            ClearAlbumCoverTextures();
             _album.text = string.Empty;
 
             _sourceBackground.enabled = false;
@@ -273,9 +264,7 @@ namespace YARG.Menu.MusicLibrary
 
             UpdateDifficulties(songEntry);
 
-            CancellationTokenSource token = new();
             var icon = SongSources.SourceToIcon(songEntry.Source);
-            token.Token.ThrowIfCancellationRequested();
 
             if (icon is not null)
             {
@@ -289,8 +278,7 @@ namespace YARG.Menu.MusicLibrary
             // _sidebarContents.gameObject.SetActive(true);
 
             _cancellationToken = new();
-            _albumCover.LoadAlbumCover(songEntry, _cancellationToken.Token, 0.05f);
-            _albumCoverSmall.LoadAlbumCover(songEntry, _cancellationToken.Token);
+            LoadAlbumCover(songEntry, _cancellationToken.Token).Forget();
         }
 
         // Wrap and shrink long sidebar fields (album/source/charter) if they are too long to fit
@@ -471,6 +459,87 @@ namespace YARG.Menu.MusicLibrary
             {
                 _playButton.DisableButton();
             }
+        }
+
+        private void OnDisable()
+        {
+            CancelAlbumLoad();
+            ClearAlbumCoverTextures();
+        }
+
+        private async UniTaskVoid LoadAlbumCover(SongEntry songEntry, CancellationToken cancellationToken)
+        {
+            Texture2D texture = null;
+
+            try
+            {
+                using var image = await UniTask.RunOnThreadPool(songEntry.LoadAlbumData, cancellationToken: cancellationToken);
+                if (image != null)
+                {
+                    texture = image.LoadTexture(false);
+                }
+
+                if (cancellationToken.IsCancellationRequested
+                    || _currentView is not SongViewType currentView
+                    || currentView.SongEntry != songEntry)
+                {
+                    if (texture != null)
+                    {
+                        Destroy(texture);
+                    }
+                    return;
+                }
+
+                ClearAlbumCoverTextures();
+
+                SetAlbumCover(_albumCover, texture, 0.05f);
+                SetAlbumCover(_albumCoverSmall, texture, 1f);
+            }
+            catch (OperationCanceledException)
+            {
+                if (texture != null)
+                {
+                    Destroy(texture);
+                }
+            }
+        }
+
+        private void CancelAlbumLoad()
+        {
+            if (_cancellationToken == null)
+            {
+                return;
+            }
+
+            _cancellationToken.Cancel();
+            _cancellationToken.Dispose();
+            _cancellationToken = null;
+        }
+
+        private void ClearAlbumCoverTextures()
+        {
+            var mainTexture = _albumCover.texture;
+            var smallTexture = _albumCoverSmall.texture;
+
+            if (mainTexture != null)
+            {
+                Destroy(mainTexture);
+            }
+
+            if (smallTexture != null && !ReferenceEquals(mainTexture, smallTexture))
+            {
+                Destroy(smallTexture);
+            }
+
+            SetAlbumCover(_albumCover, null, 0.05f);
+            SetAlbumCover(_albumCoverSmall, null, 1f);
+        }
+
+        private static void SetAlbumCover(RawImage image, Texture2D texture, float alpha)
+        {
+            image.texture = texture;
+            image.uvRect = new Rect(0f, 0f, 1f, -1f);
+            image.color = texture != null ? Color.white.WithAlpha(alpha) : Color.clear;
         }
 
         public void PrimaryButtonClick()

--- a/Assets/Script/Menu/MusicLibrary/ViewTypes/SortHeaderViewType.cs
+++ b/Assets/Script/Menu/MusicLibrary/ViewTypes/SortHeaderViewType.cs
@@ -32,6 +32,7 @@ namespace YARG.Menu.MusicLibrary
         private static readonly HashSet<string> CharterCounter = new();
         private static readonly HashSet<string> GenreCounter   = new();
         private static readonly HashSet<string> SubgenreCounter = new();
+        private static readonly Dictionary<string, Sprite> IconCache = new();
         private readonly string _stableId;
 
         public SortHeaderViewType(string headerText, int songCount, string shortcutName, SongEntry[] songsUnderCategory,
@@ -106,7 +107,12 @@ namespace YARG.Menu.MusicLibrary
 #nullable disable
         {
             string assetKey = Collapsed ? "MusicLibraryIcons[Right]" : "MusicLibraryIcons[Down]";
-            return Addressables.LoadAssetAsync<Sprite>(assetKey).WaitForCompletion();
+            if (!IconCache.TryGetValue(assetKey, out var icon))
+            {
+                IconCache[assetKey] = icon = Addressables.LoadAssetAsync<Sprite>(assetKey).WaitForCompletion();
+            }
+
+            return icon;
         }
 
         public override void PrimaryButtonClick()


### PR DESCRIPTION
This fixes a significant memory leak issue with the song library where the album textures are loaded but never destroyed. There are also other memory allocation related fixes (sprite caching for example) as well as cleaning up the audio preview handling.

YARG.Core PR needed: https://github.com/YARC-Official/YARG.Core/pull/364