### PR TITLE
Fix audio buffer toggle not applying

### DIFF
--- a/Assets/Script/Audio/Bass/BassAudioManager.cs
+++ b/Assets/Script/Audio/Bass/BassAudioManager.cs
@@ -122,12 +122,7 @@ namespace YARG.Audio.BASS
 
             // Documentation recommends setting the device buffer to at least 2x the device period
             // https://www.un4seen.com/doc/#bass/BASS_CONFIG_DEV_BUFFER.html
-#if !UNITY_EDITOR && UNITY_STANDALONE_LINUX
-            // Linux sometimes needs a higher buffer length to prevent underruns
-            Bass.DeviceBufferLength = 4 * devPeriod;
-#else
             Bass.DeviceBufferLength = 2 * devPeriod;
-#endif
 
             // Affects Windows only. Forces device names to be in UTF-8 on Windows rather than ANSI.
             Bass.UnicodeDeviceInformation = true;
@@ -565,10 +560,6 @@ namespace YARG.Audio.BASS
             Bass.GlobalSampleVolume = (int) (10_000 * volume);
         }
 
-        protected override void ToggleBuffer_Internal(bool enable)
-        {
-            // Nothing
-        }
 
         protected override void SetBufferLength_Internal(int length)
         {

--- a/Assets/Script/Audio/Bass/BassStemMixer.cs
+++ b/Assets/Script/Audio/Bass/BassStemMixer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -105,6 +105,8 @@ namespace YARG.Audio.BASS
             SetOutputChannel_Internal(outputChannel);
             SetVolume_Internal(volume);
             SetSpeed_Internal(speed, true);
+
+            _BufferSetter(SettingsManager.Settings.PlaybackBufferLength.Value);
         }
 
 
@@ -534,21 +536,18 @@ namespace YARG.Audio.BASS
             return true;
         }
 
-        protected override void ToggleBuffer_Internal(bool enable)
-        {
-            _BufferSetter(enable, Bass.PlaybackBufferLength);
-        }
-
         protected override void SetBufferLength_Internal(int length)
         {
-            _BufferSetter(SettingsManager.Settings.EnablePlaybackBuffer.Value, length);
+            _BufferSetter(length);
         }
 
-        private void _BufferSetter(bool enable, int length)
+        private void _BufferSetter(int length)
         {
-            if (!enable)
+            // 0 is a special value in BASS that disables buffering. 
+            // Any positive buffer length must be at least the minimum supported limit to prevent errors.
+            if (length > 0 && length < GlobalAudioHandler.MinimumBufferLength)
             {
-                length = 0;
+                length = GlobalAudioHandler.MinimumBufferLength;
             }
 
             if (!Bass.ChannelSetAttribute(_tempoStreamHandle, ChannelAttribute.Buffer, length))

--- a/Assets/Script/Settings/SettingsManager.Settings.cs
+++ b/Assets/Script/Settings/SettingsManager.Settings.cs
@@ -265,10 +265,8 @@ namespace YARG.Settings
             public VolumeSetting MusicPlayerVolume { get; } = new(0.15f, MusicPlayerVolumeCallback);
             public VolumeSetting VocalMonitoring { get; } = new(0.7f, VocalMonitoringCallback);
 
-            public ToggleSetting EnablePlaybackBuffer { get; } = new(true, GlobalAudioHandler.TogglePlaybackBuffer);
-
             public IntSetting PlaybackBufferLength { get; }
-                = new(75, GlobalAudioHandler.MinimumBufferLength, GlobalAudioHandler.MaximumBufferLength,
+                = new(75, 0, GlobalAudioHandler.MaximumBufferLength,
                     GlobalAudioHandler.SetBufferLength);
 
             public SliderSetting MicrophoneSensitivity { get; } = new(2f, -50f, 50f);

--- a/Assets/Script/Settings/SettingsManager.cs
+++ b/Assets/Script/Settings/SettingsManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -108,7 +108,6 @@ namespace YARG.Settings
                 new FieldMetadata(nameof(Settings.MetronomeVolume), isAdvanced: true),
 
                 new HeaderMetadata("Customization", isAdvanced: true),
-                new FieldMetadata(nameof(Settings.EnablePlaybackBuffer), isAdvanced: true),
                 new FieldMetadata(nameof(Settings.PlaybackBufferLength), isAdvanced: true),
 
                 new HeaderMetadata("Input"),

--- a/Assets/StreamingAssets/lang/en-US.json
+++ b/Assets/StreamingAssets/lang/en-US.json
@@ -1,4 +1,4 @@
-﻿{
+{
     "Language": {
         "Name": "English",
         "Region": "United States",
@@ -1597,13 +1597,9 @@
                 "Name": "DMX Pulse Duration (MS)",
                 "Description": "How long a DMX channel stays on after receiving a trigger, in milliseconds. Increase this value if lights are not firing reliably. Set to 0 to disable pulse stretching entirely."
             },
-            "EnablePlaybackBuffer": {
-                "Name": "Use Audio Playback Buffer",
-                "Description": "Buffers audio data by decoding ahead-of-time in chunks. Improves audio stability on low-performance devices, at the cost of added latency on sound effects."
-            },
             "PlaybackBufferLength": {
                 "Name": "Playback Buffer Length",
-                "Description": "The size of the playback buffer, in milliseconds. Larger buffers provide more stability, but further increase the latency of sound effects."
+                "Description": "The size of the playback buffer, in milliseconds. Set to 0 to disable. Larger buffers provide more stability, but increase the latency of sound effects."
             },
             "ShowTime": {
                 "Name": "Show Time",


### PR DESCRIPTION
Core PR: https://github.com/YARC-Official/YARG.Core/pull/385

Turns out the toggle was only applying to the currently playing song.  

We decided to just simplify the settings UI so there is only a single input for audio buffer length, removing the toggle.  For no buffering, set to 0.

Because 0 is a special value and BASS has its own internal minimums, values 1-14 will internally be converted to a buffer size of 15.  For users I think this is a better UI and reduces bugs with maintaining two different states for the buffer.

<img width="1052" height="169" alt="image" src="https://github.com/user-attachments/assets/af0f725c-2e52-479e-ace6-89be8efbdc96" />




