### PR TITLE
Fix 3-note trill rendering, remove open lane start visual offset

### DIFF
--- a/Assets/Script/Gameplay/Player/TrackPlayer.cs
+++ b/Assets/Script/Gameplay/Player/TrackPlayer.cs
@@ -824,14 +824,12 @@ namespace YARG.Gameplay.Player
 
                         if (childNote.IsLane)
                         {
-                            if (laneStartNotes.ContainsKey(childNote.LaneNote))
-                            {
-                                laneEndTimes[childNote.LaneNote] = noteRef.Time;
-                            }
-                            else
+                            if (!laneStartNotes.ContainsKey(childNote.LaneNote))
                             {
                                 laneStartNotes[childNote.LaneNote] = childNote;
                             }
+
+                            laneEndTimes[childNote.LaneNote] = noteRef.Time;
                         }
                     }
 

--- a/Assets/Script/Gameplay/Visuals/TrackElements/LaneElement.cs
+++ b/Assets/Script/Gameplay/Visuals/TrackElements/LaneElement.cs
@@ -135,7 +135,7 @@ namespace YARG.Gameplay.Visuals
             _startTime = startTime - 0.01;
             EndTime = endTime;
 
-            _zLength = GetZPositionAtTime(endTime) - GetZPositionAtTime(startTime);
+            _zLength = GetZPositionAtTime(endTime) - GetZPositionAtTime(_startTime);
 
             if (Initialized)
             {

--- a/Assets/Script/Gameplay/Visuals/TrackElements/LaneElement.cs
+++ b/Assets/Script/Gameplay/Visuals/TrackElements/LaneElement.cs
@@ -132,10 +132,10 @@ namespace YARG.Gameplay.Visuals
 
         public void SetTimeRange(double startTime, double endTime)
         {
-            _startTime = startTime - 0.01;
+            _startTime = startTime;
             EndTime = endTime;
 
-            _zLength = GetZPositionAtTime(endTime) - GetZPositionAtTime(_startTime);
+            _zLength = GetZPositionAtTime(endTime) - GetZPositionAtTime(startTime);
 
             if (Initialized)
             {

--- a/Assets/Script/Gameplay/Visuals/TrackElements/LaneElement.cs
+++ b/Assets/Script/Gameplay/Visuals/TrackElements/LaneElement.cs
@@ -19,7 +19,6 @@ namespace YARG.Gameplay.Visuals
         private const float LANE_LENGTH_RATIO = 0.02f;
 
         private const float OPEN_LANE_SCALE = 0.5f;
-        private const float OPEN_LANE_START_TIME_OFFSET = 0.05f;
 
         private static readonly int EmissionColor = Shader.PropertyToID("_EmissionColor");
 
@@ -133,7 +132,7 @@ namespace YARG.Gameplay.Visuals
 
         public void SetTimeRange(double startTime, double endTime)
         {
-            _startTime = startTime;
+            _startTime = startTime - 0.01;
             EndTime = endTime;
 
             _zLength = GetZPositionAtTime(endTime) - GetZPositionAtTime(startTime);
@@ -259,8 +258,6 @@ namespace YARG.Gameplay.Visuals
             if (_isOpen == true)
             {
                 SetXPosition(0);
-
-                SetTimeRange(_startTime - OPEN_LANE_START_TIME_OFFSET, EndTime);
 
                 _scale = OPEN_LANE_SCALE;
 


### PR DESCRIPTION
Currently, if a chart contains a 3-note trill (yes, [they exist](https://www.youtube.com/watch?v=Cca99kyGUyY&pp=ygUUdHJpYW5nbGUgdHJpbGwgbGFuZXM%3D)), we don't render any lane at all for the middle note. This PR changes the lane rendering behavior so we render a minimal 1-note lane around the middle note.

We could make it more readable with some special casing to expand the 1-note lane a little, but this is just the minimal fix so that we render _something_.

This also removes the current `0.05f` offset for the start time of open lanes.