### PR TITLE
Fix crackly audio on Linux

### DIFF
--- a/Assets/Script/Audio/Bass/BassAudioManager.cs
+++ b/Assets/Script/Audio/Bass/BassAudioManager.cs
@@ -122,7 +122,12 @@ namespace YARG.Audio.BASS
 
             // Documentation recommends setting the device buffer to at least 2x the device period
             // https://www.un4seen.com/doc/#bass/BASS_CONFIG_DEV_BUFFER.html
+#if !UNITY_EDITOR && UNITY_STANDALONE_LINUX
+            // Linux sometimes needs a higher buffer length to prevent underruns
+            Bass.DeviceBufferLength = 4 * devPeriod;
+#else
             Bass.DeviceBufferLength = 2 * devPeriod;
+#endif
 
             // Affects Windows only. Forces device names to be in UTF-8 on Windows rather than ANSI.
             Bass.UnicodeDeviceInformation = true;


### PR DESCRIPTION
On Bazzite I am hearing crackly audio when using a 48000 hz output device.

This only happens in compiled nightly builds, not in the Unity Editor.  

The fix was to increase the `Bass.DeviceBufferLength`.  Anything lower than 4 * devPeriod seems to cause crackling.

It's also possible that some of the crackling issues reported on MacOS could be related.

I don't really know why this happens, maybe it has to do with resampling taking too long on Linux or something in the audio pipeline.  

Possible related issues:
https://discord.com/channels/1086048856678084609/1492841773872185486
https://discord.com/channels/1086048856678084609/1472842469304570063
https://discord.com/channels/1086048856678084609/1463010857889042484
https://discord.com/channels/1086048856678084609/1337445275014533170