### PR TITLE
add wind parameter to character manager and pause VRM springs during pause

### DIFF
--- a/Assets/Script/Venue/Characters/CharacterManager.cs
+++ b/Assets/Script/Venue/Characters/CharacterManager.cs
@@ -21,7 +21,8 @@ namespace YARG.Venue.Characters
 
         [SerializeField]
         private Vector3 _wind;
-        private Vector3 _lastUpdatedWind = Vector3.zero;
+        private Vector3 _lastUpdatedWind     = Vector3.zero;
+        private bool    _lastKnownPausedState = false;
 
         private readonly Dictionary<VenueCharacter.CharacterType, VenueCharacter> _characters = new();
         public Dictionary<VenueCharacter.CharacterType, VenueCharacter> Characters => _characters;
@@ -241,12 +242,18 @@ namespace YARG.Venue.Characters
                         break;
                 }
 
+                if (_lastKnownPausedState != GameManager.Paused && character is VRMCharacter)
+                {
+                    ((VRMCharacter) character).SetSpringPause(GameManager.Paused);
+                }
+
                 if (_wind != _lastUpdatedWind && character is VRMCharacter)
                 {
                     ((VRMCharacter) character).SetWind(_wind);
                 }
             }
 
+            _lastKnownPausedState = GameManager.Paused;
             _lastUpdatedWind = _wind;
         }
 

--- a/Assets/Script/Venue/Characters/CharacterManager.cs
+++ b/Assets/Script/Venue/Characters/CharacterManager.cs
@@ -19,6 +19,10 @@ namespace YARG.Venue.Characters
         [SerializeField]
         private GameObject _venue;
 
+        [SerializeField]
+        private Vector3 _wind;
+        private Vector3 _lastUpdatedWind = Vector3.zero;
+
         private readonly Dictionary<VenueCharacter.CharacterType, VenueCharacter> _characters = new();
         public Dictionary<VenueCharacter.CharacterType, VenueCharacter> Characters => _characters;
 
@@ -236,7 +240,14 @@ namespace YARG.Venue.Characters
                         ProcessDrums(character);
                         break;
                 }
+
+                if (_wind != _lastUpdatedWind && character is VRMCharacter)
+                {
+                    ((VRMCharacter) character).SetWind(_wind);
+                }
             }
+
+            _lastUpdatedWind = _wind;
         }
 
         public void ResetTime(double time)

--- a/Assets/Script/Venue/Characters/VRMCharacter.cs
+++ b/Assets/Script/Venue/Characters/VRMCharacter.cs
@@ -37,8 +37,9 @@ namespace YARG.Venue.Characters
         [Tooltip("Set to true if you want to use custom animations instead of the default ones.")]
         public bool UseCustomAnimations;
 
-        private ExpressionKey _lipsyncKey;
-        private bool          _hasVrmInstance;
+        private ExpressionKey       _lipsyncKey;
+        private bool                _hasVrmInstance;
+        private BlittableModelLevel _modelLevels;
 
         private Vector3 _initialPosition;
 
@@ -82,6 +83,7 @@ namespace YARG.Venue.Characters
             _characterManager = characterManager;
             VrmInstance = GetComponent<Vrm10Instance>();
             _hasVrmInstance = VrmInstance != null;
+            _modelLevels = new BlittableModelLevel();
             _expression = VrmInstance.Runtime.Expression;
 
             if (_characterManager != null)
@@ -166,7 +168,27 @@ namespace YARG.Venue.Characters
             {
                 return;
             }
-            VrmInstance.Runtime.SpringBone.SetModelLevel(VrmInstance.transform, new BlittableModelLevel(externalForce: wind));
+
+            //update external force
+            _modelLevels = new BlittableModelLevel(externalForce: wind,
+                stopSpringBoneWriteback: _modelLevels.StopSpringBoneWriteback,
+                supportsScalingAtRuntime: _modelLevels.SupportsScalingAtRuntime);
+            //push model level changes to VRM runtime
+            VrmInstance.Runtime.SpringBone.SetModelLevel(VrmInstance.transform, _modelLevels);
+        }
+
+        public void SetSpringPause(bool paused)
+        {
+            if (!_hasVrmInstance)
+            {
+                return;
+            }
+            //set spring bone paused state
+            _modelLevels = new BlittableModelLevel(externalForce: _modelLevels.ExternalForce,
+                stopSpringBoneWriteback: paused,
+                supportsScalingAtRuntime: _modelLevels.SupportsScalingAtRuntime);
+            //push model level changes to VRM runtime
+            VrmInstance.Runtime.SpringBone.SetModelLevel(VrmInstance.transform, _modelLevels);
         }
 
         public override void OnChartEvent(ChartEvent e)

--- a/Assets/Script/Venue/Characters/VRMCharacter.cs
+++ b/Assets/Script/Venue/Characters/VRMCharacter.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using DG.Tweening;
+using UniGLTF.SpringBoneJobs.Blittables;
 using UnityEngine;
 using UniVRM10;
 using YARG.Core.Chart;
@@ -157,6 +158,15 @@ namespace YARG.Venue.Characters
             }
 
             _expression.SetWeight(_lipsyncKey, lipsyncEvent.Value);
+        }
+
+        public void SetWind(Vector3 wind)
+        {
+            if (!_hasVrmInstance)
+            {
+                return;
+            }
+            VrmInstance.Runtime.SpringBone.SetModelLevel(VrmInstance.transform, new BlittableModelLevel(externalForce: wind));
         }
 
         public override void OnChartEvent(ChartEvent e)


### PR DESCRIPTION
adds a new Vector Setting to the character manager, which sets a wind that will be applied to VRM-character's springbones.
a slight wind could look good on outside venues :)
i made it check for updates to the wind so that animating the wind vector on the character manager can be possible