### PR TITLE
Clean up multiplier text cache implementation and fix vocals bug

### DIFF
--- a/Assets/Script/Gameplay/HUD/VocalsPlayerHUD.cs
+++ b/Assets/Script/Gameplay/HUD/VocalsPlayerHUD.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections;
+using System.Collections.Generic;
 using Cysharp.Text;
 using DG.Tweening;
 using TMPro;
@@ -7,6 +8,7 @@ using UnityEngine;
 using UnityEngine.UI;
 using YARG.Core.Game;
 using YARG.Helpers.Extensions;
+using YARG.Helpers.UI;
 using YARG.Localization;
 using YARG.Player;
 
@@ -34,13 +36,13 @@ namespace YARG.Gameplay.HUD
 
         private Coroutine _hudCoroutine;
 
-        private bool _shouldPulse;
-        private bool _hudShowing = true;
-        private TextMeshProUGUI[] _textCache;
+        private bool                             _shouldPulse;
+        private bool                             _hudShowing = true;
+        private Dictionary<int, TextMeshProUGUI> _textCache;
 
         public void Initialize(EnginePreset enginePreset)
         {
-            InitializeMultiplierTextCache(EnginePreset.DEFAULT_MAX_MULTIPLIER);
+            _textCache = MultiplierTextHelper.CreateMultiplierTextCache(EnginePreset.DEFAULT_MAX_MULTIPLIER, _multiplierText, GameManager.Players.Count > 1);
 
             if (enginePreset == EnginePreset.Default)
             {
@@ -61,35 +63,6 @@ namespace YARG.Gameplay.HUD
             }
 
             _starPowerFill.fillAmount = 0f;
-        }
-
-        private void InitializeMultiplierTextCache(int maxMultiplier)
-        {
-            if (_textCache != null)
-            {
-                foreach (var t in _textCache)
-                {
-                    t.enabled = false;
-                }
-
-                _multiplierText = _textCache[0];
-                return;
-            }
-
-            _textCache = new TextMeshProUGUI[maxMultiplier - 1];
-            for (int i = 0; i < _textCache.Length; i++)
-            {
-                var text = i == 0
-                    ? _multiplierText
-                    : Instantiate(_multiplierText, _multiplierText.transform.parent, true);
-
-                text.enabled = false;
-                text.text = string.Empty;
-                text.SetTextFormat("{0}<sub>x</sub>", i + 2);
-                _textCache[i] = text;
-            }
-
-            _multiplierText = _textCache[0];
         }
 
         private void Update()
@@ -126,7 +99,7 @@ namespace YARG.Gameplay.HUD
             _multiplierText.enabled = false;
             if (multiplier > 1)
             {
-                _multiplierText = _textCache[multiplier - 2];
+                _multiplierText = _textCache[multiplier];
                 _multiplierText.enabled = true;
             }
 

--- a/Assets/Script/Gameplay/HUD/VocalsPlayerHUD.cs
+++ b/Assets/Script/Gameplay/HUD/VocalsPlayerHUD.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections;
-using System.Collections.Generic;
-using Cysharp.Text;
+﻿using System.Collections;
 using DG.Tweening;
 using TMPro;
 using UnityEngine;
@@ -38,7 +35,7 @@ namespace YARG.Gameplay.HUD
 
         private bool                             _shouldPulse;
         private bool                             _hudShowing = true;
-        private Dictionary<int, TextMeshProUGUI> _textCache;
+        private TextMeshProUGUI[] _textCache;
 
         public void Initialize(EnginePreset enginePreset)
         {
@@ -99,7 +96,7 @@ namespace YARG.Gameplay.HUD
             _multiplierText.enabled = false;
             if (multiplier > 1)
             {
-                _multiplierText = _textCache[multiplier];
+                _multiplierText = _textCache[multiplier - 2];
                 _multiplierText.enabled = true;
             }
 

--- a/Assets/Script/Gameplay/Player/TrackPlayer.cs
+++ b/Assets/Script/Gameplay/Player/TrackPlayer.cs
@@ -229,8 +229,7 @@ namespace YARG.Gameplay.Player
             var events = NoteTrack.TextEvents;
 
             Engine = CreateEngine();
-
-            base.ComboMeter.Initialize(player.EnginePreset, Engine.BaseParameters.MaxMultiplier);
+            base.ComboMeter.Initialize(player.EnginePreset, Engine.BaseParameters.MaxMultiplier, GameManager.Players.Count > 1);
 
             Engine.OnComboIncrement += OnComboIncrement;
             Engine.OnComboReset += OnComboReset;

--- a/Assets/Script/Gameplay/Visuals/ComboMeter.cs
+++ b/Assets/Script/Gameplay/Visuals/ComboMeter.cs
@@ -1,10 +1,6 @@
-﻿using System.Collections.Generic;
-using System.Diagnostics;
-using Cysharp.Text;
-using TMPro;
+﻿using TMPro;
 using UnityEngine;
 using YARG.Core.Game;
-using YARG.Core.Logging;
 using YARG.Helpers.UI;
 
 namespace YARG.Gameplay.Visuals
@@ -36,7 +32,7 @@ namespace YARG.Gameplay.Visuals
         [SerializeField]
         private Color _soloTapsPresetColor;
 
-        private Dictionary<int, TextMeshPro> _textCache;
+        private TextMeshPro[] _textCache;
 
         public void Initialize(EnginePreset preset, int maxMultiplier, bool isMultiplayer)
         {
@@ -76,7 +72,7 @@ namespace YARG.Gameplay.Visuals
 
             if (displayMultiplier > 1)
             {
-                _multiplierText = _textCache[displayMultiplier];
+                _multiplierText = _textCache[displayMultiplier - 2];
                 _multiplierText.enabled = true;
             }
 

--- a/Assets/Script/Gameplay/Visuals/ComboMeter.cs
+++ b/Assets/Script/Gameplay/Visuals/ComboMeter.cs
@@ -1,9 +1,11 @@
-﻿using System.Diagnostics;
+﻿using System.Collections.Generic;
+using System.Diagnostics;
 using Cysharp.Text;
 using TMPro;
 using UnityEngine;
 using YARG.Core.Game;
 using YARG.Core.Logging;
+using YARG.Helpers.UI;
 
 namespace YARG.Gameplay.Visuals
 {
@@ -34,19 +36,13 @@ namespace YARG.Gameplay.Visuals
         [SerializeField]
         private Color _soloTapsPresetColor;
 
-        private TextMeshPro[] _textCache;
+        private Dictionary<int, TextMeshPro> _textCache;
 
-        public void Initialize(EnginePreset preset, int maxMultiplier)
+        public void Initialize(EnginePreset preset, int maxMultiplier, bool isMultiplayer)
         {
             _multiplierText.enabled = false;
             _multiplierText.text = string.Empty;
-            _textCache = new TextMeshPro[maxMultiplier * 2 - 1];
-            _textCache[0] = _multiplierText;
-            for(int i = 0; i < _textCache.Length; ++i)
-            {
-                _textCache[i] = Instantiate(_multiplierText, _multiplierText.transform.parent, true);
-                _textCache[i].SetTextFormat("{0}<sub>x</sub>", i + 2);
-            }
+            _textCache = MultiplierTextHelper.CreateMultiplierTextCache(maxMultiplier, _multiplierText, isMultiplayer);
 
             Color color;
 
@@ -80,7 +76,7 @@ namespace YARG.Gameplay.Visuals
 
             if (displayMultiplier > 1)
             {
-                _multiplierText = _textCache[displayMultiplier - 2];
+                _multiplierText = _textCache[displayMultiplier];
                 _multiplierText.enabled = true;
             }
 

--- a/Assets/Script/Helpers/UI/MultiplierTextHelper.cs
+++ b/Assets/Script/Helpers/UI/MultiplierTextHelper.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using Cysharp.Text;
+﻿using Cysharp.Text;
 using TMPro;
 
 namespace YARG.Helpers.UI
@@ -14,19 +12,22 @@ namespace YARG.Helpers.UI
         /// <param name="multiplierTextPrefab">The prefab of the text to instantiate.</param>
         /// <param name="isMultiplayer"> Whether we are playing multiplayer (and therefore do not need to generate SP multipliers).</param>
         /// <typeparam name="T">TextMeshPro type being used</typeparam>
-        /// <returns>Dictionary with keys as multiplier values, and values as TMP objects.</returns>
-        public static Dictionary<int, T> CreateMultiplierTextCache<T>(int maxMultiplier, T multiplierTextPrefab,
+        /// <returns>Array where the corresponding TMP object is at arr[multiplier - 2]</returns>
+        public static T[] CreateMultiplierTextCache<T>(int maxMultiplier, T multiplierTextPrefab,
             bool isMultiplayer) where T : TMP_Text
         {
-            var textCache = new Dictionary<int, T>();
-            // I know this is non-conventional for for-loops, but it makes i correspond with the actual multipliers
-            for (int i = 1; i <= maxMultiplier; i++)
+            var textCache = isMultiplayer ? new T[maxMultiplier - 1] : new T[2 * maxMultiplier - 1];
+            for (int i = 2; i <= maxMultiplier; i++)
             {
-                textCache[i] = GenerateMultiplierText(i, multiplierTextPrefab);
-                // Also SP, but only in single-player as multiplayer uses band multipliers
-                if (!isMultiplayer)
+                if (textCache[i - 2] == null)
                 {
-                    textCache[i * 2] = GenerateMultiplierText(i * 2, multiplierTextPrefab);
+                    textCache[i - 2] = GenerateMultiplierText(i, multiplierTextPrefab);
+                }
+
+                // Also SP, but only in single-player as multiplayer uses band multipliers
+                if (!isMultiplayer && textCache[i * 2 - 2] == null)
+                {
+                    textCache[i * 2 - 2] = GenerateMultiplierText(i * 2, multiplierTextPrefab);
                 }
             }
 

--- a/Assets/Script/Helpers/UI/MultiplierTextHelper.cs
+++ b/Assets/Script/Helpers/UI/MultiplierTextHelper.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using Cysharp.Text;
+using TMPro;
+
+namespace YARG.Helpers.UI
+{
+    public static class MultiplierTextHelper
+    {
+        /// <summary>
+        /// Create a TMP cache of all available multiplier texts.
+        /// </summary>
+        /// <param name="maxMultiplier">The max multiplier to generate WITHOUT Star Power.</param>
+        /// <param name="multiplierTextPrefab">The prefab of the text to instantiate.</param>
+        /// <param name="isMultiplayer"> Whether we are playing multiplayer (and therefore do not need to generate SP multipliers).</param>
+        /// <typeparam name="T">TextMeshPro type being used</typeparam>
+        /// <returns>Dictionary with keys as multiplier values, and values as TMP objects.</returns>
+        public static Dictionary<int, T> CreateMultiplierTextCache<T>(int maxMultiplier, T multiplierTextPrefab,
+            bool isMultiplayer) where T : TMP_Text
+        {
+            var textCache = new Dictionary<int, T>();
+            // I know this is non-conventional for for-loops, but it makes i correspond with the actual multipliers
+            for (int i = 1; i <= maxMultiplier; i++)
+            {
+                textCache[i] = GenerateMultiplierText(i, multiplierTextPrefab);
+                // Also SP, but only in single-player as multiplayer uses band multipliers
+                if (!isMultiplayer)
+                {
+                    textCache[i * 2] = GenerateMultiplierText(i * 2, multiplierTextPrefab);
+                }
+            }
+
+            return textCache;
+        }
+
+        private static T GenerateMultiplierText<T>(int multiplier, T multiplierTextPrefab) where T : TMP_Text
+        {
+            var text = UnityEngine.Object.Instantiate(multiplierTextPrefab, multiplierTextPrefab.transform.parent);
+            text.SetTextFormat("{0}<sub>x</sub>", multiplier);
+            text.enabled = false;
+            return text;
+        }
+    }
+}

--- a/Assets/Script/Helpers/UI/MultiplierTextHelper.cs.meta
+++ b/Assets/Script/Helpers/UI/MultiplierTextHelper.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 366ee705c4514a04b1cd5567040d27df
+timeCreated: 1776548045


### PR DESCRIPTION
Switched to using a dictionary over a raw array, and moved the methods to their own helper.

I don't know if this even helps performance on vocals since they are TextMeshProUGUI which I think draws directly to the canvas instead of being a mesh, but this at least fixes vocals for the time being.