### PR TITLE
Fix lyric bar visual behaviour on rewind

### DIFF
--- a/Assets/Script/Gameplay/GameManager.cs
+++ b/Assets/Script/Gameplay/GameManager.cs
@@ -989,6 +989,11 @@ namespace YARG.Gameplay
         {
             YargLogger.LogFormatDebug("Rewinding {0} seconds at VisualTime {1}", seconds, VisualTime);
 
+            if (_lyricBar.gameObject.activeSelf)
+            {
+                _lyricBar.Rewind(VisualTime - seconds, 0.5f);
+            }
+
             // Rewind players
             foreach (var player in _players)
             {

--- a/Assets/Script/Gameplay/HUD/LyricBar.cs
+++ b/Assets/Script/Gameplay/HUD/LyricBar.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Cysharp.Threading.Tasks;
 using DG.Tweening;
 using UnityEngine;
 using YARG.Core.Chart;
@@ -188,14 +189,19 @@ namespace YARG.Gameplay.HUD
             // In case we are disabled already
             enabled = true;
 
-            _fadeIndex = 0;
-
             // Tell LyricBarPhrase about the new time
             foreach (var lyricTextObject in _lyricTextObjects)
             {
                 lyricTextObject.gameObject.SetActive(true);
                 lyricTextObject.SetSongTime(time);
             }
+
+            SetFadeTime(time);
+        }
+
+        private void SetFadeTime(double time)
+        {
+            _fadeIndex = 0;
 
             // set the fade start index
             while (_fadeStartTimings.Count > 0 && _fadeIndex < _fadeStartTimings.Count &&
@@ -250,6 +256,21 @@ namespace YARG.Gameplay.HUD
             }
 
             _fadeIndex++;
+        }
+
+        public async void Rewind(double targetVisualTime, float duration)
+        {
+            foreach (var lyricTextObject in _lyricTextObjects)
+            {
+                lyricTextObject.gameObject.SetActive(true);
+                lyricTextObject.RewindTargetTime = targetVisualTime;
+            }
+            await UniTask.Delay(TimeSpan.FromSeconds(duration));
+            foreach (var lyricTextObject in _lyricTextObjects)
+            {
+                lyricTextObject.RewindTargetTime = null;
+            }
+            SetFadeTime(targetVisualTime);
         }
     }
 }

--- a/Assets/Script/Gameplay/HUD/LyricBarPhrase.cs
+++ b/Assets/Script/Gameplay/HUD/LyricBarPhrase.cs
@@ -47,9 +47,10 @@ namespace YARG.Gameplay.HUD
         private readonly Vector2 _finishedPosition = new(0f, 15f);
 
         private int                     _currentLyricIndex;
-        private double                  _greatestVisualTime;
         private Utf16ValueStringBuilder _builder;
         private RectTransform           _lyricTextTransform;
+        public double?                    RewindTargetTime;
+        private bool IsRewinding => RewindTargetTime != null;
 
         protected override void GameplayAwake()
         {
@@ -114,13 +115,9 @@ namespace YARG.Gameplay.HUD
             var currentPhrase = _phrases[_currentPhraseIndex];
             float timeFraction;
             var time = GameManager.VisualTime;
-            if (time < _greatestVisualTime)
-            {
-                return;
-            }
             if (time >= currentPhrase.ExitTransition.Time)
             {
-                if (Mathf.Approximately(_lyricTextTransform.anchoredPosition.y, _finishedPosition.y))
+                if (Mathf.Approximately(_lyricTextTransform.anchoredPosition.y, _finishedPosition.y) && !IsRewinding)
                 {
                     return;
                 }
@@ -134,7 +131,7 @@ namespace YARG.Gameplay.HUD
 
             if (time >= currentPhrase.ActiveTransition.Time)
             {
-                if (Mathf.Approximately(_lyricTextTransform.anchoredPosition.y, _activePosition.y))
+                if (Mathf.Approximately(_lyricTextTransform.anchoredPosition.y, _activePosition.y) && !IsRewinding)
                 {
                     return;
                 }
@@ -150,7 +147,7 @@ namespace YARG.Gameplay.HUD
 
             if (time >= currentPhrase.UpcomingTransition.Time)
             {
-                if (Mathf.Approximately(_lyricTextTransform.anchoredPosition.y, _upcomingPosition.y))
+                if (Mathf.Approximately(_lyricTextTransform.anchoredPosition.y, _upcomingPosition.y) && !IsRewinding)
                 {
                     return;
                 }
@@ -168,6 +165,11 @@ namespace YARG.Gameplay.HUD
             if (currentPhrase == null)
             {
                 return;
+            }
+
+            if (IsRewinding)
+            {
+                RewindHandler();
             }
 
             var time = GameManager.VisualTime;
@@ -189,18 +191,13 @@ namespace YARG.Gameplay.HUD
 
             UpdatePosition();
 
-            if (time > _greatestVisualTime)
-            {
-                _greatestVisualTime = time;
-            }
-
         }
 
         private void UpdateHighlighting()
         {
             var lyrics = _phrases[_currentPhraseIndex].Phrase.Lyrics;
             var time = GameManager.VisualTime;
-            if (time < _greatestVisualTime)
+            if (IsRewinding)
             {
                 _currentLyricIndex = 0;
             }
@@ -211,7 +208,7 @@ namespace YARG.Gameplay.HUD
                 currentIndex++;
             }
 
-            if (_currentLyricIndex == currentIndex)
+            if (_currentLyricIndex == currentIndex && !IsRewinding)
             {
                 return;
             }
@@ -257,8 +254,16 @@ namespace YARG.Gameplay.HUD
         public void SetSongTime(double time)
         {
             _currentPhraseIndex = 0;
-            _greatestVisualTime = 0;
             MoveToPhraseAtTime(time);
+        }
+
+        private void RewindHandler()
+        {
+            if (!IsRewinding || _phrases[_currentPhraseIndex] == null || _currentPhraseIndex == 0 || _phrases[_currentPhraseIndex - 1].ExitTransition.TimeEnd < RewindTargetTime!.Value)
+            {
+                return;
+            }
+            SetSongTime(GameManager.VisualTime);
         }
     }
 }

--- a/Assets/Script/Gameplay/HUD/LyricBarPhrase.cs
+++ b/Assets/Script/Gameplay/HUD/LyricBarPhrase.cs
@@ -47,6 +47,7 @@ namespace YARG.Gameplay.HUD
         private readonly Vector2 _finishedPosition = new(0f, 15f);
 
         private int                     _currentLyricIndex;
+        private double                  _greatestVisualTime;
         private Utf16ValueStringBuilder _builder;
         private RectTransform           _lyricTextTransform;
 
@@ -113,6 +114,10 @@ namespace YARG.Gameplay.HUD
             var currentPhrase = _phrases[_currentPhraseIndex];
             float timeFraction;
             var time = GameManager.VisualTime;
+            if (time < _greatestVisualTime)
+            {
+                return;
+            }
             if (time >= currentPhrase.ExitTransition.Time)
             {
                 if (Mathf.Approximately(_lyricTextTransform.anchoredPosition.y, _finishedPosition.y))
@@ -166,6 +171,7 @@ namespace YARG.Gameplay.HUD
             }
 
             var time = GameManager.VisualTime;
+
             if (GameManager.VisualTime >= currentPhrase.ExitTransition.TimeEnd)
             {
                 MoveToPhraseAtTime(time);
@@ -182,14 +188,25 @@ namespace YARG.Gameplay.HUD
             }
 
             UpdatePosition();
+
+            if (time > _greatestVisualTime)
+            {
+                _greatestVisualTime = time;
+            }
+
         }
 
         private void UpdateHighlighting()
         {
             var lyrics = _phrases[_currentPhraseIndex].Phrase.Lyrics;
+            var time = GameManager.VisualTime;
+            if (time < _greatestVisualTime)
+            {
+                _currentLyricIndex = 0;
+            }
             int currentIndex = _currentLyricIndex;
 
-            while (currentIndex < lyrics.Count && lyrics[currentIndex].Time <= GameManager.VisualTime)
+            while (currentIndex < lyrics.Count && lyrics[currentIndex].Time <= time)
             {
                 currentIndex++;
             }
@@ -240,6 +257,7 @@ namespace YARG.Gameplay.HUD
         public void SetSongTime(double time)
         {
             _currentPhraseIndex = 0;
+            _greatestVisualTime = 0;
             MoveToPhraseAtTime(time);
         }
     }


### PR DESCRIPTION
I know this isn't really a big issue, but it was bugging me, and was easy enough to fix. Also, now the highlighting can go backwards during a rewind, which is neat.