### PR TITLE
Use a single PlayerScoreRecord to display best score/percentage/stars in music library

### DIFF
--- a/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
+++ b/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
@@ -600,7 +600,7 @@ namespace YARG.Menu.MusicLibrary
             if (humanCount == 1)
             {
                 var player = PlayerContainer.Players.First(e => !e.Profile.IsBot);
-                var playerScoreRecord = ScoreContainer.GetHighScore(
+                var playerScoreRecord = ScoreContainer.GetBestPercentageScore(
                     song.Hash, player.Profile.Id, player.Profile.CurrentInstrument);
                 return playerScoreRecord?.Stars;
             }

--- a/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
+++ b/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
@@ -574,11 +574,13 @@ namespace YARG.Menu.MusicLibrary
                     }
                     else
                     {
-                        starAmount = GetStarAmountForSong(song);
+                        starAmount = SongViewType.GetStarAmountForSong(song);
                     }
 
                     if (starAmount is not null)
-                        sectionTotalStars += StarAmountHelper.GetStarCount(starAmount.Value);
+                    {
+                        sectionTotalStars += starAmount.Value.GetStarCount();
+                    }
                 }
                 _totalStarCount += sectionTotalStars;
 
@@ -586,27 +588,11 @@ namespace YARG.Menu.MusicLibrary
                 {
                     sortHeader.TotalStarsCount = sectionTotalStars;
                 }
-
             }
 
             _totalSongCount = songCount;
             CalculateCategoryHeaderIndices(list);
             return list;
-        }
-
-        private static StarAmount? GetStarAmountForSong(SongEntry song)
-        {
-            var humanCount = PlayerContainer.Players.Count(p => !p.Profile.IsBot);
-            if (humanCount == 1)
-            {
-                var player = PlayerContainer.Players.First(e => !e.Profile.IsBot);
-                var playerScoreRecord = ScoreContainer.GetBestPercentageScore(
-                    song.Hash, player.Profile.Id, player.Profile.CurrentInstrument);
-                return playerScoreRecord?.Stars;
-            }
-
-            var bandScoreRecord = ScoreContainer.GetBandHighScore(song.Hash);
-            return bandScoreRecord?.BandStars;
         }
 
         private void ExitLibrary()

--- a/Assets/Script/Menu/MusicLibrary/ViewTypes/SongViewType.cs
+++ b/Assets/Script/Menu/MusicLibrary/ViewTypes/SongViewType.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using Cysharp.Text;
+using JetBrains.Annotations;
 using UnityEngine;
 using YARG.Core.Game;
 using YARG.Core.Song;
@@ -110,12 +111,26 @@ namespace YARG.Menu.MusicLibrary
         {
             FetchHighScores();
 
-            if (_bandScoreRecord is not null)
+            return GetStarAmount(_playerPercentRecord, _bandScoreRecord);
+        }
+
+        public static StarAmount? GetStarAmountForSong(SongEntry songEntry)
+        {
+            FetchHighScores(songEntry, out var playerPercentRecord, out var bandScoreRecord);
+
+            return GetStarAmount(playerPercentRecord, bandScoreRecord);
+        }
+
+        private static StarAmount? GetStarAmount(
+            [CanBeNull] PlayerScoreRecord playerPercentRecord,
+            [CanBeNull] GameRecord bandScoreRecord)
+        {
+            if (bandScoreRecord is not null)
             {
-                return _bandScoreRecord.BandStars;
+                return bandScoreRecord.BandStars;
             }
 
-            return _playerPercentRecord?.Stars;
+            return playerPercentRecord?.Stars;
         }
 
         public override FavoriteInfo GetFavoriteInfo()
@@ -201,18 +216,25 @@ namespace YARG.Menu.MusicLibrary
                 return;
             }
 
+            FetchHighScores(SongEntry, out _playerPercentRecord, out _bandScoreRecord);
             _fetchedScores = true;
+        }
+
+        private static void FetchHighScores(SongEntry songEntry, out PlayerScoreRecord playerPercentRecord, out GameRecord bandScoreRecord)
+        {
+            playerPercentRecord = null;
+            bandScoreRecord = null;
 
             var humanCount = PlayerContainer.Players.Count(p => !p.Profile.IsBot);
             if (humanCount == 1)
             {
                 var player = PlayerContainer.Players.First(e => !e.Profile.IsBot);
-                _playerPercentRecord = ScoreContainer.GetBestPercentageScore(
-                    SongEntry.Hash, player.Profile.Id, player.Profile.CurrentInstrument);
+                playerPercentRecord = ScoreContainer.GetBestPercentageScore(
+                    songEntry.Hash, player.Profile.Id, player.Profile.CurrentInstrument);
             }
             else
             {
-                _bandScoreRecord = ScoreContainer.GetBandHighScore(SongEntry.Hash);
+                bandScoreRecord = ScoreContainer.GetBandHighScore(songEntry.Hash);
             }
         }
     }

--- a/Assets/Script/Menu/MusicLibrary/ViewTypes/SongViewType.cs
+++ b/Assets/Script/Menu/MusicLibrary/ViewTypes/SongViewType.cs
@@ -4,7 +4,6 @@ using JetBrains.Annotations;
 using UnityEngine;
 using YARG.Core.Game;
 using YARG.Core.Song;
-using YARG.Helpers;
 using YARG.Player;
 using YARG.Playlists;
 using YARG.Scores;
@@ -34,7 +33,7 @@ namespace YARG.Menu.MusicLibrary
         private readonly string _contentStableId;
 
         private bool _fetchedScores;
-        private PlayerScoreRecord _playerPercentRecord;
+        private PlayerScoreRecord _playerScoreRecord;
         private GameRecord _bandScoreRecord;
 
         public SongViewType(MusicLibraryMenu musicLibrary, SongEntry songEntry, string context = "library")
@@ -76,14 +75,14 @@ namespace YARG.Menu.MusicLibrary
             }
 
             // Never played!
-            if (_playerPercentRecord is null)
+            if (_playerScoreRecord is null)
             {
                 return string.Empty;
             }
 
-            var scoreColor = _playerPercentRecord.IsFc ? "#ffd029" : "#ffffff";
+            var scoreColor = _playerScoreRecord.IsFc ? "#ffd029" : "#ffffff";
             builder.AppendFormat("<mspace=.5em><color={1}>{0:N0}</color></mspace>",
-                _playerPercentRecord.Score, scoreColor);
+                _playerScoreRecord.Score, scoreColor);
             return builder.ToString();
         }
 
@@ -92,18 +91,18 @@ namespace YARG.Menu.MusicLibrary
             FetchHighScores();
 
             // Never played!
-            if (_playerPercentRecord is null)
+            if (_playerScoreRecord is null)
             {
                 return null;
             }
 
             return new ScoreInfo
             {
-                Score = _playerPercentRecord.Score,
-                Difficulty = _playerPercentRecord.Difficulty,
-                Percent = _playerPercentRecord.GetPercent(),
-                Instrument = _playerPercentRecord.Instrument,
-                IsFc = _playerPercentRecord.IsFc
+                Score = _playerScoreRecord.Score,
+                Difficulty = _playerScoreRecord.Difficulty,
+                Percent = _playerScoreRecord.GetPercent(),
+                Instrument = _playerScoreRecord.Instrument,
+                IsFc = _playerScoreRecord.IsFc
             };
         }
 
@@ -111,18 +110,18 @@ namespace YARG.Menu.MusicLibrary
         {
             FetchHighScores();
 
-            return GetStarAmount(_playerPercentRecord, _bandScoreRecord);
+            return GetStarAmount(_playerScoreRecord, _bandScoreRecord);
         }
 
         public static StarAmount? GetStarAmountForSong(SongEntry songEntry)
         {
-            FetchHighScores(songEntry, out var playerPercentRecord, out var bandScoreRecord);
+            FetchHighScores(songEntry, out var playerScoreRecord, out var bandScoreRecord);
 
-            return GetStarAmount(playerPercentRecord, bandScoreRecord);
+            return GetStarAmount(playerScoreRecord, bandScoreRecord);
         }
 
         private static StarAmount? GetStarAmount(
-            [CanBeNull] PlayerScoreRecord playerPercentRecord,
+            [CanBeNull] PlayerScoreRecord playerScoreRecord,
             [CanBeNull] GameRecord bandScoreRecord)
         {
             if (bandScoreRecord is not null)
@@ -130,7 +129,7 @@ namespace YARG.Menu.MusicLibrary
                 return bandScoreRecord.BandStars;
             }
 
-            return playerPercentRecord?.Stars;
+            return playerScoreRecord?.Stars;
         }
 
         public override FavoriteInfo GetFavoriteInfo()
@@ -216,20 +215,20 @@ namespace YARG.Menu.MusicLibrary
                 return;
             }
 
-            FetchHighScores(SongEntry, out _playerPercentRecord, out _bandScoreRecord);
+            FetchHighScores(SongEntry, out _playerScoreRecord, out _bandScoreRecord);
             _fetchedScores = true;
         }
 
-        private static void FetchHighScores(SongEntry songEntry, out PlayerScoreRecord playerPercentRecord, out GameRecord bandScoreRecord)
+        private static void FetchHighScores(SongEntry songEntry, out PlayerScoreRecord playerScoreRecord, out GameRecord bandScoreRecord)
         {
-            playerPercentRecord = null;
+            playerScoreRecord = null;
             bandScoreRecord = null;
 
             var humanCount = PlayerContainer.Players.Count(p => !p.Profile.IsBot);
             if (humanCount == 1)
             {
                 var player = PlayerContainer.Players.First(e => !e.Profile.IsBot);
-                playerPercentRecord = ScoreContainer.GetBestPercentageScore(
+                playerScoreRecord = ScoreContainer.GetPreferredHighScore(
                     songEntry.Hash, player.Profile.Id, player.Profile.CurrentInstrument);
             }
             else

--- a/Assets/Script/Menu/MusicLibrary/ViewTypes/SongViewType.cs
+++ b/Assets/Script/Menu/MusicLibrary/ViewTypes/SongViewType.cs
@@ -1,6 +1,5 @@
 using System.Linq;
 using Cysharp.Text;
-using JetBrains.Annotations;
 using UnityEngine;
 using YARG.Core.Game;
 using YARG.Core.Song;
@@ -121,8 +120,8 @@ namespace YARG.Menu.MusicLibrary
         }
 
         private static StarAmount? GetStarAmount(
-            [CanBeNull] PlayerScoreRecord playerScoreRecord,
-            [CanBeNull] GameRecord bandScoreRecord)
+            PlayerScoreRecord? playerScoreRecord,
+            GameRecord? bandScoreRecord)
         {
             if (bandScoreRecord is not null)
             {

--- a/Assets/Script/Menu/MusicLibrary/ViewTypes/SongViewType.cs
+++ b/Assets/Script/Menu/MusicLibrary/ViewTypes/SongViewType.cs
@@ -33,7 +33,6 @@ namespace YARG.Menu.MusicLibrary
         private readonly string _contentStableId;
 
         private bool _fetchedScores;
-        private PlayerScoreRecord _playerScoreRecord;
         private PlayerScoreRecord _playerPercentRecord;
         private GameRecord _bandScoreRecord;
 
@@ -76,14 +75,14 @@ namespace YARG.Menu.MusicLibrary
             }
 
             // Never played!
-            if (_playerScoreRecord is null)
+            if (_playerPercentRecord is null)
             {
                 return string.Empty;
             }
 
-            var percentColor = _playerPercentRecord.IsFc ? "#ffd029" : "#ffffff";
+            var scoreColor = _playerPercentRecord.IsFc ? "#ffd029" : "#ffffff";
             builder.AppendFormat("<mspace=.5em><color={1}>{0:N0}</color></mspace>",
-                _playerScoreRecord.Score, percentColor);
+                _playerPercentRecord.Score, scoreColor);
             return builder.ToString();
         }
 
@@ -92,17 +91,17 @@ namespace YARG.Menu.MusicLibrary
             FetchHighScores();
 
             // Never played!
-            if (_playerScoreRecord is null)
+            if (_playerPercentRecord is null)
             {
                 return null;
             }
 
             return new ScoreInfo
             {
-                Score = _playerScoreRecord.Score,
-                Difficulty = _playerScoreRecord.Difficulty,
+                Score = _playerPercentRecord.Score,
+                Difficulty = _playerPercentRecord.Difficulty,
                 Percent = _playerPercentRecord.GetPercent(),
-                Instrument = _playerScoreRecord.Instrument,
+                Instrument = _playerPercentRecord.Instrument,
                 IsFc = _playerPercentRecord.IsFc
             };
         }
@@ -116,7 +115,7 @@ namespace YARG.Menu.MusicLibrary
                 return _bandScoreRecord.BandStars;
             }
 
-            return _playerScoreRecord?.Stars;
+            return _playerPercentRecord?.Stars;
         }
 
         public override FavoriteInfo GetFavoriteInfo()
@@ -208,8 +207,6 @@ namespace YARG.Menu.MusicLibrary
             if (humanCount == 1)
             {
                 var player = PlayerContainer.Players.First(e => !e.Profile.IsBot);
-                _playerScoreRecord = ScoreContainer.GetHighScore(
-                    SongEntry.Hash, player.Profile.Id, player.Profile.CurrentInstrument);
                 _playerPercentRecord = ScoreContainer.GetBestPercentageScore(
                     SongEntry.Hash, player.Profile.Id, player.Profile.CurrentInstrument);
             }

--- a/Assets/Script/Scores/ScoreContainer.cs
+++ b/Assets/Script/Scores/ScoreContainer.cs
@@ -16,8 +16,10 @@ namespace YARG.Scores
 {
     public enum HighScoreHistoryMode
     {
-        HighestOverall,
-        HighestDifficulty,
+        HighestPercentageOverall = 0,
+        HighestPercentageDifficulty = 1,
+        HighestScoreOverall = 2,
+        HighestScoreDifficulty = 3,
     }
 
     public static partial class ScoreContainer
@@ -38,7 +40,14 @@ namespace YARG.Scores
         private static bool       _scoresWereFetched;
 
         private static bool HighestDifficultyOnly
-            => SettingsManager.Settings.HighScoreHistory.Value == HighScoreHistoryMode.HighestDifficulty;
+            => SettingsManager.Settings.HighScoreHistory.Value is
+                HighScoreHistoryMode.HighestPercentageDifficulty or
+                HighScoreHistoryMode.HighestScoreDifficulty;
+
+        private static bool UseHighestScore
+            => SettingsManager.Settings.HighScoreHistory.Value is
+                HighScoreHistoryMode.HighestScoreOverall or
+                HighScoreHistoryMode.HighestScoreDifficulty;
 
         private static bool AllowScoresWithBots => SettingsManager.Settings.SaveScoresWithBots.Value;
 
@@ -248,6 +257,13 @@ namespace YARG.Scores
         public static GameRecord GetBandHighScore(HashWrapper songChecksum)
         {
             return BandHighScores.GetValueOrDefault(songChecksum);
+        }
+
+        public static PlayerScoreRecord GetPreferredHighScore(HashWrapper songChecksum, Guid playerId, Instrument instrument, bool allowCacheUpdate = true)
+        {
+            return UseHighestScore
+                ? GetHighScore(songChecksum, playerId, instrument, allowCacheUpdate)
+                : GetBestPercentageScore(songChecksum, playerId, instrument, allowCacheUpdate);
         }
 
         private static PlayerScoreRecord GetHighScoreFromDatabase(HashWrapper songChecksum, Guid playerId, Instrument instrument)

--- a/Assets/Script/Settings/SettingsManager.Settings.cs
+++ b/Assets/Script/Settings/SettingsManager.Settings.cs
@@ -213,10 +213,12 @@ namespace YARG.Settings
                 };
 
             public DropdownSetting<HighScoreHistoryMode> HighScoreHistory { get; }
-                = new(HighScoreHistoryMode.HighestDifficulty, _ => ScoreContainer.InvalidateScoreCache())
+                = new(HighScoreHistoryMode.HighestPercentageDifficulty, _ => ScoreContainer.InvalidateScoreCache())
                 {
-                    HighScoreHistoryMode.HighestOverall,
-                    HighScoreHistoryMode.HighestDifficulty,
+                    HighScoreHistoryMode.HighestPercentageOverall,
+                    HighScoreHistoryMode.HighestPercentageDifficulty,
+                    HighScoreHistoryMode.HighestScoreOverall,
+                    HighScoreHistoryMode.HighestScoreDifficulty,
                 };
 
             public ToggleSetting ShowPercentDecimals { get; } = new(false);

--- a/Assets/StreamingAssets/lang/en-US.json
+++ b/Assets/StreamingAssets/lang/en-US.json
@@ -1174,10 +1174,12 @@
             },
             "HighScoreHistory": {
                 "Name": "High Score History",
-                "Description": "Changes how score history gets used for high score information displayed in the Music Library.",
+                "Description": "Changes which score or percentage record is used for high score information displayed in the Music Library.",
                 "Dropdown": {
-                    "HighestOverall": "Highest across all difficulties",
-                    "HighestDifficulty": "Highest-played difficulty only"
+                    "HighestPercentageOverall": "Best percentage across all difficulties",
+                    "HighestPercentageDifficulty": "Best percentage on highest-played difficulty",
+                    "HighestScoreOverall": "Highest score across all difficulties",
+                    "HighestScoreDifficulty": "Highest score on highest-played difficulty"
                 }
             },
             "HighwayTiltMultiplier": {


### PR DESCRIPTION
This fixes the Music Library high score display ambiguity by making the selected high score history mode choose a single source record for score, stars, difficulty, percentage, and FC color.
•  Added explicit high score history modes for:
  •  Best percentage across all difficulties
  •  Best percentage on highest-played difficulty
  •  Highest score across all difficulties
  •  Highest score on highest-played difficulty
•  Updated Music Library song rows to use the selected mode consistently via GetPreferredHighScore().
  •  Updated setting text to clarify score vs percentage behavior.
  •  Kept collapsed-section star totals aligned with the same selected record source.