### PR TITLE
Use Sort String for Playlist Sorting and Simplify Sort By Popup Text

### DIFF
--- a/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.SortFilter.cs
+++ b/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.SortFilter.cs
@@ -65,8 +65,6 @@ namespace YARG.Menu.MusicLibrary
         }
 
         private SongCategory[] _sortedSongs;
-        private SortAttribute _playlistSort = SortAttribute.Name;
-        private bool _playlistSortAscending = true;
         private static readonly Dictionary<SortAttribute, HashSet<SongCategory>> _collapsedHeaders = new();
 
         private List<int> _sectionHeaderIndices = new();
@@ -359,29 +357,11 @@ namespace YARG.Menu.MusicLibrary
                         return;
                 }
 
-                _playlistSort = sort;
-                _playlistSortAscending = ascending;
                 RefreshAndReselect();
                 return;
             }
 
             ChangeSort(sort);
-        }
-
-        public SortAttribute GetPopupSortAttribute()
-        {
-            return MenuState == MenuState.Playlist ? _playlistSort : SettingsManager.Settings.LibrarySort;
-        }
-
-        public string GetPopupSortLabel()
-        {
-            var sort = GetPopupSortAttribute().ToLocalizedName();
-            if (MenuState != MenuState.Playlist)
-            {
-                return sort;
-            }
-
-            return _playlistSortAscending ? $"{sort} (A-Z)" : $"{sort} (Z-A)";
         }
 
         private void UpdateSortInformationHeader()

--- a/Assets/Script/Menu/MusicLibrary/PopupMenu.cs
+++ b/Assets/Script/Menu/MusicLibrary/PopupMenu.cs
@@ -130,7 +130,7 @@ namespace YARG.Menu.MusicLibrary
 
             if (_musicLibrary.MenuState != MenuState.PlaylistSelect)
             {
-                CreateItem("SortBy", _musicLibrary.GetPopupSortLabel(), () =>
+                CreateItem("SortBy", () =>
                 {
                     _menuState = State.SortSelect;
                     UpdateForState();

--- a/Assets/Script/Playlists/Playlist.cs
+++ b/Assets/Script/Playlists/Playlist.cs
@@ -118,15 +118,7 @@ namespace YARG.Playlists
         {
             // Get all songs, sort by name, then rebuild hash list
             var songs = ToList();
-
-            if (ascending)
-            {
-                songs.Sort((a, b) => string.Compare(a.Name, b.Name, System.StringComparison.OrdinalIgnoreCase));
-            }
-            else
-            {
-                songs.Sort((a, b) => string.Compare(b.Name, a.Name, System.StringComparison.OrdinalIgnoreCase));
-            }
+            songs.Sort((a, b) => CompareSongsByName(a, b, ascending));
 
             SongHashes.Clear();
             foreach (var song in songs)
@@ -144,15 +136,7 @@ namespace YARG.Playlists
         {
             // Get all songs, sort by artist, then rebuild hash list
             var songs = ToList();
-
-            if (ascending)
-            {
-                songs.Sort((a, b) => string.Compare(a.Artist, b.Artist, System.StringComparison.OrdinalIgnoreCase));
-            }
-            else
-            {
-                songs.Sort((a, b) => string.Compare(b.Artist, a.Artist, System.StringComparison.OrdinalIgnoreCase));
-            }
+            songs.Sort((a, b) => CompareSongsByArtist(a, b, ascending));
 
             SongHashes.Clear();
             foreach (var song in songs)
@@ -164,6 +148,47 @@ namespace YARG.Playlists
             {
                 PlaylistContainer.SavePlaylist(this);
             }
+        }
+
+        private static int CompareSongsByName(SongEntry lhs, SongEntry rhs, bool ascending)
+        {
+            int result = CompareSortStrings(lhs.Name, rhs.Name);
+            if (result == 0)
+            {
+                result = CompareSortStrings(lhs.Artist, rhs.Artist);
+            }
+            if (result == 0)
+            {
+                result = lhs.SortBasedLocation.CompareTo(rhs.SortBasedLocation);
+            }
+
+            return ascending ? result : -result;
+        }
+
+        private static int CompareSongsByArtist(SongEntry lhs, SongEntry rhs, bool ascending)
+        {
+            int result = CompareSortStrings(lhs.Artist, rhs.Artist);
+            if (result == 0)
+            {
+                result = CompareSortStrings(lhs.Name, rhs.Name);
+            }
+            if (result == 0)
+            {
+                result = lhs.SortBasedLocation.CompareTo(rhs.SortBasedLocation);
+            }
+
+            return ascending ? result : -result;
+        }
+
+        private static int CompareSortStrings(SortString lhs, SortString rhs)
+        {
+            int result = lhs.CompareTo(rhs);
+            if (result == 0)
+            {
+                result = string.Compare(lhs.Original, rhs.Original, StringComparison.OrdinalIgnoreCase);
+            }
+
+            return result;
         }
     }
 }

--- a/Assets/StreamingAssets/lang/en-US.json
+++ b/Assets/StreamingAssets/lang/en-US.json
@@ -328,7 +328,7 @@
                     "RandomSong": "Random Song",
                     "BackToTop": "Back to Top",
                     "ScanSongs": "Scan Songs",
-                    "SortBy": "Sort By: {0}",
+                    "SortBy": "Sort By...",
                     "GoToSection": "Go To Section...",
                     "AddToFavorites": "Add To Favorites",
                     "RemoveFromFavorites": "Remove From Favorites",


### PR DESCRIPTION
1. Update playlist sorting for Song (A-Z), Song (Z-A), Artist (A-Z), and Artist (Z-A) to compare `SortString` values instead of raw display strings.  This matches the main music library behavior where leading articles like "A", "An", and "The" are ignored for sorting.

2. Change the main popup item from "Sort By: {text}" to "Sort By...".  The previous text could be inaccurate for playlists because it implied a current sort state.  The new label matches "Add To Playlist..." and makes it clearer that selecting it opens another menu.

This fixes https://discord.com/channels/1086048856678084609/1517640993367789799