### PR TITLE
Fix vocals practice lead in

### DIFF
--- a/Assets/Script/Gameplay/Player/VocalsPlayer.cs
+++ b/Assets/Script/Gameplay/Player/VocalsPlayer.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 using UnityEngine.AddressableAssets;
 using YARG.Core;
@@ -55,6 +56,8 @@ namespace YARG.Gameplay.Player
         private VocalsPlayerHUD _hud;
         private VocalPercussionTrack _percussionTrack;
         private bool _shouldHideNeedle;
+        private bool _handlesCountdown;
+        private List<VocalsPart> _allVocalParts;
 
         private int _phraseIndex = -1;
 
@@ -83,6 +86,8 @@ namespace YARG.Gameplay.Player
             // Get the notes from the specific harmony or solo part
 
             var multiTrack = chart.GetVocalsTrack(Player.Profile.CurrentInstrument);
+            _allVocalParts = multiTrack.Parts;
+            _handlesCountdown = vocalIndex == 0;
 
             var track = multiTrack.Parts[Player.Profile.HarmonyIndex];
             player.Profile.ApplyVocalModifiers(track);
@@ -126,26 +131,6 @@ namespace YARG.Gameplay.Player
 
             Engine = CreateEngine();
 
-            Engine.OnComboIncrement += OnComboIncrement;
-            Engine.OnComboReset += OnComboReset;
-
-            if (vocalIndex == 0)
-            {
-                if (Player.Profile.CurrentInstrument == Instrument.Vocals)
-                {
-                    Engine.BuildCountdownsFromSelectedPart();
-                }
-                else
-                {
-                    Engine.BuildCountdownsFromAllParts(multiTrack.Parts);
-                }
-
-                Engine.OnCountdownChange += (countdownLength, endTime) =>
-                {
-                    GameManager.VocalTrack.UpdateCountdown(countdownLength, endTime);
-                };
-            }
-
             if (GameManager.IsPractice)
             {
                 Engine.SetSpeed(GameManager.SongSpeed >= 1 ? GameManager.SongSpeed : 1);
@@ -183,6 +168,9 @@ namespace YARG.Gameplay.Player
 
             var engine = new YargVocalsEngine(NoteTrack, SyncTrack, EngineParams, Player.Profile.IsBot);
             EngineContainer = GameManager.EngineManager.Register(engine, NoteTrack.Instrument, Player.Profile.HarmonyIndex, _chart, Player.RockMeterPreset);
+
+            engine.OnComboIncrement += OnComboIncrement;
+            engine.OnComboReset += OnComboReset;
 
             engine.OnStarPowerPhraseHit += _ => OnStarPowerPhraseHit();
             engine.OnStarPowerStatus += OnStarPowerStatus;
@@ -238,6 +226,23 @@ namespace YARG.Gameplay.Player
                     ? GameManager.InputTime
                     : null;
             };
+
+            if (_handlesCountdown)
+            {
+                if (Player.Profile.CurrentInstrument == Instrument.Vocals)
+                {
+                    engine.BuildCountdownsFromSelectedPart();
+                }
+                else
+                {
+                    engine.BuildCountdownsFromAllParts(_allVocalParts);
+                }
+
+                engine.OnCountdownChange += (countdownLength, endTime) =>
+                {
+                    GameManager.VocalTrack.UpdateCountdown(countdownLength, endTime);
+                };
+            }
 
             return engine;
         }
@@ -590,6 +595,7 @@ namespace YARG.Gameplay.Player
             _phraseIndex = -1;
 
             Engine = CreateEngine();
+            Engine.SetSpeed(GameManager.SongSpeed >= 1 ? GameManager.SongSpeed : 1);
             ResetPracticeSection();
         }
 

--- a/Assets/Script/Gameplay/Player/VocalsPlayer.cs
+++ b/Assets/Script/Gameplay/Player/VocalsPlayer.cs
@@ -583,7 +583,7 @@ namespace YARG.Gameplay.Player
 
         public override void SetPracticeSection(uint start, uint end)
         {
-            var practiceNotes = OriginalNoteTrack.Notes.Where(n => n.Tick >= start && n.Tick < end).ToList();
+            var practiceNotes = OriginalNoteTrack.Notes.Where(n => IsVocalPhraseInPracticeRange(n, start, end)).ToList();
 
             NoteTrack = new InstrumentDifficulty<VocalNote>(
                 OriginalNoteTrack.Instrument,
@@ -597,6 +597,17 @@ namespace YARG.Gameplay.Player
             Engine = CreateEngine();
             Engine.SetSpeed(GameManager.SongSpeed >= 1 ? GameManager.SongSpeed : 1);
             ResetPracticeSection();
+        }
+
+        private static bool IsVocalPhraseInPracticeRange(VocalNote note, uint start, uint end)
+        {
+            if (note.Tick >= start && note.Tick < end)
+            {
+                return true;
+            }
+
+            return note.ChildNotes.Count > 0 &&
+                note.ChildNotes.All(child => child.Tick >= start && child.TotalTickEnd <= end);
         }
 
         public override void SetStemMuteState(bool muted)


### PR DESCRIPTION
- Updated VocalsPlayer.SetPracticeSection() to include vocal phrases whose child notes are fully inside the practice range, even if the phrase start tick is before it.
- Moved combo/countdown event wiring into CreateEngine() so recreated practice-mode vocal engines keep the same callbacks.
- Restores vocal engine speed after recreating the engine for practice mode.
- Stores all vocal parts for harmony countdown rebuilding after engine recreation.

Depends on https://github.com/YARC-Official/YARG.Core/pull/390