### PR TITLE
Force venue output alpha channel to 1.0 even if post processing is disabled

### DIFF
--- a/Assets/Art/Shaders/VenueShaders/VenueAlphaFix.shader
+++ b/Assets/Art/Shaders/VenueShaders/VenueAlphaFix.shader
@@ -1,0 +1,31 @@
+Shader "Hidden/YARG/VenueAlphaFix"
+{
+    HLSLINCLUDE
+        #include "Packages/com.unity.render-pipelines.core/Runtime/Utilities/Blit.hlsl"
+
+        half4 FragAlphaFix(Varyings input) : SV_Target
+        {
+            half4 color = FragBlit(input, sampler_LinearClamp);
+            color.a = 1.0;
+            return color;
+        }
+    ENDHLSL
+
+    SubShader
+    {
+        Tags { "RenderPipeline" = "UniversalPipeline" }
+
+        Pass
+        {
+            Name "AlphaFix"
+            ZWrite Off ZTest Always Blend Off Cull Off
+
+            HLSLPROGRAM
+                #pragma vertex Vert
+                #pragma fragment FragAlphaFix
+            ENDHLSL
+        }
+    }
+
+    Fallback Off
+}

--- a/Assets/Art/Shaders/VenueShaders/VenueAlphaFix.shader
+++ b/Assets/Art/Shaders/VenueShaders/VenueAlphaFix.shader
@@ -1,6 +1,7 @@
 Shader "Hidden/YARG/VenueAlphaFix"
 {
     HLSLINCLUDE
+        #include "Packages/com.unity.render-pipelines.universal/ShaderLibrary/Core.hlsl"
         #include "Packages/com.unity.render-pipelines.core/Runtime/Utilities/Blit.hlsl"
 
         half4 FragAlphaFix(Varyings input) : SV_Target

--- a/Assets/Art/Shaders/VenueShaders/VenueAlphaFix.shader.meta
+++ b/Assets/Art/Shaders/VenueShaders/VenueAlphaFix.shader.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: 5014b77ad61c322b0a33c7e6f43a4eb5
+ShaderImporter:
+  externalObjects: {}
+  defaultTextures: []
+  nonModifiableTextures: []
+  preprocessorOverride: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant:

--- a/Assets/Script/Gameplay/VenueCameraRenderer.cs
+++ b/Assets/Script/Gameplay/VenueCameraRenderer.cs
@@ -223,13 +223,9 @@ namespace YARG.Gameplay
                 _timeSinceLastRender = float.MaxValue;
             }
 
-            var stack = VolumeManager.instance.stack;
-
-            VolumeManager.instance.Update(_renderCamera.gameObject.transform, _venueLayerMask);
-
             _effectiveFps = FPS;
 
-            var fpsEffect = stack.GetComponent<SlowFPSComponent>();
+            var fpsEffect = VolumeManager.instance.stack.GetComponent<SlowFPSComponent>();
 
             if (fpsEffect.IsActive())
             {
@@ -288,6 +284,12 @@ namespace YARG.Gameplay
             }
 
             Shader.SetGlobalFloat(_IsVenueId, 1);
+
+            // URP replaces VolumeManager.instance.stack with either the global stack
+            // or the camera's local volumeStack during rendering setup, depending on
+            // the volume framework update mode. We need to update the same stack that
+            // URP is using, so we update it here (after URP's setup) before reading.
+            VolumeManager.instance.Update(VolumeManager.instance.stack, _renderCamera.gameObject.transform, _venueLayerMask);
 
             var stack = VolumeManager.instance.stack;
 

--- a/Assets/Script/Gameplay/VenueCameraRenderer.cs
+++ b/Assets/Script/Gameplay/VenueCameraRenderer.cs
@@ -23,6 +23,8 @@ namespace YARG.Gameplay
         private Camera _renderCamera;
         private float _originalFactor;
         private UniversalRenderPipelineAsset UniversalRenderPipelineAsset;
+        private readonly RenderPipeline.StandardRequest _renderRequest = new();
+        private bool _supportsRenderRequest;
 
         private static RawImage _venueOutput;
         private static RenderTexture _venueTexture;
@@ -101,6 +103,7 @@ namespace YARG.Gameplay
             }
             UniversalRenderPipelineAsset = GraphicsSettings.currentRenderPipeline as UniversalRenderPipelineAsset;
             _originalFactor = UniversalRenderPipelineAsset.renderScale;
+            _supportsRenderRequest = RenderPipeline.SupportsRenderRequest(_renderCamera, _renderRequest);
 
             FPS = SettingsManager.Settings.VenueFpsCap.Value;
             _venueLayerMask = LayerMask.GetMask("Venue");
@@ -268,11 +271,6 @@ namespace YARG.Gameplay
             {
                 return;
             }
-
-            // Disable the camera after rendering so it only renders when explicitly triggered
-            _renderCamera.enabled = false;
-            _renderCamera.targetTexture = null;
-
             Shader.SetGlobalInteger(_posterizeStepsId, 0);
             Shader.SetGlobalFloat(_startTimeId, 0);
             Shader.SetGlobalFloat(_IsVenueId, 0);
@@ -339,9 +337,14 @@ namespace YARG.Gameplay
 
         private void Render()
         {
-            // Set target texture and enable the camera so it renders through the normal pipeline
-            _renderCamera.targetTexture = _venueTexture;
-            _renderCamera.enabled = true;
+            if (!_supportsRenderRequest)
+            {
+                return;
+            }
+
+            _renderRequest.destination = _venueTexture;
+            // Render camera and fill texture2D with its view
+            RenderPipeline.SubmitRenderRequest(_renderCamera, _renderRequest);
 
             if (!IsRendered)
             {

--- a/Assets/Script/Gameplay/VenueCameraRenderer.cs
+++ b/Assets/Script/Gameplay/VenueCameraRenderer.cs
@@ -380,22 +380,12 @@ namespace YARG.Gameplay
 
                 // Blit through alpha-fix shader to force alpha to 1.0, preventing transparency artifacts
                 // when the venue renders without post-processing (UberPP doesn't run to fix alpha).
-                var targetDesc = renderGraph.GetTextureDesc(source);
-                targetDesc.name = "_VenueAlphaFix";
-                targetDesc.clearBuffer = false;
-                TextureHandle alphaFixedTexture = renderGraph.CreateTexture(targetDesc);
 
-                var blitParams = new BlitMaterialParameters(source, alphaFixedTexture, _alphaFixMaterial, 0);
-                renderGraph.AddBlitPass(blitParams, passName: "Venue Alpha Fix");
+                var blitParams = new BlitMaterialParameters(source, trailsTexture, _alphaFixMaterial, 0);
+                renderGraph.AddBlitPass(blitParams, passName: "Venue Alpha Fix / Trails Copy");
 
-                // Update cameraColor so the final blit (no PP) or UberPP (with PP) uses the alpha-fixed texture.
-                resourceData.cameraColor = alphaFixedTexture;
-
-                // Store frame for trails using the alpha-fixed texture.
-                renderGraph.AddCopyPass(alphaFixedTexture, trailsTexture, "Store frame for trail");
-
-                // Update the global shader texture so trails sampling in UberPP uses the latest frame.
-                Shader.SetGlobalTexture(_trailsTextureId, _trailsTexture);
+                // Update cameraColor so the final blit uses the alpha-fixed texture.
+                resourceData.cameraColor = trailsTexture;
             }
         }
 

--- a/Assets/Script/Gameplay/VenueCameraRenderer.cs
+++ b/Assets/Script/Gameplay/VenueCameraRenderer.cs
@@ -2,6 +2,7 @@ using UnityEngine;
 using UnityEngine.Rendering;
 using UnityEngine.Rendering.RenderGraphModule;
 using UnityEngine.Rendering.RenderGraphModule.Util;
+using static UnityEngine.Rendering.RenderGraphModule.Util.RenderGraphUtils;
 using UnityEngine.Rendering.Universal;
 using UnityEngine.SceneManagement;
 using UnityEngine.UI;
@@ -42,6 +43,7 @@ namespace YARG.Gameplay
         private static readonly string[] _mirrorKeywords = { "YARG_MIRROR_LEFT", "YARG_MIRROR_RIGHT", "YARG_MIRROR_CLOCK_CCW", "YARG_MIRROR_NONE" };
 
         private VenuePostPostProcessingPass _pass;
+        private Material _alphaFixMaterial;
 
         public static float ActualFPS;
         public static float TargetFPS;
@@ -68,6 +70,7 @@ namespace YARG.Gameplay
 
         private void Awake()
         {
+            _alphaFixMaterial = CreateMaterial("Hidden/YARG/VenueAlphaFix");
             _pass = new VenuePostPostProcessingPass(this);
 
             Shader.SetGlobalColor(_scanlineColor, Color.black);
@@ -177,6 +180,12 @@ namespace YARG.Gameplay
                 _trailsTexture.Release();
                 Destroy(_trailsTexture);
                 _trailsTexture = null;
+            }
+
+            if (_alphaFixMaterial != null)
+            {
+                CoreUtils.Destroy(_alphaFixMaterial);
+                _alphaFixMaterial = null;
             }
 
             _venueOutput = null;
@@ -354,16 +363,39 @@ namespace YARG.Gameplay
 
         private sealed class VenuePostPostProcessingPass : ScriptableRenderPass
         {
+            private readonly Material _alphaFixMaterial;
+
             public VenuePostPostProcessingPass(VenueCameraRenderer vcr)
             {
                 renderPassEvent = RenderPassEvent.AfterRenderingPostProcessing;
+                _alphaFixMaterial = vcr._alphaFixMaterial;
             }
 
             public override void RecordRenderGraph(RenderGraph renderGraph, ContextContainer frameData)
             {
                 UniversalResourceData resourceData = frameData.Get<UniversalResourceData>();
+
+                TextureHandle source = resourceData.activeColorTexture;
                 TextureHandle trailsTexture = renderGraph.ImportTexture(_trailsTextureHandle);
-                renderGraph.AddCopyPass(resourceData.activeColorTexture, trailsTexture, "Store frame for trail");
+
+                // Blit through alpha-fix shader to force alpha to 1.0, preventing transparency artifacts
+                // when the venue renders without post-processing (UberPP doesn't run to fix alpha).
+                var targetDesc = renderGraph.GetTextureDesc(source);
+                targetDesc.name = "_VenueAlphaFix";
+                targetDesc.clearBuffer = false;
+                TextureHandle alphaFixedTexture = renderGraph.CreateTexture(targetDesc);
+
+                var blitParams = new BlitMaterialParameters(source, alphaFixedTexture, _alphaFixMaterial, 0);
+                renderGraph.AddBlitPass(blitParams, passName: "Venue Alpha Fix");
+
+                // Update cameraColor so the final blit (no PP) or UberPP (with PP) uses the alpha-fixed texture.
+                resourceData.cameraColor = alphaFixedTexture;
+
+                // Store frame for trails using the alpha-fixed texture.
+                renderGraph.AddCopyPass(alphaFixedTexture, trailsTexture, "Store frame for trail");
+
+                // Update the global shader texture so trails sampling in UberPP uses the latest frame.
+                Shader.SetGlobalTexture(_trailsTextureId, _trailsTexture);
             }
         }
 

--- a/Assets/Script/Gameplay/VenueCameraRenderer.cs
+++ b/Assets/Script/Gameplay/VenueCameraRenderer.cs
@@ -22,8 +22,6 @@ namespace YARG.Gameplay
         private Camera _renderCamera;
         private float _originalFactor;
         private UniversalRenderPipelineAsset UniversalRenderPipelineAsset;
-        private readonly RenderPipeline.StandardRequest _renderRequest = new();
-        private bool _supportsRenderRequest;
 
         private static RawImage _venueOutput;
         private static RenderTexture _venueTexture;
@@ -100,7 +98,6 @@ namespace YARG.Gameplay
             }
             UniversalRenderPipelineAsset = GraphicsSettings.currentRenderPipeline as UniversalRenderPipelineAsset;
             _originalFactor = UniversalRenderPipelineAsset.renderScale;
-            _supportsRenderRequest = RenderPipeline.SupportsRenderRequest(_renderCamera, _renderRequest);
 
             FPS = SettingsManager.Settings.VenueFpsCap.Value;
             _venueLayerMask = LayerMask.GetMask("Venue");
@@ -262,6 +259,11 @@ namespace YARG.Gameplay
             {
                 return;
             }
+
+            // Disable the camera after rendering so it only renders when explicitly triggered
+            _renderCamera.enabled = false;
+            _renderCamera.targetTexture = null;
+
             Shader.SetGlobalInteger(_posterizeStepsId, 0);
             Shader.SetGlobalFloat(_startTimeId, 0);
             Shader.SetGlobalFloat(_IsVenueId, 0);
@@ -328,14 +330,9 @@ namespace YARG.Gameplay
 
         private void Render()
         {
-            if (!_supportsRenderRequest)
-            {
-                return;
-            }
-
-            _renderRequest.destination = _venueTexture;
-            // Render camera and fill texture2D with its view
-            RenderPipeline.SubmitRenderRequest(_renderCamera, _renderRequest);
+            // Set target texture and enable the camera so it renders through the normal pipeline
+            _renderCamera.targetTexture = _venueTexture;
+            _renderCamera.enabled = true;
 
             if (!IsRendered)
             {

--- a/Assets/Script/Gameplay/VenueCameraRenderer.cs
+++ b/Assets/Script/Gameplay/VenueCameraRenderer.cs
@@ -223,9 +223,14 @@ namespace YARG.Gameplay
                 _timeSinceLastRender = float.MaxValue;
             }
 
+            // Update the global volume stack with venue effects so SlowFPS
+            // (and any other effects read in Update()) can access them.
+            VolumeManager.instance.Update(_renderCamera.gameObject.transform, _venueLayerMask);
+
             _effectiveFps = FPS;
 
-            var fpsEffect = VolumeManager.instance.stack.GetComponent<SlowFPSComponent>();
+            var stack = VolumeManager.instance.stack;
+            var fpsEffect = stack.GetComponent<SlowFPSComponent>();
 
             if (fpsEffect.IsActive())
             {

--- a/Assets/Script/Gameplay/VenueCameraRenderer.cs
+++ b/Assets/Script/Gameplay/VenueCameraRenderer.cs
@@ -23,8 +23,6 @@ namespace YARG.Gameplay
         private Camera _renderCamera;
         private float _originalFactor;
         private UniversalRenderPipelineAsset UniversalRenderPipelineAsset;
-        private readonly RenderPipeline.StandardRequest _renderRequest = new();
-        private bool _supportsRenderRequest;
 
         private static RawImage _venueOutput;
         private static RenderTexture _venueTexture;
@@ -103,7 +101,6 @@ namespace YARG.Gameplay
             }
             UniversalRenderPipelineAsset = GraphicsSettings.currentRenderPipeline as UniversalRenderPipelineAsset;
             _originalFactor = UniversalRenderPipelineAsset.renderScale;
-            _supportsRenderRequest = RenderPipeline.SupportsRenderRequest(_renderCamera, _renderRequest);
 
             FPS = SettingsManager.Settings.VenueFpsCap.Value;
             _venueLayerMask = LayerMask.GetMask("Venue");
@@ -271,6 +268,11 @@ namespace YARG.Gameplay
             {
                 return;
             }
+
+            // Disable the camera after rendering so it only renders when explicitly triggered
+            _renderCamera.enabled = false;
+            _renderCamera.targetTexture = null;
+
             Shader.SetGlobalInteger(_posterizeStepsId, 0);
             Shader.SetGlobalFloat(_startTimeId, 0);
             Shader.SetGlobalFloat(_IsVenueId, 0);
@@ -337,14 +339,9 @@ namespace YARG.Gameplay
 
         private void Render()
         {
-            if (!_supportsRenderRequest)
-            {
-                return;
-            }
-
-            _renderRequest.destination = _venueTexture;
-            // Render camera and fill texture2D with its view
-            RenderPipeline.SubmitRenderRequest(_renderCamera, _renderRequest);
+            // Set target texture and enable the camera so it renders through the normal pipeline
+            _renderCamera.targetTexture = _venueTexture;
+            _renderCamera.enabled = true;
 
             if (!IsRendered)
             {

--- a/Assets/Script/Gameplay/VenueCameraRenderer.cs
+++ b/Assets/Script/Gameplay/VenueCameraRenderer.cs
@@ -63,9 +63,9 @@ namespace YARG.Gameplay
 
         private int _venueLayerMask;
 
-        private int _frameCount;
-        private float _elapsedTime;
-        private static float _timeSinceLastRender;
+        private static float _frameAccumulator = 0f;
+        private static float _fpsWindowStart = 0f;
+        private static int _fpsWindowFrames = 0;
         private bool _needsInitialization = true;
 
         private void Awake()
@@ -148,10 +148,17 @@ namespace YARG.Gameplay
             Graphics.Blit(Texture2D.blackTexture, _trailsTexture);
         }
 
+        private static void ResetRenderState()
+        {
+            _frameAccumulator = 0f;
+            _fpsWindowStart = 0f;
+            _fpsWindowFrames = 0;
+        }
+
         private void OnEnable()
         {
             FPS = SettingsManager.Settings.VenueFpsCap.Value;
-            _timeSinceLastRender = 0f;
+            ResetRenderState();
             RenderPipelineManager.beginCameraRendering += OnPreCameraRender;
             RenderPipelineManager.endCameraRendering += OnEndCameraRender;
             SceneManager.sceneUnloaded += OnSceneUnloaded;
@@ -220,7 +227,7 @@ namespace YARG.Gameplay
                 RecreateTextures();
                 _needsInitialization = false;
                 // Force a render this frame to avoid flickering when resizing
-                _timeSinceLastRender = float.MaxValue;
+                ResetRenderState();
             }
 
             // Update the global volume stack with venue effects so SlowFPS
@@ -248,23 +255,32 @@ namespace YARG.Gameplay
             }
 
             // Increment wall clock time regardless of whether we render a frame
-            _timeSinceLastRender += Time.unscaledDeltaTime;
-            _elapsedTime += Time.unscaledDeltaTime;
+            var currentFrameTime = Time.unscaledTime;
 
-            if (_effectiveFps == 0 || _timeSinceLastRender >= 1f / _effectiveFps)
+            // Accumulator-based FPS limiting: smooths quantization over time.
+            // Add dt each frame, when accumulator >= frameInterval, render and subtract.
+            // This averages to the exact target FPS regardless of Update() frequency.
+            float frameInterval = _effectiveFps > 0 ? 1f / _effectiveFps : 0f;
+            _frameAccumulator += Time.unscaledDeltaTime;
+
+            if (_effectiveFps == 0 || _frameAccumulator >= frameInterval)
             {
+                // Sliding window: reset every ~1 second, compute FPS from frame count / elapsed time.
+                if (_fpsWindowStart > 0f && currentFrameTime - _fpsWindowStart > 1.0f)
+                {
+                    ActualFPS = _fpsWindowFrames / (currentFrameTime - _fpsWindowStart);
+                    _fpsWindowStart = currentFrameTime;
+                    _fpsWindowFrames = 0;
+                }
+
+                _fpsWindowFrames++;
+                if (_fpsWindowFrames == 1)
+                {
+                    _fpsWindowStart = currentFrameTime;
+                }
+
                 Render();
-
-                _timeSinceLastRender = 0f;
-                _frameCount++;
-            }
-
-            // Update FPS counter
-            if (_elapsedTime >= 1f)
-            {
-                ActualFPS = _frameCount / _elapsedTime;
-                _frameCount = 0;
-                _elapsedTime = 0f;
+                _frameAccumulator -= frameInterval;
             }
         }
 

--- a/Assets/Script/Gameplay/VenueCameraRenderer.cs
+++ b/Assets/Script/Gameplay/VenueCameraRenderer.cs
@@ -234,12 +234,17 @@ namespace YARG.Gameplay
 
             if (fpsEffect.IsActive())
             {
-                // The divisor is relative to 60 fps, so we need to adjust for that if FPS is something other than 60
-                var fpsRatio = ActualFPS / 60f;
-                var adjustedDivisor = fpsRatio * fpsEffect.Divisor.value;
-                _effectiveFps = Mathf.RoundToInt(FPS / adjustedDivisor);
-                // Don't allow a rate higher than the FPS cap
-                _effectiveFps = Mathf.Min(FPS, _effectiveFps);
+                if (FPS == 0)
+                {
+                    _effectiveFps = Mathf.RoundToInt(60f / fpsEffect.Divisor.value);
+                } else {
+                    // The divisor is relative to 60 fps, so we need to adjust for that if FPS is something other than 60
+                    var fpsRatio = ActualFPS / 60f;
+                    var adjustedDivisor = fpsRatio * fpsEffect.Divisor.value;
+                    _effectiveFps = Mathf.RoundToInt(FPS / adjustedDivisor);
+                    // Don't allow a rate higher than the FPS cap
+                    _effectiveFps = Mathf.Min(FPS, _effectiveFps);
+                }
             }
 
             // Increment wall clock time regardless of whether we render a frame


### PR DESCRIPTION
This fixes older visualisers that didn't write alpha channel at all