### PR TITLE
Add 'Mute On Focus Loss' setting

### DIFF
--- a/Assets/Script/Persistent/GlobalVariables.cs
+++ b/Assets/Script/Persistent/GlobalVariables.cs
@@ -102,6 +102,27 @@ namespace YARG
             LoadScene(SceneIndex.Menu);
         }
 
+        // Tracks whether audio was muted because the window lost focus,
+        // so it can be restored when focus returns.
+        private bool _mutedFromFocusLoss;
+
+        private void OnApplicationFocus(bool hasFocus)
+        {
+            if (!hasFocus)
+            {
+                if (SettingsManager.Settings.MuteOnFocusLoss.Value && !_mutedFromFocusLoss)
+                {
+                    GlobalAudioHandler.SetMasterVolume(0);
+                    _mutedFromFocusLoss = true;
+                }
+            }
+            else if (_mutedFromFocusLoss)
+            {
+                GlobalAudioHandler.SetMasterVolume(SettingsManager.Settings.MasterMusicVolume.Value);
+                _mutedFromFocusLoss = false;
+            }
+        }
+
 #if UNITY_EDITOR
 
         // For respecting the editor's mute button

--- a/Assets/Script/Settings/SettingsManager.Settings.cs
+++ b/Assets/Script/Settings/SettingsManager.Settings.cs
@@ -148,6 +148,7 @@ namespace YARG.Settings
 
             public ToggleSetting PauseOnDeviceDisconnect { get; } = new(true);
             public ToggleSetting PauseOnFocusLoss { get; } = new(true);
+            public ToggleSetting MuteOnFocusLoss { get; } = new(false);
 
             public ToggleSetting WrapAroundNavigation { get; } = new(true);
 

--- a/Assets/Script/Settings/SettingsManager.cs
+++ b/Assets/Script/Settings/SettingsManager.cs
@@ -66,6 +66,7 @@ namespace YARG.Settings
                 new FieldMetadata(nameof(Settings.ShowCursorTimer), isAdvanced: true),
                 nameof(Settings.PauseOnDeviceDisconnect),
                 nameof(Settings.PauseOnFocusLoss),
+                nameof(Settings.MuteOnFocusLoss),
                 nameof(Settings.WrapAroundNavigation),
                 nameof(Settings.DiscordRichPresence),
                 new FieldMetadata(nameof(Settings.AmIAwesome), isAdvanced: true),

--- a/Assets/StreamingAssets/lang/en-US.json
+++ b/Assets/StreamingAssets/lang/en-US.json
@@ -1539,6 +1539,10 @@
                 "Name": "Pause On Focus Loss",
                 "Description": "Pauses the game if it tabbed out/loses focus in the middle of a song."
             },
+            "MuteOnFocusLoss": {
+                "Name": "Mute On Focus Loss",
+                "Description": "Mutes all game audio when the game is tabbed out/loses focus, including menu music. Audio is restored when focus returns."
+            },
             "ApplyVolumesInMusicLibrary": {
                 "Name": "Apply Volume Settings to Music Library Previews",
                 "Description": "Volume settings for specific instrumments will be applied in the Music Library as well."


### PR DESCRIPTION
Adds a "Mute On Focus Loss" toggle (Settings → Other) that mutes all audio when the window loses focus and restores it on refocus. Independent of Pause On Focus Loss. Default off.

Closes #1237