### PR TITLE
Reduced Minimum Highway Length to better scale steep angle highways

### DIFF
--- a/Assets/Script/Menu/ProfileList/ProfileSidebar.cs
+++ b/Assets/Script/Menu/ProfileList/ProfileSidebar.cs
@@ -405,7 +405,7 @@ namespace YARG.Menu.ProfileList
         {
             if (float.TryParse(_highwayLengthField.text, out var speed))
             {
-                _profile.HighwayLength = Mathf.Clamp(speed, 0.1f, 10f);
+                _profile.HighwayLength = Mathf.Clamp(speed, 0.001f, 10f);
             }
 
             // Always format it after


### PR DESCRIPTION
This is a change to make gitadora/drum mania style vertical playfields scale better. While i was trying to make the scale better, i learned that lowering the highway length increased the scale of the playfield until it fills the bounds of its player area. This change lowers the minimum to allow for the playfield to reach its maximum size with a 90 degree vertical playfield.

<img width="894" height="504" alt="Screenshot 2026-06-24 150522" src="https://github.com/user-attachments/assets/e8b59203-7a7c-41fa-94e9-a0cb925f3cde" />
This Image contains from left to right:

Old minimum highway length, 4 lane pro drums
New minimum highway length, 4 lane pro drums
Old minimum highway length, 9 lane pro drums
New minimum highway length, 9 lane pro drums

The camera preset used is a custom with the settings:
Camera FOV: 40
Camera Y position: 4.00
Camera Z position: 4.50
Camera Rotation: 90.00
Fade Size: 0.00
Curve Factor: 0.00

Ive found these to be the most comfortable settings, adjusting the Z position to make the camera closer crops out the top of the playfield, makeing it difficult to read.