### PR TITLE
Fix logic for showing "Collapse All" and "Expand All" in popup menu

### DIFF
--- a/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.SortFilter.cs
+++ b/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.SortFilter.cs
@@ -41,6 +41,29 @@ namespace YARG.Menu.MusicLibrary
 
         public bool HasSortHeaders { get; private set; }
 
+        public void GetSortHeaderCollapseState(out bool hasCollapsed, out bool hasExpanded)
+        {
+            hasCollapsed = false;
+            hasExpanded = false;
+
+            if (_sortedSongs is null) return;
+
+            var collapsedHeaders = _collapsedHeaders[SettingsManager.Settings.LibrarySort];
+            foreach (var section in _sortedSongs)
+            {
+                if (collapsedHeaders.Contains(section))
+                {
+                    hasCollapsed = true;
+                }
+                else
+                {
+                    hasExpanded = true;
+                }
+
+                if (hasCollapsed && hasExpanded) return;
+            }
+        }
+
         private SongCategory[] _sortedSongs;
         private SortAttribute _playlistSort = SortAttribute.Name;
         private bool _playlistSortAscending = true;

--- a/Assets/Script/Menu/MusicLibrary/PopupMenu.cs
+++ b/Assets/Script/Menu/MusicLibrary/PopupMenu.cs
@@ -150,21 +150,7 @@ namespace YARG.Menu.MusicLibrary
 
             if (_musicLibrary.MenuState == MenuState.Library && !_musicLibrary.PlaylistMode)
             {
-                bool hasCollapsed = false;
-                bool hasExpanded = false;
-                foreach (var section in _musicLibrary.SortedSongs)
-                {
-                    if (section.Collapsed)
-                    {
-                        hasCollapsed = true;
-                    }
-                    else
-                    {
-                        hasExpanded = true;
-                    }
-
-                    if (hasCollapsed && hasExpanded) break;
-                }
+                _musicLibrary.GetSortHeaderCollapseState(out bool hasCollapsed, out bool hasExpanded);
 
                 if (hasCollapsed)
                 {


### PR DESCRIPTION
This resolves a regression from #1454 and the issue, #1531.