### PR TITLE
Vocals visual fixes

### DIFF
--- a/Assets/Script/Gameplay/Player/Vocals/VocalTrack.cs
+++ b/Assets/Script/Gameplay/Player/Vocals/VocalTrack.cs
@@ -210,19 +210,18 @@ namespace YARG.Gameplay.Player
             var imageAspectRatio = vocalsSize.width / vocalsSize.height;
             var clampedAspectRatio = Math.Clamp(imageAspectRatio, MIN_ASPECT_RATIO, MAX_ASPECT_RATIO);
 
-            float heightPixels = vocalsSize.height;
-            float widthPixels = heightPixels * clampedAspectRatio;
-
-            // Convert to normalized coordinates
-            float heightNormalized = heightPixels / Screen.height;
-            float widthNormalized = widthPixels / Screen.width;
-
             // Center horizontally and position below stats overlay
-            float xPos = (1.0f - widthNormalized) / 2.0f;
-            var statsHeightNormalized = StatsManager.Instance.GetComponent<RectTransform>().ToScreenSpace().height / Screen.height;
-            float yPos = 1.0f - heightNormalized - statsHeightNormalized;
+            float heightPixels = Mathf.Round(vocalsSize.height);
+            float widthPixels = Mathf.Round(heightPixels * clampedAspectRatio);
+            float xPixels = Mathf.Round((Screen.width - widthPixels) / 2.0f);
+            float statsHeightPixels = Mathf.Round(StatsManager.Instance.GetComponent<RectTransform>().ToScreenSpace().height);
+            float yPixels = Mathf.Round(Screen.height - heightPixels - statsHeightPixels);
 
-            _trackCamera.rect = new Rect(xPos, yPos, widthNormalized, heightNormalized);
+            _trackCamera.rect = new Rect(
+                xPixels / Screen.width,
+                yPixels / Screen.height,
+                widthPixels / Screen.width,
+                heightPixels / Screen.height);
             _trackCamera.targetTexture = renderTexture;
         }
 

--- a/Assets/Script/Gameplay/Visuals/BaseElement.cs
+++ b/Assets/Script/Gameplay/Visuals/BaseElement.cs
@@ -30,7 +30,7 @@
             Initialized = true;
 
             // Force update the position once just in case to prevent flickering
-            Update();
+            UpdateVisualElement();
         }
 
         protected abstract void InitializeElement();
@@ -39,7 +39,12 @@
 
         protected abstract bool UpdateElementPosition();
 
-        protected void Update()
+        private void LateUpdate()
+        {
+            UpdateVisualElement();
+        }
+
+        private void UpdateVisualElement()
         {
             // Skip if not initialized
             if (!Initialized) return;

--- a/Assets/Script/Gameplay/Visuals/VocalElements/VocalScrollingLyricSyllableElement.cs
+++ b/Assets/Script/Gameplay/Visuals/VocalElements/VocalScrollingLyricSyllableElement.cs
@@ -7,8 +7,12 @@ namespace YARG.Gameplay.Visuals
 {
     public class VocalScrollingLyricSyllableElement : VocalElement
     {
+        private static readonly int _sharpness = Shader.PropertyToID("_Sharpness");
+        private const float VOCAL_LYRIC_SHARPNESS = 0.5f;
+
         private LyricEvent _lyricRef;
         private double _lyricLength;
+        private bool _sharpnessApplied;
 
         private double _minimumTime;
         private bool _isStarpower;
@@ -38,6 +42,8 @@ namespace YARG.Gameplay.Visuals
 
         protected override void InitializeElement()
         {
+            ApplySharpness();
+
             if (_lyricRef.HarmonyHidden && _allowHiding)
             {
                 _lyricText.text = string.Empty;
@@ -75,6 +81,22 @@ namespace YARG.Gameplay.Visuals
 
         protected override void HideElement()
         {
+        }
+
+        private void ApplySharpness()
+        {
+            if (_sharpnessApplied)
+            {
+                return;
+            }
+
+            var material = _lyricText.fontMaterial;
+            if (material != null && material.HasFloat(_sharpness))
+            {
+                material.SetFloat(_sharpness, VOCAL_LYRIC_SHARPNESS);
+            }
+
+            _sharpnessApplied = true;
         }
     }
 }

--- a/Assets/Script/Gameplay/Visuals/VocalElements/VocalStaticLyricPhraseElement.cs
+++ b/Assets/Script/Gameplay/Visuals/VocalElements/VocalStaticLyricPhraseElement.cs
@@ -16,6 +16,9 @@ namespace YARG.Gameplay.Visuals
 {
     public class VocalStaticLyricPhraseElement : BaseElement // not a VocalElement because it doesn't scroll along the highway
     {
+        private static readonly int _sharpness = Shader.PropertyToID("_Sharpness");
+        private const float VOCAL_LYRIC_SHARPNESS = 0.5f;
+
         private const string PAST_LYRIC_COLOR_TAG = "<color=#595959>";
         private const string PAST_STAR_POWER_LYRIC_COLOR_TAG = "<color=#757519>";
         private const string PRESENT_LYRIC_COLOR_TAG = "<color=#13f0a6>";
@@ -31,6 +34,7 @@ namespace YARG.Gameplay.Visuals
         private bool _allowHiding;
         private float _x;
         private bool _isFuture = true;
+        private bool _sharpnessApplied;
 
         private Utf16ValueStringBuilder _builder;
 
@@ -59,6 +63,8 @@ namespace YARG.Gameplay.Visuals
 
         protected override void InitializeElement()
         {
+            ApplySharpness();
+
             var mergedLyricIdx = 0;
 
             var mainPhrase = _phrasePairRef.MainPhrase;
@@ -233,6 +239,22 @@ namespace YARG.Gameplay.Visuals
 
         protected override void HideElement()
         {
+        }
+
+        private void ApplySharpness()
+        {
+            if (_sharpnessApplied)
+            {
+                return;
+            }
+
+            var material = _phraseText.fontMaterial;
+            if (material != null && material.HasFloat(_sharpness))
+            {
+                material.SetFloat(_sharpness, VOCAL_LYRIC_SHARPNESS);
+            }
+
+            _sharpnessApplied = true;
         }
 
         private void BuilderAppendWithColorTag(string text, string colorTag)


### PR DESCRIPTION
In playing YARG, I always found the vocal lyrics to be a bit blurry. This is especially true for songs with faster lyrics. These should be relatively subtle changes which I believe make a difference.

- Pixel-snaps the vocal camera viewport before assigning Camera.rect, reducing fractional render texture sampling for the vocal track.
- Moves pooled gameplay visual element updates from Update() to LateUpdate() so visual positions are updated after all of the gameplay logic has been updated.
- Applies a vocal-specific TMP _Sharpness value to scrolling and static lyric text material instances to make lyric edges render more crisply.

Feel free to let me know if you don't think these are worth it. At the very least, I think the Update() to LateUpdate() change is worth it since we can ensure that all of the game logic is executed first before trying to move any of the visuals during that frame.