### PR TITLE
Prevent navigation flicker when leaving settings page

### DIFF
--- a/Assets/Script/Menu/MenuManager.cs
+++ b/Assets/Script/Menu/MenuManager.cs
@@ -141,11 +141,16 @@ namespace YARG.Menu
             }
         }
 
-        public void ReactivateCurrentMenu()
+        public void ReactivateCurrentMenu(bool forceRefreshIfActive = true)
         {
             // Show the under one
             if (_openMenus.TryPeek(out var menu) && _menus.TryGetValue(menu, out var newMenu))
             {
+                if (!forceRefreshIfActive && newMenu.gameObject.activeSelf)
+                {
+                    return;
+                }
+
                 if (_reactivateCoroutine != null)
                 {
                     StopCoroutine(_reactivateCoroutine);

--- a/Assets/Script/Menu/Settings/SettingsMenu.cs
+++ b/Assets/Script/Menu/Settings/SettingsMenu.cs
@@ -453,9 +453,8 @@ namespace YARG.Menu.Settings
                 return;
             }
 
-            //This is a bit of a hack to update the CurrentNavigationGroup again.
-            //ideally the settings menu should work just like every other menu so this isn't needed
-            MenuManager.Instance.ReactivateCurrentMenu();
+            // The settings menu overlays the current menu, so avoid toggling an already-active menu.
+            MenuManager.Instance.ReactivateCurrentMenu(false);
         }
 
         protected override void SingletonDestroy()


### PR DESCRIPTION
There was an annoying visual artifact in the last fix I put in to allow the calibration back button to go back immediately to the settings page. It felt pretty unprofessional so this PR should rectify that.