### PR TITLE
Add 'Background FPS Cap' setting

### DIFF
--- a/Assets/Scenes/PersistentScene.unity
+++ b/Assets/Scenes/PersistentScene.unity
@@ -2348,6 +2348,7 @@ GameObject:
   - component: {fileID: 788257161}
   - component: {fileID: 788257162}
   - component: {fileID: 788257167}
+  - component: {fileID: 788257168}
   m_Layer: 0
   m_Name: Global Variables
   m_TagString: Untagged
@@ -2408,6 +2409,18 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _navigationIcons: {fileID: 11400000, guid: a5527a10e86be16408e824bfff6a124d, type: 2}
   _colors: {fileID: 11400000, guid: 8d1613cfd8baba7469ae5fb576fc2691, type: 2}
+--- !u!114 &788257168
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 788257159}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 19ef870a41104f6ba594d5912281e605, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1051339763
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Script/Persistent/FocusHandler.cs
+++ b/Assets/Script/Persistent/FocusHandler.cs
@@ -1,0 +1,59 @@
+using UnityEngine;
+using YARG.Core.Audio;
+using YARG.Settings;
+
+namespace YARG
+{
+    /// <summary>
+    /// Handles behavior that reacts to the application window gaining or losing focus,
+    /// such as muting audio and capping the framerate while unfocused.
+    /// </summary>
+    public class FocusHandler : MonoSingleton<FocusHandler>
+    {
+        // Tracks whether audio was muted because the window lost focus,
+        // so it can be restored when focus returns.
+        private bool _mutedFromFocusLoss;
+
+        // Tracks whether the framerate was capped because the window lost focus,
+        // so it can be restored when focus returns.
+        private bool _framerateLimitedFromFocusLoss;
+
+        private void OnApplicationFocus(bool hasFocus)
+        {
+            if (!hasFocus)
+            {
+                if (SettingsManager.Settings.MuteOnFocusLoss.Value && !_mutedFromFocusLoss)
+                {
+                    GlobalAudioHandler.SetMasterVolume(0);
+                    _mutedFromFocusLoss = true;
+                }
+
+                int backgroundFpsCap = SettingsManager.Settings.BackgroundFpsCap.Value;
+                if (backgroundFpsCap > 0 && !_framerateLimitedFromFocusLoss)
+                {
+                    // VSync would otherwise pin the framerate to the monitor's refresh
+                    // rate, ignoring targetFrameRate, so disable it while unfocused.
+                    QualitySettings.vSyncCount = 0;
+                    Application.targetFrameRate = backgroundFpsCap;
+                    _framerateLimitedFromFocusLoss = true;
+                }
+            }
+            else
+            {
+                if (_mutedFromFocusLoss)
+                {
+                    GlobalAudioHandler.SetMasterVolume(SettingsManager.Settings.MasterMusicVolume.Value);
+                    _mutedFromFocusLoss = false;
+                }
+
+                if (_framerateLimitedFromFocusLoss)
+                {
+                    // Restore from the live settings so changes made while unfocused are respected.
+                    QualitySettings.vSyncCount = SettingsManager.Settings.VSync.Value ? 1 : 0;
+                    Application.targetFrameRate = SettingsManager.Settings.FpsCap.Value;
+                    _framerateLimitedFromFocusLoss = false;
+                }
+            }
+        }
+    }
+}

--- a/Assets/Script/Persistent/FocusHandler.cs.meta
+++ b/Assets/Script/Persistent/FocusHandler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 19ef870a41104f6ba594d5912281e605
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Script/Persistent/GlobalVariables.cs
+++ b/Assets/Script/Persistent/GlobalVariables.cs
@@ -107,54 +107,6 @@ namespace YARG
             LoadScene(SceneIndex.Menu);
         }
 
-        // Tracks whether audio was muted because the window lost focus,
-        // so it can be restored when focus returns.
-        private bool _mutedFromFocusLoss;
-
-        // Framerate the engine is limited to while the window is unfocused.
-        private const int BackgroundFrameRate = 10;
-
-        // Tracks whether the framerate was limited because the window lost focus,
-        // so it can be restored when focus returns.
-        private bool _framerateLimitedFromFocusLoss;
-
-        private void OnApplicationFocus(bool hasFocus)
-        {
-            if (!hasFocus)
-            {
-                if (SettingsManager.Settings.MuteOnFocusLoss.Value && !_mutedFromFocusLoss)
-                {
-                    GlobalAudioHandler.SetMasterVolume(0);
-                    _mutedFromFocusLoss = true;
-                }
-
-                if (SettingsManager.Settings.LimitBackgroundFramerate.Value && !_framerateLimitedFromFocusLoss)
-                {
-                    // VSync would otherwise pin the framerate to the monitor's refresh
-                    // rate, ignoring targetFrameRate, so disable it while unfocused.
-                    QualitySettings.vSyncCount = 0;
-                    Application.targetFrameRate = BackgroundFrameRate;
-                    _framerateLimitedFromFocusLoss = true;
-                }
-            }
-            else
-            {
-                if (_mutedFromFocusLoss)
-                {
-                    GlobalAudioHandler.SetMasterVolume(SettingsManager.Settings.MasterMusicVolume.Value);
-                    _mutedFromFocusLoss = false;
-                }
-
-                if (_framerateLimitedFromFocusLoss)
-                {
-                    // Restore from the live settings so changes made while unfocused are respected.
-                    QualitySettings.vSyncCount = SettingsManager.Settings.VSync.Value ? 1 : 0;
-                    Application.targetFrameRate = SettingsManager.Settings.FpsCap.Value;
-                    _framerateLimitedFromFocusLoss = false;
-                }
-            }
-        }
-
 #if UNITY_EDITOR
 
         // For respecting the editor's mute button

--- a/Assets/Script/Persistent/GlobalVariables.cs
+++ b/Assets/Script/Persistent/GlobalVariables.cs
@@ -111,6 +111,13 @@ namespace YARG
         // so it can be restored when focus returns.
         private bool _mutedFromFocusLoss;
 
+        // Framerate the engine is limited to while the window is unfocused.
+        private const int BackgroundFrameRate = 10;
+
+        // Tracks whether the framerate was limited because the window lost focus,
+        // so it can be restored when focus returns.
+        private bool _framerateLimitedFromFocusLoss;
+
         private void OnApplicationFocus(bool hasFocus)
         {
             if (!hasFocus)
@@ -120,11 +127,31 @@ namespace YARG
                     GlobalAudioHandler.SetMasterVolume(0);
                     _mutedFromFocusLoss = true;
                 }
+
+                if (SettingsManager.Settings.LimitBackgroundFramerate.Value && !_framerateLimitedFromFocusLoss)
+                {
+                    // VSync would otherwise pin the framerate to the monitor's refresh
+                    // rate, ignoring targetFrameRate, so disable it while unfocused.
+                    QualitySettings.vSyncCount = 0;
+                    Application.targetFrameRate = BackgroundFrameRate;
+                    _framerateLimitedFromFocusLoss = true;
+                }
             }
-            else if (_mutedFromFocusLoss)
+            else
             {
-                GlobalAudioHandler.SetMasterVolume(SettingsManager.Settings.MasterMusicVolume.Value);
-                _mutedFromFocusLoss = false;
+                if (_mutedFromFocusLoss)
+                {
+                    GlobalAudioHandler.SetMasterVolume(SettingsManager.Settings.MasterMusicVolume.Value);
+                    _mutedFromFocusLoss = false;
+                }
+
+                if (_framerateLimitedFromFocusLoss)
+                {
+                    // Restore from the live settings so changes made while unfocused are respected.
+                    QualitySettings.vSyncCount = SettingsManager.Settings.VSync.Value ? 1 : 0;
+                    Application.targetFrameRate = SettingsManager.Settings.FpsCap.Value;
+                    _framerateLimitedFromFocusLoss = false;
+                }
             }
         }
 

--- a/Assets/Script/Settings/SettingsManager.Settings.cs
+++ b/Assets/Script/Settings/SettingsManager.Settings.cs
@@ -326,9 +326,10 @@ namespace YARG.Settings
 
             #region Graphics
 
-            public ToggleSetting VSync       { get; } = new(true, VSyncCallback);
-            public IntSetting    FpsCap      { get; } = new(60, 0, onChange: FpsCapCallback);
-            public IntSetting    VenueFpsCap { get; } = new(60, 0);
+            public ToggleSetting VSync            { get; } = new(true, VSyncCallback);
+            public IntSetting    FpsCap           { get; } = new(60, 0, onChange: FpsCapCallback);
+            public IntSetting    VenueFpsCap      { get; } = new(60, 0);
+            public IntSetting    BackgroundFpsCap { get; } = new(10, 0);
 
             public DropdownSetting<FullScreenMode> FullscreenMode { get; }
                 = new(FullScreenMode.FullScreenWindow, FullscreenModeCallback)

--- a/Assets/Script/Settings/SettingsManager.cs
+++ b/Assets/Script/Settings/SettingsManager.cs
@@ -135,6 +135,7 @@ namespace YARG.Settings
                 nameof(Settings.VSync),
                 new FieldMetadata(nameof(Settings.FpsCap)),
                 new FieldMetadata(nameof(Settings.VenueFpsCap), isAdvanced: true),
+                nameof(Settings.BackgroundFpsCap),
                 nameof(Settings.FullscreenMode),
                 nameof(Settings.Resolution),
                 new FieldMetadata(nameof(Settings.FpsStats), isAdvanced: true),

--- a/Assets/StreamingAssets/lang/en-US.json
+++ b/Assets/StreamingAssets/lang/en-US.json
@@ -1167,6 +1167,10 @@
                 "Name": "FPS Cap",
                 "Description": "The framerate cap. <color=white>YOU DO NOT NEED TO PLAY YARG ON 1000FPS.</color> VSync recommended."
             },
+            "BackgroundFpsCap": {
+                "Name": "Background FPS Cap",
+                "Description": "Caps the framerate while YARG is unfocused (tabbed out) to lower CPU/GPU usage, then restores it when focus returns. Set to 0 to disable."
+            },
             "FpsStats": {
                 "Name": "Show FPS Counter",
                 "Description": "Shows the framerate counter on the Status Bar."


### PR DESCRIPTION
Adds a "Background FPS Cap" setting (Graphics → Display, default 10) that caps the framerate while the window is unfocused to lower CPU/GPU load, restoring the configured framerate on refocus. Set to 0 to disable. VSync is disabled while capped so the limit applies, and restored from the live setting on refocus. Independent of Pause on Focus Loss.