### PR TITLE
Improve vocal lyric spawning performance and stability

### DIFF
--- a/Assets/Script/Gameplay/Player/Vocals/VocalLyricContainer.cs
+++ b/Assets/Script/Gameplay/Player/Vocals/VocalLyricContainer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using TMPro;
 using UnityEngine;
 using YARG.Core.Chart;
 using YARG.Gameplay.Visuals;
@@ -10,6 +11,13 @@ namespace YARG.Gameplay.Player
 {
     public class VocalLyricContainer : MonoBehaviour
     {
+        public enum LyricSpawnResult
+        {
+            Spawned,
+            Suppressed,
+            PoolUnavailable
+        }
+
         public const float LYRIC_SPACING = 0.25f;
         public const float STATIC_PHRASE_SPACING = .5f;
 
@@ -30,17 +38,16 @@ namespace YARG.Gameplay.Player
         public float TrackSpeed { get; set; }
 
         private string _lastSecondHarmonyLyric;
+        private TextMeshPro[] _scrollingWidthTesters;
+        private TextMeshPro[] _staticWidthTesters;
 
-        public bool TrySpawnScrollingLyric(LyricEvent lyric, VocalNote probableNotePair, bool isStarpower, int totalHarms, int harmIndex)
+        public static int GetLaneIndex(int totalHarms, int harmIndex)
         {
             var combineHarmonyLyrics = !SettingsManager.Settings.UseThreeLaneLyricsInHarmony.Value;
 
-            // Choose the correct lane for the lyrics
-            int laneIndex;
-
             if (combineHarmonyLyrics || totalHarms == 2)
             {
-                laneIndex = harmIndex switch
+                return harmIndex switch
                 {
                     0 => 0,
                     1 => 2,
@@ -48,35 +55,96 @@ namespace YARG.Gameplay.Player
                     _ => throw new InvalidOperationException("Unexpected lyric lane count")
                 };
             }
-            else
+
+            return harmIndex;
+        }
+
+        public void PrewarmScrollingPool(int laneIndex, int targetTotalCount)
+        {
+            _scrollingPools[laneIndex].PrewarmTo(targetTotalCount);
+        }
+
+        public void PrewarmStaticPool(int laneIndex, int targetTotalCount)
+        {
+            _staticPools[laneIndex].PrewarmTo(targetTotalCount);
+        }
+
+        public VocalScrollingLyricSyllableElement.PreparedLyric PrepareScrollingLyric(
+            LyricEvent lyric, VocalNote probableNote, int totalHarms, int harmIndex)
+        {
+            var combineHarmonyLyrics = !SettingsManager.Settings.UseThreeLaneLyricsInHarmony.Value;
+            bool allowHiding = harmIndex != 0 && combineHarmonyLyrics;
+            string displayText = lyric.HarmonyHidden && allowHiding ? string.Empty : lyric.Text;
+
+            float width = 0f;
+            if (!string.IsNullOrEmpty(displayText))
             {
-                laneIndex = harmIndex;
+                var tester = GetScrollingWidthTester(GetLaneIndex(totalHarms, harmIndex));
+                tester.fontStyle = lyric.NonPitched ? FontStyles.Italic : FontStyles.Normal;
+                tester.text = displayText;
+                width = tester.GetPreferredValues().x;
             }
+
+            return new VocalScrollingLyricSyllableElement.PreparedLyric(lyric, probableNote, allowHiding, width);
+        }
+
+        public VocalStaticLyricPhraseElement.PreparedPhrase PrepareStaticLyricPhrase(
+            VocalPhrasePair phrasePair, List<VocalsPhrase> scoringPhrases, int totalHarms, int harmIndex)
+        {
+            var combineHarmonyLyrics = !SettingsManager.Settings.UseThreeLaneLyricsInHarmony.Value;
+            bool allowHiding = harmIndex != 0 && combineHarmonyLyrics;
+            var preparedPhrase = new VocalStaticLyricPhraseElement.PreparedPhrase(
+                phrasePair, scoringPhrases, allowHiding, 0f);
+
+            var tester = GetStaticWidthTester(GetLaneIndex(totalHarms, harmIndex));
+            tester.fontStyle = FontStyles.Normal;
+            tester.text = preparedPhrase.FutureText;
+            var width = tester.GetPreferredValues().x;
+
+            return preparedPhrase.WithWidth(width);
+        }
+
+        public LyricSpawnResult TrySpawnScrollingLyric(VocalScrollingLyricSyllableElement.PreparedLyric preparedLyric,
+            bool isStarpower, int totalHarms, int harmIndex)
+        {
+            var combineHarmonyLyrics = !SettingsManager.Settings.UseThreeLaneLyricsInHarmony.Value;
+            var lyric = preparedLyric.Lyric;
+            int laneIndex = GetLaneIndex(totalHarms, harmIndex);
 
             // When combining lyrics, never show HARM3's lyrics unless they're different from HARM2's lyric
             if (combineHarmonyLyrics && harmIndex == 2 && _lastSecondHarmonyLyric == lyric.Text)
             {
                 _lastSecondHarmonyLyric = null;
-                return true;
+                return LyricSpawnResult.Suppressed;
+            }
+
+            if (preparedLyric.IsHidden)
+            {
+                _lastLyricEdgeTime[laneIndex] = Math.Max(lyric.Time, _lastLyricEdgeTime[laneIndex]) +
+                    LYRIC_SPACING / TrackSpeed;
+
+                if (combineHarmonyLyrics && harmIndex == 1)
+                {
+                    _lastSecondHarmonyLyric = lyric.Text;
+                }
+
+                return LyricSpawnResult.Suppressed;
             }
 
             // Skip this frame if the pool is full
             if (!_scrollingPools[laneIndex].CanSpawnAmount(1))
             {
-                return false;
+                return LyricSpawnResult.PoolUnavailable;
             }
-
-            // Get the info from the probably note pair, IF it exists
-            double length = probableNotePair?.TotalTimeLength ?? 0;
 
             // Spawn the vocal lyric
             bool allowHiding = harmIndex != 0 && combineHarmonyLyrics;
             var obj = (VocalScrollingLyricSyllableElement) _scrollingPools[laneIndex].TakeWithoutEnabling();
-            obj.Initialize(lyric, _lastLyricEdgeTime[laneIndex], length, isStarpower, harmIndex, allowHiding);
+            obj.Initialize(preparedLyric, _lastLyricEdgeTime[laneIndex], preparedLyric.NoteLength, isStarpower, harmIndex, allowHiding);
             obj.EnableFromPool();
 
             // Set the edge time
-            _lastLyricEdgeTime[laneIndex] = obj.ElementTime + (obj.Width + LYRIC_SPACING) / TrackSpeed;
+            _lastLyricEdgeTime[laneIndex] = obj.ElementTime + (preparedLyric.Width + LYRIC_SPACING) / TrackSpeed;
 
             // When combining lyrics, prevent duplicates on HARM3
             if (combineHarmonyLyrics && harmIndex == 1)
@@ -84,31 +152,14 @@ namespace YARG.Gameplay.Player
                 _lastSecondHarmonyLyric = lyric.Text;
             }
 
-            return true;
+            return LyricSpawnResult.Spawned;
         }
 
         #nullable enable
-        public VocalStaticLyricPhraseElement? TrySpawnStaticLyricPhrase(VocalPhrasePair phrasePair, List<VocalsPhrase> scoringPhrases,
-            int totalHarms, int harmIndex, float x)
+        public VocalStaticLyricPhraseElement? TrySpawnStaticLyricPhrase(
+            VocalStaticLyricPhraseElement.PreparedPhrase preparedPhrase, int totalHarms, int harmIndex, float x)
         {
-            var combineHarmonyLyrics = !SettingsManager.Settings.UseThreeLaneLyricsInHarmony.Value;
-
-            int laneIndex;
-
-            if (combineHarmonyLyrics || totalHarms == 2)
-            {
-                laneIndex = harmIndex switch
-                {
-                    0 => 0,
-                    1 => 2,
-                    2 => 2,
-                    _ => throw new InvalidOperationException("Unexpected lyric lane count")
-                };
-            }
-            else
-            {
-                laneIndex = harmIndex;
-            }
+            int laneIndex = GetLaneIndex(totalHarms, harmIndex);
 
             // Skip this frame if the pool is full
             if (!_staticPools[laneIndex].CanSpawnAmount(1))
@@ -117,9 +168,8 @@ namespace YARG.Gameplay.Player
             }
 
             // Spawn the vocal lyric
-            bool allowHiding = harmIndex != 0 && combineHarmonyLyrics;
             var obj = (VocalStaticLyricPhraseElement) _staticPools[laneIndex].TakeWithoutEnabling();
-            obj.Initialize(phrasePair, scoringPhrases, laneIndex, allowHiding, x);
+            obj.Initialize(preparedPhrase, x);
             obj.EnableFromPool();
 
             return obj;
@@ -141,6 +191,29 @@ namespace YARG.Gameplay.Player
             {
                 pool.ReturnAllObjects();
             }
+        }
+
+        private TextMeshPro GetScrollingWidthTester(int laneIndex)
+        {
+            _scrollingWidthTesters ??= new TextMeshPro[_scrollingPools.Length];
+            return _scrollingWidthTesters[laneIndex] ??=
+                CreateWidthTester(_scrollingPools[laneIndex].Prefab, $"Scrolling Lyric Width Tester {laneIndex}");
+        }
+
+        private TextMeshPro GetStaticWidthTester(int laneIndex)
+        {
+            _staticWidthTesters ??= new TextMeshPro[_staticPools.Length];
+            return _staticWidthTesters[laneIndex] ??=
+                CreateWidthTester(_staticPools[laneIndex].Prefab, $"Static Lyric Width Tester {laneIndex}");
+        }
+
+        private TextMeshPro CreateWidthTester(GameObject prefab, string name)
+        {
+            var instance = Instantiate(prefab, transform);
+            instance.name = name;
+            instance.SetActive(false);
+
+            return instance.GetComponentInChildren<TextMeshPro>(true);
         }
     }
 }

--- a/Assets/Script/Gameplay/Player/Vocals/VocalTrack.Spawning.cs
+++ b/Assets/Script/Gameplay/Player/Vocals/VocalTrack.Spawning.cs
@@ -1,4 +1,5 @@
 ﻿using DG.Tweening;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
@@ -17,14 +18,18 @@ namespace YARG.Gameplay.Player
         private const float STATIC_LYRICS_SPACING_FROM_SING_LINE = .25f;
         private const float STATIC_LYRICS_LEFT_EDGE = VocalElement.SING_LINE_POS + STATIC_LYRICS_SPACING_FROM_SING_LINE;
         private const float DEFAULT_STATIC_LYRICS_RIGHT_EDGE = STATIC_LYRICS_LEFT_EDGE + VocalLyricContainer.STATIC_PHRASE_SPACING;
-        private const float MAXIMUM_STATIC_PHRASE_QUEUE_SIZE = 10;
+        private const int MAXIMUM_STATIC_PHRASE_QUEUE_SIZE = 10;
         private const float STATIC_LYRIC_SHIFT_DURATION = .1f;
+        private const int SCROLLING_LYRIC_SPAWN_BUDGET = 4;
+        private const int STATIC_PHRASE_ENQUEUE_BUDGET = 2;
 
         private ScrollingPhraseNoteTracker[] _scrollingNoteTrackers;
         private ScrollingPhraseNoteTracker[] _scrollingLyricTrackers;
         private StaticPhraseTracker[] _staticPhraseTrackers;
         private Queue<VocalStaticLyricPhraseElement>[] _staticPhraseQueues;
 
+        private Dictionary<LyricEvent, VocalScrollingLyricSyllableElement.PreparedLyric> _preparedScrollingLyrics;
+        private List<VocalStaticLyricPhraseElement.PreparedPhrase>[] _preparedStaticPhrases;
 
         private int[] _highestEnqueuedPhrasePairIndices = { -1, -1, -1 };
         private float[] _rightEdges = {
@@ -100,17 +105,25 @@ namespace YARG.Gameplay.Player
 
         private void SpawnScrollingLyrics(ScrollingPhraseNoteTracker tracker, int harmonyIndex)
         {
-            while (tracker.CurrentLyricInBounds && tracker.CurrentLyric.Time <= GameManager.SongTime + SpawnTimeOffset)
+            int spawnedThisFrame = 0;
+            while (tracker.CurrentLyricInBounds &&
+                tracker.CurrentLyric.Time <= GameManager.SongTime + SpawnTimeOffset &&
+                spawnedThisFrame < SCROLLING_LYRIC_SPAWN_BUDGET)
             {
-                if (!_lyricContainer.TrySpawnScrollingLyric(
-                    tracker.CurrentLyric,
-                    tracker.GetProbableNoteAtLyric(),
+                var spawnResult = _lyricContainer.TrySpawnScrollingLyric(
+                    _preparedScrollingLyrics[tracker.CurrentLyric],
                     AllowStarPower && tracker.CurrentPhrase.IsStarPower,
                     _totalHarms,
-                    harmonyIndex))
+                    harmonyIndex);
+
+                if (spawnResult == VocalLyricContainer.LyricSpawnResult.PoolUnavailable)
                 {
-                    tracker.NextLyric();
                     return;
+                }
+
+                if (spawnResult == VocalLyricContainer.LyricSpawnResult.Spawned)
+                {
+                    spawnedThisFrame++;
                 }
 
                 tracker.NextLyric();
@@ -127,12 +140,19 @@ namespace YARG.Gameplay.Player
             var change = tracker.UpdateCurrentPhrase(GameManager.SongTime);
             var queue = _staticPhraseQueues[harmonyIndex];
 
+            EnqueueStaticPhrases(harmonyIndex, STATIC_PHRASE_ENQUEUE_BUDGET);
+
             switch (change)
             {
                 case StaticLyricShiftType.None:
                     break;
                 case StaticLyricShiftType.PhraseToGap:
                 {
+                    if (queue.Count == 0)
+                    {
+                        return;
+                    }
+
                     var leftmostPhraseElement = queue.Dequeue();
                     var leftShift = leftmostPhraseElement.Width;
 
@@ -147,6 +167,16 @@ namespace YARG.Gameplay.Player
                 }
                 case StaticLyricShiftType.PhraseToPhrase:
                 {
+                    if (queue.Count < 2)
+                    {
+                        EnqueueStaticPhrases(harmonyIndex, 2 - queue.Count);
+                    }
+
+                    if (queue.Count < 2)
+                    {
+                        return;
+                    }
+
                     var leftmostPhraseElement = queue.Dequeue();
                     var leftShift = leftmostPhraseElement.Width + VocalLyricContainer.STATIC_PHRASE_SPACING;
                     queue.Peek().Activate();
@@ -163,6 +193,16 @@ namespace YARG.Gameplay.Player
                 }
                 case StaticLyricShiftType.GapToPhrase:
                 {
+                    if (queue.Count < 1)
+                    {
+                        EnqueueStaticPhrases(harmonyIndex, 1);
+                    }
+
+                    if (queue.Count < 1)
+                    {
+                        return;
+                    }
+
                     var leftmostPhraseElement = queue.Peek();
 
                     _rightEdges[harmonyIndex] -= VocalLyricContainer.STATIC_PHRASE_SPACING;
@@ -179,6 +219,11 @@ namespace YARG.Gameplay.Player
                 case StaticLyricShiftType.FinalPhraseComplete:
                 {
                     _noMoreStaticPhrases[harmonyIndex] = true;
+                    if (queue.Count == 0)
+                    {
+                        break;
+                    }
+
                     var finalPhraseElement = queue.Dequeue();
                     finalPhraseElement.Dismiss();
                     break;
@@ -187,29 +232,44 @@ namespace YARG.Gameplay.Player
                     _noMoreStaticPhrases[harmonyIndex] = true;
                     break;
             }
+        }
+
+        private void EnqueueStaticPhrases(int harmonyIndex, int budget)
+        {
+            var queue = _staticPhraseQueues[harmonyIndex];
+            var preparedPhrases = _preparedStaticPhrases[harmonyIndex];
+            int enqueued = 0;
 
             // Enqueue more phrases, if we have room
-            for (var phraseIdx = _highestEnqueuedPhrasePairIndices[harmonyIndex] + 1; phraseIdx < _staticPhraseTrackers[harmonyIndex].PhrasePairs.Count; phraseIdx++)
+            for (var phraseIdx = _highestEnqueuedPhrasePairIndices[harmonyIndex] + 1;
+                phraseIdx < preparedPhrases.Count && enqueued < budget;
+                phraseIdx++)
             {
-                if (queue.Count > MAXIMUM_STATIC_PHRASE_QUEUE_SIZE)
+                if (queue.Count >= MAXIMUM_STATIC_PHRASE_QUEUE_SIZE)
                 {
                     break;
                 }
 
-                var phrase = _staticPhraseTrackers[harmonyIndex].PhrasePairs[phraseIdx];
+                var phrase = preparedPhrases[phraseIdx];
 
-                if (phrase.IsPercussion)
+                if (phrase.PhrasePair.IsPercussion)
                 {
                     continue;
                 }
 
-                var newPhraseElement = _lyricContainer.TrySpawnStaticLyricPhrase(phrase, _vocalsTrack.Parts[harmonyIndex].NotePhrases, _totalHarms, harmonyIndex, _rightEdges[harmonyIndex]);
+                var newPhraseElement = _lyricContainer.TrySpawnStaticLyricPhrase(
+                    phrase, _totalHarms, harmonyIndex, _rightEdges[harmonyIndex]);
 
                 if (newPhraseElement != null)
                 {
                     _rightEdges[harmonyIndex] += newPhraseElement.Width + VocalLyricContainer.STATIC_PHRASE_SPACING;
                     _highestEnqueuedPhrasePairIndices[harmonyIndex] = phraseIdx;
                     queue.Enqueue(newPhraseElement);
+                    enqueued++;
+                }
+                else
+                {
+                    break;
                 }
             }
         }
@@ -231,6 +291,133 @@ namespace YARG.Gameplay.Player
 
             // Update the index value
             _phraseMarkerIndices[harmonyIndex] = index;
+        }
+
+        private void PrepareLyricSpawns()
+        {
+            _preparedScrollingLyrics = new();
+            for (int partIndex = 0; partIndex < _vocalsTrack.Parts.Count; partIndex++)
+            {
+                var part = _vocalsTrack.Parts[partIndex];
+
+                foreach (var phrase in part.NotePhrases)
+                {
+                    foreach (var lyric in phrase.Lyrics)
+                    {
+                        var probableNote = phrase.PhraseParentNote.ChildNotes
+                            .FirstOrDefault(note => note.Tick == lyric.Tick);
+                        _preparedScrollingLyrics[lyric] =
+                            _lyricContainer.PrepareScrollingLyric(lyric, probableNote, _totalHarms, partIndex);
+                    }
+                }
+            }
+
+            _preparedStaticPhrases = new List<VocalStaticLyricPhraseElement.PreparedPhrase>[_staticPhraseTrackers.Length];
+            for (int harmonyIndex = 0; harmonyIndex < _staticPhraseTrackers.Length; harmonyIndex++)
+            {
+                var tracker = _staticPhraseTrackers[harmonyIndex];
+                if (tracker == null)
+                {
+                    _preparedStaticPhrases[harmonyIndex] = new();
+                    continue;
+                }
+
+                var preparedPhrases = new List<VocalStaticLyricPhraseElement.PreparedPhrase>(tracker.PhrasePairs.Count);
+                foreach (var phrasePair in tracker.PhrasePairs)
+                {
+                    preparedPhrases.Add(_lyricContainer.PrepareStaticLyricPhrase(
+                        phrasePair,
+                        _vocalsTrack.Parts[harmonyIndex].NotePhrases,
+                        _totalHarms,
+                        harmonyIndex));
+                }
+
+                _preparedStaticPhrases[harmonyIndex] = preparedPhrases;
+            }
+        }
+
+        private void PrewarmVocalPools()
+        {
+            var visibleWindow = SpawnTimeOffset + (10f / TrackSpeed);
+            var scrollingTimesByLane = new List<double>[] { new(), new(), new() };
+            var phraseLineTimes = new List<double>();
+            var talkieTimes = new List<double>();
+
+            for (int harmonyIndex = 0; harmonyIndex < _vocalsTrack.Parts.Count; harmonyIndex++)
+            {
+                var part = _vocalsTrack.Parts[harmonyIndex];
+                int laneIndex = VocalLyricContainer.GetLaneIndex(_totalHarms, harmonyIndex);
+                var noteTimes = new List<double>();
+                double longestNoteLength = 0;
+
+                foreach (var phrase in part.NotePhrases)
+                {
+                    phraseLineTimes.Add(phrase.TimeEnd);
+
+                    foreach (var lyric in phrase.Lyrics)
+                    {
+                        if (_preparedScrollingLyrics.TryGetValue(lyric, out var preparedLyric) && !preparedLyric.IsHidden)
+                        {
+                            scrollingTimesByLane[laneIndex].Add(lyric.Time);
+                        }
+                    }
+
+                    foreach (var note in phrase.PhraseParentNote.ChildNotes)
+                    {
+                        longestNoteLength = Math.Max(longestNoteLength, note.TotalTimeLength);
+                        if (note.IsNonPitched)
+                        {
+                            talkieTimes.Add(note.Time);
+                        }
+                        else if (!note.IsPercussion)
+                        {
+                            noteTimes.Add(note.Time);
+                        }
+                    }
+                }
+
+                _notePools[harmonyIndex].PrewarmTo(Math.Max(5,
+                    GetMaxEventsInWindow(noteTimes, visibleWindow + longestNoteLength)));
+            }
+
+            for (int laneIndex = 0; laneIndex < scrollingTimesByLane.Length; laneIndex++)
+            {
+                _lyricContainer.PrewarmScrollingPool(laneIndex, Math.Max(5,
+                    GetMaxEventsInWindow(scrollingTimesByLane[laneIndex], visibleWindow)));
+            }
+
+            for (int harmonyIndex = 0; harmonyIndex < LyricLaneCount; harmonyIndex++)
+            {
+                int laneIndex = VocalLyricContainer.GetLaneIndex(_totalHarms, harmonyIndex);
+                _lyricContainer.PrewarmStaticPool(laneIndex, MAXIMUM_STATIC_PHRASE_QUEUE_SIZE);
+            }
+
+            _phraseLinePool.PrewarmTo(Math.Max(3, GetMaxEventsInWindow(phraseLineTimes, visibleWindow)));
+            _talkiePool.PrewarmTo(Math.Max(5, GetMaxEventsInWindow(talkieTimes, visibleWindow)));
+        }
+
+        private static int GetMaxEventsInWindow(List<double> times, double window)
+        {
+            if (times.Count == 0)
+            {
+                return 0;
+            }
+
+            times.Sort();
+
+            int max = 0;
+            int left = 0;
+            for (int right = 0; right < times.Count; right++)
+            {
+                while (times[right] - times[left] > window)
+                {
+                    left++;
+                }
+
+                max = Math.Max(max, right - left + 1);
+            }
+
+            return max;
         }
     }
 }

--- a/Assets/Script/Gameplay/Player/Vocals/VocalTrack.Tracking.cs
+++ b/Assets/Script/Gameplay/Player/Vocals/VocalTrack.Tracking.cs
@@ -88,7 +88,7 @@ namespace YARG.Gameplay.Player
                 PhrasePairs = new();
                 foreach (var phrasePair in phrasePairs)
                 {
-                    if (!phrasePair.IsPercussion)
+                    if (!phrasePair.IsPercussion && phrasePair.HasNotes)
                     {
                         PhrasePairs.Add(phrasePair);
                     }

--- a/Assets/Script/Gameplay/Player/Vocals/VocalTrack.cs
+++ b/Assets/Script/Gameplay/Player/Vocals/VocalTrack.cs
@@ -176,6 +176,7 @@ namespace YARG.Gameplay.Player
         private VocalsTrack _vocalsTrack;
 
         private Material _guidelineMaterial;
+        private TextMeshPro _lyricWidthTester;
 
         private bool _isRangeChanging;
         private Range _viewRange;
@@ -376,6 +377,9 @@ namespace YARG.Gameplay.Player
 
             // Hide overlay
             _starpowerMaterial.SetFloat(_alphaMultiplier, 0f);
+
+            PrepareLyricSpawns();
+            PrewarmVocalPools();
 
             AllowStarPower = true;
         }
@@ -611,7 +615,23 @@ namespace YARG.Gameplay.Player
             uint rangesStart = _vocalsTrack.RangeShifts.LowerBoundElement(start).Tick;
             _vocalsTrack.RangeShifts.RemoveAll(n => n.Tick < rangesStart || n.Tick >= end);
 
+            PrepareLyricSpawns();
+            PrewarmVocalPools();
+
             ResetPracticeSection();
+        }
+
+        private TextMeshPro GetLyricWidthTester()
+        {
+            if (_lyricWidthTester != null)
+            {
+                return _lyricWidthTester;
+            }
+
+            _lyricWidthTester = gameObject.AddComponent<TextMeshPro>();
+            _lyricWidthTester.enabled = false;
+            _lyricWidthTester.text = string.Empty;
+            return _lyricWidthTester;
         }
 
         // Should only be used when the chart did not provide an explicit vocal scroll speed. Finds the largest distance
@@ -619,7 +639,7 @@ namespace YARG.Gameplay.Player
         // that distance is too big, returns an increased vocal scroll speed
         private float GetScrollSpeedScalingFactor(List<VocalsPart> parts)
         {
-            var textWidthTester = gameObject.AddComponent<TextMeshPro>();
+            var textWidthTester = GetLyricWidthTester();
 
             const float DEFAULT_TRACK_SPEED = 5;
             const int THRESHOLD = 300;

--- a/Assets/Script/Gameplay/Player/Vocals/VocalTrack.cs
+++ b/Assets/Script/Gameplay/Player/Vocals/VocalTrack.cs
@@ -728,37 +728,54 @@ namespace YARG.Gameplay.Player
 
             public readonly bool IsStarPower => MainPhrase?.IsStarPower ?? MergedPhrase!.IsStarPower;
 
+            public readonly bool HasNotes => HasNotesInPhrase(MainPhrase) || HasNotesInPhrase(MergedPhrase);
+
             public double Duration => GetLastNoteTotalEndTime() - GetFirstNoteStartTime();
 
             public double GetFirstNoteStartTime()
             {
-                if (MergedPhrase is null)
+                if (!HasNotes)
+                {
+                    return Time;
+                }
+
+                if (!HasNotesInPhrase(MergedPhrase))
                 {
                     return MainPhrase!.PhraseParentNote.Time;
                 }
-                if (MainPhrase is null)
+
+                if (!HasNotesInPhrase(MainPhrase))
                 {
-                    return MergedPhrase.PhraseParentNote.Time;
-                } else
-                {
-                    return Math.Min(MainPhrase.PhraseParentNote.Time, MergedPhrase.PhraseParentNote.Time);
+                    return MergedPhrase!.PhraseParentNote.Time;
                 }
+
+                return Math.Min(MainPhrase!.PhraseParentNote.Time, MergedPhrase!.PhraseParentNote.Time);
             }
 
             public double GetLastNoteTotalEndTime()
             {
-                if (MergedPhrase is null)
+                if (!HasNotes)
+                {
+                    return Time;
+                }
+
+                if (!HasNotesInPhrase(MergedPhrase))
                 {
                     return MainPhrase!.PhraseParentNote.ChildNotes[^1].TotalTimeEnd;
                 }
-                if (MainPhrase is null)
+
+                if (!HasNotesInPhrase(MainPhrase))
                 {
-                    return MergedPhrase.PhraseParentNote.ChildNotes[^1].TotalTimeEnd;
+                    return MergedPhrase!.PhraseParentNote.ChildNotes[^1].TotalTimeEnd;
                 }
-                else
-                {
-                    return Math.Max(MainPhrase.PhraseParentNote.ChildNotes[^1].TotalTimeEnd, MergedPhrase.PhraseParentNote.ChildNotes[^1].TotalTimeEnd);
-                }
+
+                return Math.Max(MainPhrase!.PhraseParentNote.ChildNotes[^1].TotalTimeEnd,
+                    MergedPhrase!.PhraseParentNote.ChildNotes[^1].TotalTimeEnd);
+            }
+
+            private static bool HasNotesInPhrase(VocalsPhrase? phrase)
+            {
+                return phrase?.PhraseParentNote.ChildNotes.Count > 0;
             }
         }
 

--- a/Assets/Script/Gameplay/Pool.cs
+++ b/Assets/Script/Gameplay/Pool.cs
@@ -35,9 +35,20 @@ namespace YARG.Gameplay
 
         protected virtual void Awake()
         {
-            for (int i = 0; i < _prewarmAmount; i++)
+            PrewarmTo(_prewarmAmount);
+        }
+
+        public void PrewarmTo(int targetTotalCount)
+        {
+            while (TotalCount < targetTotalCount)
             {
-                _pooled.Push(CreateNew());
+                var poolable = CreateNew();
+                if (poolable == null)
+                {
+                    break;
+                }
+
+                _pooled.Push(poolable);
             }
         }
 
@@ -49,11 +60,7 @@ namespace YARG.Gameplay
             _pooled.Clear();
             _spawnedObjects.Clear();
 
-            // Re-prewarm
-            for (int i = 0; i < _prewarmAmount; i++)
-            {
-                _pooled.Push(CreateNew());
-            }
+            PrewarmTo(_prewarmAmount);
         }
 
         private IPoolable CreateNew()

--- a/Assets/Script/Gameplay/Visuals/VocalElements/VocalScrollingLyricSyllableElement.cs
+++ b/Assets/Script/Gameplay/Visuals/VocalElements/VocalScrollingLyricSyllableElement.cs
@@ -7,7 +7,28 @@ namespace YARG.Gameplay.Visuals
 {
     public class VocalScrollingLyricSyllableElement : VocalElement
     {
+        public sealed class PreparedLyric
+        {
+            public readonly LyricEvent Lyric;
+            public readonly string DisplayText;
+            public readonly FontStyles FontStyle;
+            public readonly float Width;
+            public readonly double NoteLength;
+            public readonly bool IsHidden;
+
+            public PreparedLyric(LyricEvent lyric, VocalNote probableNote, bool allowHiding, float width)
+            {
+                Lyric = lyric;
+                NoteLength = probableNote?.TotalTimeLength ?? 0;
+                DisplayText = lyric.HarmonyHidden && allowHiding ? string.Empty : lyric.Text;
+                FontStyle = lyric.NonPitched ? FontStyles.Italic : FontStyles.Normal;
+                IsHidden = string.IsNullOrEmpty(DisplayText);
+                Width = IsHidden ? 0f : width;
+            }
+        }
+
         private LyricEvent _lyricRef;
+        private PreparedLyric _preparedLyric;
         private double _lyricLength;
 
         private double _minimumTime;
@@ -21,12 +42,13 @@ namespace YARG.Gameplay.Visuals
         [SerializeField]
         private TextMeshPro _lyricText;
 
-        public float Width => _lyricText.GetPreferredValues().x;
+        public float Width => _preparedLyric.Width;
 
-        public void Initialize(LyricEvent lyric, double minTime, double lyricLength,
+        public void Initialize(PreparedLyric preparedLyric, double minTime, double lyricLength,
             bool isStarpower, int harmonyIndex, bool allowHiding)
         {
-            _lyricRef = lyric;
+            _preparedLyric = preparedLyric;
+            _lyricRef = preparedLyric.Lyric;
             _lyricLength = lyricLength;
 
             _minimumTime = minTime;
@@ -38,17 +60,8 @@ namespace YARG.Gameplay.Visuals
 
         protected override void InitializeElement()
         {
-            if (_lyricRef.HarmonyHidden && _allowHiding)
-            {
-                _lyricText.text = string.Empty;
-            }
-            else
-            {
-                _lyricText.text = _lyricRef.Text;
-            }
-
-            // If it's a talkie, italicize it
-            _lyricText.fontStyle = _lyricRef.NonPitched ? FontStyles.Italic : FontStyles.Normal;
+            _lyricText.text = _preparedLyric.DisplayText;
+            _lyricText.fontStyle = _preparedLyric.FontStyle;
 
             // Disable automatically if the text is just nothing
             if (string.IsNullOrEmpty(_lyricText.text))

--- a/Assets/Script/Gameplay/Visuals/VocalElements/VocalStaticLyricPhraseElement.cs
+++ b/Assets/Script/Gameplay/Visuals/VocalElements/VocalStaticLyricPhraseElement.cs
@@ -1,15 +1,10 @@
 ﻿using Cysharp.Text;
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using TMPro;
 using UnityEngine;
 using YARG.Core.Chart;
 using YARG.Gameplay.Player;
-using YARG.Gameplay.Visuals;
-using YARG.Settings;
 using static YARG.Gameplay.Player.VocalTrack;
 
 namespace YARG.Gameplay.Visuals
@@ -25,44 +20,208 @@ namespace YARG.Gameplay.Visuals
         private const string FUTURE_STAR_POWER_PHRASE_COLOR_TAG = "<color=#757519>";
         private const string CLOSE_COLOR_TAG = "</color>";
 
-        private VocalPhrasePair _phrasePairRef;
-        private List<VocalsPhrase> _scoringPhrases; // Needed to determine which syllables should have star power coloring
-        private int _harmonyIndex;
-        private bool _allowHiding;
+        public sealed class PreparedPhrase
+        {
+            public readonly VocalPhrasePair PhrasePair;
+            public readonly List<StaticLyricSyllable> Syllables;
+            public readonly string FutureText;
+            public readonly float Width;
+            public readonly double Duration;
+
+            public PreparedPhrase(VocalPhrasePair phrasePair, List<VocalsPhrase> scoringPhrases,
+                bool allowHiding, float width)
+            {
+                PhrasePair = phrasePair;
+                Duration = phrasePair.Duration;
+                Syllables = BuildSyllables(phrasePair, scoringPhrases, allowHiding);
+                FutureText = BuildFutureText(Syllables);
+                Width = width;
+            }
+
+            private PreparedPhrase(VocalPhrasePair phrasePair, double duration,
+                List<StaticLyricSyllable> syllables, string futureText, float width)
+            {
+                PhrasePair = phrasePair;
+                Duration = duration;
+                Syllables = syllables;
+                FutureText = futureText;
+                Width = width;
+            }
+
+            public PreparedPhrase WithWidth(float width)
+            {
+                return new PreparedPhrase(PhrasePair, Duration, Syllables, FutureText, width);
+            }
+        }
+
+        public readonly struct StaticLyricSyllable
+        {
+            public readonly string Text;
+            public readonly double Time;
+            public readonly double TimeEnd;
+            public readonly bool IsStarpower;
+
+            public StaticLyricSyllable(string text, double time, double timeEnd, bool isStarpower,
+                LyricSymbolFlags flags, bool isLastLyricOfPhrase)
+            {
+                var builder = ZString.CreateStringBuilder(false);
+
+                Time = time;
+                TimeEnd = timeEnd;
+                IsStarpower = isStarpower;
+
+                if ((flags & LyricSymbolFlags.NonPitched) != 0)
+                {
+                    builder.Append("<i>");
+                }
+
+                if ((flags & LyricSymbolFlags.JoinWithNext) != 0)
+                {
+                    builder.Append(text[0..^1]);
+                }
+                else
+                {
+                    builder.Append(text);
+                }
+
+                if ((flags & LyricSymbolFlags.NonPitched) != 0)
+                {
+                    builder.Append("</i>");
+                }
+
+                if (!isLastLyricOfPhrase && (flags & LyricSymbolFlags.JoinWithNext) == 0 &&
+                    (flags & LyricSymbolFlags.HyphenateWithNext) == 0)
+                {
+                    builder.Append(" ");
+                }
+
+                Text = builder.ToString();
+            }
+        }
+
+        private PreparedPhrase _preparedPhrase;
         private float _x;
         private bool _isFuture = true;
+        private int _lastRenderState = int.MinValue;
 
         private Utf16ValueStringBuilder _builder;
 
-        private List<StaticLyricSyllable> _syllables = new();
-
-        public override double ElementTime => _phrasePairRef.Time;
+        public override double ElementTime => _preparedPhrase.PhrasePair.Time;
 
         [SerializeField]
         private TextMeshPro _phraseText;
 
-        public float Width => _phraseText.GetPreferredValues().x;
+        public float Width => _preparedPhrase.Width;
 
-        public double Duration => _phrasePairRef.Duration;
+        public double Duration => _preparedPhrase.Duration;
 
-        public void Initialize(VocalPhrasePair phrasePair, List<VocalsPhrase> scoringPhrases, int harmonyIndex,
-            bool allowHiding, float x)
+        public void Initialize(PreparedPhrase preparedPhrase, float x)
         {
-            _phrasePairRef = phrasePair;
-            _scoringPhrases = scoringPhrases;
-            _harmonyIndex = harmonyIndex;
-            _allowHiding = allowHiding;
+            _preparedPhrase = preparedPhrase;
             _x = x;
-
+            _isFuture = true;
             _builder = ZString.CreateStringBuilder(false);
+            _lastRenderState = int.MinValue;
         }
 
         protected override void InitializeElement()
         {
+            transform.localPosition = transform.localPosition.WithX(_x);
+            _phraseText.text = _preparedPhrase.FutureText;
+        }
+
+        public void Activate()
+        {
+            _isFuture = false;
+            _lastRenderState = int.MinValue;
+        }
+
+        public void Dismiss()
+        {
+            _isFuture = true;
+            _lastRenderState = int.MinValue;
+            _builder.Clear();
+            DisableIntoPool();
+            ParentPool.Return(this);
+        }
+
+        protected override void UpdateElement()
+        {
+            if (_isFuture)
+            {
+                return;
+            }
+
+            var renderState = GetRenderState();
+            if (renderState == _lastRenderState)
+            {
+                return;
+            }
+
+            _lastRenderState = renderState;
+            _builder.Clear();
+
+            foreach (var syllable in _preparedPhrase.Syllables)
+            {
+                if (GameManager.VisualTime < syllable.Time)
+                {
+                    BuilderAppendWithColorTag(syllable.Text, syllable.IsStarpower ? FUTURE_STAR_POWER_LYRIC_COLOR_TAG : FUTURE_LYRIC_COLOR_TAG);
+                }
+                else if (syllable.Time <= GameManager.VisualTime && GameManager.VisualTime < syllable.TimeEnd)
+                {
+                    BuilderAppendWithColorTag(syllable.Text, PRESENT_LYRIC_COLOR_TAG);
+                }
+                else {
+                    BuilderAppendWithColorTag(syllable.Text, syllable.IsStarpower ? PAST_STAR_POWER_LYRIC_COLOR_TAG : PAST_LYRIC_COLOR_TAG);
+                }
+            }
+
+            _phraseText.text = _builder.ToString();
+        }
+
+        protected override bool UpdateElementPosition()
+        {
+            return true;
+        }
+
+        protected override void HideElement()
+        {
+        }
+
+        private int GetRenderState()
+        {
+            for (int i = 0; i < _preparedPhrase.Syllables.Count; i++)
+            {
+                var syllable = _preparedPhrase.Syllables[i];
+                if (GameManager.VisualTime < syllable.Time)
+                {
+                    return i * 2;
+                }
+
+                if (GameManager.VisualTime < syllable.TimeEnd)
+                {
+                    return i * 2 + 1;
+                }
+            }
+
+            return _preparedPhrase.Syllables.Count * 2;
+        }
+
+        private void BuilderAppendWithColorTag(string text, string colorTag)
+        {
+            _builder.Append(colorTag);
+            _builder.Append(text);
+            _builder.Append(CLOSE_COLOR_TAG);
+        }
+
+        private static List<StaticLyricSyllable> BuildSyllables(VocalPhrasePair phrasePair,
+            List<VocalsPhrase> scoringPhrases, bool allowHiding)
+        {
+            var syllables = new List<StaticLyricSyllable>();
             var mergedLyricIdx = 0;
 
-            var mainPhrase = _phrasePairRef.MainPhrase;
-            var mergedPhrase = _phrasePairRef.MergedPhrase;
+            var mainPhrase = phrasePair.MainPhrase;
+            var mergedPhrase = phrasePair.MergedPhrase;
 
             // Handle HARM3-only phrases
             if (mainPhrase is null)
@@ -79,11 +238,12 @@ namespace YARG.Gameplay.Visuals
                         continue;
                     }
 
-                    MakeStaticLyricSyllable(mergedLyric.Text, mergedLyric.Time, probableMergedLyricEnd.Value, mergedLyric.Flags, isLastLyricOfMergedPhrase);
+                    MakeStaticLyricSyllable(syllables, scoringPhrases, allowHiding, mergedLyric.Text,
+                        mergedLyric.Time, probableMergedLyricEnd.Value, mergedLyric.Flags, isLastLyricOfMergedPhrase);
                 }
             }
-
-            else {
+            else
+            {
                 for (var mainLyricIdx = 0; mainLyricIdx < mainPhrase.Lyrics.Count; mainLyricIdx++)
                 {
                     var mainLyric = mainPhrase.Lyrics[mainLyricIdx];
@@ -113,7 +273,8 @@ namespace YARG.Gameplay.Visuals
                             }
 
                             // isLastLyricOfPhrase is definitely false, because we still have at least one main phrase lyric to add
-                            MakeStaticLyricSyllable(mergedLyric.Text, mergedLyric.Time, probableMergedLyricEnd.Value, mergedLyric.Flags, false);
+                            MakeStaticLyricSyllable(syllables, scoringPhrases, allowHiding, mergedLyric.Text,
+                                mergedLyric.Time, probableMergedLyricEnd.Value, mergedLyric.Flags, false);
                         }
                     }
 
@@ -128,7 +289,8 @@ namespace YARG.Gameplay.Visuals
                         mainLyricIsLastLyricOfEntirePhrase = false;
                     }
 
-                    MakeStaticLyricSyllable(mainLyric.Text, mainLyric.Time, probableMainLyricEnd.Value, mainLyric.Flags, mainLyricIsLastLyricOfEntirePhrase);
+                    MakeStaticLyricSyllable(syllables, scoringPhrases, allowHiding, mainLyric.Text,
+                        mainLyric.Time, probableMainLyricEnd.Value, mainLyric.Flags, mainLyricIsLastLyricOfEntirePhrase);
 
                     // If there's a simultaneous syllable in the merged part...
                     if (mergedPhrase is not null && mergedLyricIdx < mergedPhrase.Lyrics.Count && mergedPhrase.Lyrics[mergedLyricIdx].Time == mainLyric.Time)
@@ -146,6 +308,9 @@ namespace YARG.Gameplay.Visuals
 
                                 // ...add it after the main syllable
                                 MakeStaticLyricSyllable(
+                                    syllables,
+                                    scoringPhrases,
+                                    allowHiding,
                                     simultaneousMergedLyric.Text,
                                     simultaneousMergedLyric.Time,
                                     probableSimultaneousMergedLyricEnd.Value,
@@ -170,76 +335,13 @@ namespace YARG.Gameplay.Visuals
                         }
 
                         var isLastLyricOfMergedPhrase = mergedLyricIdx == mergedPhrase.Lyrics.Count - 1;
-                        MakeStaticLyricSyllable(mergedLyric.Text, mergedLyric.Time, probableMergedLyricEnd.Value, mergedLyric.Flags, mergedLyricIdx == mergedPhrase.Lyrics.Count - 1);
+                        MakeStaticLyricSyllable(syllables, scoringPhrases, allowHiding, mergedLyric.Text,
+                            mergedLyric.Time, probableMergedLyricEnd.Value, mergedLyric.Flags, isLastLyricOfMergedPhrase);
                     }
                 }
             }
 
-            transform.localPosition = transform.localPosition.WithX(_x);
-
-            foreach (var syllable in _syllables)
-            {
-                BuilderAppendWithColorTag(syllable.Text, syllable.IsStarpower ? FUTURE_STAR_POWER_PHRASE_COLOR_TAG : FUTURE_PHRASE_COLOR_TAG);
-            }
-
-            _phraseText.text = _builder.ToString();
-        }
-
-        public void Activate()
-        {
-            _isFuture = false;
-        }
-
-        public void Dismiss()
-        {
-            _isFuture = true;
-            _syllables.Clear();
-            _builder.Clear();
-            DisableIntoPool();
-            ParentPool.Return(this);
-        }
-
-        protected override void UpdateElement()
-        {
-            if (_isFuture)
-            {
-                return;
-            }
-
-            _builder.Clear();
-
-            foreach (var syllable in _syllables)
-            {
-                if (GameManager.VisualTime < syllable.Time)
-                {
-                    BuilderAppendWithColorTag(syllable.Text, syllable.IsStarpower ? FUTURE_STAR_POWER_LYRIC_COLOR_TAG : FUTURE_LYRIC_COLOR_TAG);
-                }
-                else if (syllable.Time <= GameManager.VisualTime && GameManager.VisualTime < syllable.TimeEnd)
-                {
-                    BuilderAppendWithColorTag(syllable.Text, PRESENT_LYRIC_COLOR_TAG);
-                }
-                else {
-                    BuilderAppendWithColorTag(syllable.Text, syllable.IsStarpower ? PAST_STAR_POWER_LYRIC_COLOR_TAG : PAST_LYRIC_COLOR_TAG);
-                }
-            }
-
-            _phraseText.text = _builder.ToString();
-        }
-
-        protected override bool UpdateElementPosition()
-        {
-            return true;
-        }
-
-        protected override void HideElement()
-        {
-        }
-
-        private void BuilderAppendWithColorTag(string text, string colorTag)
-        {
-            _builder.Append(colorTag);
-            _builder.Append(text);
-            _builder.Append(CLOSE_COLOR_TAG);
+            return syllables;
         }
 
         private static double? GetProbableNoteEndOfLyric(VocalsPhrase phrase, LyricEvent lyric)
@@ -248,16 +350,18 @@ namespace YARG.Gameplay.Visuals
                 .FirstOrDefault(note => note.Tick == lyric.Tick)?.TotalTimeEnd;
         }
 
-        private void MakeStaticLyricSyllable(string text, double time, double timeEnd, LyricSymbolFlags flags, bool isLastLyricOfPhrase)
+        private static void MakeStaticLyricSyllable(List<StaticLyricSyllable> syllables,
+            List<VocalsPhrase> scoringPhrases, bool allowHiding, string text, double time, double timeEnd,
+            LyricSymbolFlags flags, bool isLastLyricOfPhrase)
         {
-            if (_allowHiding && ((flags & LyricSymbolFlags.HarmonyHidden) != 0))
+            if (allowHiding && ((flags & LyricSymbolFlags.HarmonyHidden) != 0))
             {
                 return;
             }
 
             // Determine whether the lyric falls within a star power scoring phrase
             var isStarpower = false;
-            foreach (var scoringPhrase in _scoringPhrases)
+            foreach (var scoringPhrase in scoringPhrases)
             {
                 if (scoringPhrase.Time > time)
                 {
@@ -276,49 +380,20 @@ namespace YARG.Gameplay.Visuals
                 isStarpower = scoringPhrase.IsStarPower;
             }
 
-            _syllables.Add(new(text, time, timeEnd, isStarpower, flags, isLastLyricOfPhrase));
+            syllables.Add(new(text, time, timeEnd, isStarpower, flags, isLastLyricOfPhrase));
         }
 
-        private struct StaticLyricSyllable
+        private static string BuildFutureText(List<StaticLyricSyllable> syllables)
         {
-            public string Text;
-            public double Time;
-            public double TimeEnd;
-            public bool IsStarpower;
-
-            public StaticLyricSyllable(string text, double time, double timeEnd, bool isStarpower, LyricSymbolFlags flags, bool isLastLyricOfPhrase)
+            var builder = ZString.CreateStringBuilder(false);
+            foreach (var syllable in syllables)
             {
-                var builder = ZString.CreateStringBuilder(false);
-
-                Time = time;
-                TimeEnd = timeEnd;
-                IsStarpower = isStarpower;
-
-                if ((flags & LyricSymbolFlags.NonPitched) != 0)
-                {
-                    builder.Append("<i>");
-                }
-
-                if ((flags & LyricSymbolFlags.JoinWithNext) != 0)
-                {
-                    builder.Append(text[0..^1]);
-                } else
-                {
-                    builder.Append(text);
-                }
-
-                if ((flags & LyricSymbolFlags.NonPitched) != 0)
-                {
-                    builder.Append("</i>");
-                }
-
-                if (!isLastLyricOfPhrase && (flags & LyricSymbolFlags.JoinWithNext) == 0 && (flags & LyricSymbolFlags.HyphenateWithNext) == 0)
-                {
-                    builder.Append(" ");
-                }
-
-                Text = builder.ToString();
+                builder.Append(syllable.IsStarpower ? FUTURE_STAR_POWER_PHRASE_COLOR_TAG : FUTURE_PHRASE_COLOR_TAG);
+                builder.Append(syllable.Text);
+                builder.Append(CLOSE_COLOR_TAG);
             }
+
+            return builder.ToString();
         }
     }
 }


### PR DESCRIPTION
I had noticed with some particularly faster paced songs (Nu-metal, Rap, etc) that there would be pretty significant hitching when the vocals would come in. After some profiling, it was pretty clear that those frames would take dramatically longer to complete while instantiating the needed game objects to render the vocal tracks.

This PR optimizes vocal lyric spawning by preparing lyric text, width, timing, and static phrase data up front during vocal track initialization and practice-section changes. Scrolling and static lyric elements now consume prepared lyric/phrase objects instead of rebuilding text and measuring widths during spawn/update.

It also adds targeted pool prewarming for vocal notes, lyrics, phrase lines, and talkies based on the song’s visible event density, plus a per-frame spawn/enqueue budget for lyric-heavy sections. This should reduce frame spikes when dense vocal lyrics enter view.

**Behavior Changes**
- Prevents null objects from being pushed into pools when the object cap is reached.
- Adds safer handling for empty/no-note vocal phrases so static lyric tracking does not crash on songs with unusual phrase data.
- Suppresses hidden harmony lyrics without spawning empty lyric objects.
- Caches static lyric render states so active static phrases only rebuild text when syllable timing state changes.
- Adds guards around static lyric queue shifts so missing queued phrases do not cause invalid dequeues.

I ran some manual testing and didn't see any obvious issues. I did see, however, that VocalTrack.Update() never spikes even in lyrically intensive songs.