### PR TITLE
Hide missed notes on rewind

### DIFF
--- a/Assets/Script/Gameplay/Player/TrackPlayer.cs
+++ b/Assets/Script/Gameplay/Player/TrackPlayer.cs
@@ -392,7 +392,14 @@ namespace YARG.Gameplay.Player
 
         public override void Rewind(double visualTime)
         {
-
+            for (int index = NotePool.AllSpawned.Count - 1; index >= 0; index--)
+            {
+                var poolable = NotePool.AllSpawned[index];
+                if (poolable is INoteElement note)
+                {
+                    note.OnRewind();
+                }
+            }
         }
 
         public override void PostRewind(double visualTime)

--- a/Assets/Script/Gameplay/Visuals/TrackElements/NoteElement.cs
+++ b/Assets/Script/Gameplay/Visuals/TrackElements/NoteElement.cs
@@ -45,7 +45,6 @@ namespace YARG.Gameplay.Visuals
 
         private   bool _lastStarPowerState;
         private   bool _lastStarPowerActiveState;
-        private   bool _wasMissed;
         protected bool IsStarPowerVisible => CalcStarPowerVisible();
 
         public abstract void SetThemeModels(ThemeDict models, ThemeDict starPowerModels);
@@ -117,14 +116,13 @@ namespace YARG.Gameplay.Visuals
         /// </summary>
         public virtual void MissNote()
         {
-            _wasMissed = true;
             SustainState = SustainState.Missed;
             OnNoteStateChanged();
         }
 
         public void OnRewind()
         {
-            if (_wasMissed)
+            if (NoteRef.WasMissed)
             {
                 ParentPool.Return(this);
             }

--- a/Assets/Script/Gameplay/Visuals/TrackElements/NoteElement.cs
+++ b/Assets/Script/Gameplay/Visuals/TrackElements/NoteElement.cs
@@ -16,7 +16,12 @@ namespace YARG.Gameplay.Visuals
         Missed
     }
 
-    public abstract class NoteElement<TNote, TPlayer> : TrackElement<TPlayer>, IThemeNoteCreator
+    public interface INoteElement
+    {
+        void OnRewind();
+    }
+
+    public abstract class NoteElement<TNote, TPlayer> : TrackElement<TPlayer>, IThemeNoteCreator, INoteElement
         where TNote : Note<TNote>
         where TPlayer : TrackPlayer
     {
@@ -38,9 +43,9 @@ namespace YARG.Gameplay.Visuals
 
         public override double ElementTime => NoteRef.Time;
 
-        private bool _lastStarPowerState;
-        private bool _lastStarPowerActiveState;
-
+        private   bool _lastStarPowerState;
+        private   bool _lastStarPowerActiveState;
+        private   bool _wasMissed;
         protected bool IsStarPowerVisible => CalcStarPowerVisible();
 
         public abstract void SetThemeModels(ThemeDict models, ThemeDict starPowerModels);
@@ -112,8 +117,17 @@ namespace YARG.Gameplay.Visuals
         /// </summary>
         public virtual void MissNote()
         {
+            _wasMissed = true;
             SustainState = SustainState.Missed;
             OnNoteStateChanged();
+        }
+
+        public void OnRewind()
+        {
+            if (_wasMissed)
+            {
+                ParentPool.Return(this);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Mildly janky, but it does work? Not sure about the whole `INoteElement` thing, but otherwise it does not seem to be able to recognize `NoteElement` class types because of the type parameters, so aside from reflection or duplicating the same method 5 times I don't know of a good alternative?

https://github.com/user-attachments/assets/c2082c78-63e2-4a08-b3d5-ebcc10858613

