### PR TITLE
Fix venue texture flickering on camera cuts

### DIFF
--- a/Assets/Script/Gameplay/VenueCameraRenderer.cs
+++ b/Assets/Script/Gameplay/VenueCameraRenderer.cs
@@ -66,7 +66,6 @@ namespace YARG.Gameplay
         private static float _frameAccumulator = 0f;
         private static float _fpsWindowStart = 0f;
         private static int _fpsWindowFrames = 0;
-        private bool _needsInitialization = true;
 
         private void Awake()
         {
@@ -225,10 +224,9 @@ namespace YARG.Gameplay
 
         private void Update()
         {
-            if (ScreenSizeDetector.HasScreenSizeChanged || _needsInitialization)
+            if (ScreenSizeDetector.HasScreenSizeChanged || _venueTexture == null)
             {
                 RecreateTextures();
-                _needsInitialization = false;
                 // Force a render this frame to avoid flickering when resizing
                 ResetRenderState();
             }


### PR DESCRIPTION
It was recreating output textures every time a camera in the venue was enabled for the first time.

If venue fps limiting was used this could lead to a frame or two of uninitialized texture frame