### PR TITLE
Normalize sample channels

### DIFF
--- a/Assets/Script/Audio/Bass/BassAudioManager.cs
+++ b/Assets/Script/Audio/Bass/BassAudioManager.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using ManagedBass;
 using ManagedBass.Fx;
 using ManagedBass.Mix;
@@ -383,7 +382,7 @@ namespace YARG.Audio.BASS
         }
 
         /**
-         * Normalizes sample channel volumes by a single factor per category
+         * When normalization is enabled, scales all sample channels by a fixed factor.
          */
         protected override void ApplySampleNormalization()
         {
@@ -392,43 +391,22 @@ namespace YARG.Audio.BASS
                 return;
             }
 
-            var sfxPaths = SfxSamples.Where(s => s != null)
-                .Select(s => s.FilePath)
-                .ToArray();
-            var sfxMult = BassHelpers.GetNormalizationMultiplier(sfxPaths);
+            const float mult = 0.5f;
             foreach (var sample in SfxSamples)
             {
-                sample?.SetNormalizationMultiplier(sfxMult);
+                sample?.SetNormalizationMultiplier(mult);
             }
-
-            var drumPaths = DrumSfxSamples.Where(s => s != null)
-                .Select(s => s.FilePath)
-                .ToArray();
-            var drumMult = BassHelpers.GetNormalizationMultiplier(drumPaths);
             foreach (var sample in DrumSfxSamples)
             {
-                sample?.SetNormalizationMultiplier(drumMult);
+                sample?.SetNormalizationMultiplier(mult);
             }
-
-            var voxPaths = VoxSamples.Where(s => s != null).Select(s => s.Path).ToArray();
-            var voxMult = BassHelpers.GetNormalizationMultiplier(voxPaths);
             foreach (var sample in VoxSamples)
             {
-                sample?.SetNormalizationMultiplier(voxMult);
+                sample?.SetNormalizationMultiplier(mult);
             }
-
-            var metronomePaths = MetronomeSamples
-                .Where(s => s != null)
-                .SelectMany(s => new[]
-                {
-                    s.HiFilePath,
-                    s.LoFilePath
-                })
-                .ToArray();
-            var metronomeMult = BassHelpers.GetNormalizationMultiplier(metronomePaths);
             foreach (var sample in MetronomeSamples)
             {
-                sample?.SetNormalizationMultipliers(metronomeMult, metronomeMult);
+                sample?.SetNormalizationMultipliers(mult, mult);
             }
         }
 

--- a/Assets/Script/Audio/Bass/BassAudioManager.cs
+++ b/Assets/Script/Audio/Bass/BassAudioManager.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using ManagedBass;
 using ManagedBass.Fx;
 using ManagedBass.Mix;
@@ -379,6 +380,56 @@ namespace YARG.Audio.BASS
             }
 
             return null;
+        }
+
+        /**
+         * Normalizes sample channel volumes by a single factor per category
+         */
+        protected override void ApplySampleNormalization()
+        {
+            if (!BassHelpers.IsNormalizationEnabled)
+            {
+                return;
+            }
+
+            var sfxPaths = SfxSamples.Where(s => s != null)
+                .Select(s => s.FilePath)
+                .ToArray();
+            var sfxMult = BassHelpers.GetNormalizationMultiplier(sfxPaths);
+            foreach (var sample in SfxSamples)
+            {
+                sample?.SetNormalizationMultiplier(sfxMult);
+            }
+
+            var drumPaths = DrumSfxSamples.Where(s => s != null)
+                .Select(s => s.FilePath)
+                .ToArray();
+            var drumMult = BassHelpers.GetNormalizationMultiplier(drumPaths);
+            foreach (var sample in DrumSfxSamples)
+            {
+                sample?.SetNormalizationMultiplier(drumMult);
+            }
+
+            var voxPaths = VoxSamples.Where(s => s != null).Select(s => s.Path).ToArray();
+            var voxMult = BassHelpers.GetNormalizationMultiplier(voxPaths);
+            foreach (var sample in VoxSamples)
+            {
+                sample?.SetNormalizationMultiplier(voxMult);
+            }
+
+            var metronomePaths = MetronomeSamples
+                .Where(s => s != null)
+                .SelectMany(s => new[]
+                {
+                    s.HiFilePath,
+                    s.LoFilePath
+                })
+                .ToArray();
+            var metronomeMult = BassHelpers.GetNormalizationMultiplier(metronomePaths);
+            foreach (var sample in MetronomeSamples)
+            {
+                sample?.SetNormalizationMultipliers(metronomeMult, metronomeMult);
+            }
         }
 
         private void LoadSfx()

--- a/Assets/Script/Audio/Bass/BassDrumSampleChannel.cs
+++ b/Assets/Script/Audio/Bass/BassDrumSampleChannel.cs
@@ -1,8 +1,10 @@
-﻿using ManagedBass;
+using System;
+using ManagedBass;
 using UnityEngine;
 using YARG.Core.Audio;
 using YARG.Core.Logging;
 using YARG.Input;
+using YARG.Settings;
 
 namespace YARG.Audio.BASS
 {
@@ -27,19 +29,23 @@ namespace YARG.Audio.BASS
                 return null;
             }
 
-            return new BassDrumSampleChannel(handle, channel, sample, path, playbackCount, outputChannel);
+            float normMultiplier = BassHelpers.GetNormMultiplier(path);
+
+            return new BassDrumSampleChannel(handle, channel, sample, path, playbackCount, outputChannel, normMultiplier);
         }
 
         private readonly int _sfxHandle;
         private readonly int _channel;
+        private readonly float _normalizationMultiplier;
 
 #nullable enable
-        private BassDrumSampleChannel(int handle, int channel, DrumSfxSample sample, string path, int playbackCount, OutputChannel? outputChannel)
+        private BassDrumSampleChannel(int handle, int channel, DrumSfxSample sample, string path, int playbackCount, OutputChannel? outputChannel, float normalizationMultiplier)
             : base(sample, path, playbackCount)
 #nullable disable
         {
             _sfxHandle = handle;
             _channel = channel;
+            _normalizationMultiplier = normalizationMultiplier;
             SetOutputChannel_Internal(outputChannel);
         }
 
@@ -53,6 +59,7 @@ namespace YARG.Audio.BASS
 
         protected override void SetVolume_Internal(double volume)
         {
+            volume *= _normalizationMultiplier;
             if (!Bass.ChannelSetAttribute(_channel, ChannelAttribute.Volume, volume))
             {
                 YargLogger.LogFormatError("Failed to set {0} volume: {1}!", Sample, Bass.LastError);

--- a/Assets/Script/Audio/Bass/BassDrumSampleChannel.cs
+++ b/Assets/Script/Audio/Bass/BassDrumSampleChannel.cs
@@ -29,23 +29,20 @@ namespace YARG.Audio.BASS
                 return null;
             }
 
-            float normMultiplier = BassHelpers.GetNormMultiplier(path);
-
-            return new BassDrumSampleChannel(handle, channel, sample, path, playbackCount, outputChannel, normMultiplier);
+            return new BassDrumSampleChannel(handle, channel, sample, path, playbackCount, outputChannel);
         }
 
         private readonly int _sfxHandle;
         private readonly int _channel;
-        private readonly float _normalizationMultiplier;
+        private float _normalizationMultiplier = 1.0f;
 
 #nullable enable
-        private BassDrumSampleChannel(int handle, int channel, DrumSfxSample sample, string path, int playbackCount, OutputChannel? outputChannel, float normalizationMultiplier)
+        private BassDrumSampleChannel(int handle, int channel, DrumSfxSample sample, string path, int playbackCount, OutputChannel? outputChannel)
             : base(sample, path, playbackCount)
 #nullable disable
         {
             _sfxHandle = handle;
             _channel = channel;
-            _normalizationMultiplier = normalizationMultiplier;
             SetOutputChannel_Internal(outputChannel);
         }
 
@@ -55,6 +52,11 @@ namespace YARG.Audio.BASS
             {
                 YargLogger.LogFormatError("Failed to play {0} channel: {1}!", Sample, Bass.LastError);
             }
+        }
+
+        public override void SetNormalizationMultiplier(float multiplier)
+        {
+            _normalizationMultiplier = multiplier;
         }
 
         protected override void SetVolume_Internal(double volume)

--- a/Assets/Script/Audio/Bass/BassHelpers.cs
+++ b/Assets/Script/Audio/Bass/BassHelpers.cs
@@ -1,15 +1,23 @@
-﻿using System;
+using System;
 using ManagedBass;
 using ManagedBass.DirectX8;
 using ManagedBass.Fx;
 using UnityEngine;
 using YARG.Core.Audio;
 using YARG.Core.Logging;
+using YARG.Settings;
 
 namespace YARG.Audio.BASS
 {
     public static class BassHelpers
     {
+        public const float TARGET_RMS = 0.12f;
+
+        public static bool IsNormalizationEnabled => SettingsManager.Settings?.EnableNormalization?.Value ?? false;
+
+        public const float MIN_NORMALIZATION_MULTIPLIER = 0.1f;
+        public const float MAX_NORMALIZATION_MULTIPLIER = 2.0f;
+
         public const int PLAYBACK_BUFFER_LENGTH = 75;
         public const double PLAYBACK_BUFFER_DESYNC = PLAYBACK_BUFFER_LENGTH / 1000.0;
 
@@ -21,6 +29,65 @@ namespace YARG.Audio.BASS
         public const int REVERB_SLIDE_OUT_MILLISECONDS = 500;
 
         public const EffectType REVERB_TYPE = EffectType.Freeverb;
+
+        private static float MeasureRms(string path)
+        {
+            if (string.IsNullOrEmpty(path) || !System.IO.File.Exists(path))
+            {
+                return TARGET_RMS;
+            }
+
+            int decodeStream = Bass.CreateStream(path, 0, 0, BassFlags.Decode);
+            if (decodeStream == 0)
+            {
+                return TARGET_RMS;
+            }
+
+            try
+            {
+                long lengthBytes = Bass.ChannelGetLength(decodeStream);
+                double lengthSeconds = Bass.ChannelBytes2Seconds(decodeStream, lengthBytes);
+                if (lengthSeconds <= 0)
+                {
+                    return TARGET_RMS;
+                }
+
+                float[] levels = new float[1];
+                if (Bass.ChannelGetLevel(decodeStream, levels, (float) lengthSeconds,
+                    LevelRetrievalFlags.Mono | LevelRetrievalFlags.RMS))
+                {
+                    return levels[0];
+                }
+            }
+            catch (Exception ex)
+            {
+                YargLogger.LogError($"Failed to measure RMS for sample {path}: {ex.Message}");
+            }
+            finally
+            {
+                Bass.StreamFree(decodeStream);
+            }
+
+            return TARGET_RMS;
+        }
+
+        /// <summary>
+        /// Calculates the normalization multiplier for a sample file by measuring its RMS level
+        /// and computing the gain required to match the target song RMS.
+        /// </summary>
+        /// <param name="path">The file path to the audio sample.</param>
+        /// <returns>A clamped normalization multiplier to apply to the channel volume.</returns>
+        public static float GetNormMultiplier(string path)
+        {
+            if (!IsNormalizationEnabled)
+            {
+                return 1.0f;
+            }
+
+            float rms = MeasureRms(path) + float.Epsilon;
+            return Math.Clamp(TARGET_RMS / rms,
+                MIN_NORMALIZATION_MULTIPLIER, MAX_NORMALIZATION_MULTIPLIER);
+        }
 
         /*
          * From Bass documentation (http://bass.radio42.com/help/html/4c663bda-2751-c2c3-eaf2-770b846b6652.htm)

--- a/Assets/Script/Audio/Bass/BassHelpers.cs
+++ b/Assets/Script/Audio/Bass/BassHelpers.cs
@@ -1,4 +1,5 @@
-using System;
+﻿using System;
+using System.Collections.Generic;
 using ManagedBass;
 using ManagedBass.DirectX8;
 using ManagedBass.Fx;
@@ -12,6 +13,9 @@ namespace YARG.Audio.BASS
     public static class BassHelpers
     {
         public const float TARGET_RMS = 0.12f;
+        public const float TARGET_PEAK = 0.5f;
+
+        private static readonly Dictionary<string, float> _peakCache = new();
 
         public static bool IsNormalizationEnabled => SettingsManager.Settings?.EnableNormalization?.Value ?? false;
 
@@ -30,17 +34,22 @@ namespace YARG.Audio.BASS
 
         public const EffectType REVERB_TYPE = EffectType.Freeverb;
 
-        private static float MeasureRms(string path)
+        private static float MeasurePeak(string path)
         {
             if (string.IsNullOrEmpty(path) || !System.IO.File.Exists(path))
             {
-                return TARGET_RMS;
+                return 0f;
+            }
+
+            if (_peakCache.TryGetValue(path, out float cachedPeak))
+            {
+                return cachedPeak;
             }
 
             int decodeStream = Bass.CreateStream(path, 0, 0, BassFlags.Decode);
             if (decodeStream == 0)
             {
-                return TARGET_RMS;
+                return 0f;
             }
 
             try
@@ -49,43 +58,66 @@ namespace YARG.Audio.BASS
                 double lengthSeconds = Bass.ChannelBytes2Seconds(decodeStream, lengthBytes);
                 if (lengthSeconds <= 0)
                 {
-                    return TARGET_RMS;
+                    return 0f;
                 }
 
                 float[] levels = new float[1];
                 if (Bass.ChannelGetLevel(decodeStream, levels, (float) lengthSeconds,
-                    LevelRetrievalFlags.Mono | LevelRetrievalFlags.RMS))
+                    LevelRetrievalFlags.Mono))
                 {
-                    return levels[0];
+                    float peak = levels[0];
+                    _peakCache[path] = peak;
+                    return peak;
                 }
             }
             catch (Exception ex)
             {
-                YargLogger.LogError($"Failed to measure RMS for sample {path}: {ex.Message}");
+                YargLogger.LogError($"Failed to measure peak for sample {path}: {ex.Message}");
             }
             finally
             {
                 Bass.StreamFree(decodeStream);
             }
 
-            return TARGET_RMS;
+            return 0f;
         }
 
         /// <summary>
-        /// Calculates the normalization multiplier for a sample file by measuring its RMS level
-        /// and computing the gain required to match the target song RMS.
+        /// Calculates a single shared peak normalization multiplier for a group of sample
+        /// files.  Reduces volume of the peak volume of the loudest sample in the group to the target peak.
+        /// Applying one shared multiplier to all samples in a category preserves dynamics within the group.
         /// </summary>
-        /// <param name="path">The file path to the audio sample.</param>
-        /// <returns>A clamped normalization multiplier to apply to the channel volume.</returns>
-        public static float GetNormMultiplier(string path)
+        /// <param name="paths">The file paths of all samples in the category.</param>
+        /// <returns>A clamped normalization multiplier shared by all samples in the category.</returns>
+        public static float GetNormalizationMultiplier(IEnumerable<string> paths)
         {
             if (!IsNormalizationEnabled)
             {
                 return 1.0f;
             }
 
-            float rms = MeasureRms(path) + float.Epsilon;
-            return Math.Clamp(TARGET_RMS / rms,
+            float maxPeak = 0f;
+            foreach (string path in paths)
+            {
+                if (string.IsNullOrEmpty(path))
+                {
+                    continue;
+                }
+
+                float peak = MeasurePeak(path);
+                if (peak > maxPeak)
+                {
+                    maxPeak = peak;
+                }
+            }
+
+            if (maxPeak <= 0f)
+            {
+                // All silent / empty group: nothing to normalize; avoid div-by-zero / NaN.
+                return 1.0f;
+            }
+
+            return Math.Clamp(TARGET_PEAK / (maxPeak + float.Epsilon),
                 MIN_NORMALIZATION_MULTIPLIER, MAX_NORMALIZATION_MULTIPLIER);
         }
 
@@ -93,12 +125,12 @@ namespace YARG.Audio.BASS
          * From Bass documentation (http://bass.radio42.com/help/html/4c663bda-2751-c2c3-eaf2-770b846b6652.htm)
          * "With a ratio of 4:1, when the (time averaged) input level is 4 dB over the threshold, the output signal level will be 1 dB over the threshold."
          * "[Additionally,] with any threshold/ratio combination, you could calculate the gain for a 0dB peak like this: fGain=fThreshold*(1/fRatio-1)"
-         * 
+         *
          * The intention of the gain is to normalize 0dB signals back to 0dB after compression.
          * However, we only want the compressors to handle "clipping" situations (audio that exceeds 0dB).
          * So we set the gain and thresholds both to zero - which still follows the formula.
          * We can then set the ratio to whatever we want.
-         * 
+         *
          * Note: you don't want to apply a negative gain as the gain value effects ALL audio, not just the part that got compressed.
          * We don't want to make quiet parts even quieter.
          */
@@ -106,7 +138,7 @@ namespace YARG.Audio.BASS
         {
             fGain = 0f, fThreshold = 0, fAttack = 10f, fRelease = 100f, fRatio = 8,
         };
-        
+
         public static readonly PeakEQParameters LowEqParams = new()
         {
             fBandwidth = 1.25f, fCenter = 250.0f, fGain = -12f

--- a/Assets/Script/Audio/Bass/BassHelpers.cs
+++ b/Assets/Script/Audio/Bass/BassHelpers.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using ManagedBass;
 using ManagedBass.DirectX8;
 using ManagedBass.Fx;
@@ -13,14 +12,8 @@ namespace YARG.Audio.BASS
     public static class BassHelpers
     {
         public const float TARGET_RMS = 0.12f;
-        public const float TARGET_PEAK = 0.5f;
-
-        private static readonly Dictionary<string, float> _peakCache = new();
 
         public static bool IsNormalizationEnabled => SettingsManager.Settings?.EnableNormalization?.Value ?? false;
-
-        public const float MIN_NORMALIZATION_MULTIPLIER = 0.1f;
-        public const float MAX_NORMALIZATION_MULTIPLIER = 2.0f;
 
         public const int PLAYBACK_BUFFER_LENGTH = 75;
         public const double PLAYBACK_BUFFER_DESYNC = PLAYBACK_BUFFER_LENGTH / 1000.0;
@@ -33,93 +26,6 @@ namespace YARG.Audio.BASS
         public const int REVERB_SLIDE_OUT_MILLISECONDS = 500;
 
         public const EffectType REVERB_TYPE = EffectType.Freeverb;
-
-        private static float MeasurePeak(string path)
-        {
-            if (string.IsNullOrEmpty(path) || !System.IO.File.Exists(path))
-            {
-                return 0f;
-            }
-
-            if (_peakCache.TryGetValue(path, out float cachedPeak))
-            {
-                return cachedPeak;
-            }
-
-            int decodeStream = Bass.CreateStream(path, 0, 0, BassFlags.Decode);
-            if (decodeStream == 0)
-            {
-                return 0f;
-            }
-
-            try
-            {
-                long lengthBytes = Bass.ChannelGetLength(decodeStream);
-                double lengthSeconds = Bass.ChannelBytes2Seconds(decodeStream, lengthBytes);
-                if (lengthSeconds <= 0)
-                {
-                    return 0f;
-                }
-
-                float[] levels = new float[1];
-                if (Bass.ChannelGetLevel(decodeStream, levels, (float) lengthSeconds,
-                    LevelRetrievalFlags.Mono))
-                {
-                    float peak = levels[0];
-                    _peakCache[path] = peak;
-                    return peak;
-                }
-            }
-            catch (Exception ex)
-            {
-                YargLogger.LogError($"Failed to measure peak for sample {path}: {ex.Message}");
-            }
-            finally
-            {
-                Bass.StreamFree(decodeStream);
-            }
-
-            return 0f;
-        }
-
-        /// <summary>
-        /// Calculates a single shared peak normalization multiplier for a group of sample
-        /// files.  Reduces volume of the peak volume of the loudest sample in the group to the target peak.
-        /// Applying one shared multiplier to all samples in a category preserves dynamics within the group.
-        /// </summary>
-        /// <param name="paths">The file paths of all samples in the category.</param>
-        /// <returns>A clamped normalization multiplier shared by all samples in the category.</returns>
-        public static float GetNormalizationMultiplier(IEnumerable<string> paths)
-        {
-            if (!IsNormalizationEnabled)
-            {
-                return 1.0f;
-            }
-
-            float maxPeak = 0f;
-            foreach (string path in paths)
-            {
-                if (string.IsNullOrEmpty(path))
-                {
-                    continue;
-                }
-
-                float peak = MeasurePeak(path);
-                if (peak > maxPeak)
-                {
-                    maxPeak = peak;
-                }
-            }
-
-            if (maxPeak <= 0f)
-            {
-                // All silent / empty group: nothing to normalize; avoid div-by-zero / NaN.
-                return 1.0f;
-            }
-
-            return Math.Clamp(TARGET_PEAK / (maxPeak + float.Epsilon),
-                MIN_NORMALIZATION_MULTIPLIER, MAX_NORMALIZATION_MULTIPLIER);
-        }
 
         /*
          * From Bass documentation (http://bass.radio42.com/help/html/4c663bda-2751-c2c3-eaf2-770b846b6652.htm)

--- a/Assets/Script/Audio/Bass/BassMetronomeSampleChannel.cs
+++ b/Assets/Script/Audio/Bass/BassMetronomeSampleChannel.cs
@@ -1,8 +1,10 @@
+using System;
 using ManagedBass;
 using UnityEngine;
 using YARG.Core.Audio;
 using YARG.Core.Logging;
 using YARG.Input;
+using YARG.Settings;
 
 namespace YARG.Audio.BASS
 {
@@ -43,7 +45,10 @@ namespace YARG.Audio.BASS
                 return null;
             }
 
-            return new BassMetronomeSampleChannel(sample, hiHandle, hiChannel, hiPath, loHandle, loChannel, loPath, outputChannel);
+            float hiNormMultiplier = BassHelpers.GetNormMultiplier(hiPath);
+            float loNormMultiplier = BassHelpers.GetNormMultiplier(loPath);
+
+            return new BassMetronomeSampleChannel(sample, hiHandle, hiChannel, hiPath, loHandle, loChannel, loPath, outputChannel, hiNormMultiplier, loNormMultiplier);
         }
 
         private readonly int _hiHandle;
@@ -51,10 +56,12 @@ namespace YARG.Audio.BASS
         private readonly int _loHandle;
         private readonly int _loChannel;
         private double _volumeSetting = 1;
+        private readonly float _hiNormalizationMultiplier;
+        private readonly float _loNormalizationMultiplier;
 
 #nullable enable
         private BassMetronomeSampleChannel(MetronomeSample sample, int hiHandle, int hiChannel, string hiPath, int loHandle, int loChannel, string loPath,
-            OutputChannel? outputChannel)
+            OutputChannel? outputChannel, float hiNormalizationMultiplier, float loNormalizationMultiplier)
             : base(sample, hiPath, loPath)
 #nullable disable
         {
@@ -62,12 +69,15 @@ namespace YARG.Audio.BASS
             _hiChannel = hiChannel;
             _loHandle = loHandle;
             _loChannel = loChannel;
+            _hiNormalizationMultiplier = hiNormalizationMultiplier;
+            _loNormalizationMultiplier = loNormalizationMultiplier;
             SetOutputChannel_Internal(outputChannel);
             SetVolume_Internal(GlobalAudioHandler.GetTrueVolume(SongStem.Metronome));
         }
 
         protected override void PlayHi_Internal()
         {
+            SetVolume_Internal(_volumeSetting);
             if (!Bass.ChannelPlay(_hiChannel, true))
             {
                 YargLogger.LogFormatError("Failed to play {0} hi channel: {1}!", Sample, Bass.LastError);
@@ -76,6 +86,7 @@ namespace YARG.Audio.BASS
 
         protected override void PlayLo_Internal()
         {
+            SetVolume_Internal(_volumeSetting);
             if (!Bass.ChannelPlay(_loChannel, true))
             {
                 YargLogger.LogFormatError("Failed to play {0} lo channel: {1}!", Sample, Bass.LastError);
@@ -87,12 +98,12 @@ namespace YARG.Audio.BASS
             _volumeSetting = volume;
             volume *= AudioHelpers.MetronomeSamples[(int) Sample].Volume;
 
-            if (!Bass.ChannelSetAttribute(_hiChannel, ChannelAttribute.Volume, volume))
+            if (!Bass.ChannelSetAttribute(_hiChannel, ChannelAttribute.Volume, volume * _hiNormalizationMultiplier))
             {
                 YargLogger.LogFormatError("Failed to set {0} hi volume: {1}!", Sample, Bass.LastError);
             }
 
-            if (!Bass.ChannelSetAttribute(_loChannel, ChannelAttribute.Volume, volume))
+            if (!Bass.ChannelSetAttribute(_loChannel, ChannelAttribute.Volume, volume * _loNormalizationMultiplier))
             {
                 YargLogger.LogFormatError("Failed to set {0} lo volume: {1}!", Sample, Bass.LastError);
             }

--- a/Assets/Script/Audio/Bass/BassMetronomeSampleChannel.cs
+++ b/Assets/Script/Audio/Bass/BassMetronomeSampleChannel.cs
@@ -45,10 +45,7 @@ namespace YARG.Audio.BASS
                 return null;
             }
 
-            float hiNormMultiplier = BassHelpers.GetNormMultiplier(hiPath);
-            float loNormMultiplier = BassHelpers.GetNormMultiplier(loPath);
-
-            return new BassMetronomeSampleChannel(sample, hiHandle, hiChannel, hiPath, loHandle, loChannel, loPath, outputChannel, hiNormMultiplier, loNormMultiplier);
+            return new BassMetronomeSampleChannel(sample, hiHandle, hiChannel, hiPath, loHandle, loChannel, loPath, outputChannel);
         }
 
         private readonly int _hiHandle;
@@ -56,12 +53,12 @@ namespace YARG.Audio.BASS
         private readonly int _loHandle;
         private readonly int _loChannel;
         private double _volumeSetting = 1;
-        private readonly float _hiNormalizationMultiplier;
-        private readonly float _loNormalizationMultiplier;
+        private float _hiNormalizationMultiplier = 1.0f;
+        private float _loNormalizationMultiplier = 1.0f;
 
 #nullable enable
         private BassMetronomeSampleChannel(MetronomeSample sample, int hiHandle, int hiChannel, string hiPath, int loHandle, int loChannel, string loPath,
-            OutputChannel? outputChannel, float hiNormalizationMultiplier, float loNormalizationMultiplier)
+            OutputChannel? outputChannel)
             : base(sample, hiPath, loPath)
 #nullable disable
         {
@@ -69,10 +66,15 @@ namespace YARG.Audio.BASS
             _hiChannel = hiChannel;
             _loHandle = loHandle;
             _loChannel = loChannel;
-            _hiNormalizationMultiplier = hiNormalizationMultiplier;
-            _loNormalizationMultiplier = loNormalizationMultiplier;
             SetOutputChannel_Internal(outputChannel);
             SetVolume_Internal(GlobalAudioHandler.GetTrueVolume(SongStem.Metronome));
+        }
+
+        public override void SetNormalizationMultipliers(float hiMultiplier, float loMultiplier)
+        {
+            _hiNormalizationMultiplier = hiMultiplier;
+            _loNormalizationMultiplier = loMultiplier;
+            SetVolume_Internal(_volumeSetting);
         }
 
         protected override void PlayHi_Internal()

--- a/Assets/Script/Audio/Bass/BassNormalizer.cs
+++ b/Assets/Script/Audio/Bass/BassNormalizer.cs
@@ -21,8 +21,7 @@ namespace YARG.Audio.BASS
     /// </summary>
     public class BassNormalizer : IDisposable
     {
-        // Target RMS to normalize to, typically results in around -14 LUFS
-        private const float TARGET_RMS         = 0.12f;
+
 
         // Low initial gain so it typically ramps up instead of ramps down
         private const float INITIAL_GAIN       = 0.3f;
@@ -211,7 +210,7 @@ namespace YARG.Audio.BASS
                     totalSamples += samplesPerWindow;
 
                     double rms = Math.Sqrt(cumulativeSumSquares / totalSamples);
-                    float targetGain = (float) Math.Min(MAX_GAIN, TARGET_RMS / rms);
+                    float targetGain = (float) Math.Min(MAX_GAIN, BassHelpers.TARGET_RMS / rms);
                     float delta = Math.Clamp(targetGain - Gain, -MAX_GAIN_STEP, MAX_GAIN_STEP);
                     Gain += delta;
                     progress?.Report(Gain);

--- a/Assets/Script/Audio/Bass/BassSampleChannel.cs
+++ b/Assets/Script/Audio/Bass/BassSampleChannel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using ManagedBass;
 using UnityEngine;
 using YARG.Core.Audio;
@@ -12,7 +12,7 @@ namespace YARG.Audio.BASS
 #nullable enable
         public static BassSampleChannel? Create(SfxSample sample, string path, int playbackCount,
             OutputChannel? outputChannel, bool loop = false)
-#nullable disable
+#nullable enable
         {
             BassFlags flags = 0;
             // flags = BassFlags.Decode;
@@ -44,7 +44,9 @@ namespace YARG.Audio.BASS
                 YargLogger.LogFormatError("Failed to set {0} volume: {1}!", sample, Bass.LastError);
             }
 
-            return new BassSampleChannel(handle, channel, sample, path, playbackCount, outputChannel);
+            float normMultiplier = BassHelpers.GetNormMultiplier(path);
+
+            return new BassSampleChannel(handle, channel, sample, path, playbackCount, outputChannel, normMultiplier);
         }
 
         private readonly int _sfxHandle;
@@ -52,17 +54,19 @@ namespace YARG.Audio.BASS
         private double _lastPlaybackTime;
 
         private double _volumeSetting = 1;
+        private readonly float _normalizationMultiplier;
 
         private int _syncHandle;
 
 #nullable enable
-        private BassSampleChannel(int handle, int channel, SfxSample sample, string path, int playbackCount, OutputChannel? outputChannel)
+        private BassSampleChannel(int handle, int channel, SfxSample sample, string path, int playbackCount, OutputChannel? outputChannel, float normalizationMultiplier)
             : base(sample, path, playbackCount)
 #nullable disable
         {
             _sfxHandle = handle;
             _channel = channel;
             _lastPlaybackTime = -1;
+            _normalizationMultiplier = normalizationMultiplier;
             SetOutputChannel_Internal(outputChannel);
             SetVolume_Internal(GlobalAudioHandler.GetTrueVolume(SongStem.Sfx));
         }
@@ -85,7 +89,7 @@ namespace YARG.Audio.BASS
             {
                 var time = (int) Math.Round(duration * 1000);
                 Bass.ChannelSetAttribute(_channel, ChannelAttribute.Volume, 0);
-                var sfxVolume = AudioHelpers.SfxSamples[(int) Sample].Volume * (float) _volumeSetting;
+                var sfxVolume = AudioHelpers.SfxSamples[(int) Sample].Volume * (float) _volumeSetting * _normalizationMultiplier;
                 if (!Bass.ChannelSlideAttribute(_channel, ChannelAttribute.Volume, sfxVolume, time))
                 {
                     YargLogger.LogFormatError("Failed to set volume slide for {0}: {1}!", Sample, Bass.LastError);
@@ -189,6 +193,7 @@ namespace YARG.Audio.BASS
         {
             _volumeSetting = volume;
             volume *= AudioHelpers.SfxSamples[(int) Sample].Volume;
+            volume *= _normalizationMultiplier;
             if (!Bass.ChannelSetAttribute(_channel, ChannelAttribute.Volume, volume))
             {
                 YargLogger.LogFormatError("Failed to set {0} volume: {1}!", Sample, Bass.LastError);

--- a/Assets/Script/Audio/Bass/BassSampleChannel.cs
+++ b/Assets/Script/Audio/Bass/BassSampleChannel.cs
@@ -44,29 +44,25 @@ namespace YARG.Audio.BASS
                 YargLogger.LogFormatError("Failed to set {0} volume: {1}!", sample, Bass.LastError);
             }
 
-            float normMultiplier = BassHelpers.GetNormMultiplier(path);
-
-            return new BassSampleChannel(handle, channel, sample, path, playbackCount, outputChannel, normMultiplier);
+            return new BassSampleChannel(handle, channel, sample, path, playbackCount, outputChannel);
         }
 
         private readonly int _sfxHandle;
         private readonly int _channel;
         private double _lastPlaybackTime;
 
-        private double _volumeSetting = 1;
-        private readonly float _normalizationMultiplier;
+        private float _normalizationMultiplier = 1.0f;
 
         private int _syncHandle;
 
 #nullable enable
-        private BassSampleChannel(int handle, int channel, SfxSample sample, string path, int playbackCount, OutputChannel? outputChannel, float normalizationMultiplier)
+        private BassSampleChannel(int handle, int channel, SfxSample sample, string path, int playbackCount, OutputChannel? outputChannel)
             : base(sample, path, playbackCount)
 #nullable disable
         {
             _sfxHandle = handle;
             _channel = channel;
             _lastPlaybackTime = -1;
-            _normalizationMultiplier = normalizationMultiplier;
             SetOutputChannel_Internal(outputChannel);
             SetVolume_Internal(GlobalAudioHandler.GetTrueVolume(SongStem.Sfx));
         }
@@ -187,6 +183,12 @@ namespace YARG.Audio.BASS
             {
                 YargLogger.LogFormatError("Failed to resume {0} channel: {1}!", Sample, Bass.LastError);
             }
+        }
+
+        public override void SetNormalizationMultiplier(float multiplier)
+        {
+            _normalizationMultiplier = multiplier;
+            SetVolume_Internal(_volumeSetting);
         }
 
         protected override void SetVolume_Internal(double volume)

--- a/Assets/Script/Audio/Bass/BassVoxSampleChannel.cs
+++ b/Assets/Script/Audio/Bass/BassVoxSampleChannel.cs
@@ -48,9 +48,7 @@ namespace YARG.Audio.BASS
                 YargLogger.LogFormatError("Failed to set {0} volume: {1}!", sample, Bass.LastError);
             }
 
-            float normMultiplier = BassHelpers.GetNormMultiplier(path);
-
-            return new BassVoxSampleChannel(handle, channel, sample, path, outputChannel, normMultiplier);
+            return new BassVoxSampleChannel(handle, channel, sample, path, outputChannel);
         }
 
         private static void QueuePlayback(BassVoxSampleChannel channel)
@@ -87,16 +85,15 @@ namespace YARG.Audio.BASS
         }
 
         private readonly int    _channel;
-        private readonly float  _normalizationMultiplier;
+        private float  _normalizationMultiplier = 1.0f;
 
 #nullable enable
-        private BassVoxSampleChannel(int handle, int channel, VoxSample sample, string path, OutputChannel? outputChannel, float normalizationMultiplier)
+        private BassVoxSampleChannel(int handle, int channel, VoxSample sample, string path, OutputChannel? outputChannel)
             : base(sample, path)
 #nullable disable
         {
             _sampleHandle = handle;
             _channel = channel;
-            _normalizationMultiplier = normalizationMultiplier;
             SetOutputChannel_Internal(outputChannel);
             Channels.Add(this);
             SetVolume_Internal(GlobalAudioHandler.GetTrueVolume(SongStem.VoxSample));
@@ -123,6 +120,12 @@ namespace YARG.Audio.BASS
             {
                 YargLogger.LogFormatError("Failed to play {0} channel: {1}!", Sample, Bass.LastError);
             }
+        }
+
+        public override void SetNormalizationMultiplier(float multiplier)
+        {
+            _normalizationMultiplier = multiplier;
+            SetVolume_Internal(GlobalAudioHandler.GetTrueVolume(SongStem.VoxSample));
         }
 
         protected override void SetVolume_Internal(double volume)

--- a/Assets/Script/Audio/Bass/BassVoxSampleChannel.cs
+++ b/Assets/Script/Audio/Bass/BassVoxSampleChannel.cs
@@ -1,4 +1,4 @@
-﻿#nullable enable
+#nullable enable
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -48,7 +48,9 @@ namespace YARG.Audio.BASS
                 YargLogger.LogFormatError("Failed to set {0} volume: {1}!", sample, Bass.LastError);
             }
 
-            return new BassVoxSampleChannel(handle, channel, sample, path, outputChannel);
+            float normMultiplier = BassHelpers.GetNormMultiplier(path);
+
+            return new BassVoxSampleChannel(handle, channel, sample, path, outputChannel, normMultiplier);
         }
 
         private static void QueuePlayback(BassVoxSampleChannel channel)
@@ -85,14 +87,16 @@ namespace YARG.Audio.BASS
         }
 
         private readonly int    _channel;
+        private readonly float  _normalizationMultiplier;
 
 #nullable enable
-        private BassVoxSampleChannel(int handle, int channel, VoxSample sample, string path, OutputChannel? outputChannel)
+        private BassVoxSampleChannel(int handle, int channel, VoxSample sample, string path, OutputChannel? outputChannel, float normalizationMultiplier)
             : base(sample, path)
 #nullable disable
         {
             _sampleHandle = handle;
             _channel = channel;
+            _normalizationMultiplier = normalizationMultiplier;
             SetOutputChannel_Internal(outputChannel);
             Channels.Add(this);
             SetVolume_Internal(GlobalAudioHandler.GetTrueVolume(SongStem.VoxSample));
@@ -113,6 +117,8 @@ namespace YARG.Audio.BASS
                 return;
             }
 
+            SetVolume_Internal(GlobalAudioHandler.GetTrueVolume(SongStem.VoxSample));
+
             if (!Bass.ChannelPlay(_channel, true))
             {
                 YargLogger.LogFormatError("Failed to play {0} channel: {1}!", Sample, Bass.LastError);
@@ -121,7 +127,8 @@ namespace YARG.Audio.BASS
 
         protected override void SetVolume_Internal(double volume)
         {
-            volume *= AudioHelpers.SfxSamples[(int) Sample].Volume;
+            volume *= AudioHelpers.VoxSamples[(int) Sample].Volume;
+            volume *= _normalizationMultiplier;
             if (!Bass.ChannelSetAttribute(_channel, ChannelAttribute.Volume, volume))
             {
                 YargLogger.LogFormatError("Failed to set {0} volume: {1}!", Sample, Bass.LastError);

--- a/Assets/Script/Gameplay/GameManager.Loading.cs
+++ b/Assets/Script/Gameplay/GameManager.Loading.cs
@@ -49,7 +49,7 @@ namespace YARG.Gameplay
         private GameObject _proGuitarPrefab;
 
         private LoadFailureState _loadState;
-        private string _loadFailureMessage;
+        private string           _loadFailureMessage;
 
         // All access to chart data must be done through this event,
         // since things are loaded asynchronously
@@ -106,6 +106,8 @@ namespace YARG.Gameplay
             using var context = new LoadingContext();
             var global = GlobalVariables.Instance;
 
+            GlobalAudioHandler.ApplySampleNormalization();
+
             // Disable until everything's loaded
             enabled = false;
 
@@ -113,12 +115,14 @@ namespace YARG.Gameplay
 
             if (ReplayInfo != null)
             {
-                if (!SongContainer.SongsByHash.TryGetValue(GlobalVariables.State.CurrentReplay.SongChecksum, out var songs))
+                if (!SongContainer.SongsByHash.TryGetValue(GlobalVariables.State.CurrentReplay.SongChecksum,
+                    out var songs))
                 {
                     ToastManager.ToastWarning("Song not present in library");
                     global.LoadScene(SceneIndex.Menu);
                     return;
                 }
+
                 Song = songs[0];
 
                 context.SetLoadingText("Loading replay...");
@@ -140,7 +144,7 @@ namespace YARG.Gameplay
                     players.AddRange(PlayerContainer.Players);
                     for (int i = 0; i < YargPlayers.Count; i++)
                     {
-                         players.Add(YargPlayers[i]);
+                        players.Add(YargPlayers[i]);
                     }
 
                     YargPlayers = players.ToArray();
@@ -196,9 +200,10 @@ namespace YARG.Gameplay
             // Spawn players
             CreatePlayers();
             YargLogger.LogFormatDebug("Calculating star cutoffs for {0} players", _players.Count);
-            EngineManager.StarScoreThresholds = EngineManager.GetStarScoreCutoffs(_players.ConvertAll(p => p.BaseEngine.StarScoreThresholds));
-            YargLogger.LogFormatDebug("Star score thresholds: {0}", string.Join(", ", EngineManager.StarScoreThresholds));
-
+            EngineManager.StarScoreThresholds =
+                EngineManager.GetStarScoreCutoffs(_players.ConvertAll(p => p.BaseEngine.StarScoreThresholds));
+            YargLogger.LogFormatDebug("Star score thresholds: {0}",
+                string.Join(", ", EngineManager.StarScoreThresholds));
 
             // Set up the crowd stem so it can be restored after muting (if it exists)
             if (_stemStates.TryGetValue(SongStem.Crowd, out var state))
@@ -269,7 +274,10 @@ namespace YARG.Gameplay
 
         private bool LoadReplay()
         {
-            var readOptions = new ReplayReadOptions { KeepFrameTimes = GlobalVariables.VerboseReplays };
+            var readOptions = new ReplayReadOptions
+            {
+                KeepFrameTimes = GlobalVariables.VerboseReplays
+            };
             var (result, data) = ReplayIO.TryLoadData(ReplayInfo, readOptions);
             if (result != ReplayReadResult.Valid)
             {
@@ -317,15 +325,17 @@ namespace YARG.Gameplay
             // If we have no venue events, attempt to load from milo
             if (Chart.VenueTrack.IsEmpty)
             {
-                    SongChart.LoadVenueFromMilo(Chart, Song);
+                SongChart.LoadVenueFromMilo(Chart, Song);
 
-                    YargLogger.LogFormatDebug("Loaded {0} lighting events from milo", Chart.VenueTrack.Lighting.Count);
+                YargLogger.LogFormatDebug("Loaded {0} lighting events from milo", Chart.VenueTrack.Lighting.Count);
             }
 
             if (File.Exists(VenueAutoGenerationPreset.DefaultPath))
             {
                 var preset = new VenueAutoGenerationPreset(VenueAutoGenerationPreset.DefaultPath);
-                if (!preset.ChartHasFog(Chart)) // This is separate because we may want to add fog even if venue is authored
+                if (
+                    !preset.ChartHasFog(
+                        Chart)) // This is separate because we may want to add fog even if venue is authored
                 {
                     Chart = preset.GenerateFogEvents(Chart);
                 }
@@ -409,6 +419,7 @@ namespace YARG.Gameplay
                     {
                         continue;
                     }
+
                     index++;
 
                     if (!player.IsReplay)
@@ -418,7 +429,8 @@ namespace YARG.Gameplay
                         player.RefreshPresets();
                     }
 
-                    var lastHighScore = ScoreContainer.GetHighScore(Song.Hash, player.Profile.Id, player.Profile.CurrentInstrument, false)?.Score;
+                    var lastHighScore = ScoreContainer
+                        .GetHighScore(Song.Hash, player.Profile.Id, player.Profile.CurrentInstrument, false)?.Score;
                     YargLogger.LogFormatInfo("Current high score for player {0} on {1}: {2}",
                         player.Profile.Name, player.Profile.CurrentInstrument, lastHighScore ?? 0);
 
@@ -431,10 +443,14 @@ namespace YARG.Gameplay
                             GameMode.SixFretGuitar  => _sixFretGuitarPrefab,
                             GameMode.FourLaneDrums  => _fourLaneDrumsPrefab,
                             GameMode.FiveLaneDrums  => _fiveLaneDrumsPrefab,
-                            GameMode.EliteDrums     => Song.HasInstrument(Instrument.FiveLaneDrums) ? _fiveLaneDrumsPrefab : _fourLaneDrumsPrefab,
-                            GameMode.ProKeys        => player.Profile.CurrentInstrument is Instrument.ProKeys ? _proKeysPrefab : _fiveLaneKeysPrefab,
-                            GameMode.ProGuitar      => _proGuitarPrefab,
-                            _                       => null
+                            GameMode.EliteDrums => Song.HasInstrument(Instrument.FiveLaneDrums)
+                                ? _fiveLaneDrumsPrefab
+                                : _fourLaneDrumsPrefab,
+                            GameMode.ProKeys => player.Profile.CurrentInstrument is Instrument.ProKeys
+                                ? _proKeysPrefab
+                                : _fiveLaneKeysPrefab,
+                            GameMode.ProGuitar => _proGuitarPrefab,
+                            _                  => null
                         };
 
                         // Skip if there's no prefab for the game mode
@@ -481,7 +497,8 @@ namespace YARG.Gameplay
 
                         var percussionTrack = VocalTrack.CreatePercussionTrack();
                         percussionTrack.TrackSpeed = VocalTrack.TrackSpeed;
-                        vocalsPlayer.Initialize(index, vocalIndex, player, Chart, playerHud, percussionTrack, lastHighScore, VocalTrack.TrackSpeed);
+                        vocalsPlayer.Initialize(index, vocalIndex, player, Chart, playerHud, percussionTrack,
+                            lastHighScore, VocalTrack.TrackSpeed);
 
                         _players.Add(vocalsPlayer);
                     }

--- a/Assets/Script/Persistent/GlobalVariables.cs
+++ b/Assets/Script/Persistent/GlobalVariables.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using UnityEngine;
@@ -85,8 +85,6 @@ namespace YARG
             int savedCount = PlayerContainer.SaveProfiles(false);
             YargLogger.LogFormatInfo("Saved {0} profiles", savedCount);
 
-            SettingsManager.LoadSettings();
-
             GlobalAudioHandler.Initialize<BassAudioManager>();
 
             Players = new List<YargPlayer>();
@@ -98,6 +96,7 @@ namespace YARG
 
         private void Start()
         {
+            SettingsManager.LoadSettings();
             InputManager.Initialize();
 
             LoadScene(SceneIndex.Menu);

--- a/Assets/Script/Persistent/GlobalVariables.cs
+++ b/Assets/Script/Persistent/GlobalVariables.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using UnityEngine;
@@ -85,6 +85,8 @@ namespace YARG
             int savedCount = PlayerContainer.SaveProfiles(false);
             YargLogger.LogFormatInfo("Saved {0} profiles", savedCount);
 
+            SettingsManager.LoadSettings();
+
             GlobalAudioHandler.Initialize<BassAudioManager>();
 
             Players = new List<YargPlayer>();
@@ -96,7 +98,6 @@ namespace YARG
 
         private void Start()
         {
-            SettingsManager.LoadSettings();
             InputManager.Initialize();
 
             LoadScene(SceneIndex.Menu);


### PR DESCRIPTION
This allows for normalizing sample channels to reach the TARGET_RMS value so that at 100% volume it will be approximately the same as the currently playing song

This fixes issues where normalization of songs only tends to reduce their volume, which makes samples sound loud by contrast