### PR TITLE
Back button on Calibrator should bring player back to settings

### DIFF
--- a/Assets/Script/Menu/Calibrator/Calibrator.cs
+++ b/Assets/Script/Menu/Calibrator/Calibrator.cs
@@ -51,6 +51,7 @@ namespace YARG.Menu.Calibrator
 #nullable disable
 
         private bool _wasWhammyEnabled;
+        private bool _hasNavigationScheme;
 
         private void Awake()
         {
@@ -65,6 +66,7 @@ namespace YARG.Menu.Calibrator
         private void OnDestroy()
         {
             InputManager.MenuInput -= OnMenuInput;
+            ClearNavigation();
             _mixer?.Dispose();
         }
 
@@ -175,7 +177,7 @@ namespace YARG.Menu.Calibrator
 
         private void SetConfirmNavigation()
         {
-            Navigator.Instance.PushScheme(new NavigationScheme(new()
+            SetNavigation(new NavigationScheme(new()
             {
                 new NavigationScheme.Entry(MenuAction.Green, "Menu.Common.Confirm", () => StartAudioMode()),
                 new NavigationScheme.Entry(MenuAction.Red, "Menu.Common.Back", () => BackButton()),
@@ -184,17 +186,35 @@ namespace YARG.Menu.Calibrator
 
         private void SetBackNavigation()
         {
-            Navigator.Instance.PopScheme();
-            Navigator.Instance.PushScheme(new NavigationScheme(new()
+            SetNavigation(new NavigationScheme(new()
             {
                 new NavigationScheme.Entry(MenuAction.Red, "Menu.Common.Back", () => BackButton()),
             }, true));
         }
+
         private void SetEmptyNavigation()
         {
-            Navigator.Instance.PopScheme();
-            Navigator.Instance.PushScheme(NavigationScheme.Empty);
+            SetNavigation(NavigationScheme.Empty);
         }
+
+        private void SetNavigation(NavigationScheme scheme)
+        {
+            ClearNavigation();
+            Navigator.Instance.PushScheme(scheme);
+            _hasNavigationScheme = true;
+        }
+
+        private void ClearNavigation()
+        {
+            if (!_hasNavigationScheme || Navigator.Instance == null)
+            {
+                return;
+            }
+
+            Navigator.Instance.PopScheme();
+            _hasNavigationScheme = false;
+        }
+
         private void CalculateAudioLatency()
         {
             // Drop all discrepancies

--- a/Assets/Script/Menu/Main/MainMenu.cs
+++ b/Assets/Script/Menu/Main/MainMenu.cs
@@ -34,6 +34,11 @@ namespace YARG.Menu.Main
 
                 _antiPiracyDialogShown = true;
             }
+
+            if (SettingsMenu.ConsumeOpenOnNextMenuLoad())
+            {
+                SettingsMenu.Instance.gameObject.SetActive(true);
+            }
         }
 
         private void OnEnable()

--- a/Assets/Script/Menu/Settings/SettingsButton.cs
+++ b/Assets/Script/Menu/Settings/SettingsButton.cs
@@ -49,7 +49,7 @@ namespace YARG.Menu.Settings
 
                 var capture = buttonInfo.Action;
                 button.GetComponentInChildren<Button>()
-                    .onClick.AddListener(() => capture?.Invoke());
+                    .onClick.AddListener(() => InvokeFocusedAction(capture));
 
                 _navGroup.AddNavigatable(button.GetComponentInChildren<NavigatableUnityButton>());
             }
@@ -71,7 +71,7 @@ namespace YARG.Menu.Settings
                 // Set button action
                 var capture = buttonName;
                 button.GetComponentInChildren<Button>()
-                    .onClick.AddListener(() => SettingsManager.InvokeButton(capture));
+                    .onClick.AddListener(() => InvokeFocusedAction(() => SettingsManager.InvokeButton(capture)));
 
                 // Add to nav group
                 _navGroup.AddNavigatable(button.GetComponentInChildren<NavigatableUnityButton>());
@@ -85,7 +85,7 @@ namespace YARG.Menu.Settings
         {
             _buttonTemplate.GetComponentInChildren<TextMeshProUGUI>().text = Localize.Key(localizationKey);
 
-            _buttonTemplate.GetComponentInChildren<Button>().onClick.AddListener(() => action?.Invoke());
+            _buttonTemplate.GetComponentInChildren<Button>().onClick.AddListener(() => InvokeFocusedAction(action));
         }
 
         public override void Confirm()
@@ -95,7 +95,7 @@ namespace YARG.Menu.Settings
                 NavigationScheme.Entry.NavigateSelect,
                 new NavigationScheme.Entry(MenuAction.Red, "Menu.Common.Back", () =>
                 {
-                    Navigator.Instance.PopScheme();
+                    CloseFocusedNavigation();
                 }),
                 NavigationScheme.Entry.NavigateUp,
                 NavigationScheme.Entry.NavigateDown
@@ -114,6 +114,20 @@ namespace YARG.Menu.Settings
             _navGroup.SelectFirst();
         }
 
+        private void InvokeFocusedAction(Action action)
+        {
+            CloseFocusedNavigation();
+            action?.Invoke();
+        }
+
+        private void CloseFocusedNavigation()
+        {
+            if (_focused)
+            {
+                Navigator.Instance.PopScheme();
+            }
+        }
+
         protected override void OnSelectionChanged(bool selected)
         {
             base.OnSelectionChanged(selected);
@@ -125,7 +139,7 @@ namespace YARG.Menu.Settings
             // If the visual's nav scheme is still in the stack, make sure to pop it.
             if (_focused)
             {
-                Navigator.Instance.PopScheme();
+                CloseFocusedNavigation();
             }
         }
     }

--- a/Assets/Script/Menu/Settings/SettingsMenu.cs
+++ b/Assets/Script/Menu/Settings/SettingsMenu.cs
@@ -184,6 +184,14 @@ namespace YARG.Menu.Settings
             if (_headerTabs.SelectedTabId is null)
             {
                 SelectTab(SettingsManager.GetTabByName(name));
+                return;
+            }
+
+            // Selecting the already-selected header tab does not fire TabChanged.
+            // This matters when reopening settings after CurrentTab was cleared on close.
+            if (CurrentTab?.Name != _headerTabs.SelectedTabId)
+            {
+                SelectTab(SettingsManager.GetTabByName(_headerTabs.SelectedTabId));
             }
         }
 

--- a/Assets/Script/Menu/Settings/SettingsMenu.cs
+++ b/Assets/Script/Menu/Settings/SettingsMenu.cs
@@ -54,6 +54,8 @@ namespace YARG.Menu.Settings
 
         public event Action SettingChanged;
 
+        private static bool _openOnNextMenuLoad;
+
         // Workaround to avoid errors when deactivating menu during startup
         private bool _ready;
         private bool _tabsInitialized;
@@ -76,6 +78,22 @@ namespace YARG.Menu.Settings
                     _showAdvanced = value;
                 }
             }
+        }
+
+        public static void OpenOnNextMenuLoad()
+        {
+            _openOnNextMenuLoad = true;
+        }
+
+        public static bool ConsumeOpenOnNextMenuLoad()
+        {
+            if (!_openOnNextMenuLoad)
+            {
+                return false;
+            }
+
+            _openOnNextMenuLoad = false;
+            return true;
         }
 
         protected override void SingletonAwake()

--- a/Assets/Script/Menu/Settings/SettingsMenu.cs
+++ b/Assets/Script/Menu/Settings/SettingsMenu.cs
@@ -5,6 +5,7 @@ using DG.Tweening;
 using TMPro;
 using UnityEngine;
 using UnityEngine.AddressableAssets;
+using UnityEngine.SceneManagement;
 using UnityEngine.UI;
 using YARG.Core.Input;
 using YARG.Helpers;
@@ -55,6 +56,7 @@ namespace YARG.Menu.Settings
         public event Action SettingChanged;
 
         private static bool _openOnNextMenuLoad;
+        private static bool _skipMenuReactivationOnDisable;
 
         // Workaround to avoid errors when deactivating menu during startup
         private bool _ready;
@@ -94,6 +96,19 @@ namespace YARG.Menu.Settings
 
             _openOnNextMenuLoad = false;
             return true;
+        }
+
+        public void PrepareForSceneTransition()
+        {
+            _skipMenuReactivationOnDisable = true;
+            SceneManager.sceneLoaded -= HideAfterSceneTransition;
+            SceneManager.sceneLoaded += HideAfterSceneTransition;
+        }
+
+        private void HideAfterSceneTransition(Scene scene, LoadSceneMode mode)
+        {
+            SceneManager.sceneLoaded -= HideAfterSceneTransition;
+            gameObject.SetActive(false);
         }
 
         protected override void SingletonAwake()
@@ -432,9 +447,20 @@ namespace YARG.Menu.Settings
             SettingsManager.SaveSettings();
             CustomContentManager.SaveAll();
 
+            if (_skipMenuReactivationOnDisable)
+            {
+                _skipMenuReactivationOnDisable = false;
+                return;
+            }
+
             //This is a bit of a hack to update the CurrentNavigationGroup again.
             //ideally the settings menu should work just like every other menu so this isn't needed
             MenuManager.Instance.ReactivateCurrentMenu();
+        }
+
+        protected override void SingletonDestroy()
+        {
+            SceneManager.sceneLoaded -= HideAfterSceneTransition;
         }
     }
 }

--- a/Assets/Script/Settings/SettingsManager.Settings.cs
+++ b/Assets/Script/Settings/SettingsManager.Settings.cs
@@ -94,6 +94,7 @@ namespace YARG.Settings
 
             public void OpenCalibrator()
             {
+                SettingsMenu.OpenOnNextMenuLoad();
                 GlobalVariables.Instance.LoadScene(SceneIndex.Calibration);
                 SettingsMenu.Instance.gameObject.SetActive(false);
             }

--- a/Assets/Script/Settings/SettingsManager.Settings.cs
+++ b/Assets/Script/Settings/SettingsManager.Settings.cs
@@ -95,8 +95,8 @@ namespace YARG.Settings
             public void OpenCalibrator()
             {
                 SettingsMenu.OpenOnNextMenuLoad();
+                SettingsMenu.Instance.PrepareForSceneTransition();
                 GlobalVariables.Instance.LoadScene(SceneIndex.Calibration);
-                SettingsMenu.Instance.gameObject.SetActive(false);
             }
 
             public IntSetting AudioCalibration { get; } = new(0);


### PR DESCRIPTION
This PR does the following:

- Calibrator now owns its navigation scheme more safely: it tracks whether it pushed a scheme and clears it on state changes/destruction.

- Settings button rows now close their focused navigation scheme before invoking button actions, preventing stale nav state.

- Opening the calibrator from settings now sets a one-shot flag so returning to the main menu reopens settings.

- Settings menu tab restore logic now handles the case where the selected header tab is already selected but CurrentTab was cleared. This fixes a bug where the Player could go into settings, leave settings, go back into settings and hit "show advanced" which would end up clearing all the settings on that page until navigating to a new tab