### PR TITLE
Fix linux mic issues by trying common sample rates for mic devices

### DIFF
--- a/Assets/Script/Audio/Bass/BassMicDevice.cs
+++ b/Assets/Script/Audio/Bass/BassMicDevice.cs
@@ -104,14 +104,14 @@ namespace YARG.Audio.BASS
 
     internal class RecordingHandle : IDisposable
     {
-        private static readonly int[] SampleRates = { 48000, 44100, 96000, 16000 };
+        private static readonly int[] _sampleRates = { 48000, 44100, 96000, 16000 };
 
 #nullable enable
         public static RecordingHandle? CreateRecordingHandle(RecordProcedure procedure)
 #nullable disable
         {
             var devPeriod = Bass.GetConfig(Configuration.DevicePeriod);
-            foreach (int sampleRate in SampleRates)
+            foreach (int sampleRate in _sampleRates)
             {
                 int handle = Bass.RecordStart(sampleRate, 1, BassFlags.Default, devPeriod, procedure, IntPtr.Zero);
                 if (handle == 0)
@@ -129,7 +129,6 @@ namespace YARG.Audio.BASS
                     continue;
                 }
 
-                YargLogger.LogFormatInfo("Mic opened successfully at {0} Hz", sampleRate);
                 return new RecordingHandle(handle, processedHandle, devPeriod, sampleRate);
             }
 
@@ -206,7 +205,7 @@ namespace YARG.Audio.BASS
                 return null;
             }
 
-            device._pitchDetector = new PitchTracker(sampleRate: device._recordHandle.SampleRate);
+            device._pitchDetector = new PitchTracker(device._recordHandle.SampleRate);
 
             var monitorPlayback = MonitorPlaybackHandle.Create(device._recordHandle.SampleRate);
             if (monitorPlayback == null)

--- a/Assets/Script/Audio/Bass/BassMicDevice.cs
+++ b/Assets/Script/Audio/Bass/BassMicDevice.cs
@@ -21,11 +21,11 @@ namespace YARG.Audio.BASS
         };
 
 #nullable enable
-        public static MonitorPlaybackHandle? Create()
+        public static MonitorPlaybackHandle? Create(int sampleRate)
 #nullable disable
         {
             // Set up monitoring stream
-            int monitorPlaybackHandle = Bass.CreateStream(44100, 1, BassFlags.Default, StreamProcedureType.Push);
+            int monitorPlaybackHandle = Bass.CreateStream(sampleRate, 1, BassFlags.Default, StreamProcedureType.Push);
             if (monitorPlaybackHandle == 0)
             {
                 YargLogger.LogFormatError("Failed to create monitor stream: {0}!", Bass.LastError);
@@ -104,41 +104,53 @@ namespace YARG.Audio.BASS
 
     internal class RecordingHandle : IDisposable
     {
+        private static readonly int[] SampleRates = { 48000, 44100, 96000, 16000 };
+
 #nullable enable
         public static RecordingHandle? CreateRecordingHandle(RecordProcedure procedure)
 #nullable disable
         {
             var devPeriod = Bass.GetConfig(Configuration.DevicePeriod);
-
-            int handle = Bass.RecordStart(44100, 1, BassFlags.Default, devPeriod, procedure, IntPtr.Zero);
-            if (handle == 0)
+            foreach (int sampleRate in SampleRates)
             {
-                YargLogger.LogFormatError("Failed to start clean recording: {0}!", Bass.LastError);
-                return null;
+                int handle = Bass.RecordStart(sampleRate, 1, BassFlags.Default, devPeriod, procedure, IntPtr.Zero);
+                if (handle == 0)
+                {
+                    YargLogger.LogFormatTrace("Failed to start clean recording at {0} Hz: {1}!", sampleRate, Bass.LastError);
+                    continue;
+                }
+
+                int processedHandle = Bass.CreateStream(sampleRate, 1, BassFlags.Decode, StreamProcedureType.Push);
+                if (processedHandle == 0)
+                {
+                    YargLogger.LogFormatError("Failed to create processed recording stream at {0} Hz: {1}!", sampleRate, Bass.LastError);
+                    Bass.ChannelStop(handle);
+                    Bass.StreamFree(handle);
+                    continue;
+                }
+
+                YargLogger.LogFormatInfo("Mic opened successfully at {0} Hz", sampleRate);
+                return new RecordingHandle(handle, processedHandle, devPeriod, sampleRate);
             }
 
-            int processedHandle = Bass.CreateStream(44100, 1, BassFlags.Decode, StreamProcedureType.Push);
-            if (processedHandle == 0)
-            {
-                YargLogger.LogFormatError("Failed to create processed recording stream: {0}!", Bass.LastError);
-                return null;
-            }
-
-            return new RecordingHandle(handle, processedHandle, devPeriod);
+            YargLogger.LogError("Failed to start recording at any supported sample rate!");
+            return null;
         }
 
         public readonly int Handle;
         public readonly int ProcessedHandle;
 
         public readonly int RecordPeriod;
+        public readonly int SampleRate;
 
         private bool _disposed;
 
-        private RecordingHandle(int handle, int processedHandle, int period)
+        private RecordingHandle(int handle, int processedHandle, int period, int sampleRate)
         {
             Handle = handle;
             ProcessedHandle = processedHandle;
             RecordPeriod = period;
+            SampleRate = sampleRate;
         }
 
         private void Dispose(bool disposing)
@@ -185,21 +197,24 @@ namespace YARG.Audio.BASS
                 Bass.CurrentRecordingDevice = deviceId;
             }
 
-            var monitorPlayback = MonitorPlaybackHandle.Create();
-            if (monitorPlayback == null)
-            {
-                return null;
-            }
-
-            var device = new BassMicDevice(deviceId, name, monitorPlayback);
+            var device = new BassMicDevice(deviceId, name);
             device._recordHandle = RecordingHandle.CreateRecordingHandle(device.ProcessRecordData);
             if (device._recordHandle == null)
             {
                 // Not device.Dispose() as to not free resources that we may want to keep around
                 // i.e, the record-enabled device
-                monitorPlayback.Dispose();
                 return null;
             }
+
+            device._pitchDetector = new PitchTracker(sampleRate: device._recordHandle.SampleRate);
+
+            var monitorPlayback = MonitorPlaybackHandle.Create(device._recordHandle.SampleRate);
+            if (monitorPlayback == null)
+            {
+                device._recordHandle.Dispose();
+                return null;
+            }
+            device._monitorHandle = monitorPlayback;
 
             int lowEqHandle = BassHelpers.AddEqToChannel(device._recordHandle.ProcessedHandle, _lowEqParameters);
             int highEqHandle = BassHelpers.AddEqToChannel(device._recordHandle.ProcessedHandle, _highEqParameters);
@@ -227,9 +242,9 @@ namespace YARG.Audio.BASS
 
         private readonly ConcurrentQueue<MicOutputFrame> _frameQueue = new();
 
-        private readonly PitchTracker _pitchDetector = new();
+        private PitchTracker _pitchDetector;
 
-        private readonly MonitorPlaybackHandle _monitorHandle;
+        private MonitorPlaybackHandle _monitorHandle;
 
         private readonly int _deviceId;
 
@@ -314,11 +329,10 @@ namespace YARG.Audio.BASS
             return new SerializedMic(DisplayName);
         }
 
-        private BassMicDevice(int deviceId, string name, MonitorPlaybackHandle monitorHandle)
+        private BassMicDevice(int deviceId, string name)
             : base(name)
         {
             _deviceId = deviceId;
-            _monitorHandle = monitorHandle;
         }
 
         private bool ProcessRecordData(int handle, IntPtr buffer, int length, IntPtr user)


### PR DESCRIPTION
This fixes the issue where we hardcoded a 44100 sample rate for input devices (microphone).  Devices that did not use a 44100 sample rate would not open in BASS, and a cascade of errors would cause the device to disappear from the device list.

On Linux, mic sample rates are not converted by ALSA to 44100 on demand so hardcoding 44100 doesn't work.  Windows and MacOS do not seem to have this problem.

BASS on Linux also doesn't support querying the native sample rate of the device.  

Given that BASS does its own 44100 hz conversion at output time, defined by the Bass.Init which hardcodes 44100, it is safe to just test different common sample rates until we find one that works.

The pitch tracker also has to be initialized with the proper sample rate to work properly.

Tested with my 48000 hz mic on Bazzite, pitch tracking worked fine, monitoring worked fine