### PR TITLE
Remove Dead Playlist Hashes

### DIFF
--- a/Assets/Script/Playlists/Playlist.cs
+++ b/Assets/Script/Playlists/Playlist.cs
@@ -47,20 +47,14 @@ namespace YARG.Playlists
             if (!ContainsSong(song))
             {
                 SongHashes.Add(song.Hash);
-                if (!Ephemeral)
-                {
-                    PlaylistContainer.SavePlaylist(this);
-                }
+                SaveAfterManualEdit();
             }
         }
 
         public void RemoveSong(SongEntry song)
         {
             SongHashes.Remove(song.Hash);
-            if (!Ephemeral)
-            {
-                PlaylistContainer.SavePlaylist(this);
-            }
+            SaveAfterManualEdit();
         }
 
         public bool ContainsSong(SongEntry song)
@@ -92,7 +86,7 @@ namespace YARG.Playlists
             if (index > 0)
             {
                 (SongHashes[index - 1], SongHashes[index]) = (SongHashes[index], SongHashes[index - 1]);
-                PlaylistContainer.SavePlaylist(this);
+                SaveAfterManualEdit();
             }
         }
 
@@ -105,7 +99,7 @@ namespace YARG.Playlists
             if (index < SongHashes.Count - 1)
             {
                 (SongHashes[index + 1], SongHashes[index]) = (SongHashes[index], SongHashes[index + 1]);
-                PlaylistContainer.SavePlaylist(this);
+                SaveAfterManualEdit();
             }
         }
 
@@ -134,10 +128,7 @@ namespace YARG.Playlists
                 SongHashes.Add(song.Hash);
             }
 
-            if (!Ephemeral)
-            {
-                PlaylistContainer.SavePlaylist(this);
-            }
+            SaveAfterManualEdit();
         }
 
         public void SortByArtist(bool ascending = true)
@@ -160,10 +151,18 @@ namespace YARG.Playlists
                 SongHashes.Add(song.Hash);
             }
 
-            if (!Ephemeral)
+            SaveAfterManualEdit();
+        }
+
+        private void SaveAfterManualEdit()
+        {
+            if (Ephemeral)
             {
-                PlaylistContainer.SavePlaylist(this);
+                return;
             }
+
+            PlaylistContainer.RemoveDeadHashes(this, SongContainer.SongsByHash);
+            PlaylistContainer.SavePlaylist(this);
         }
     }
 }

--- a/Assets/Script/Playlists/PlaylistContainer.cs
+++ b/Assets/Script/Playlists/PlaylistContainer.cs
@@ -92,6 +92,68 @@ namespace YARG.Playlists
             SavePlaylist(FavoritesPlaylist, _favoritesPath);
         }
 
+        public static int RemoveDeadHashes(IReadOnlyDictionary<HashWrapper, List<SongEntry>> songsByHash)
+        {
+            if (songsByHash == null)
+            {
+                return 0;
+            }
+
+            int removed = 0;
+
+            if (FavoritesPlaylist != null)
+            {
+                if (RemoveDeadHashesFromPlaylist(FavoritesPlaylist, songsByHash, ref removed))
+                {
+                    SavePlaylist(FavoritesPlaylist, _favoritesPath);
+                }
+            }
+
+            foreach (var playlist in _playlists)
+            {
+                if (RemoveDeadHashesFromPlaylist(playlist, songsByHash, ref removed))
+                {
+                    SavePlaylist(playlist);
+                }
+            }
+
+            if (removed > 0)
+            {
+                YargLogger.LogFormatInfo("Removed {0} dead song hashes from playlists", removed);
+            }
+
+            return removed;
+        }
+
+        private static bool RemoveDeadHashesFromPlaylist(Playlist playlist, IReadOnlyDictionary<HashWrapper, List<SongEntry>> songsByHash, ref int removed)
+        {
+            if (playlist.SongHashes == null || playlist.SongHashes.Count == 0)
+            {
+                return false;
+            }
+
+            int originalCount = playlist.SongHashes.Count;
+            var kept = new List<HashWrapper>(originalCount);
+
+            foreach (var hash in playlist.SongHashes)
+            {
+                if (songsByHash.ContainsKey(hash))
+                {
+                    kept.Add(hash);
+                }
+            }
+
+            if (kept.Count == originalCount)
+            {
+                return false;
+            }
+
+            removed += originalCount - kept.Count;
+            playlist.SongHashes.Clear();
+            playlist.SongHashes.AddRange(kept);
+            return true;
+        }
+
         public static void SavePlaylist(Playlist playlist)
         {
             var path = Path.Join(PlaylistDirectory, GetFileNameForPlaylist(playlist));
@@ -192,7 +254,16 @@ namespace YARG.Playlists
 
         private static void SortPlaylistsByName()
         {
-            _playlists.Sort((a, b) => string.Compare(a.Name, b.Name, StringComparison.OrdinalIgnoreCase));
+            _playlists.Sort((a, b) =>
+            {
+                string nameA = a?.Name ?? string.Empty;
+                string nameB = b?.Name ?? string.Empty;
+                string sortA = RichTextUtils.StripRichTextTags(nameA);
+                string sortB = RichTextUtils.StripRichTextTags(nameB);
+
+                int result = string.Compare(sortA, sortB, StringComparison.OrdinalIgnoreCase);
+                return result != 0 ? result : string.Compare(nameA, nameB, StringComparison.OrdinalIgnoreCase);
+            });
         }
     }
 }

--- a/Assets/Script/Playlists/PlaylistContainer.cs
+++ b/Assets/Script/Playlists/PlaylistContainer.cs
@@ -92,34 +92,19 @@ namespace YARG.Playlists
             SavePlaylist(FavoritesPlaylist, _favoritesPath);
         }
 
-        public static int RemoveDeadHashes(IReadOnlyDictionary<HashWrapper, List<SongEntry>> songsByHash)
+        public static int RemoveDeadHashes(Playlist playlist, IReadOnlyDictionary<HashWrapper, List<SongEntry>> songsByHash)
         {
-            if (songsByHash == null)
+            if (playlist == null || songsByHash == null)
             {
                 return 0;
             }
 
             int removed = 0;
-
-            if (FavoritesPlaylist != null)
-            {
-                if (RemoveDeadHashesFromPlaylist(FavoritesPlaylist, songsByHash, ref removed))
-                {
-                    SavePlaylist(FavoritesPlaylist, _favoritesPath);
-                }
-            }
-
-            foreach (var playlist in _playlists)
-            {
-                if (RemoveDeadHashesFromPlaylist(playlist, songsByHash, ref removed))
-                {
-                    SavePlaylist(playlist);
-                }
-            }
+            RemoveDeadHashesFromPlaylist(playlist, songsByHash, ref removed);
 
             if (removed > 0)
             {
-                YargLogger.LogFormatInfo("Removed {0} dead song hashes from playlists", removed);
+                YargLogger.LogInfo($"Removed {removed} dead song hashes from playlist '{playlist.Name}'");
             }
 
             return removed;

--- a/Assets/Script/Song/SongContainer.cs
+++ b/Assets/Script/Song/SongContainer.cs
@@ -14,7 +14,6 @@ using YARG.Helpers.Extensions;
 using YARG.Localization;
 using YARG.Menu.MusicLibrary;
 using YARG.Player;
-using YARG.Playlists;
 using YARG.Scores;
 using YARG.Settings;
 
@@ -182,7 +181,6 @@ namespace YARG.Song
             }
             SongSorting.SortEntries(_songCache, _sortedSongs);
             FillContainers();
-            PlaylistContainer.RemoveDeadHashes(SongsByHash);
             stopwatch.Stop();
 
             YargLogger.LogFormatInfo("Scan time: {0}s", stopwatch.Elapsed.TotalSeconds);

--- a/Assets/Script/Song/SongContainer.cs
+++ b/Assets/Script/Song/SongContainer.cs
@@ -14,6 +14,7 @@ using YARG.Helpers.Extensions;
 using YARG.Localization;
 using YARG.Menu.MusicLibrary;
 using YARG.Player;
+using YARG.Playlists;
 using YARG.Scores;
 using YARG.Settings;
 
@@ -181,6 +182,7 @@ namespace YARG.Song
             }
             SongSorting.SortEntries(_songCache, _sortedSongs);
             FillContainers();
+            PlaylistContainer.RemoveDeadHashes(SongsByHash);
             stopwatch.Stop();
 
             YargLogger.LogFormatInfo("Scan time: {0}s", stopwatch.Elapsed.TotalSeconds);


### PR DESCRIPTION
When deleting or modifying a song on disc _(and therefore, removing/changing song hash)_, that inaccessible, *dead* hash was still on the playlist file.
For normal users, this resulted in empty spaces in the playlist manager in game.  You could press left/right to re-order your playlist, and it would sometimes look like nothing is happening because you're moving songs around the *dead* hashes that no longer exist.
For power users/developers, the playlist in game will say one number, and the playlist file on disc will include all the *dead* hashes and show a higher number.
~~Made a change so when rescanning your library, it removes the *dead* hashes from existing playlists.~~ (see feedback item below)

_note:_ This change was originally part of #1413.  I've split it out as they were only very loosely related.