### PR TITLE
Fix practice static vocals

### DIFF
--- a/Assets/Script/Gameplay/Player/Vocals/VocalTrack.cs
+++ b/Assets/Script/Gameplay/Player/Vocals/VocalTrack.cs
@@ -330,28 +330,7 @@ namespace YARG.Gameplay.Player
             {
                 _scrollingNoteTrackers[i] = new ScrollingPhraseNoteTracker(parts[i], false);
                 _scrollingLyricTrackers[i] = new ScrollingPhraseNoteTracker(parts[i], true);
-
-                if (SettingsManager.Settings.UseThreeLaneLyricsInHarmony.Value)
-                {
-                    // If we're in 3-lane mode, just give each lane its own tracker with no merging
-                    _staticPhraseTrackers[i] = new StaticPhraseTracker(GetVocalPhrasePairs(parts[i], null));
-                }
-                else
-                {
-                    // If we're in 2-lane mode...
-                    switch (i)
-                    {
-                        case 0:
-                            // ...HARM1 gets its own tracker with no merging...
-                            _staticPhraseTrackers[i] = new StaticPhraseTracker(GetVocalPhrasePairs(parts[i], null));
-                            break;
-                        case 1:
-                            // ...but HARM2 gets HARM3 as a merged part
-                            _staticPhraseTrackers[i] = new StaticPhraseTracker(GetVocalPhrasePairs(parts[i], parts[i + 1]));
-                            break;
-                            // Do nothing for HARM3, because it's being handled by HARM2
-                    }
-                }
+                _staticPhraseTrackers[i] = CreateStaticPhraseTracker(parts, i);
                 _staticPhraseQueues[i] = new Queue<VocalStaticLyricPhraseElement>();
             }
 
@@ -629,19 +608,7 @@ namespace YARG.Gameplay.Player
             // Keep this separate from the trimming loop so merged harmony lanes only use fully-trimmed parts
             for (int i = 0; i < parts.Count; i++)
             {
-                if (SettingsManager.Settings.UseThreeLaneLyricsInHarmony.Value)
-                {
-                    _staticPhraseTrackers[i] = new StaticPhraseTracker(GetVocalPhrasePairs(parts[i], null));
-                }
-                else
-                {
-                    _staticPhraseTrackers[i] = i switch
-                    {
-                        0 => new StaticPhraseTracker(GetVocalPhrasePairs(parts[i], null)),
-                        1 => new StaticPhraseTracker(GetVocalPhrasePairs(parts[i], parts[i + 1])),
-                        _ => _staticPhraseTrackers[i]
-                    };
-                }
+                _staticPhraseTrackers[i] = CreateStaticPhraseTracker(parts, i);
                 _staticPhraseQueues[i].Clear();
             }
 
@@ -719,6 +686,25 @@ namespace YARG.Gameplay.Player
             int severity = (((int)greatestOffset - THRESHOLD) / 200) + 1;
 
             return 1f + (severity * 0.2f);
+        }
+
+        private StaticPhraseTracker CreateStaticPhraseTracker(List<VocalsPart> parts, int index)
+        {
+            if (SettingsManager.Settings.UseThreeLaneLyricsInHarmony.Value || index == 0)
+            {
+                // In 3-lane mode, each lane gets its own tracker with no merging.
+                // In 2-lane mode, HARM1 still gets its own tracker with no merging.
+                return new StaticPhraseTracker(GetVocalPhrasePairs(parts[index], null));
+            }
+
+            return index switch
+            {
+                // In 2-lane mode, HARM2 gets HARM3 as a merged part.
+                1 => new StaticPhraseTracker(GetVocalPhrasePairs(parts[index],
+                    index + 1 < parts.Count ? parts[index + 1] : null)),
+                // HARM3 is handled by HARM2 in 2-lane mode.
+                _ => null
+            };
         }
 
         // Necessary for combining HARM2 and HARM3 in two-lane view

--- a/Assets/Script/Gameplay/Player/Vocals/VocalTrack.cs
+++ b/Assets/Script/Gameplay/Player/Vocals/VocalTrack.cs
@@ -614,24 +614,34 @@ namespace YARG.Gameplay.Player
             }
 
             _vocalsTrack = _originalVocalsTrack.Clone();
+            var parts = _vocalsTrack.Parts;
 
-            // Remove all events not in the section
-            for (int i = 0; i < _vocalsTrack.Parts.Count; i++)
+            // Trim out all the parts not in section
+            for (int i = 0; i < parts.Count; i++)
             {
-                var part = _vocalsTrack.Parts[i];
-                part.NotePhrases.RemoveAll(n => n.Tick < start || n.Tick >= end);
-                part.TextEvents.RemoveAll(n => n.Tick < start || n.Tick >= end);
+                var part = parts[i];
+                part.TrimToTickRange(start, end);
 
-                _scrollingNoteTrackers[i] = new(part, false);
-                _scrollingLyricTrackers[i] = new(part, true);
+                _scrollingNoteTrackers[i] = new ScrollingPhraseNoteTracker(part, false);
+                _scrollingLyricTrackers[i] = new ScrollingPhraseNoteTracker(part, true);
             }
 
-            for (int i = 0; i < LyricLaneCount; i++)
+            // Keep this separate from the trimming loop so merged harmony lanes only use fully-trimmed parts
+            for (int i = 0; i < parts.Count; i++)
             {
-                var phrasePairs = _staticPhraseTrackers[i].PhrasePairs;
-                phrasePairs.RemoveAll(n => n.Tick < start || n.Tick >= end);
-
-                _staticPhraseTrackers[i] = new(phrasePairs);
+                if (SettingsManager.Settings.UseThreeLaneLyricsInHarmony.Value)
+                {
+                    _staticPhraseTrackers[i] = new StaticPhraseTracker(GetVocalPhrasePairs(parts[i], null));
+                }
+                else
+                {
+                    _staticPhraseTrackers[i] = i switch
+                    {
+                        0 => new StaticPhraseTracker(GetVocalPhrasePairs(parts[i], null)),
+                        1 => new StaticPhraseTracker(GetVocalPhrasePairs(parts[i], parts[i + 1])),
+                        _ => _staticPhraseTrackers[i]
+                    };
+                }
                 _staticPhraseQueues[i].Clear();
             }
 

--- a/Assets/Script/Gameplay/Player/Vocals/VocalTrack.cs
+++ b/Assets/Script/Gameplay/Player/Vocals/VocalTrack.cs
@@ -592,29 +592,16 @@ namespace YARG.Gameplay.Player
                 return;
             }
 
-            _vocalsTrack = _originalVocalsTrack.Clone();
+            _vocalsTrack = _originalVocalsTrack.CloneInTickRange(start, end);
             var parts = _vocalsTrack.Parts;
-
-            // Trim out all the parts not in section
             for (int i = 0; i < parts.Count; i++)
             {
                 var part = parts[i];
-                part.TrimToTickRange(start, end);
-
                 _scrollingNoteTrackers[i] = new ScrollingPhraseNoteTracker(part, false);
                 _scrollingLyricTrackers[i] = new ScrollingPhraseNoteTracker(part, true);
-            }
-
-            // Keep this separate from the trimming loop so merged harmony lanes only use fully-trimmed parts
-            for (int i = 0; i < parts.Count; i++)
-            {
                 _staticPhraseTrackers[i] = CreateStaticPhraseTracker(parts, i);
                 _staticPhraseQueues[i].Clear();
             }
-
-            // The most recent range shift before the start tick should still be preserved
-            uint rangesStart = _vocalsTrack.RangeShifts.LowerBoundElement(start).Tick;
-            _vocalsTrack.RangeShifts.RemoveAll(n => n.Tick < rangesStart || n.Tick >= end);
 
             PrepareLyricSpawns();
             PrewarmVocalPools();


### PR DESCRIPTION
Instead of cloning the full track and manually filtering parts/range shifts in VocalTrack.

   •  Rebuilt static lyric trackers from the freshly section-scoped vocal parts, rather than filtering existing _staticPhraseTrackers, which fixed static vocals disappearing after changing practice sections.

   •  Extracted static phrase tracker creation into CreateStaticPhraseTracker(...) so initialization and practice-section reset use the same harmony-lane merging behavior.

   •  Simplified SetPracticeSection() to one loop now that CloneInTickRange() returns already-trimmed parts.

   •  Preserved the existing harmony behavior:
     •  3-lane mode: HARM1/HARM2/HARM3 each get their own tracker.
     •  2-lane mode: HARM1 gets its own tracker; HARM2 merges HARM3; HARM3 has no separate
         static tracker
         
This PR depends on the following YARG.Core change. https://github.com/YARC-Official/YARG.Core/pull/384