### PR TITLE
Visual fixes for configurable drum highways

### DIFF
--- a/Assets/Script/Gameplay/Player/DrumsPlayer.cs
+++ b/Assets/Script/Gameplay/Player/DrumsPlayer.cs
@@ -804,7 +804,6 @@ namespace YARG.Gameplay.Player
 
                 if (padToPress is not null)
                 {
-
                     _fretArray.SetPressedDrum(padToPress.Value, lowestDelta < DRUM_PAD_FLASH_HOLD_DURATION, GetAnimType(padToPress.Value));
                     _fretArray.UpdateAccentColorState(padToPress.Value,
                         _animTypeToPadToLastPressedDelta[Fret.AnimType.CorrectHard][padToPress.Value] <

--- a/Assets/Script/Gameplay/Player/DrumsPlayer.cs
+++ b/Assets/Script/Gameplay/Player/DrumsPlayer.cs
@@ -58,7 +58,7 @@ namespace YARG.Gameplay.Player
         // Record of the most recent time that each BRE lane has been lit up by any of the actions that map to it
         private Dictionary<DrumsBreLaneIndex, double> _breLaneIndexToMostRecentTime = new();
 
-        private int DrumsActionToHighwayIndex(DrumsAction action)
+        private int DrumsActionToPad(DrumsAction action)
         {
             if (_fiveLaneMode)
             {
@@ -140,8 +140,8 @@ namespace YARG.Gameplay.Player
         private int[] _drumSoundEffectRoundRobin = new int[8];
         private float _drumSoundEffectAccentThreshold;
 
-        private Dictionary<int, float>                            _fretToLastPressedTimeDelta       = new();
-        private Dictionary<Fret.AnimType, Dictionary<int, float>> _animTypeToFretToLastPressedDelta = new();
+        private Dictionary<int, float>                            _padToLastPressedTimeDelta       = new();
+        private Dictionary<Fret.AnimType, Dictionary<int, float>> _animTypeToPadToLastPressedDelta = new();
 
 
         public override void Initialize(int index, YargPlayer player, SongChart chart, TrackView trackView, StemMixer mixer,
@@ -518,7 +518,7 @@ namespace YARG.Gameplay.Player
 
         private void OnLaneHit(int fret)
         {
-            fret = DrumsActionToHighwayIndex((DrumsAction) fret);
+            fret = DrumsActionToPad((DrumsAction) fret);
             _fretArray.PlayCodaHitAnimation(fret);
         }
 
@@ -541,7 +541,7 @@ namespace YARG.Gameplay.Player
 
         private void OnPadHit(DrumsAction action, bool wasNoteHit, bool wasNoteHitCorrectly, bool wasOverhitInLane, DrumNoteType type, float velocity)
         {
-            var fret = DrumsActionToHighwayIndex(action);
+            var fret = DrumsActionToPad(action);
 
             // This is done here for drums rather than in-engine because engine doesn't know about pad ordering
             if (Engine.IsCodaActive)
@@ -714,9 +714,9 @@ namespace YARG.Gameplay.Player
 
         private void InitializeHitTimes()
         {
-            foreach (var fretIdx in _highwayOrdering.Keys)
+            foreach (var pad in _highwayOrdering.Keys)
             {
-                _fretToLastPressedTimeDelta[fretIdx] = float.MaxValue;
+                _padToLastPressedTimeDelta[pad] = float.MaxValue;
             }
         }
 
@@ -724,11 +724,11 @@ namespace YARG.Gameplay.Player
         {
             foreach (var animType in AnimTypes)
             {
-                _animTypeToFretToLastPressedDelta[animType] = new Dictionary<int, float>();
+                _animTypeToPadToLastPressedDelta[animType] = new Dictionary<int, float>();
 
-                foreach (var fretIdx in _highwayOrdering.Keys)
+                foreach (var pad in _highwayOrdering.Keys)
                 {
-                    _animTypeToFretToLastPressedDelta[animType][fretIdx] = float.MaxValue;
+                    _animTypeToPadToLastPressedDelta[animType][pad] = float.MaxValue;
                 }
             }
         }
@@ -736,8 +736,8 @@ namespace YARG.Gameplay.Player
         // i.e., flash this fret by making it seem pressed
         private void ZeroOutHitTime(DrumsAction action, Fret.AnimType animType)
         {
-            int fretIdx = DrumsActionToHighwayIndex(action);
-            ZeroOutHitTime(fretIdx, animType);
+            int pad = DrumsActionToPad(action);
+            ZeroOutHitTime(pad, animType);
 
             // When kicks have split dedicated lanes, zero out both for kick inputs
             if (action is DrumsAction.Kick && NumberOfDedicatedKickLanes == 2)
@@ -747,17 +747,17 @@ namespace YARG.Gameplay.Player
         }
 
         // i.e., flash this fret by making it seem pressed
-        private void ZeroOutHitTime(int index, Fret.AnimType animType)
+        private void ZeroOutHitTime(int pad, Fret.AnimType animType)
         {
-            _fretToLastPressedTimeDelta[index] = 0f;
-            _animTypeToFretToLastPressedDelta[animType][index] = 0f;
+            _padToLastPressedTimeDelta[pad] = 0f;
+            _animTypeToPadToLastPressedDelta[animType][pad] = 0f;
         }
 
         private void UpdateHitTimes()
         {
-            foreach (var fretIdx in _highwayOrdering.Keys)
+            foreach (var pad in _highwayOrdering.Keys)
             {
-                _fretToLastPressedTimeDelta[fretIdx] += Time.deltaTime;
+                _padToLastPressedTimeDelta[pad] += Time.deltaTime;
             }
         }
 
@@ -765,40 +765,70 @@ namespace YARG.Gameplay.Player
         {
             foreach (var animType in AnimTypes)
             {
-                foreach (var fretIdx in _highwayOrdering.Keys)
+                foreach (var pad in _highwayOrdering.Keys)
                 {
-                    _animTypeToFretToLastPressedDelta[animType][fretIdx] += Time.deltaTime;
+                    _animTypeToPadToLastPressedDelta[animType][pad] += Time.deltaTime;
                 }
             }
         }
 
         private void UpdateFretArray()
         {
-            foreach (var fretIdx in _highwayOrdering.Keys)
+            // For each visual fret...
+            for (var i = 0; i < LaneCount; i++)
             {
-                _fretArray.SetPressedDrum(fretIdx, _fretToLastPressedTimeDelta[fretIdx] < DRUM_PAD_FLASH_HOLD_DURATION, GetAnimType(fretIdx));
-                _fretArray.UpdateAccentColorState(fretIdx,
-                    _animTypeToFretToLastPressedDelta[Fret.AnimType.CorrectHard][fretIdx] <
-                    DRUM_PAD_FLASH_HOLD_DURATION);
+                // ...find the lowest last-pressed delta among pads that the visual fret represents
+                // Usually there's just one pad for each fret, but tom+cymbal frets have two so we
+                // want to take the minimum of those
+
+                var lowestDelta = float.MaxValue;
+
+                // The fret array's animation functions take pads, so we need to know which pad is relevant for the
+                // current visual fret. If there are multiple (shared fret), we can send it either; the fret array
+                // forwards shared fret indices to the right fret. If we don't find any pads, we won't call any
+                // animations.
+                int? padToPress = null;
+
+                foreach (var (pad, highwayOrderingInfo) in _highwayOrdering)
+                {
+                    // We only care about pads that are mapped to this position
+                    if (highwayOrderingInfo.Position == i)
+                    {
+                        padToPress ??= pad;
+                        if (_padToLastPressedTimeDelta[pad] < lowestDelta)
+                        {
+                            lowestDelta = _padToLastPressedTimeDelta[pad];
+                        }
+                    }
+                }
+
+                if (padToPress is not null)
+                {
+
+                    _fretArray.SetPressedDrum(padToPress.Value, lowestDelta < DRUM_PAD_FLASH_HOLD_DURATION, GetAnimType(padToPress.Value));
+                    _fretArray.UpdateAccentColorState(padToPress.Value,
+                        _animTypeToPadToLastPressedDelta[Fret.AnimType.CorrectHard][padToPress.Value] <
+                        DRUM_PAD_FLASH_HOLD_DURATION);
+                }
             }
         }
 
         private Fret.AnimType GetAnimType(int fretIdx)
         {
             // Prioritize the length of certain animations
-            if (_animTypeToFretToLastPressedDelta[Fret.AnimType.CorrectNormal][fretIdx] < DRUM_PAD_FLASH_HOLD_DURATION)
+            if (_animTypeToPadToLastPressedDelta[Fret.AnimType.CorrectNormal][fretIdx] < DRUM_PAD_FLASH_HOLD_DURATION)
             {
                 return Fret.AnimType.CorrectNormal;
             }
 
             // Don't hold an accent over a normal note
-            if (_animTypeToFretToLastPressedDelta[Fret.AnimType.CorrectHard][fretIdx] < DRUM_PAD_FLASH_HOLD_DURATION)
+            if (_animTypeToPadToLastPressedDelta[Fret.AnimType.CorrectHard][fretIdx] < DRUM_PAD_FLASH_HOLD_DURATION)
             {
                 return Fret.AnimType.CorrectHard;
             }
 
             // Don't cut a bright anim short if a ghost is played
-            if (_animTypeToFretToLastPressedDelta[Fret.AnimType.CorrectSoft][fretIdx] < DRUM_PAD_FLASH_HOLD_DURATION)
+            if (_animTypeToPadToLastPressedDelta[Fret.AnimType.CorrectSoft][fretIdx] < DRUM_PAD_FLASH_HOLD_DURATION)
             {
                 return Fret.AnimType.CorrectSoft;
             }
@@ -809,7 +839,7 @@ namespace YARG.Gameplay.Player
 
         private void AnimateAction(DrumsAction action)
         {
-            var index = DrumsActionToHighwayIndex(action);
+            var index = DrumsActionToPad(action);
 
             if (_fiveLaneMode)
             {

--- a/Assets/Script/Gameplay/Player/DrumsPlayer.cs
+++ b/Assets/Script/Gameplay/Player/DrumsPlayer.cs
@@ -306,7 +306,9 @@ namespace YARG.Gameplay.Player
                     continue;
                 }
 
-                var fillLanePosition = GetHighwayOrderingInfo(rightmostNote.Pad).Position;
+                var highwayOrderingIndex = rightmostNote.IsDoubleKick ? DOUBLE_KICK_FRET_INDEX : rightmostNote.Pad;
+
+                var fillLanePosition = GetHighwayOrderingInfo(highwayOrderingIndex).Position;
 
                 int candidateIndex = -1;
 

--- a/Assets/Script/Gameplay/Visuals/Fret/FretArray.cs
+++ b/Assets/Script/Gameplay/Visuals/Fret/FretArray.cs
@@ -35,6 +35,8 @@ namespace YARG.Gameplay.Visuals
         [SerializeField]
         private Transform _rightKickFretPosition;
 
+        public Dictionary<int, Fret> Frets => _frets;
+
         private readonly Dictionary<int, Fret> _frets = new();
         private readonly List<KickFret> _kickFrets = new();
 
@@ -74,8 +76,6 @@ namespace YARG.Gameplay.Visuals
             _frets.Clear();
             foreach (var (noteType, highwayOrderingInfo) in highwayOrdering)
             {
-                // Note that the correctness of this depends on instruments with shared lanes having the note type that
-                // corresponds to the fret color coming first in their pad/fret/whatever enum
                 if (!_usedFretIndexes.Add(highwayOrderingInfo.Position))
                 {
                     // Find the earlier highway ordering info with the same position

--- a/Assets/Script/Menu/HighwayConfiguration/DrumsHighwayItemView.cs
+++ b/Assets/Script/Menu/HighwayConfiguration/DrumsHighwayItemView.cs
@@ -256,6 +256,9 @@ namespace YARG.Menu.HighwayConfiguration
                 BreLaneIndex = breLaneIndex;
             }
 
+            // If there are multiple elements (creating a shared fret for multiple note types, like tom+cymbal lanes
+            // on Pro Drums), the first element in the list is the one whose color profile settings will be used for
+            // the resulting fret
             public List<HighwayOrderingElement> Elements{ get; set; }
             public DrumsBreLaneIndex BreLaneIndex { get; set; }
         }


### PR DESCRIPTION
* Split 2x kicks that are activations now correctly generate the activation trail in their own lane, rather than 1x kicks' lane
* Tom+cymbal frets now correctly show the "pressed" (a.k.a. "whitened") state for inputs of either type
* Renamed some identifiers in `DrumsPlayer` to clarify what exactly is being indexed in certain dictionaries
* Removed an incorrect comment from `DrumsPlayer` that stated that enum ordering was responsible for tom>cymbal color priority, and placed a new comment in `DrumsHighwayItemView` that explains the actual priority system

There is a "corresponding" [YARG.Core PR](https://github.com/YARC-Official/YARG.Core/pull/379) for another visual fix, but the PRs' code changes are completely independent and they can be merged separately.