### PR TITLE
Save and Load Collapsed Headers Between Music Library Visits

### DIFF
--- a/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.SortFilter.cs
+++ b/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.SortFilter.cs
@@ -42,6 +42,7 @@ namespace YARG.Menu.MusicLibrary
         public bool HasSortHeaders { get; private set; }
 
         private SongCategory[] _sortedSongs;
+        private SongCategory[] _collapsedHeaderTargets;
         private SortAttribute _playlistSort = SortAttribute.Name;
         private bool _playlistSortAscending = true;
         private static readonly Dictionary<SortAttribute, HashSet<SongCategory>> _collapsedHeaders = new();
@@ -112,6 +113,7 @@ namespace YARG.Menu.MusicLibrary
             if (!PlaylistMode)
             {
                 _sortedSongs = _searchField.Search(SettingsManager.Settings.LibrarySort);
+                _collapsedHeaderTargets = _sortedSongs;
                 // _sortedSongs = ApplyCollapsedSectionsForCurrentSort(_sortedSongs);
                 _searchField.gameObject.SetActive(true);
             }
@@ -134,6 +136,7 @@ namespace YARG.Menu.MusicLibrary
                 {
                     new(GetPlaylistDisplayName(SelectedPlaylist), songs[..count], null)
                 };
+                _collapsedHeaderTargets = _sortedSongs;
 
                 _searchField.gameObject.SetActive(false);
             }
@@ -150,9 +153,8 @@ namespace YARG.Menu.MusicLibrary
             bool shouldApplyFilters = inLibrary && predicate != null;
             bool shouldShowFilteredCounts = inLibrary && (_searchField.IsSearching || predicate != null);
 
-            if (shouldApplyFilters) {
-                _sortedSongs = ApplyFilterPredicate(_sortedSongs, predicate);
-            }
+            if (shouldApplyFilters)
+                _sortedSongs = ApplyFilterPredicate(_sortedSongs, predicate, _collapsedHeaderTargets, out _collapsedHeaderTargets);
 
             if (shouldShowFilteredCounts)
             {
@@ -527,13 +529,28 @@ namespace YARG.Menu.MusicLibrary
             return menu != null && menu.gameObject.activeInHierarchy;
         }
 
-        private static SongCategory[] ApplyFilterPredicate(SongCategory[] categories, Func<SongEntry, bool> predicate)
+        private SongCategory GetCollapseTarget(int index, SongCategory fallback)
         {
+            if (_collapsedHeaderTargets != null && (uint) index < (uint) _collapsedHeaderTargets.Length)
+                return _collapsedHeaderTargets[index];
+
+            return fallback;
+        }
+
+        private static SongCategory[] ApplyFilterPredicate(
+            SongCategory[] categories,
+            Func<SongEntry, bool> predicate,
+            SongCategory[] collapseTargets,
+            out SongCategory[] filteredCollapseTargets)
+        {
+            collapseTargets ??= categories;
             var result = new SongCategory[categories.Length];
+            var filteredTargets = new SongCategory[categories.Length];
             int count = 0;
 
-            foreach (var category in categories)
+            for (int i = 0; i < categories.Length; i++)
             {
+                var category = categories[i];
                 var songs = category.Songs.Where(predicate).ToArray();
                 if (songs.Length > 0)
                 {
@@ -542,9 +559,13 @@ namespace YARG.Menu.MusicLibrary
                         songs,
                         category.CategoryGroup,
                         category.Collapsed);
+                    filteredTargets[count - 1] = (uint) i < (uint) collapseTargets.Length
+                        ? collapseTargets[i]
+                        : category;
                 }
             }
 
+            filteredCollapseTargets = filteredTargets[..count];
             return result[..count];
         }
 
@@ -559,7 +580,7 @@ namespace YARG.Menu.MusicLibrary
 
             public override int GetHashCode(SongCategory obj)
             {
-                return HashCode.Combine(obj.Category, obj.CategoryGroup, obj.Collapsed);
+                return HashCode.Combine(obj.Category, obj.CategoryGroup, obj.Songs);
             }
         }
     }

--- a/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.SortFilter.cs
+++ b/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.SortFilter.cs
@@ -42,7 +42,6 @@ namespace YARG.Menu.MusicLibrary
         public bool HasSortHeaders { get; private set; }
 
         private SongCategory[] _sortedSongs;
-        private SongCategory[] _collapsedHeaderTargets;
         private SortAttribute _playlistSort = SortAttribute.Name;
         private bool _playlistSortAscending = true;
         private static readonly Dictionary<SortAttribute, HashSet<SongCategory>> _collapsedHeaders = new();
@@ -113,7 +112,6 @@ namespace YARG.Menu.MusicLibrary
             if (!PlaylistMode)
             {
                 _sortedSongs = _searchField.Search(SettingsManager.Settings.LibrarySort);
-                _collapsedHeaderTargets = _sortedSongs;
                 // _sortedSongs = ApplyCollapsedSectionsForCurrentSort(_sortedSongs);
                 _searchField.gameObject.SetActive(true);
             }
@@ -136,7 +134,6 @@ namespace YARG.Menu.MusicLibrary
                 {
                     new(GetPlaylistDisplayName(SelectedPlaylist), songs[..count], null)
                 };
-                _collapsedHeaderTargets = _sortedSongs;
 
                 _searchField.gameObject.SetActive(false);
             }
@@ -154,7 +151,7 @@ namespace YARG.Menu.MusicLibrary
             bool shouldShowFilteredCounts = inLibrary && (_searchField.IsSearching || predicate != null);
 
             if (shouldApplyFilters)
-                _sortedSongs = ApplyFilterPredicate(_sortedSongs, predicate, _collapsedHeaderTargets, out _collapsedHeaderTargets);
+                _sortedSongs = ApplyFilterPredicate(_sortedSongs, predicate);
 
             if (shouldShowFilteredCounts)
             {
@@ -529,23 +526,9 @@ namespace YARG.Menu.MusicLibrary
             return menu != null && menu.gameObject.activeInHierarchy;
         }
 
-        private SongCategory GetCollapseTarget(int index, SongCategory fallback)
+        private static SongCategory[] ApplyFilterPredicate(SongCategory[] categories, Func<SongEntry, bool> predicate)
         {
-            if (_collapsedHeaderTargets != null && (uint) index < (uint) _collapsedHeaderTargets.Length)
-                return _collapsedHeaderTargets[index];
-
-            return fallback;
-        }
-
-        private static SongCategory[] ApplyFilterPredicate(
-            SongCategory[] categories,
-            Func<SongEntry, bool> predicate,
-            SongCategory[] collapseTargets,
-            out SongCategory[] filteredCollapseTargets)
-        {
-            collapseTargets ??= categories;
             var result = new SongCategory[categories.Length];
-            var filteredTargets = new SongCategory[categories.Length];
             int count = 0;
 
             for (int i = 0; i < categories.Length; i++)
@@ -559,13 +542,9 @@ namespace YARG.Menu.MusicLibrary
                         songs,
                         category.CategoryGroup,
                         category.Collapsed);
-                    filteredTargets[count - 1] = (uint) i < (uint) collapseTargets.Length
-                        ? collapseTargets[i]
-                        : category;
                 }
             }
 
-            filteredCollapseTargets = filteredTargets[..count];
             return result[..count];
         }
 
@@ -574,13 +553,12 @@ namespace YARG.Menu.MusicLibrary
             public override bool Equals(SongCategory x, SongCategory y)
             {
                 return x.Category == y.Category &&
-                    x.CategoryGroup == y.CategoryGroup &&
-                    x.Songs == y.Songs;
+                    x.CategoryGroup == y.CategoryGroup;
             }
 
             public override int GetHashCode(SongCategory obj)
             {
-                return HashCode.Combine(obj.Category, obj.CategoryGroup, obj.Songs);
+                return HashCode.Combine(obj.Category, obj.CategoryGroup);
             }
         }
     }

--- a/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.SortFilter.cs
+++ b/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.SortFilter.cs
@@ -44,60 +44,13 @@ namespace YARG.Menu.MusicLibrary
         private SongCategory[] _sortedSongs;
         private SortAttribute _playlistSort = SortAttribute.Name;
         private bool _playlistSortAscending = true;
-        private static readonly Dictionary<SortAttribute, HashSet<string>> _collapsedHeaders = new();
+        private static readonly Dictionary<SortAttribute, HashSet<SongCategory>> _collapsedHeaders = new();
 
         private List<int> _sectionHeaderIndices = new();
         private int _primaryHeaderIndex;
         private int _recommendedHeaderIndex = -1;
 
-        private static string GetCategoryCollapseKey(SongCategory category)
-        {
-            return $"{category.CategoryGroup ?? string.Empty}\u001F{category.Category ?? string.Empty}";
-        }
-
-        private void SaveCollapsedHeaders()
-        {
-            if (PlaylistMode || _sortedSongs == null) return;
-
-            var collapsed = new HashSet<string>(StringComparer.Ordinal);
-            foreach (var category in _sortedSongs)
-            {
-                if (category.Collapsed)
-                    collapsed.Add(GetCategoryCollapseKey(category));
-            }
-
-            _collapsedHeaders[SettingsManager.Settings.LibrarySort] = collapsed;
-        }
-
-        private SongCategory[] ApplyCollapsedSectionsForCurrentSort(SongCategory[] categories)
-        {
-            if (PlaylistMode || categories == null)
-                return categories;
-
-            if (!_collapsedHeaders.TryGetValue(SettingsManager.Settings.LibrarySort, out var collapsed) ||
-                collapsed.Count == 0)
-            {
-                return categories;
-            }
-
-            SongCategory[] updated = null;
-            for (int i = 0; i < categories.Length; i++)
-            {
-                bool shouldCollapse = collapsed.Contains(GetCategoryCollapseKey(categories[i]));
-                if (categories[i].Collapsed == shouldCollapse)
-                    continue;
-
-                updated ??= (SongCategory[]) categories.Clone();
-                var category = categories[i];
-                updated[i] = new SongCategory(
-                    category.Category,
-                    category.Songs,
-                    category.CategoryGroup,
-                    shouldCollapse);
-            }
-
-            return updated ?? categories;
-        }
+        private SongCategoryEqualityComparer _comparer = new();
 
         private void CalculateCategoryHeaderIndices(List<ViewType> list)
         {
@@ -158,9 +111,8 @@ namespace YARG.Menu.MusicLibrary
             int previousSelectedIndex = SelectedIndex;
             if (!PlaylistMode)
             {
-                SaveCollapsedHeaders();
                 _sortedSongs = _searchField.Search(SettingsManager.Settings.LibrarySort);
-                _sortedSongs = ApplyCollapsedSectionsForCurrentSort(_sortedSongs);
+                // _sortedSongs = ApplyCollapsedSectionsForCurrentSort(_sortedSongs);
                 _searchField.gameObject.SetActive(true);
             }
             else
@@ -594,6 +546,21 @@ namespace YARG.Menu.MusicLibrary
             }
 
             return result[..count];
+        }
+
+        private class SongCategoryEqualityComparer : EqualityComparer<SongCategory>
+        {
+            public override bool Equals(SongCategory x, SongCategory y)
+            {
+                return x.Category == y.Category &&
+                    x.CategoryGroup == y.CategoryGroup &&
+                    x.Songs == y.Songs;
+            }
+
+            public override int GetHashCode(SongCategory obj)
+            {
+                return HashCode.Combine(obj.Category, obj.CategoryGroup, obj.Collapsed);
+            }
         }
     }
 }

--- a/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.SortFilter.cs
+++ b/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.SortFilter.cs
@@ -44,10 +44,60 @@ namespace YARG.Menu.MusicLibrary
         private SongCategory[] _sortedSongs;
         private SortAttribute _playlistSort = SortAttribute.Name;
         private bool _playlistSortAscending = true;
+        private static readonly Dictionary<SortAttribute, HashSet<string>> _collapsedHeaders = new();
 
         private List<int> _sectionHeaderIndices = new();
         private int _primaryHeaderIndex;
         private int _recommendedHeaderIndex = -1;
+
+        private static string GetCategoryCollapseKey(SongCategory category)
+        {
+            return $"{category.CategoryGroup ?? string.Empty}\u001F{category.Category ?? string.Empty}";
+        }
+
+        private void SaveCollapsedHeaders()
+        {
+            if (PlaylistMode || _sortedSongs == null) return;
+
+            var collapsed = new HashSet<string>(StringComparer.Ordinal);
+            foreach (var category in _sortedSongs)
+            {
+                if (category.Collapsed)
+                    collapsed.Add(GetCategoryCollapseKey(category));
+            }
+
+            _collapsedHeaders[SettingsManager.Settings.LibrarySort] = collapsed;
+        }
+
+        private SongCategory[] ApplyCollapsedSectionsForCurrentSort(SongCategory[] categories)
+        {
+            if (PlaylistMode || categories == null)
+                return categories;
+
+            if (!_collapsedHeaders.TryGetValue(SettingsManager.Settings.LibrarySort, out var collapsed) ||
+                collapsed.Count == 0)
+            {
+                return categories;
+            }
+
+            SongCategory[] updated = null;
+            for (int i = 0; i < categories.Length; i++)
+            {
+                bool shouldCollapse = collapsed.Contains(GetCategoryCollapseKey(categories[i]));
+                if (categories[i].Collapsed == shouldCollapse)
+                    continue;
+
+                updated ??= (SongCategory[]) categories.Clone();
+                var category = categories[i];
+                updated[i] = new SongCategory(
+                    category.Category,
+                    category.Songs,
+                    category.CategoryGroup,
+                    shouldCollapse);
+            }
+
+            return updated ?? categories;
+        }
 
         private void CalculateCategoryHeaderIndices(List<ViewType> list)
         {
@@ -108,7 +158,9 @@ namespace YARG.Menu.MusicLibrary
             int previousSelectedIndex = SelectedIndex;
             if (!PlaylistMode)
             {
+                SaveCollapsedHeaders();
                 _sortedSongs = _searchField.Search(SettingsManager.Settings.LibrarySort);
+                _sortedSongs = ApplyCollapsedSectionsForCurrentSort(_sortedSongs);
                 _searchField.gameObject.SetActive(true);
             }
             else
@@ -533,7 +585,11 @@ namespace YARG.Menu.MusicLibrary
                 var songs = category.Songs.Where(predicate).ToArray();
                 if (songs.Length > 0)
                 {
-                    result[count++] = new SongCategory(category.Category, songs, category.CategoryGroup);
+                    result[count++] = new SongCategory(
+                        category.Category,
+                        songs,
+                        category.CategoryGroup,
+                        category.Collapsed);
                 }
             }
 

--- a/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
+++ b/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
@@ -134,6 +134,15 @@ namespace YARG.Menu.MusicLibrary
 
             // Fill in sort information
             UpdateSortInformationHeader();
+
+            // This should go in its own method
+            foreach (SortAttribute attribute in Enum.GetValues(typeof(SortAttribute)))
+            {
+                if (!_collapsedHeaders.ContainsKey(attribute))
+                {
+                    _collapsedHeaders.Add(attribute, new HashSet<SongCategory>(_comparer));
+                }
+            }
         }
 
         protected override void OnEnable()
@@ -521,13 +530,14 @@ namespace YARG.Menu.MusicLibrary
                         onHeaderClicked = () =>
                         {
                             var category = _sortedSongs[index];
-                            _sortedSongs[index] = new SongCategory(
-                                category.Category,
-                                category.Songs,
-                                category.CategoryGroup,
-                                !category.Collapsed
-                            );
-                            SaveCollapsedHeaders();
+                            if (_collapsedHeaders[SettingsManager.Settings.LibrarySort].Contains(category))
+                            {
+                                _collapsedHeaders[SettingsManager.Settings.LibrarySort].Remove(category);
+                            }
+                            else
+                            {
+                                _collapsedHeaders[SettingsManager.Settings.LibrarySort].Add(category);
+                            }
 
                             var (headerIndex, offset) = GetClosestHeaderIndexAndOffset();
                             RequestViewListUpdate();
@@ -546,13 +556,13 @@ namespace YARG.Menu.MusicLibrary
                         section.Songs.Length,
                         section.CategoryGroup,
                         section.Songs,
-                        section.Collapsed,
+                        _collapsedHeaders[SettingsManager.Settings.LibrarySort].Contains(section),
                         onHeaderClicked);
                     list.Add(sortHeader);
                 }
 
                 int sectionTotalStars = 0;
-                bool includeSongs = _sortedSongs.Length <= 1 || !section.Collapsed;
+                bool includeSongs = _sortedSongs.Length <= 1 || !_collapsedHeaders[SettingsManager.Settings.LibrarySort].Contains(section);
 
                 foreach (var song in section.Songs)
                 {
@@ -795,7 +805,6 @@ namespace YARG.Menu.MusicLibrary
             {
                 _hasSavedSelectionSnapshot = false;
             }
-            SaveCollapsedHeaders();
 
             Navigator.Instance.PopScheme();
 
@@ -947,10 +956,7 @@ namespace YARG.Menu.MusicLibrary
         public void ExpandAll()
         {
             var (headerIndex, offset) = GetClosestHeaderIndexAndOffset();
-            _sortedSongs = _sortedSongs
-                .Select(cat => new SongCategory(cat.Category, cat.Songs, cat.CategoryGroup, false))
-                .ToArray();
-            SaveCollapsedHeaders();
+            _collapsedHeaders[SettingsManager.Settings.LibrarySort].Clear();
             RequestViewListUpdate();
             SelectedIndex = _sectionHeaderIndices[headerIndex] + offset;
         }
@@ -958,10 +964,10 @@ namespace YARG.Menu.MusicLibrary
         public void CollapseAll()
         {
             var (headerIndex, offset) = GetClosestHeaderIndexAndOffset();
-            _sortedSongs = _sortedSongs
-                .Select(cat => new SongCategory(cat.Category, cat.Songs, cat.CategoryGroup, true))
-                .ToArray();
-            SaveCollapsedHeaders();
+            foreach (var cat in _sortedSongs)
+            {
+                _collapsedHeaders[SettingsManager.Settings.LibrarySort].Add(cat);
+            }
             RequestViewListUpdate();
             var closestHeader = ViewList[_sectionHeaderIndices[headerIndex]];
             if (closestHeader is SortHeaderViewType sortHeader && sortHeader.Collapsed)

--- a/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
+++ b/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
@@ -527,6 +527,7 @@ namespace YARG.Menu.MusicLibrary
                                 category.CategoryGroup,
                                 !category.Collapsed
                             );
+                            SaveCollapsedHeaders();
 
                             var (headerIndex, offset) = GetClosestHeaderIndexAndOffset();
                             RequestViewListUpdate();
@@ -794,6 +795,7 @@ namespace YARG.Menu.MusicLibrary
             {
                 _hasSavedSelectionSnapshot = false;
             }
+            SaveCollapsedHeaders();
 
             Navigator.Instance.PopScheme();
 
@@ -948,6 +950,7 @@ namespace YARG.Menu.MusicLibrary
             _sortedSongs = _sortedSongs
                 .Select(cat => new SongCategory(cat.Category, cat.Songs, cat.CategoryGroup, false))
                 .ToArray();
+            SaveCollapsedHeaders();
             RequestViewListUpdate();
             SelectedIndex = _sectionHeaderIndices[headerIndex] + offset;
         }
@@ -958,6 +961,7 @@ namespace YARG.Menu.MusicLibrary
             _sortedSongs = _sortedSongs
                 .Select(cat => new SongCategory(cat.Category, cat.Songs, cat.CategoryGroup, true))
                 .ToArray();
+            SaveCollapsedHeaders();
             RequestViewListUpdate();
             var closestHeader = ViewList[_sectionHeaderIndices[headerIndex]];
             if (closestHeader is SortHeaderViewType sortHeader && sortHeader.Collapsed)

--- a/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
+++ b/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
@@ -135,6 +135,7 @@ namespace YARG.Menu.MusicLibrary
             // Fill in sort information
             UpdateSortInformationHeader();
 
+            // Ensure collapsed-header sets exist for each sort attribute
             InitializeCollapsedHeaderSets();
         }
 

--- a/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
+++ b/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
@@ -493,7 +493,6 @@ namespace YARG.Menu.MusicLibrary
 
             foreach (var (section, index) in _sortedSongs.Select((s, i) => (s, i)))
             {
-                var collapseTarget = GetCollapseTarget(index, section);
                 var displayName = section.Category;
                 if (SettingsManager.Settings.LibrarySort == SortAttribute.Source)
                 {
@@ -524,13 +523,14 @@ namespace YARG.Menu.MusicLibrary
                     {
                         onHeaderClicked = () =>
                         {
-                            if (_collapsedHeaders[SettingsManager.Settings.LibrarySort].Contains(collapseTarget))
+                            var category = _sortedSongs[index];
+                            if (_collapsedHeaders[SettingsManager.Settings.LibrarySort].Contains(category))
                             {
-                                _collapsedHeaders[SettingsManager.Settings.LibrarySort].Remove(collapseTarget);
+                                _collapsedHeaders[SettingsManager.Settings.LibrarySort].Remove(category);
                             }
                             else
                             {
-                                _collapsedHeaders[SettingsManager.Settings.LibrarySort].Add(collapseTarget);
+                                _collapsedHeaders[SettingsManager.Settings.LibrarySort].Add(category);
                             }
 
                             var (headerIndex, offset) = GetClosestHeaderIndexAndOffset();
@@ -550,13 +550,13 @@ namespace YARG.Menu.MusicLibrary
                         section.Songs.Length,
                         section.CategoryGroup,
                         section.Songs,
-                        _collapsedHeaders[SettingsManager.Settings.LibrarySort].Contains(collapseTarget),
+                        _collapsedHeaders[SettingsManager.Settings.LibrarySort].Contains(section),
                         onHeaderClicked);
                     list.Add(sortHeader);
                 }
 
                 int sectionTotalStars = 0;
-                bool includeSongs = _sortedSongs.Length <= 1 || !_collapsedHeaders[SettingsManager.Settings.LibrarySort].Contains(collapseTarget);
+                bool includeSongs = _sortedSongs.Length <= 1 || !_collapsedHeaders[SettingsManager.Settings.LibrarySort].Contains(section);
 
                 foreach (var song in section.Songs)
                 {
@@ -969,9 +969,9 @@ namespace YARG.Menu.MusicLibrary
         public void CollapseAll()
         {
             var (headerIndex, offset) = GetClosestHeaderIndexAndOffset();
-            foreach (var (section, index) in _sortedSongs.Select((s, i) => (s, i)))
+            foreach (var cat in _sortedSongs)
             {
-                _collapsedHeaders[SettingsManager.Settings.LibrarySort].Add(GetCollapseTarget(index, section));
+                _collapsedHeaders[SettingsManager.Settings.LibrarySort].Add(cat);
             }
 
             RequestViewListUpdate();

--- a/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
+++ b/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
@@ -135,14 +135,7 @@ namespace YARG.Menu.MusicLibrary
             // Fill in sort information
             UpdateSortInformationHeader();
 
-            // This should go in its own method
-            foreach (SortAttribute attribute in Enum.GetValues(typeof(SortAttribute)))
-            {
-                if (!_collapsedHeaders.ContainsKey(attribute))
-                {
-                    _collapsedHeaders.Add(attribute, new HashSet<SongCategory>(_comparer));
-                }
-            }
+            InitializeCollapsedHeaderSets();
         }
 
         protected override void OnEnable()
@@ -499,6 +492,7 @@ namespace YARG.Menu.MusicLibrary
 
             foreach (var (section, index) in _sortedSongs.Select((s, i) => (s, i)))
             {
+                var collapseTarget = GetCollapseTarget(index, section);
                 var displayName = section.Category;
                 if (SettingsManager.Settings.LibrarySort == SortAttribute.Source)
                 {
@@ -529,14 +523,13 @@ namespace YARG.Menu.MusicLibrary
                     {
                         onHeaderClicked = () =>
                         {
-                            var category = _sortedSongs[index];
-                            if (_collapsedHeaders[SettingsManager.Settings.LibrarySort].Contains(category))
+                            if (_collapsedHeaders[SettingsManager.Settings.LibrarySort].Contains(collapseTarget))
                             {
-                                _collapsedHeaders[SettingsManager.Settings.LibrarySort].Remove(category);
+                                _collapsedHeaders[SettingsManager.Settings.LibrarySort].Remove(collapseTarget);
                             }
                             else
                             {
-                                _collapsedHeaders[SettingsManager.Settings.LibrarySort].Add(category);
+                                _collapsedHeaders[SettingsManager.Settings.LibrarySort].Add(collapseTarget);
                             }
 
                             var (headerIndex, offset) = GetClosestHeaderIndexAndOffset();
@@ -556,13 +549,13 @@ namespace YARG.Menu.MusicLibrary
                         section.Songs.Length,
                         section.CategoryGroup,
                         section.Songs,
-                        _collapsedHeaders[SettingsManager.Settings.LibrarySort].Contains(section),
+                        _collapsedHeaders[SettingsManager.Settings.LibrarySort].Contains(collapseTarget),
                         onHeaderClicked);
                     list.Add(sortHeader);
                 }
 
                 int sectionTotalStars = 0;
-                bool includeSongs = _sortedSongs.Length <= 1 || !_collapsedHeaders[SettingsManager.Settings.LibrarySort].Contains(section);
+                bool includeSongs = _sortedSongs.Length <= 1 || !_collapsedHeaders[SettingsManager.Settings.LibrarySort].Contains(collapseTarget);
 
                 foreach (var song in section.Songs)
                 {
@@ -822,6 +815,17 @@ namespace YARG.Menu.MusicLibrary
             StemSettings.ApplySettings = true;
         }
 
+        private void InitializeCollapsedHeaderSets()
+        {
+            foreach (SortAttribute attribute in Enum.GetValues(typeof(SortAttribute)))
+            {
+                if (!_collapsedHeaders.ContainsKey(attribute))
+                {
+                    _collapsedHeaders.Add(attribute, new HashSet<SongCategory>(_comparer));
+                }
+            }
+        }
+
         public void Back()
         {
             if (_searchField.IsSearching)
@@ -964,11 +968,13 @@ namespace YARG.Menu.MusicLibrary
         public void CollapseAll()
         {
             var (headerIndex, offset) = GetClosestHeaderIndexAndOffset();
-            foreach (var cat in _sortedSongs)
+            foreach (var (section, index) in _sortedSongs.Select((s, i) => (s, i)))
             {
-                _collapsedHeaders[SettingsManager.Settings.LibrarySort].Add(cat);
+                _collapsedHeaders[SettingsManager.Settings.LibrarySort].Add(GetCollapseTarget(index, section));
             }
+
             RequestViewListUpdate();
+
             var closestHeader = ViewList[_sectionHeaderIndices[headerIndex]];
             if (closestHeader is SortHeaderViewType sortHeader && sortHeader.Collapsed)
             {


### PR DESCRIPTION
Without this commit, the collapsed headers would get re-expanded every time the Music Library loads.  This saves collapsed headers, and restores them when returning.

Tested scenarios include:
- Instrument/Difficulty Selection _(including changing instrument)_
- Playing a Song
- Main Menu
- Re-scanning Library _(new headers added will always default expanded)_
- Filters Menu, and changing Filters _(but not **Sort**)_

This **does not** save to disc.  Closing and re-opening the game will re-expand all collapsed headers.