### PR TITLE
Ensure that all note related visual updates occur after all the gameplay logic

### DIFF
--- a/Assets/Script/Gameplay/Visuals/BaseElement.cs
+++ b/Assets/Script/Gameplay/Visuals/BaseElement.cs
@@ -30,7 +30,7 @@
             Initialized = true;
 
             // Force update the position once just in case to prevent flickering
-            Update();
+            UpdateVisualElement();
         }
 
         protected abstract void InitializeElement();
@@ -39,7 +39,12 @@
 
         protected abstract bool UpdateElementPosition();
 
-        protected void Update()
+        protected void LateUpdate()
+        {
+            UpdateVisualElement();
+        }
+
+        private void UpdateVisualElement()
         {
             // Skip if not initialized
             if (!Initialized) return;


### PR DESCRIPTION
While this was mostly true already since most of the game logic runs through GameManager.Update() which has a "[DefaultExecutionOrder(-1)]", there were still some cases where some state logic would happen in-between element updates at the whim of the Unity scheduler. By changing to LateUpdate() for element visuals, we prevent the possibility of that.