### PR TITLE
Fix drums error message when song has multiple drum stems

### DIFF
--- a/Assets/Script/Gameplay/GameManager.Audio.cs
+++ b/Assets/Script/Gameplay/GameManager.Audio.cs
@@ -100,8 +100,7 @@ namespace YARG.Gameplay
             _backgroundStem = SongStem.Song;
             foreach (var channel in _mixer.Channels)
             {
-                var stemState = new StemState(channel.Stem);
-                _stemStates.Add(channel.Stem, stemState);
+                _stemStates.TryAdd(channel.Stem, new StemState(channel.Stem));
             }
 
             _backgroundStem = _stemStates.Count > 1 ? SongStem.Song : _stemStates.First().Key;


### PR DESCRIPTION
We used to call TryAdd before I broke this in https://github.com/YARC-Official/YARG/pull/1182

We should still call TryAdd here.

What's happening is we are iterating mixer channels, which can have channels for drums1 drums2 and drums3 but we really only care about 1 stem state for all 3 (`drums`).  StemState controls volume, etc. 

So, just swallow the error with `TryAdd`.