### PR TITLE
Fix vocal percussion song state

### DIFF
--- a/Assets/Script/Gameplay/Player/Vocals/VocalPercussionTrack.cs
+++ b/Assets/Script/Gameplay/Player/Vocals/VocalPercussionTrack.cs
@@ -46,6 +46,8 @@ namespace YARG.Gameplay.Player
 
         public void Initialize(List<VocalNote> notes)
         {
+            _pool.ReturnAllObjects();
+
             _notes = notes;
             _phraseIndex = 0;
             _noteIndex = 0;
@@ -91,7 +93,10 @@ namespace YARG.Gameplay.Player
         public void HitPercussionNote(VocalNote note)
         {
             var obj = _pool.GetByKey(note);
-            _pool.Return(obj);
+            if (obj != null)
+            {
+                _pool.Return(obj);
+            }
 
             _hitEffects.Play();
         }

--- a/Assets/Script/Gameplay/Player/Vocals/VocalPercussionTrack.cs
+++ b/Assets/Script/Gameplay/Player/Vocals/VocalPercussionTrack.cs
@@ -47,6 +47,11 @@ namespace YARG.Gameplay.Player
         public void Initialize(List<VocalNote> notes)
         {
             _notes = notes;
+            _phraseIndex = 0;
+            _noteIndex = 0;
+
+            _percussionFret.transform.rotation = Quaternion.Euler(0f, 0f, 0f);
+            _percussionFret.gameObject.SetActive(false);
         }
 
         private void Update()
@@ -103,7 +108,7 @@ namespace YARG.Gameplay.Player
                 return;
             }
 
-            StartCoroutine(ShowPercussionFretAnimation(show));
+            _fretShowCoroutine = StartCoroutine(ShowPercussionFretAnimation(show));
         }
 
         private IEnumerator ShowPercussionFretAnimation(bool show)

--- a/Assets/Script/Gameplay/Player/Vocals/VocalPercussionTrack.cs
+++ b/Assets/Script/Gameplay/Player/Vocals/VocalPercussionTrack.cs
@@ -101,6 +101,7 @@ namespace YARG.Gameplay.Player
             if (_fretShowCoroutine != null)
             {
                 StopCoroutine(_fretShowCoroutine);
+                _fretShowCoroutine = null;
             }
 
             if (show == _percussionFret.gameObject.activeSelf)

--- a/Assets/Script/Gameplay/Player/VocalsPlayer.cs
+++ b/Assets/Script/Gameplay/Player/VocalsPlayer.cs
@@ -516,8 +516,7 @@ namespace YARG.Gameplay.Player
             while (_phraseIndex < NoteTrack.Notes.Count &&
                 (_phraseIndex == -1
                     ? NoteTrack.Notes.Count > 0 &&
-                        (NoteTrack.Notes[0].Time <= time ||
-                            NoteTrack.Notes[0].ChildNotes.Any(note => note.IsPercussion))
+                        (NoteTrack.Notes[0].Time <= time || HasPercussion(NoteTrack.Notes[0]))
                     : NoteTrack.Notes[_phraseIndex].TimeEnd <= time))
             {
                 _phraseIndex++;
@@ -532,24 +531,17 @@ namespace YARG.Gameplay.Player
                 }
 
                 var phrase = NoteTrack.Notes[_phraseIndex];
-
-                bool hasPercussion = false;
-                uint totalTime = 0;
-                foreach (var note in phrase.ChildNotes)
-                {
-                    if (note.IsPercussion)
-                    {
-                        hasPercussion = true;
-                        continue;
-                    }
-
-                    totalTime += note.TotalTickLength;
-                }
+                bool hasPercussion = HasPercussion(phrase);
 
                 _hud.SetHUDShowing(!hasPercussion);
                 _percussionTrack.ShowPercussionFret(hasPercussion);
                 _shouldHideNeedle = hasPercussion;
             }
+        }
+
+        private static bool HasPercussion(VocalNote phrase)
+        {
+            return phrase.ChildNotes.Any(note => note.IsPercussion);
         }
 
         public override void SetPracticeSection(uint start, uint end)

--- a/Assets/Script/Gameplay/Player/VocalsPlayer.cs
+++ b/Assets/Script/Gameplay/Player/VocalsPlayer.cs
@@ -510,31 +510,53 @@ namespace YARG.Gameplay.Player
                 return;
             }
 
+            while (ShouldAdvancePhraseIndex(time))
+            {
+                _phraseIndex++;
+
+                // We've reached the end. No need to continue.
+                if (_phraseIndex >= NoteTrack.Notes.Count)
+                {
+                    SetPercussionMode(false);
+                    return;
+                }
+
+                var phrase = NoteTrack.Notes[_phraseIndex];
+                SetPercussionMode(HasPercussion(phrase));
+            }
+        }
+
+        private bool ShouldAdvancePhraseIndex(double time)
+        {
             // Since phrases start at the note, and not sometime before it, use
             // the end times of phrases instead (where the phrase lines are). Problem
             // with this is that we still gotta account for the first phrase, so use
             // an index of -1 for that.
-            while (_phraseIndex < NoteTrack.Notes.Count &&
-                (_phraseIndex == -1
-                    ? NoteTrack.Notes.Count > 0 &&
-                        (NoteTrack.Notes[0].Time <= time || HasPercussion(NoteTrack.Notes[0]))
-                    : NoteTrack.Notes[_phraseIndex].TimeEnd <= time))
+            bool beforeFirstPhrase = _phraseIndex == -1;
+            if (beforeFirstPhrase)
             {
-                _phraseIndex++;
-
-                // End if that's the last note
-                if (_phraseIndex >= NoteTrack.Notes.Count)
+                // Track has no notes. Bail early.
+                if (NoteTrack.Notes.Count <= 0)
                 {
-                    TogglePercussion(false);
-                    break;
+                    return false;
                 }
 
-                var phrase = NoteTrack.Notes[_phraseIndex];
-                TogglePercussion(HasPercussion(phrase));
+                var firstPhrase = NoteTrack.Notes[0];
+                var firstPhraseHasStarted = firstPhrase.Time <= time;
+                return firstPhraseHasStarted || HasPercussion(firstPhrase);
             }
+
+            bool atTheEndOfTrack = _phraseIndex >= NoteTrack.Notes.Count;
+            if (atTheEndOfTrack)
+            {
+                return false;
+            }
+
+            var currentPhrase = NoteTrack.Notes[_phraseIndex];
+            return currentPhrase.TimeEnd <= time;
         }
 
-        private void TogglePercussion(bool show)
+        private void SetPercussionMode(bool show)
         {
             _hud.SetHUDShowing(!show);
             _percussionTrack.ShowPercussionFret(show);

--- a/Assets/Script/Gameplay/Player/VocalsPlayer.cs
+++ b/Assets/Script/Gameplay/Player/VocalsPlayer.cs
@@ -525,19 +525,20 @@ namespace YARG.Gameplay.Player
                 // End if that's the last note
                 if (_phraseIndex >= NoteTrack.Notes.Count)
                 {
-                    _hud.SetHUDShowing(true);
-                    _percussionTrack.ShowPercussionFret(false);
-                    _shouldHideNeedle = false;
+                    TogglePercussion(false);
                     break;
                 }
 
                 var phrase = NoteTrack.Notes[_phraseIndex];
-                bool hasPercussion = HasPercussion(phrase);
-
-                _hud.SetHUDShowing(!hasPercussion);
-                _percussionTrack.ShowPercussionFret(hasPercussion);
-                _shouldHideNeedle = hasPercussion;
+                TogglePercussion(HasPercussion(phrase));
             }
+        }
+
+        private void TogglePercussion(bool show)
+        {
+            _hud.SetHUDShowing(!show);
+            _percussionTrack.ShowPercussionFret(show);
+            _shouldHideNeedle = show;
         }
 
         private static bool HasPercussion(VocalNote phrase)

--- a/Assets/Script/Gameplay/Player/VocalsPlayer.cs
+++ b/Assets/Script/Gameplay/Player/VocalsPlayer.cs
@@ -543,7 +543,15 @@ namespace YARG.Gameplay.Player
 
         private static bool HasPercussion(VocalNote phrase)
         {
-            return phrase.ChildNotes.Any(note => note.IsPercussion);
+            foreach (var note in phrase.ChildNotes)
+            {
+                if (note.IsPercussion)
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         public override void SetPracticeSection(uint start, uint end)

--- a/Assets/Script/Gameplay/Player/VocalsPlayer.cs
+++ b/Assets/Script/Gameplay/Player/VocalsPlayer.cs
@@ -258,6 +258,7 @@ namespace YARG.Gameplay.Player
             }
 
             _phraseIndex = -1;
+            _percussionTrack.Initialize(NoteTrack.Notes);
 
             base.ResetPracticeSection();
         }

--- a/Assets/Script/Gameplay/Player/VocalsPlayer.cs
+++ b/Assets/Script/Gameplay/Player/VocalsPlayer.cs
@@ -513,8 +513,10 @@ namespace YARG.Gameplay.Player
             // the end times of phrases instead (where the phrase lines are). Problem
             // with this is that we still gotta account for the first phrase, so use
             // an index of -1 for that.
-            while (_phraseIndex == -1 ||
-                (_phraseIndex < NoteTrack.Notes.Count && NoteTrack.Notes[_phraseIndex].TimeEnd <= time))
+            while (_phraseIndex < NoteTrack.Notes.Count &&
+                (_phraseIndex == -1
+                    ? NoteTrack.Notes.Count > 0 && NoteTrack.Notes[0].Time <= time
+                    : NoteTrack.Notes[_phraseIndex].TimeEnd <= time))
             {
                 _phraseIndex++;
 

--- a/Assets/Script/Gameplay/Player/VocalsPlayer.cs
+++ b/Assets/Script/Gameplay/Player/VocalsPlayer.cs
@@ -523,6 +523,9 @@ namespace YARG.Gameplay.Player
                 // End if that's the last note
                 if (_phraseIndex >= NoteTrack.Notes.Count)
                 {
+                    _hud.SetHUDShowing(true);
+                    _percussionTrack.ShowPercussionFret(false);
+                    _shouldHideNeedle = false;
                     break;
                 }
 

--- a/Assets/Script/Gameplay/Player/VocalsPlayer.cs
+++ b/Assets/Script/Gameplay/Player/VocalsPlayer.cs
@@ -515,7 +515,9 @@ namespace YARG.Gameplay.Player
             // an index of -1 for that.
             while (_phraseIndex < NoteTrack.Notes.Count &&
                 (_phraseIndex == -1
-                    ? NoteTrack.Notes.Count > 0 && NoteTrack.Notes[0].Time <= time
+                    ? NoteTrack.Notes.Count > 0 &&
+                        (NoteTrack.Notes[0].Time <= time ||
+                            NoteTrack.Notes[0].ChildNotes.Any(note => note.IsPercussion))
                     : NoteTrack.Notes[_phraseIndex].TimeEnd <= time))
             {
                 _phraseIndex++;


### PR DESCRIPTION
Fixes vocal percussion visibility and practice-mode note handling.
   •  Hide the percussion fret on initialization so it no longer appears at song start
   •  Trigger the fret show animation when entering a percussion phrase, including when the
      first phrase is percussion.
   •  Hide the percussion fret again, if active, after the final vocal phrase.
   •  Reset percussion visual state during practice-section resets.
   •  Avoid a NullReferenceException when hitting percussion notes after jumping into
      practice mode before the note visual has spawned.