### PR TITLE
Fix static lyric render behaviour when multiple syllables are active at the same time

### DIFF
--- a/Assets/Script/Gameplay/Visuals/VocalElements/VocalStaticLyricPhraseElement.cs
+++ b/Assets/Script/Gameplay/Visuals/VocalElements/VocalStaticLyricPhraseElement.cs
@@ -1,4 +1,5 @@
-﻿using Cysharp.Text;
+﻿using System;
+using Cysharp.Text;
 using System.Collections.Generic;
 using System.Linq;
 using TMPro;
@@ -190,21 +191,33 @@ namespace YARG.Gameplay.Visuals
 
         private int GetRenderState()
         {
+            var hash = new HashCode();
+
             for (int i = 0; i < _preparedPhrase.Syllables.Count; i++)
             {
                 var syllable = _preparedPhrase.Syllables[i];
+                int state = 2; // syllable is already hit (gray)
+
                 if (GameManager.VisualTime < syllable.Time)
                 {
-                    return i * 2;
+                    state = 0; // syllable is in current phrase (active/white)
+                }
+                else if (GameManager.VisualTime < syllable.TimeEnd)
+                {
+                    state = 1; // syllable is being hit (cyan)
                 }
 
-                if (GameManager.VisualTime < syllable.TimeEnd)
+                hash.Add(state);
+
+                if (state == 0)
                 {
-                    return i * 2 + 1;
+                    // We can reasonably assume if we run into a syllable that has not yet been hit,
+                    // there is no change after that syllable.
+                    break;
                 }
             }
 
-            return _preparedPhrase.Syllables.Count * 2;
+            return hash.ToHashCode();
         }
 
         private void BuilderAppendWithColorTag(string text, string colorTag)


### PR DESCRIPTION
Before, the `GetRenderState` method would return as soon as it ran into a syllable that is either the next to be hit, or currently being hit, but this meant that when multiple syllables on the same bar were being hit at the same time (which only happens on the merged harmony bar), syllables that were being hit would not be reflected visually until the leftmost syllable's note has ended.

This fixes that by using a `HashCode` to represent the current state of the bar, and only breaking from the loop if we run into a syllable that has not yet been hit.