### PR TITLE
Middle-align Long Text in Sidebar Containers

### DIFF
--- a/Assets/Script/Menu/MusicLibrary/Sidebar.cs
+++ b/Assets/Script/Menu/MusicLibrary/Sidebar.cs
@@ -310,6 +310,7 @@ namespace YARG.Menu.MusicLibrary
             label.enableAutoSizing = false;
             label.textWrappingMode = TextWrappingModes.Normal;
             label.overflowMode = TextOverflowModes.Overflow;
+            label.verticalAlignment = VerticalAlignmentOptions.Middle;
             label.fontSize = baseFontSize;
 
             if (measureText.Length > maxCharsBeforeShrink)


### PR DESCRIPTION
This applies to Song Source, Charter, and Album Title,

This resolves https://discord.com/channels/1086048856678084609/1497225339514912921.

Before:
<img width="664" height="122" alt="image" src="https://github.com/user-attachments/assets/ced028b1-96e6-4831-b3c8-3a59876ffb97" />

After:
<img width="664" height="122" alt="image" src="https://github.com/user-attachments/assets/4d339f51-e5af-4287-98e9-eb00c15888df" />