### PR TITLE
Fix .sng volume normalization

### DIFF
--- a/Assets/Script/Audio/Bass/BassAudioManager.cs
+++ b/Assets/Script/Audio/Bass/BassAudioManager.cs
@@ -218,8 +218,8 @@ namespace YARG.Audio.BASS
             {
                 return null;
             }
-            return new BassStemMixer(name, this, speed, mixerVolume, handle, clampStemVolume, normalize,
-                CreateOutputChannel(SettingsManager.Settings?.OutputChannelDefault.Value ?? 0));
+            return new BassStemMixer(name, this, speed, mixerVolume, handle, clampStemVolume: clampStemVolume,
+                normalize: normalize, outputChannel: CreateOutputChannel(SettingsManager.Settings?.OutputChannelDefault.Value ?? 0));
         }
 
         protected override MicDevice? GetInputDevice(string name)


### PR DESCRIPTION
Fixes volume normalization for .sng files.  The issue was caused by swapped boolean params on accident.  Fixed that and also added named params to prevent this from happening in the future.  YARG.Core PR: https://github.com/YARC-Official/YARG.Core/pull/371