### PR TITLE
Address Filters Menu Feedback Items

### DIFF
--- a/Assets/Prefabs/Menu/Settings/Visuals/LabledSetting.prefab
+++ b/Assets/Prefabs/Menu/Settings/Visuals/LabledSetting.prefab
@@ -17,7 +17,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &2452540486229604461
 RectTransform:
   m_ObjectHideFlags: 0

--- a/Assets/Script/Menu/DifficultySelect/DifficultySelectMenu.cs
+++ b/Assets/Script/Menu/DifficultySelect/DifficultySelectMenu.cs
@@ -16,6 +16,7 @@ using YARG.Helpers.Extensions;
 using YARG.Localization;
 using YARG.Menu.Navigation;
 using YARG.Menu.Persistent;
+using YARG.Menu.Filters;
 using YARG.Player;
 using YARG.Song;
 
@@ -381,6 +382,7 @@ namespace YARG.Menu.DifficultySelect
                         CurrentPlayer.Profile.PreferredInstrument = instrument;
                     }
 
+                    FiltersMenu.ResetIntensityFiltersForProfile(CurrentPlayer.Profile);
                     UpdatePossibleDifficulties();
                     UpdatePossibleModifiers();
 

--- a/Assets/Script/Menu/Filters/FilterCategoryRow.cs
+++ b/Assets/Script/Menu/Filters/FilterCategoryRow.cs
@@ -51,9 +51,8 @@ namespace YARG.Menu.Filters
         VocalParts,
         Source,
         Charter,
-        Difficulty,
-        Length,
-        Playlist
+        Intensity,
+        Length
     }
 }
 

--- a/Assets/Script/Menu/Filters/FilterCategoryRow.cs
+++ b/Assets/Script/Menu/Filters/FilterCategoryRow.cs
@@ -82,6 +82,7 @@ namespace YARG.Menu.Filters
         Decade,
         VocalParts,
         Source,
+        Playlist,
         Charter,
         Intensity,
         Length

--- a/Assets/Script/Menu/Filters/FilterCategoryRow.cs
+++ b/Assets/Script/Menu/Filters/FilterCategoryRow.cs
@@ -1,15 +1,47 @@
 ﻿using TMPro;
 using UnityEngine;
+using System;
 using YARG.Menu.Navigation;
 
 namespace YARG.Menu.Filters
 {
+    public readonly struct FilterKey : IEquatable<FilterKey>
+    {
+        public readonly FilterGroup Group;
+        public readonly Guid ContextId;
+
+        public FilterKey(FilterGroup group, Guid contextId = default)
+        {
+            Group = group;
+            ContextId = contextId;
+        }
+
+        public bool Equals(FilterKey other)
+        {
+            return Group == other.Group && ContextId.Equals(other.ContextId);
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is FilterKey other && Equals(other);
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(Group, ContextId);
+        }
+
+        public static bool operator ==(FilterKey left, FilterKey right) => left.Equals(right);
+        public static bool operator !=(FilterKey left, FilterKey right) => !left.Equals(right);
+    }
+
     public class FilterCategoryRow : NavigatableBehaviour
     {
         [SerializeField] private TMP_Text _label;
         [SerializeField] private TMP_Text _secondaryLabel;
 
-        public FilterGroup Filters { get; private set; }
+        public FilterKey Key { get; private set; }
+        public FilterGroup Group => Key.Group;
 
         private FilterRowBackgroundVisual _backgroundVisual;
 
@@ -22,9 +54,9 @@ namespace YARG.Menu.Filters
                 _backgroundVisual = gameObject.AddComponent<FilterRowBackgroundVisual>();
         }
 
-        public void Init(FilterGroup group, string label, string secondaryLabel = null)
+        public void Init(FilterKey key, string label, string secondaryLabel = null)
         {
-            Filters = group;
+            Key = key;
             _label.text = label;
             SetSecondaryText(secondaryLabel);
         }

--- a/Assets/Script/Menu/Filters/FiltersMenu.cs
+++ b/Assets/Script/Menu/Filters/FiltersMenu.cs
@@ -1330,8 +1330,7 @@ namespace YARG.Menu.Filters
                 foreach (var song in SongContainer.Songs)
                 {
                     int count = Math.Clamp(song.VocalsCount, 0, 3);
-                    if (count > 0)
-                        counts.Add(count);
+                    counts.Add(count);
                 }
 
                 var ordered = new List<string>(counts.Count);
@@ -1340,6 +1339,9 @@ namespace YARG.Menu.Filters
                     if (counts.Contains(i))
                         ordered.Add(GetVocalPartsLabel(i));
                 }
+
+                if (counts.Contains(0))
+                    ordered.Add(GetVocalPartsLabel(0));
 
                 return ordered;
             });
@@ -1368,6 +1370,7 @@ namespace YARG.Menu.Filters
                 >= 3 => Localize.Key("Menu.Filters.VocalParts.Trio"),
                 2 => Localize.Key("Menu.Filters.VocalParts.Duet"),
                 1 => Localize.Key("Menu.Filters.VocalParts.Solo"),
+                0 => Localize.Key("Menu.Filters.VocalParts.Instrumental"),
                 _ => null
             };
         }

--- a/Assets/Script/Menu/Filters/FiltersMenu.cs
+++ b/Assets/Script/Menu/Filters/FiltersMenu.cs
@@ -22,6 +22,7 @@ using YARG.Player;
 using YARG.Playlists;
 using YARG.Song;
 using YARG.Settings;
+using YARG.Helpers;
 
 namespace YARG.Menu.Filters
 {
@@ -138,6 +139,7 @@ namespace YARG.Menu.Filters
         private static IReadOnlyList<string> _cachedVocalParts;
         private static IReadOnlyList<string> _cachedSources;
         private static IReadOnlyList<string> _cachedPlaylists;
+        private static Dictionary<string, int> _cachedPlaylistCounts;
         private static IReadOnlyList<string> _cachedCharters;
         private static IReadOnlyList<string> _cachedLengths;
         private static readonly Dictionary<Instrument, IReadOnlyList<string>> _cachedIntensitiesByInstrument = new();
@@ -449,9 +451,7 @@ namespace YARG.Menu.Filters
             string profileName = string.IsNullOrWhiteSpace(context.ProfileName)
                 ? Localize.Key(IntensityLabelUnknownKey)
                 : context.ProfileName;
-            string instrumentName = context.Instrument == Instrument.EliteDrums
-                ? SortAttribute.AggregateDrums.ToLocalizedName()
-                : context.Instrument.ToLocalizedName();
+            string instrumentName = context.Instrument.ToLocalizedName();
             string contextLabel = $"({profileName} on {instrumentName})";
 
             return $"{baseLabel} {TextColorer.StyleString(contextLabel, MenuData.Colors.TrackDefaultSecondary, 400)}";
@@ -1648,25 +1648,6 @@ namespace YARG.Menu.Filters
 
         private static string GetIntensityLabel(SongEntry entry, Instrument instrument)
         {
-            if (instrument == Instrument.EliteDrums)
-            {
-                var preferredInstrument = MidiDrumkitHelper.GetPreferredInstrumentForSong(entry);
-                if (!preferredInstrument.HasValue)
-                    return Localize.Key(IntensityLabelNoPartKey);
-
-                var preferredPart = entry[preferredInstrument.Value];
-                if (!preferredPart.IsActive())
-                    return Localize.Key(IntensityLabelNoPartKey);
-
-                int preferredIntensity = preferredPart.Intensity;
-                if (preferredIntensity < 0) return Localize.Key(IntensityLabelUnknownKey);
-
-                if (preferredIntensity >= IntensityLabelKeys.Length)
-                    return GetIntensityLabelByIndex(IntensityLabelKeys.Length - 1);
-
-                return GetIntensityLabelByIndex(preferredIntensity);
-            }
-
             var part = entry[instrument];
             if (!part.IsActive()) return Localize.Key(IntensityLabelNoPartKey);
 

--- a/Assets/Script/Menu/Filters/FiltersMenu.cs
+++ b/Assets/Script/Menu/Filters/FiltersMenu.cs
@@ -7,14 +7,17 @@ using UnityEngine.AddressableAssets;
 using UnityEngine.UI;
 using YARG.Helpers.Extensions;
 using YARG.Core;
+using YARG.Core.Game;
 using YARG.Core.Input;
 using YARG.Core.Song;
 using YARG.Core.Utility;
 using YARG.Localization;
 using YARG.Menu.Navigation;
+using YARG.Menu.MusicLibrary;
 using YARG.Menu.Settings;
 using YARG.Menu.Settings.Visuals;
 using YARG.Menu.Persistent;
+using YARG.Menu.Data;
 using YARG.Player;
 using YARG.Playlists;
 using YARG.Song;
@@ -41,24 +44,43 @@ namespace YARG.Menu.Filters
 
         private readonly struct FilterDef
         {
-            public readonly FilterGroup Group;
+            public readonly FilterKey Key;
             public readonly Func<IReadOnlyList<string>> GetValues;
             public readonly Func<Dictionary<string, int>> GetCounts;
             public readonly Dictionary<string, bool> Enabled;
             public readonly Func<string, string> LabelTransform;
+            public readonly Instrument IntensityInstrument;
+
+            public FilterGroup Group => Key.Group;
 
             public FilterDef(
-                FilterGroup group,
+                FilterKey key,
                 Func<IReadOnlyList<string>> getValues,
                 Func<Dictionary<string, int>> getCounts,
                 Dictionary<string, bool> enabled,
-                Func<string, string> labelTransform = null)
+                Func<string, string> labelTransform = null,
+                Instrument intensityInstrument = default)
             {
-                Group = group;
+                Key = key;
                 GetValues = getValues;
                 GetCounts = getCounts;
                 Enabled = enabled;
                 LabelTransform = labelTransform;
+                IntensityInstrument = intensityInstrument;
+            }
+        }
+
+        private readonly struct IntensityFilterContext
+        {
+            public readonly Guid ProfileId;
+            public readonly string ProfileName;
+            public readonly Instrument Instrument;
+
+            public IntensityFilterContext(Guid profileId, string profileName, Instrument instrument)
+            {
+                ProfileId = profileId;
+                ProfileName = profileName;
+                Instrument = instrument;
             }
         }
         [SerializeField]
@@ -88,7 +110,7 @@ namespace YARG.Menu.Filters
         [SerializeField]
         private GameObject _showRecommendationsTogglePrefab;
 
-        private readonly Dictionary<FilterGroup, FilterCategoryRow> _leftRows = new();
+        private readonly Dictionary<FilterKey, FilterCategoryRow> _leftRows = new();
         private Toggle _showRecommendationsToggle;
 
         private readonly Dictionary<string, bool> _genreEnabled =
@@ -107,8 +129,8 @@ namespace YARG.Menu.Filters
             new(StringComparer.OrdinalIgnoreCase);
         private readonly Dictionary<string, bool> _lengthEnabled =
             new(StringComparer.OrdinalIgnoreCase);
-        private readonly Dictionary<string, bool> _intensityEnabled =
-            new(StringComparer.OrdinalIgnoreCase);
+        private readonly Dictionary<Guid, Dictionary<string, bool>> _intensityEnabledByProfile =
+            new();
 
         private static IReadOnlyList<string> _cachedGenres;
         private static IReadOnlyList<string> _cachedSubgenres;
@@ -118,7 +140,7 @@ namespace YARG.Menu.Filters
         private static IReadOnlyList<string> _cachedPlaylists;
         private static IReadOnlyList<string> _cachedCharters;
         private static IReadOnlyList<string> _cachedLengths;
-        private static IReadOnlyList<string> _cachedIntensities;
+        private static readonly Dictionary<Instrument, IReadOnlyList<string>> _cachedIntensitiesByInstrument = new();
 
         private static int _cachedGenreSongCount = -1;
         private static int _cachedSubgenreSongCount = -1;
@@ -131,7 +153,6 @@ namespace YARG.Menu.Filters
         private static int _cachedLengthSongCount = -1;
         private static int _cachedIntensitySongCount = -1;
 
-        private static Instrument _cachedIntensityInstrument = Instrument.FiveFretGuitar;
 
         private static GameObject _settingsButtonPrefab;
 
@@ -152,7 +173,7 @@ namespace YARG.Menu.Filters
         public static Func<SongEntry, bool> ActiveFilterPredicate { get; private set; }
 
         private static bool _hasSavedFilters;
-        private static readonly Dictionary<FilterGroup, Dictionary<string, bool>> _savedFilters =
+        private static readonly Dictionary<FilterKey, Dictionary<string, bool>> _savedFilters =
             new();
 
         private FilterSortDropdownSetting _sortDropdownSetting;
@@ -311,43 +332,14 @@ namespace YARG.Menu.Filters
             _rightNavGroup.ClearNavigatables();
             _rightContainer.DestroyChildren();
 
-            switch (row.Filters)
-            {
-                case FilterGroup.Genre:
-                    BuildOptionsFor(FilterGroup.Genre);
-                    break;
-                case FilterGroup.Subgenre:
-                    BuildOptionsFor(FilterGroup.Subgenre);
-                    break;
-                case FilterGroup.Decade:
-                    BuildOptionsFor(FilterGroup.Decade);
-                    break;
-                case FilterGroup.VocalParts:
-                    BuildOptionsFor(FilterGroup.VocalParts);
-                    break;
-                case FilterGroup.Source:
-                    BuildOptionsFor(FilterGroup.Source);
-                    break;
-                case FilterGroup.Charter:
-                    BuildOptionsFor(FilterGroup.Charter);
-                    break;
-                case FilterGroup.Intensity:
-                    BuildOptionsFor(FilterGroup.Intensity);
-                    break;
-                case FilterGroup.Length:
-                    BuildOptionsFor(FilterGroup.Length);
-                    break;
-                case FilterGroup.Playlist:
-                    BuildOptionsFor(FilterGroup.Playlist);
-                    break;
-            }
+            BuildOptionsFor(row.Key);
         }
 
         private void CacheLeftRows()
         {
             _leftRows.Clear();
             foreach (var row in _leftContainer.GetComponentsInChildren<FilterCategoryRow>(true))
-                _leftRows[row.Filters] = row;
+                _leftRows[row.Key] = row;
         }
 
 #region Unity Prefab/Asset Building
@@ -362,18 +354,23 @@ namespace YARG.Menu.Filters
 
             AddHeader(container, Localize.Key("Menu.Filters.FiltersHeader"));
             rowIndex = 0;
-            AddGroup(container, navGroup, FilterGroup.Genre,  Localize.Key("Menu.Filters.Genres"))?.AssignIndex(rowIndex++);
-            AddGroup(container, navGroup, FilterGroup.Subgenre, Localize.Key("Menu.Filters.Subgenres"))?.AssignIndex(rowIndex++);
-            AddGroup(container, navGroup, FilterGroup.Decade, Localize.Key("Menu.Filters.Decades"))?.AssignIndex(rowIndex++);
-            AddGroup(container, navGroup, FilterGroup.VocalParts, Localize.Key("Menu.Filters.VocalParts.Name"))?.AssignIndex(rowIndex++);
-            AddGroup(container, navGroup, FilterGroup.Source, Localize.Key("Menu.Filters.Sources"))?.AssignIndex(rowIndex++);
-            AddGroup(container, navGroup, FilterGroup.Charter, Localize.Key("Menu.Filters.Charters"))?.AssignIndex(rowIndex++);
-            AddGroup(container, navGroup, FilterGroup.Intensity, Localize.Key("Menu.Filters.Intensities.Name"))?.AssignIndex(rowIndex++);
-            AddGroup(container, navGroup, FilterGroup.Length, Localize.Key("Menu.Filters.Length.Name"))?.AssignIndex(rowIndex++);
+            AddGroup(container, navGroup, new FilterKey(FilterGroup.Genre), Localize.Key("Menu.Filters.Genres"))?.AssignIndex(rowIndex++);
+            AddGroup(container, navGroup, new FilterKey(FilterGroup.Subgenre), Localize.Key("Menu.Filters.Subgenres"))?.AssignIndex(rowIndex++);
+            AddGroup(container, navGroup, new FilterKey(FilterGroup.Decade), Localize.Key("Menu.Filters.Decades"))?.AssignIndex(rowIndex++);
+            AddGroup(container, navGroup, new FilterKey(FilterGroup.VocalParts), Localize.Key("Menu.Filters.VocalParts.Name"))?.AssignIndex(rowIndex++);
+            AddGroup(container, navGroup, new FilterKey(FilterGroup.Source), Localize.Key("Menu.Filters.Sources"))?.AssignIndex(rowIndex++);
+            AddGroup(container, navGroup, new FilterKey(FilterGroup.Charter), Localize.Key("Menu.Filters.Charters"))?.AssignIndex(rowIndex++);
 
-            AddHeader(container, Localize.Key("Menu.Filters.ShowAnyOfHeader"));
-            rowIndex = 0;
-            AddGroup(container, navGroup, FilterGroup.Playlist, Localize.Key("Menu.Filters.Playlists"))?.AssignIndex(rowIndex++);
+            var intensityContexts = GetIntensityFilterContexts();
+            bool showIntensityContext = intensityContexts.Count > 1;
+            foreach (var context in intensityContexts)
+            {
+                var label = BuildIntensityGroupLabel(context, showIntensityContext);
+                AddGroup(container, navGroup, new FilterKey(FilterGroup.Intensity, context.ProfileId), label)
+                    ?.AssignIndex(rowIndex++);
+            }
+
+            AddGroup(container, navGroup, new FilterKey(FilterGroup.Length), Localize.Key("Menu.Filters.Length.Name"))?.AssignIndex(rowIndex++);
         }
 
         private void AddHeader(Transform container, string text)
@@ -387,18 +384,139 @@ namespace YARG.Menu.Filters
                 tmp.text = text;
         }
 
-        private FilterCategoryRow AddGroup(Transform container, NavigationGroup navGroup, FilterGroup group, string label)
+        private FilterCategoryRow AddGroup(Transform container, NavigationGroup navGroup, FilterKey key, string label)
         {
             var prefab = _filterCategoryRowPrefab;
             if (prefab == null) return null;
 
             var row = Instantiate(prefab, container);
 
-            string secondary = group == FilterGroup.Genre ? Localize.Key("Menu.Filters.All") : string.Empty;
+            string secondary = key.Group == FilterGroup.Genre ? Localize.Key("Menu.Filters.All") : string.Empty;
 
-            row.Init(group, label, secondary);
+            row.Init(key, label, secondary);
             navGroup.AddNavigatable(row);
             return row;
+        }
+
+        private static Instrument GetIntensityInstrumentForProfile(YargProfile profile)
+        {
+            if (profile == null)
+                return Instrument.FiveFretGuitar;
+
+            return profile.GameMode == GameMode.EliteDrums
+                ? Instrument.EliteDrums
+                : profile.CurrentInstrument;
+        }
+
+        private static List<IntensityFilterContext> GetIntensityFilterContexts()
+        {
+            var players = PlayerContainer.Players.Where(player => !player.Profile.IsBot).ToList();
+            if (players.Count == 0)
+            {
+                return new List<IntensityFilterContext>
+                {
+                    new(Guid.Empty, string.Empty, Instrument.FiveFretGuitar)
+                };
+            }
+
+            var contexts = new List<IntensityFilterContext>(players.Count);
+            var seenInstruments = new HashSet<Instrument>();
+            foreach (var player in players)
+            {
+                var profile = player.Profile;
+                var instrument = GetIntensityInstrumentForProfile(profile);
+                if (!seenInstruments.Add(instrument)) continue;
+
+                contexts.Add(new IntensityFilterContext(
+                    profile.Id,
+                    profile.Name,
+                    instrument));
+            }
+
+            return contexts;
+        }
+
+        private static string BuildIntensityGroupLabel(IntensityFilterContext context, bool showContext)
+        {
+            string baseLabel = Localize.Key("Menu.Filters.Intensities.Name");
+            if (!showContext)
+                return baseLabel;
+
+            string profileName = string.IsNullOrWhiteSpace(context.ProfileName)
+                ? Localize.Key(IntensityLabelUnknownKey)
+                : context.ProfileName;
+            string instrumentName = context.Instrument == Instrument.EliteDrums
+                ? SortAttribute.AggregateDrums.ToLocalizedName()
+                : context.Instrument.ToLocalizedName();
+            string contextLabel = $"({profileName} on {instrumentName})";
+
+            return $"{baseLabel} {TextColorer.StyleString(contextLabel, MenuData.Colors.TrackDefaultSecondary, 400)}";
+        }
+
+        private static FiltersMenu GetMenuInstance()
+        {
+            var menu = Instance;
+            if (menu == null)
+            {
+                var menus = Resources.FindObjectsOfTypeAll<FiltersMenu>();
+                if (menus != null && menus.Length > 0)
+                    menu = menus[0];
+            }
+
+            return menu;
+        }
+
+        public static void ResetIntensityFiltersForProfile(YargProfile profile)
+        {
+            if (profile == null) return;
+
+            var menu = GetMenuInstance();
+            if (menu == null) return;
+
+            menu.ResetIntensityFilters(profile);
+        }
+
+        public static void RefreshActiveFilterPredicate()
+        {
+            var menu = GetMenuInstance();
+            if (menu == null) return;
+
+            menu.RestoreSavedFilters();
+            menu.EnsureAllDefaults();
+            ActiveFilterPredicate = menu.BuildFilterPredicate();
+        }
+
+        private void ResetIntensityFilters(YargProfile profile)
+        {
+            var instrument = GetIntensityInstrumentForProfile(profile);
+            ResetIntensityFilters(profile.Id, instrument);
+        }
+
+        private void ResetIntensityFilters(Guid profileId, Instrument instrument)
+        {
+            var enabled = GetIntensityEnabled(profileId);
+            enabled.Clear();
+            foreach (var value in GetAllIntensitiesCached(instrument))
+                enabled[value] = true;
+
+            var key = new FilterKey(FilterGroup.Intensity, profileId);
+            _savedFilters[key] = new Dictionary<string, bool>(enabled, StringComparer.OrdinalIgnoreCase);
+
+            ActiveFilterPredicate = BuildFilterPredicate();
+
+            var library = FindFirstObjectByType<MusicLibraryMenu>();
+            library?.RefreshAndReselect();
+        }
+
+        private Dictionary<string, bool> GetIntensityEnabled(Guid profileId)
+        {
+            if (!_intensityEnabledByProfile.TryGetValue(profileId, out var enabled))
+            {
+                enabled = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
+                _intensityEnabledByProfile[profileId] = enabled;
+            }
+
+            return enabled;
         }
 
         private BaseSettingVisual AddDropdown(Transform container, NavigationGroup navGroup, string label)
@@ -719,34 +837,32 @@ namespace YARG.Menu.Filters
 
         private IEnumerable<FilterDef> GetFilterDefs()
         {
-            var IntensityInstrument = GetIntensityFilterInstrument();
-
             yield return new FilterDef(
-                FilterGroup.Genre,
+                new FilterKey(FilterGroup.Genre),
                 GetAllGenresCached,
                 () => GetCountsFromCollections(SongContainer.Genres, key => key.ToString()),
                 _genreEnabled);
 
             yield return new FilterDef(
-                FilterGroup.Subgenre,
+                new FilterKey(FilterGroup.Subgenre),
                 GetAllSubgenresCached,
                 () => GetCountsFromCollections(SongContainer.Subgenres, key => key.ToString()),
                 _subgenreEnabled);
 
             yield return new FilterDef(
-                FilterGroup.Decade,
+                new FilterKey(FilterGroup.Decade),
                 GetAllDecadesCached,
                 GetDecadeCounts,
                 _decadeEnabled);
 
             yield return new FilterDef(
-                FilterGroup.VocalParts,
+                new FilterKey(FilterGroup.VocalParts),
                 GetAllVocalPartsCached,
                 GetVocalPartsCounts,
                 _vocalPartsEnabled);
 
             yield return new FilterDef(
-                FilterGroup.Source,
+                new FilterKey(FilterGroup.Source),
                 GetAllSourcesCached,
                 () => GetCountsFromCollections(
                     SongContainer.Sources,
@@ -754,36 +870,35 @@ namespace YARG.Menu.Filters
                 _sourceEnabled);
 
             yield return new FilterDef(
-                FilterGroup.Playlist,
-                GetAllPlaylistsCached,
-                GetPlaylistCounts,
-                _playlistEnabled);
-
-            yield return new FilterDef(
-                FilterGroup.Charter,
+                new FilterKey(FilterGroup.Charter),
                 GetAllChartersCached,
                 () => GetCountsFromCollections(SongContainer.Charters, key => key.ToString()),
                 _charterEnabled,
                 WrapCharterLabel);
 
-            yield return new FilterDef(
-                FilterGroup.Intensity,
-                () => GetAllIntensitiesCached(IntensityInstrument),
-                () => GetIntensityCounts(IntensityInstrument),
-                _intensityEnabled);
+            foreach (var context in GetIntensityFilterContexts())
+            {
+                var instrument = context.Instrument;
+                yield return new FilterDef(
+                    new FilterKey(FilterGroup.Intensity, context.ProfileId),
+                    () => GetAllIntensitiesCached(instrument),
+                    () => GetIntensityCounts(instrument),
+                    GetIntensityEnabled(context.ProfileId),
+                    intensityInstrument: instrument);
+            }
 
             yield return new FilterDef(
-                FilterGroup.Length,
+                new FilterKey(FilterGroup.Length),
                 GetAllLengthsCached,
                 GetLengthCounts,
                 _lengthEnabled);
         }
 
-        private bool TryGetFilterDef(FilterGroup group, out FilterDef def)
+        private bool TryGetFilterDef(FilterKey key, out FilterDef def)
         {
             foreach (var candidate in GetFilterDefs())
             {
-                if (candidate.Group == group)
+                if (candidate.Key == key)
                 {
                     def = candidate;
                     return true;
@@ -812,7 +927,7 @@ namespace YARG.Menu.Filters
 
             foreach (var def in GetFilterDefs())
             {
-                if (!_savedFilters.TryGetValue(def.Group, out var saved))
+                if (!_savedFilters.TryGetValue(def.Key, out var saved))
                     continue;
 
                 def.Enabled.Clear();
@@ -826,7 +941,7 @@ namespace YARG.Menu.Filters
             _savedFilters.Clear();
             foreach (var def in GetFilterDefs())
             {
-                _savedFilters[def.Group] = new Dictionary<string, bool>(
+                _savedFilters[def.Key] = new Dictionary<string, bool>(
                     def.Enabled,
                     StringComparer.OrdinalIgnoreCase);
             }
@@ -837,12 +952,12 @@ namespace YARG.Menu.Filters
         private void UpdateAllSummaries()
         {
             foreach (var def in GetFilterDefs())
-                UpdateSummary(def.Group, def.Enabled, def.GetValues());
+                UpdateSummary(def.Key, def.Enabled, def.GetValues());
         }
 
-        private void BuildOptionsFor(FilterGroup group)
+        private void BuildOptionsFor(FilterKey key)
         {
-            if (!TryGetFilterDef(group, out var def)) return;
+            if (!TryGetFilterDef(key, out var def)) return;
 
             var values = def.GetValues();
             var counts = def.GetCounts();
@@ -853,9 +968,8 @@ namespace YARG.Menu.Filters
                 values,
                 def.Enabled,
                 counts,
-                () => UpdateSummary(def.Group, def.Enabled, def.GetValues()),
-                def.LabelTransform,
-                useDefaults);
+                () => UpdateSummary(def.Key, def.Enabled, def.GetValues()),
+                def.LabelTransform);
         }
 
         private static bool TryGetSelectedSet(
@@ -942,11 +1056,11 @@ namespace YARG.Menu.Filters
         }
 
         private void UpdateSummary(
-            FilterGroup group,
+            FilterKey key,
             Dictionary<string, bool> enabled,
             IReadOnlyList<string> values)
         {
-            if (!_leftRows.TryGetValue(group, out var row)) return;
+            if (!_leftRows.TryGetValue(key, out var row)) return;
 
             int total = values.Count;
             int selected = enabled.Count(kvp => kvp.Value);
@@ -1033,13 +1147,18 @@ namespace YARG.Menu.Filters
                     return label != null && lengths.Contains(NormalizeFilterKey(label));
                 });
 
-            var intensityInstrument = GetIntensityFilterInstrument();
-            if (TryGetSelectedSet(_intensityEnabled, GetAllIntensitiesCached(intensityInstrument), NormalizeFilterKey, out var intensities))
-                predicates.Add(entry =>
-                {
-                    var label = GetIntensityLabel(entry, intensityInstrument);
-                    return label != null && intensities.Contains(NormalizeFilterKey(label));
-                });
+            foreach (var def in GetFilterDefs())
+            {
+                if (def.Group != FilterGroup.Intensity) continue;
+
+                var instrument = def.IntensityInstrument;
+                if (TryGetSelectedSet(def.Enabled, def.GetValues(), NormalizeFilterKey, out var intensities))
+                    predicates.Add(entry =>
+                    {
+                        var label = GetIntensityLabel(entry, instrument);
+                        return label != null && intensities.Contains(NormalizeFilterKey(label));
+                    });
+            }
 
             if (predicates.Count == 0) return null;
 
@@ -1455,23 +1574,20 @@ namespace YARG.Menu.Filters
         private const string IntensityLabelUnknownKey = "Menu.Filters.Intensities.Unknown";
         private const string IntensityLabelNoPartKey = "Menu.Filters.Intensities.NoPart";
 
-        private static Instrument GetIntensityFilterInstrument()
-        {
-            foreach (var player in PlayerContainer.Players)
-            {
-                if (!player.Profile.IsBot) return player.Profile.CurrentInstrument;
-            }
-            return Instrument.FiveFretGuitar;
-        }
-
         private static IReadOnlyList<string> GetAllIntensitiesCached(Instrument instrument)
         {
-            if (_cachedIntensities != null && _cachedIntensitySongCount == SongContainer.Count && _cachedIntensityInstrument == instrument) return _cachedIntensities;
+            if (_cachedIntensitySongCount != SongContainer.Count)
+            {
+                _cachedIntensitySongCount = SongContainer.Count;
+                _cachedIntensitiesByInstrument.Clear();
+            }
 
-            _cachedIntensitySongCount = SongContainer.Count;
-            _cachedIntensityInstrument = instrument;
-            _cachedIntensities = BuildIntensityList(instrument);
-            return _cachedIntensities;
+            if (_cachedIntensitiesByInstrument.TryGetValue(instrument, out var cached))
+                return cached;
+
+            var built = BuildIntensityList(instrument);
+            _cachedIntensitiesByInstrument[instrument] = built;
+            return built;
         }
 
         private static IReadOnlyList<string> BuildIntensityList(Instrument instrument)
@@ -1733,7 +1849,7 @@ namespace YARG.Menu.Filters
             foreach (var def in GetFilterDefs())
             {
                 EnsureDefaults(def.Enabled, def.GetValues());
-                if (!_savedFilters.TryGetValue(def.Group, out var saved))
+                if (!_savedFilters.TryGetValue(def.Key, out var saved))
                     return true;
 
                 if (def.Enabled.Count != saved.Count)

--- a/Assets/Script/Menu/Filters/FiltersMenu.cs
+++ b/Assets/Script/Menu/Filters/FiltersMenu.cs
@@ -371,6 +371,10 @@ namespace YARG.Menu.Filters
             }
 
             AddGroup(container, navGroup, new FilterKey(FilterGroup.Length), Localize.Key("Menu.Filters.Length.Name"))?.AssignIndex(rowIndex++);
+
+            AddHeader(container, Localize.Key("Menu.Filters.ShowAnyOfHeader"));
+            rowIndex = 0;
+            AddGroup(container, navGroup, new FilterKey(FilterGroup.Playlist), Localize.Key("Menu.Filters.Playlists"))?.AssignIndex(rowIndex++);
         }
 
         private void AddHeader(Transform container, string text)
@@ -834,6 +838,65 @@ namespace YARG.Menu.Filters
                 StringTransformations.RemoveDiacritics(
                     RichTextUtils.StripRichTextTags(text)));
         }
+        
+        private const int FilterLabelWrapLimit = 30;
+
+        private static string WrapFilterLabel(string text)
+        {
+            if (string.IsNullOrWhiteSpace(text)) return text;
+
+            string plain = RichTextUtils.StripRichTextTags(text);
+            if (plain.Length <= FilterLabelWrapLimit) return text;
+
+            int breakVisibleIndex = FindLastWhitespaceIndex(plain, FilterLabelWrapLimit);
+            if (breakVisibleIndex < 0)
+                breakVisibleIndex = FilterLabelWrapLimit;
+
+            return InsertLineBreakAtVisibleIndex(text, breakVisibleIndex);
+        }
+
+        private static int FindLastWhitespaceIndex(string text, int maxIndex)
+        {
+            int last = -1;
+            int limit = Math.Min(text.Length - 1, maxIndex);
+            for (int i = 0; i <= limit; i++)
+            {
+                if (char.IsWhiteSpace(text[i]))
+                    last = i;
+            }
+            return last;
+        }
+
+        private static string InsertLineBreakAtVisibleIndex(string text, int visibleIndex)
+        {
+            int visibleCount = 0;
+            bool inTag = false;
+            for (int i = 0; i < text.Length; i++)
+            {
+                char c = text[i];
+                if (c == '<')
+                    inTag = true;
+                else if (c == '>' && inTag)
+                {
+                    inTag = false;
+                    continue;
+                }
+
+                if (inTag)
+                    continue;
+
+                if (visibleCount == visibleIndex)
+                {
+                    if (char.IsWhiteSpace(c)) return text.Remove(i, 1).Insert(i, "\n");
+
+                    return text.Insert(i, "\n");
+                }
+
+                visibleCount++;
+            }
+
+            return text;
+        }
 
         private IEnumerable<FilterDef> GetFilterDefs()
         {
@@ -867,14 +930,22 @@ namespace YARG.Menu.Filters
                 () => GetCountsFromCollections(
                     SongContainer.Sources,
                     key => SongSources.SourceToGameName(key.ToString())),
-                _sourceEnabled);
+                _sourceEnabled,
+                WrapFilterLabel);
+
+            yield return new FilterDef(
+                new FilterKey(FilterGroup.Playlist),
+                GetAllPlaylistsCached,
+                GetPlaylistCounts,
+                _playlistEnabled,
+                WrapFilterLabel);
 
             yield return new FilterDef(
                 new FilterKey(FilterGroup.Charter),
                 GetAllChartersCached,
                 () => GetCountsFromCollections(SongContainer.Charters, key => key.ToString()),
                 _charterEnabled,
-                WrapCharterLabel);
+                WrapFilterLabel);
 
             foreach (var context in GetIntensityFilterContexts())
             {
@@ -961,7 +1032,7 @@ namespace YARG.Menu.Filters
 
             var values = def.GetValues();
             var counts = def.GetCounts();
-            bool useDefaults = group != FilterGroup.Playlist;
+            bool useDefaults = def.Group != FilterGroup.Playlist;
             if (!useDefaults)
                 EnsureDefaults(def.Enabled, values, defaultValue: false);
             BuildOptions(
@@ -1066,7 +1137,7 @@ namespace YARG.Menu.Filters
             int selected = enabled.Count(kvp => kvp.Value);
 
             string text;
-            if (group == FilterGroup.Playlist)
+            if (key.Group == FilterGroup.Playlist)
             {
                 text = selected == 0
                     ? Localize.Key("Menu.Filters.None")
@@ -1177,7 +1248,7 @@ namespace YARG.Menu.Filters
             {
                 bool? rightPanelDefault = null;
                 if (_leftNavGroup?.SelectedBehaviour is FilterCategoryRow row)
-                    rightPanelDefault = IsShowAnyOfGroup(row.Filters) ? false : true;
+                    rightPanelDefault = IsShowAnyOfGroup(row.Group) ? false : true;
 
                 if (rightPanelDefault.HasValue)
                 {
@@ -1400,64 +1471,6 @@ namespace YARG.Menu.Filters
                     .OrderBy(s => RichTextUtils.StripRichTextTags(s), StringComparer.OrdinalIgnoreCase)
                     .ThenBy(s => s, StringComparer.OrdinalIgnoreCase)
                     .ToArray());
-        }
-        private const int CharterWrapLimit = 30;
-
-        private static string WrapCharterLabel(string text)
-        {
-            if (string.IsNullOrWhiteSpace(text)) return text;
-
-            string plain = RichTextUtils.StripRichTextTags(text);
-            if (plain.Length <= CharterWrapLimit) return text;
-
-            int breakVisibleIndex = FindLastWhitespaceIndex(plain, CharterWrapLimit);
-            if (breakVisibleIndex < 0)
-                breakVisibleIndex = CharterWrapLimit;
-
-            return InsertLineBreakAtVisibleIndex(text, breakVisibleIndex);
-        }
-
-        private static int FindLastWhitespaceIndex(string text, int maxIndex)
-        {
-            int last = -1;
-            int limit = Math.Min(text.Length - 1, maxIndex);
-            for (int i = 0; i <= limit; i++)
-            {
-                if (char.IsWhiteSpace(text[i]))
-                    last = i;
-            }
-            return last;
-        }
-
-        private static string InsertLineBreakAtVisibleIndex(string text, int visibleIndex)
-        {
-            int visibleCount = 0;
-            bool inTag = false;
-            for (int i = 0; i < text.Length; i++)
-            {
-                char c = text[i];
-                if (c == '<')
-                    inTag = true;
-                else if (c == '>' && inTag)
-                {
-                    inTag = false;
-                    continue;
-                }
-
-                if (inTag)
-                    continue;
-
-                if (visibleCount == visibleIndex)
-                {
-                    if (char.IsWhiteSpace(c)) return text.Remove(i, 1).Insert(i, "\n");
-
-                    return text.Insert(i, "\n");
-                }
-
-                visibleCount++;
-            }
-
-            return text;
         }
 #endregion
 

--- a/Assets/Script/Menu/Filters/FiltersMenu.cs
+++ b/Assets/Script/Menu/Filters/FiltersMenu.cs
@@ -107,7 +107,7 @@ namespace YARG.Menu.Filters
             new(StringComparer.OrdinalIgnoreCase);
         private readonly Dictionary<string, bool> _lengthEnabled =
             new(StringComparer.OrdinalIgnoreCase);
-        private readonly Dictionary<string, bool> _difficultyEnabled =
+        private readonly Dictionary<string, bool> _intensityEnabled =
             new(StringComparer.OrdinalIgnoreCase);
 
         private static IReadOnlyList<string> _cachedGenres;
@@ -118,8 +118,7 @@ namespace YARG.Menu.Filters
         private static IReadOnlyList<string> _cachedPlaylists;
         private static IReadOnlyList<string> _cachedCharters;
         private static IReadOnlyList<string> _cachedLengths;
-        private static IReadOnlyList<string> _cachedDifficulties;
-        private static Dictionary<string, int> _cachedPlaylistCounts;
+        private static IReadOnlyList<string> _cachedIntensities;
 
         private static int _cachedGenreSongCount = -1;
         private static int _cachedSubgenreSongCount = -1;
@@ -130,9 +129,9 @@ namespace YARG.Menu.Filters
         private static int _cachedPlaylistCountsSignature = -1;
         private static int _cachedCharterSongCount = -1;
         private static int _cachedLengthSongCount = -1;
-        private static int _cachedDifficultySongCount = -1;
+        private static int _cachedIntensitySongCount = -1;
 
-        private static Instrument _cachedDifficultyInstrument = Instrument.FiveFretGuitar;
+        private static Instrument _cachedIntensityInstrument = Instrument.FiveFretGuitar;
 
         private static GameObject _settingsButtonPrefab;
 
@@ -332,8 +331,8 @@ namespace YARG.Menu.Filters
                 case FilterGroup.Charter:
                     BuildOptionsFor(FilterGroup.Charter);
                     break;
-                case FilterGroup.Difficulty:
-                    BuildOptionsFor(FilterGroup.Difficulty);
+                case FilterGroup.Intensity:
+                    BuildOptionsFor(FilterGroup.Intensity);
                     break;
                 case FilterGroup.Length:
                     BuildOptionsFor(FilterGroup.Length);
@@ -369,7 +368,7 @@ namespace YARG.Menu.Filters
             AddGroup(container, navGroup, FilterGroup.VocalParts, Localize.Key("Menu.Filters.VocalParts.Name"))?.AssignIndex(rowIndex++);
             AddGroup(container, navGroup, FilterGroup.Source, Localize.Key("Menu.Filters.Sources"))?.AssignIndex(rowIndex++);
             AddGroup(container, navGroup, FilterGroup.Charter, Localize.Key("Menu.Filters.Charters"))?.AssignIndex(rowIndex++);
-            AddGroup(container, navGroup, FilterGroup.Difficulty, Localize.Key("Menu.Filters.Difficulties.Name"))?.AssignIndex(rowIndex++);
+            AddGroup(container, navGroup, FilterGroup.Intensity, Localize.Key("Menu.Filters.Intensities.Name"))?.AssignIndex(rowIndex++);
             AddGroup(container, navGroup, FilterGroup.Length, Localize.Key("Menu.Filters.Length.Name"))?.AssignIndex(rowIndex++);
 
             AddHeader(container, Localize.Key("Menu.Filters.ShowAnyOfHeader"));
@@ -720,7 +719,7 @@ namespace YARG.Menu.Filters
 
         private IEnumerable<FilterDef> GetFilterDefs()
         {
-            var difficultyInstrument = GetDifficultyFilterInstrument();
+            var IntensityInstrument = GetIntensityFilterInstrument();
 
             yield return new FilterDef(
                 FilterGroup.Genre,
@@ -768,10 +767,10 @@ namespace YARG.Menu.Filters
                 WrapCharterLabel);
 
             yield return new FilterDef(
-                FilterGroup.Difficulty,
-                () => GetAllDifficultiesCached(difficultyInstrument),
-                () => GetDifficultyCounts(difficultyInstrument),
-                _difficultyEnabled);
+                FilterGroup.Intensity,
+                () => GetAllIntensitiesCached(IntensityInstrument),
+                () => GetIntensityCounts(IntensityInstrument),
+                _intensityEnabled);
 
             yield return new FilterDef(
                 FilterGroup.Length,
@@ -1034,12 +1033,12 @@ namespace YARG.Menu.Filters
                     return label != null && lengths.Contains(NormalizeFilterKey(label));
                 });
 
-            var difficultyInstrument = GetDifficultyFilterInstrument();
-            if (TryGetSelectedSet(_difficultyEnabled, GetAllDifficultiesCached(difficultyInstrument), NormalizeFilterKey, out var difficulties))
+            var intensityInstrument = GetIntensityFilterInstrument();
+            if (TryGetSelectedSet(_intensityEnabled, GetAllIntensitiesCached(intensityInstrument), NormalizeFilterKey, out var intensities))
                 predicates.Add(entry =>
                 {
-                    var label = GetDifficultyLabel(entry, difficultyInstrument);
-                    return label != null && difficulties.Contains(NormalizeFilterKey(label));
+                    var label = GetIntensityLabel(entry, intensityInstrument);
+                    return label != null && intensities.Contains(NormalizeFilterKey(label));
                 });
 
             if (predicates.Count == 0) return null;
@@ -1441,22 +1440,22 @@ namespace YARG.Menu.Filters
         }
 #endregion
 
-#region Difficulties
-        private static readonly string[] DifficultyLabelKeys =
+#region Intensities
+        private static readonly string[] IntensityLabelKeys =
         {
-            "Menu.Filters.Difficulties.WarmUp",
-            "Menu.Filters.Difficulties.Apprentice",
-            "Menu.Filters.Difficulties.Solid",
-            "Menu.Filters.Difficulties.Moderate",
-            "Menu.Filters.Difficulties.Challenging",
-            "Menu.Filters.Difficulties.Nightmare",
-            "Menu.Filters.Difficulties.Impossible",
+            "Menu.Filters.Intensities.WarmUp",
+            "Menu.Filters.Intensities.Apprentice",
+            "Menu.Filters.Intensities.Solid",
+            "Menu.Filters.Intensities.Moderate",
+            "Menu.Filters.Intensities.Challenging",
+            "Menu.Filters.Intensities.Nightmare",
+            "Menu.Filters.Intensities.Impossible",
         };
 
-        private const string DifficultyLabelUnknownKey = "Menu.Filters.Difficulties.Unknown";
-        private const string DifficultyLabelNoPartKey = "Menu.Filters.Difficulties.NoPart";
+        private const string IntensityLabelUnknownKey = "Menu.Filters.Intensities.Unknown";
+        private const string IntensityLabelNoPartKey = "Menu.Filters.Intensities.NoPart";
 
-        private static Instrument GetDifficultyFilterInstrument()
+        private static Instrument GetIntensityFilterInstrument()
         {
             foreach (var player in PlayerContainer.Players)
             {
@@ -1465,46 +1464,46 @@ namespace YARG.Menu.Filters
             return Instrument.FiveFretGuitar;
         }
 
-        private static IReadOnlyList<string> GetAllDifficultiesCached(Instrument instrument)
+        private static IReadOnlyList<string> GetAllIntensitiesCached(Instrument instrument)
         {
-            if (_cachedDifficulties != null && _cachedDifficultySongCount == SongContainer.Count && _cachedDifficultyInstrument == instrument) return _cachedDifficulties;
+            if (_cachedIntensities != null && _cachedIntensitySongCount == SongContainer.Count && _cachedIntensityInstrument == instrument) return _cachedIntensities;
 
-            _cachedDifficultySongCount = SongContainer.Count;
-            _cachedDifficultyInstrument = instrument;
-            _cachedDifficulties = BuildDifficultyList(instrument);
-            return _cachedDifficulties;
+            _cachedIntensitySongCount = SongContainer.Count;
+            _cachedIntensityInstrument = instrument;
+            _cachedIntensities = BuildIntensityList(instrument);
+            return _cachedIntensities;
         }
 
-        private static IReadOnlyList<string> BuildDifficultyList(Instrument instrument)
+        private static IReadOnlyList<string> BuildIntensityList(Instrument instrument)
         {
-            var counts = GetDifficultyCounts(instrument);
-            var ordered = new List<string>(DifficultyLabelKeys.Length + 2);
+            var counts = GetIntensityCounts(instrument);
+            var ordered = new List<string>(IntensityLabelKeys.Length + 2);
 
-            for (int i = 0; i < DifficultyLabelKeys.Length; i++)
+            for (int i = 0; i < IntensityLabelKeys.Length; i++)
             {
-                var label = GetDifficultyLabelByIndex(i);
+                var label = GetIntensityLabelByIndex(i);
                 if (counts.TryGetValue(label, out int count) && count > 0)
                     ordered.Add(label);
             }
 
-            var unknownLabel = Localize.Key(DifficultyLabelUnknownKey);
+            var unknownLabel = Localize.Key(IntensityLabelUnknownKey);
             if (counts.TryGetValue(unknownLabel, out int unknownCount) && unknownCount > 0)
                 ordered.Add(unknownLabel);
 
-            var noPartLabel = Localize.Key(DifficultyLabelNoPartKey);
+            var noPartLabel = Localize.Key(IntensityLabelNoPartKey);
             if (counts.TryGetValue(noPartLabel, out int noPartCount) && noPartCount > 0)
                 ordered.Add(noPartLabel);
 
             return ordered;
         }
 
-        private static Dictionary<string, int> GetDifficultyCounts(Instrument instrument)
+        private static Dictionary<string, int> GetIntensityCounts(Instrument instrument)
         {
             var dict = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
 
             foreach (var song in SongContainer.Songs)
             {
-                var label = GetDifficultyLabel(song, instrument);
+                var label = GetIntensityLabel(song, instrument);
                 if (string.IsNullOrWhiteSpace(label))
                     continue;
 
@@ -1515,25 +1514,44 @@ namespace YARG.Menu.Filters
             return dict;
         }
 
-        private static string GetDifficultyLabel(SongEntry entry, Instrument instrument)
+        private static string GetIntensityLabel(SongEntry entry, Instrument instrument)
         {
+            if (instrument == Instrument.EliteDrums)
+            {
+                var preferredInstrument = MidiDrumkitHelper.GetPreferredInstrumentForSong(entry);
+                if (!preferredInstrument.HasValue)
+                    return Localize.Key(IntensityLabelNoPartKey);
+
+                var preferredPart = entry[preferredInstrument.Value];
+                if (!preferredPart.IsActive())
+                    return Localize.Key(IntensityLabelNoPartKey);
+
+                int preferredIntensity = preferredPart.Intensity;
+                if (preferredIntensity < 0) return Localize.Key(IntensityLabelUnknownKey);
+
+                if (preferredIntensity >= IntensityLabelKeys.Length)
+                    return GetIntensityLabelByIndex(IntensityLabelKeys.Length - 1);
+
+                return GetIntensityLabelByIndex(preferredIntensity);
+            }
+
             var part = entry[instrument];
-            if (!part.IsActive()) return Localize.Key(DifficultyLabelNoPartKey);
+            if (!part.IsActive()) return Localize.Key(IntensityLabelNoPartKey);
 
             int intensity = part.Intensity;
-            if (intensity < 0) return Localize.Key(DifficultyLabelUnknownKey);
+            if (intensity < 0) return Localize.Key(IntensityLabelUnknownKey);
 
-            if (intensity >= DifficultyLabelKeys.Length) return GetDifficultyLabelByIndex(DifficultyLabelKeys.Length - 1);
+            if (intensity >= IntensityLabelKeys.Length) return GetIntensityLabelByIndex(IntensityLabelKeys.Length - 1);
 
-            return GetDifficultyLabelByIndex(intensity);
+            return GetIntensityLabelByIndex(intensity);
         }
 
-        private static string GetDifficultyLabelByIndex(int index)
+        private static string GetIntensityLabelByIndex(int index)
         {
             if (index < 0) return null;
-            if (index >= DifficultyLabelKeys.Length) index = DifficultyLabelKeys.Length - 1;
+            if (index >= IntensityLabelKeys.Length) index = IntensityLabelKeys.Length - 1;
 
-            return Localize.Key(DifficultyLabelKeys[index]);
+            return Localize.Key(IntensityLabelKeys[index]);
         }
 #endregion
 

--- a/Assets/Script/Menu/MusicLibrary/ViewTypes/SongViewType.cs
+++ b/Assets/Script/Menu/MusicLibrary/ViewTypes/SongViewType.cs
@@ -3,7 +3,7 @@ using Cysharp.Text;
 using UnityEngine;
 using YARG.Core.Game;
 using YARG.Core.Song;
-using YARG.Menu.Persistent;
+using YARG.Helpers;
 using YARG.Player;
 using YARG.Playlists;
 using YARG.Scores;

--- a/Assets/Script/Menu/ProfileList/ProfileSidebar.cs
+++ b/Assets/Script/Menu/ProfileList/ProfileSidebar.cs
@@ -12,6 +12,7 @@ using YARG.Core.Game;
 using YARG.Helpers.Extensions;
 using YARG.Localization;
 using YARG.Menu.Data;
+using YARG.Menu.Filters;
 using YARG.Menu.Persistent;
 using YARG.Menu.ProfileInfo;
 using YARG.Player;
@@ -393,6 +394,7 @@ namespace YARG.Menu.ProfileList
             _profile.CurrentInstrument = _profile.GameMode.PossibleInstruments()[0];
 
             _profileView.UpdateDisplay(_profile);
+            FiltersMenu.ResetIntensityFiltersForProfile(_profile);
             // Update sidebar when game mode changes so the correct settings are displayed
             UpdateSidebar(_profile, _profileView);
         }

--- a/Assets/Script/Player/PlayerContainer.cs
+++ b/Assets/Script/Player/PlayerContainer.cs
@@ -14,6 +14,7 @@ using YARG.Input;
 using YARG.Input.Bindings;
 using YARG.Localization;
 using YARG.Menu.MusicLibrary;
+using YARG.Menu.Filters;
 using YARG.Menu.Persistent;
 using YARG.Menu.ProfileList;
 using YARG.Settings;
@@ -185,6 +186,9 @@ namespace YARG.Player
             {
                 MusicLibraryMenu.SetReload(MusicLibraryReloadState.Full);
             }
+
+            FiltersMenu.RefreshActiveFilterPredicate();
+            MusicLibraryMenu.NeedsReload();
 
             StatsManager.Instance?.UpdateActivePlayers();
         }

--- a/Assets/StreamingAssets/lang/en-US.json
+++ b/Assets/StreamingAssets/lang/en-US.json
@@ -536,8 +536,8 @@
             },
             "Sources": "Song Sources",
             "Charters": "Charters",
-            "Difficulties": {
-                "Name": "Difficulties",
+            "Intensities": {
+                "Name": "Intensities",
                 "WarmUp": "Warm Up",
                 "Apprentice": "Apprentice",
                 "Solid": "Solid",

--- a/Assets/StreamingAssets/lang/en-US.json
+++ b/Assets/StreamingAssets/lang/en-US.json
@@ -531,8 +531,9 @@
             "VocalParts": {
                 "Name": "Number of Vocal Parts",
                 "Solo": "Solo",
-                "Duet": "2-Part Harmony",
-                "Trio": "3-Part Harmony"
+                "Duet": "Duet / 2-Part Harmony",
+                "Trio": "Trio / 3-Part Harmony",
+                "Instrumental": "Instrumental"
             },
             "Sources": "Song Sources",
             "Charters": "Charters",


### PR DESCRIPTION
- Remove "Advanced" indicator outside `SettingsMenu`
- Rename **Difficulties** to **Intensities** to reduce confusion.  **Difficulty** is Easy, Medium, Hard, Expert.  **Intensity** is a rating 0–6 (when not expanded).  _(see image 1, left side)_
- Add **Instrumental** option to **Number of Vocal Parts**  _(see image 1, right side)_
- Show **Intensity** filter option for every unique instrument  _(see image 2)_
- Make filter-option wrapping logic generic and apply to **Sources** and **Playlists**.

<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/929e63d7-3294-4779-a696-5dc31b64c7c3" />
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/ea7548a6-dc01-47c1-9710-cf02996b9032" />

_note:_ This change was originally part of #1413.  I've split it out as they were only very loosely related.