### PR TITLE
Reduce sample channel volume when normalization is enabled

### DIFF
--- a/Assets/Script/Gameplay/GameManager.Loading.cs
+++ b/Assets/Script/Gameplay/GameManager.Loading.cs
@@ -48,6 +48,9 @@ namespace YARG.Gameplay
         [SerializeField]
         private GameObject _proGuitarPrefab;
 
+        private const double NORMALIZED_SAMPLE_VOLUME_MULTIPLIER = 0.5;
+        private const double DEFAULT_SAMPLE_VOLUME_MULTIPLIER = 1.0;
+
         private LoadFailureState _loadState;
         private string _loadFailureMessage;
 
@@ -108,6 +111,8 @@ namespace YARG.Gameplay
 
             // Disable until everything's loaded
             enabled = false;
+
+            ApplySampleNormalization();
 
             YargLogger.LogFormatInfo("Loading song {0} - {1}", Song.Name, Song.Artist);
 
@@ -265,6 +270,18 @@ namespace YARG.Gameplay
             enabled = true;
             IsSongStarted = true;
             _songStarted?.Invoke();
+        }
+
+        private void ApplySampleNormalization()
+        {
+            double multiplier = SettingsManager.Settings.EnableNormalization.Value
+                ? NORMALIZED_SAMPLE_VOLUME_MULTIPLIER
+                : DEFAULT_SAMPLE_VOLUME_MULTIPLIER;
+
+            GlobalAudioHandler.SetVolumeMultiplier(SongStem.Sfx, multiplier);
+            GlobalAudioHandler.SetVolumeMultiplier(SongStem.DrumSfx, multiplier);
+            GlobalAudioHandler.SetVolumeMultiplier(SongStem.VoxSample, multiplier);
+            GlobalAudioHandler.SetVolumeMultiplier(SongStem.Metronome, multiplier);
         }
 
         private bool LoadReplay()


### PR DESCRIPTION
Core PR: https://github.com/YARC-Official/YARG.Core/pull/403

This fixes issues with normalization reducing volume of music but not sample channels.  We apply a simple 50% reduction to volume of samples channels (volume * 0.5) when normalization is enabled.