### PR TITLE
Fix issues where mic would disappear from devices list

### DIFF
--- a/Assets/Script/Audio/Bass/BassMicDevice.cs
+++ b/Assets/Script/Audio/Bass/BassMicDevice.cs
@@ -188,20 +188,15 @@ namespace YARG.Audio.BASS
             // Must initialise device before recording
             if (!Bass.RecordInit(deviceId))
             {
-                if (Bass.LastError != Errors.Already)
-                {
-                    YargLogger.LogFormatError("Failed to initialize recording device: {0}!", Bass.LastError);
-                    return null;
-                }
-                Bass.CurrentRecordingDevice = deviceId;
+                YargLogger.LogFormatError("Failed to initialize recording device: {0}!", Bass.LastError);
+                return null;
             }
 
             var device = new BassMicDevice(deviceId, name);
             device._recordHandle = RecordingHandle.CreateRecordingHandle(device.ProcessRecordData);
             if (device._recordHandle == null)
             {
-                // Not device.Dispose() as to not free resources that we may want to keep around
-                // i.e, the record-enabled device
+                FreeDevice(deviceId);
                 return null;
             }
 
@@ -211,6 +206,7 @@ namespace YARG.Audio.BASS
             if (monitorPlayback == null)
             {
                 device._recordHandle.Dispose();
+                FreeDevice(deviceId);
                 return null;
             }
             device._monitorHandle = monitorPlayback;
@@ -224,6 +220,15 @@ namespace YARG.Audio.BASS
                 return null;
             }
             return device;
+        }
+
+        private static void FreeDevice(int deviceId)
+        {
+            Bass.CurrentRecordingDevice = deviceId;
+            if (!Bass.RecordFree())
+            {
+                YargLogger.LogFormatWarning("Failed to free recording device after initialization failure: {0}!", Bass.LastError);
+            }
         }
 
         private static readonly PeakEQParameters _lowEqParameters = new()

--- a/Assets/Script/Input/Bindings/ProfileBindings.cs
+++ b/Assets/Script/Input/Bindings/ProfileBindings.cs
@@ -392,18 +392,10 @@ namespace YARG.Input
             MenuBindings.UpdateBindingsForFrame(updateTime);
         }
 
-        public bool AddMicrophone(MicDevice microphone)
+        public void AddMicrophone(MicDevice microphone)
         {
-            if (Microphone is not null)
-            {
-                microphone.Dispose();
-                return false;
-            }
-
             Microphone = microphone;
             _unresolvedMic = microphone.Serialize();
-
-            return true;
         }
 
         public void RemoveMicrophone()

--- a/Assets/Script/Menu/ProfileList/ProfileView.cs
+++ b/Assets/Script/Menu/ProfileList/ProfileView.cs
@@ -202,9 +202,19 @@ namespace YARG.Menu.ProfileList
                 dialog.AddListButton(microphone.name, () =>
                 {
                     var device = GlobalAudioHandler.CreateInputDevice(microphone.id, microphone.name);
+                    if (device is null)
+                    {
+                        YargLogger.LogFormatWarning("Failed to initialize microphone `{0}`.", microphone.name);
+                        DialogManager.Instance.ClearDialog();
+                        DialogManager.Instance.ShowMessage("Microphone Error",
+                            $"Failed to initialize microphone:\n\n{microphone.name}\n\nPlease try again or choose a different microphone.");
+                        return;
+                    }
+
                     player.Bindings.AddMicrophone(device);
                     selectedDevice = true;
-                });
+                    DialogManager.Instance.ClearDialog();
+                }, closeOnClick: false);
             }
 
             if (devicesAvailable)
@@ -358,6 +368,7 @@ namespace YARG.Menu.ProfileList
                 {
                     // Don't leak player when cancelling
                     PlayerContainer.DisposePlayer(player);
+                    _profileListMenu.RefreshList(Profile);
                     return;
                 }
             }


### PR DESCRIPTION
Issue:

1. Click connect on profile
2. See mic in devices list
3. Disconnect mic
4. Click on mic in devices list

Result: bad things happen, unable to disconnect profile, mic never shows up again, sometimes even on restart

This fixes the issues so we show an error message when we can't connect to the device for any reason, and fixes other stuff that breaks because of this in the profiles screen

We free the recording device appropriately now when it fails to initialize

<img width="1946" height="1088" alt="image" src="https://github.com/user-attachments/assets/25d1742f-74c8-4ebd-ace1-89b0f8076e39" />


