### PR TITLE
Prefer per-engine high scores and show engine ring

### DIFF
--- a/Assets/Art/Menu/Common/DifficultyIcons.png
+++ b/Assets/Art/Menu/Common/DifficultyIcons.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7d27c18287d0868e24fae2d03ab25819b3af0b6102c81eb1bde166c10cb11cd8
-size 457654
+oid sha256:22098c722af6c2a68c7e0c0bbeb4d8ef446545c2fb935b49efa7c8a5912c2507
+size 505545

--- a/Assets/Art/Menu/Common/DifficultyIcons.png.meta
+++ b/Assets/Art/Menu/Common/DifficultyIcons.png.meta
@@ -207,6 +207,28 @@ TextureImporter:
       edges: []
       weights: []
     - serializedVersion: 2
+      name: Ring
+      rect:
+        serializedVersion: 2
+        x: 1024
+        y: 0
+        width: 512
+        height: 512
+      alignment: 0
+      pivot: {x: 0.5, y: 0.5}
+      border: {x: 0, y: 0, z: 0, w: 0}
+      customData:
+      outline: []
+      physicsShape: []
+      tessellationDetail: 0
+      bones: []
+      spriteID: d20d2c8f76b04d04b989d90dd34f0f2c
+      internalID: 1723301127
+      vertices: []
+      indices:
+      edges: []
+      weights: []
+    - serializedVersion: 2
       name: Beginner
       rect:
         serializedVersion: 2
@@ -250,6 +272,7 @@ TextureImporter:
       ExpertPlus: -25976495
       Hard: -118138551
       Medium: 703388571
+      Ring: 1723301127
   mipmapLimitGroupName: 
   pSDRemoveMatte: 0
   userData: 

--- a/Assets/Prefabs/Menu/MusicLibrary/Instrument Difficulty.prefab
+++ b/Assets/Prefabs/Menu/MusicLibrary/Instrument Difficulty.prefab
@@ -32,6 +32,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 6388824535481474079}
+  - {fileID: 8765432101234567002}
   - {fileID: 2527093660762882793}
   m_Father: {fileID: 724794527332165637}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -164,6 +165,81 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls: []
   m_Sprite: {fileID: -1843738572, guid: f3ceabe704bcf1745866d8e7135c98ab, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!1 &8765432101234567001
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8765432101234567002}
+  - component: {fileID: 8765432101234567003}
+  - component: {fileID: 8765432101234567004}
+  m_Layer: 0
+  m_Name: Difficulty Ring
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8765432101234567002
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8765432101234567001}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1322352689153992488}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 0, y: 0.5}
+  m_AnchoredPosition: {x: 4, y: 0}
+  m_SizeDelta: {x: 32, y: 32}
+  m_Pivot: {x: 0, y: 0.5}
+--- !u!222 &8765432101234567003
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8765432101234567001}
+  m_CullTransparentMesh: 1
+--- !u!114 &8765432101234567004
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8765432101234567001}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 1723301127, guid: f3ceabe704bcf1745866d8e7135c98ab, type: 3}
   m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1
@@ -537,4 +613,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _instrumentIcon: {fileID: 8738765378136697063}
   _difficultyIcon: {fileID: 4230519954311980479}
+  _difficultyRing: {fileID: 8765432101234567004}
   _percentText: {fileID: 4824570177518276672}

--- a/Assets/Script/Gameplay/GameManager.Loading.cs
+++ b/Assets/Script/Gameplay/GameManager.Loading.cs
@@ -482,7 +482,12 @@ namespace YARG.Gameplay
                         player.RefreshPresets();
                     }
 
-                    var lastHighScore = ScoreContainer.GetHighScore(Song.Hash, player.Profile.Id, player.Profile.CurrentInstrument, false)?.Score;
+                    var lastHighScore = ScoreContainer.GetHighScore(
+                        Song.Hash,
+                        player.Profile.Id,
+                        player.Profile.CurrentInstrument,
+                        allowCacheUpdate: false,
+                        preferredEnginePresetId: player.Profile.EnginePreset)?.Score;
                     YargLogger.LogFormatInfo("Current high score for player {0} on {1}: {2}",
                         player.Profile.Name, player.Profile.CurrentInstrument, lastHighScore ?? 0);
 

--- a/Assets/Script/Menu/MusicLibrary/InstrumentDifficultyView.cs
+++ b/Assets/Script/Menu/MusicLibrary/InstrumentDifficultyView.cs
@@ -1,8 +1,10 @@
+using System;
 using System.Collections.Generic;
 using TMPro;
 using UnityEngine;
 using UnityEngine.AddressableAssets;
 using UnityEngine.UI;
+using YARG.Core.Game;
 using YARG.Helpers.Extensions;
 using YARG.Settings;
 
@@ -19,9 +21,17 @@ namespace YARG.Menu.MusicLibrary
         private Image _difficultyIcon;
 
         [SerializeField]
+        private Image _difficultyRing;
+
+        [SerializeField]
         private TextMeshProUGUI _percentText;
 
         private static readonly Color FcGold = new(1, 208 / 255f, 41 / 255f);
+        private static readonly Color DefaultEngineColor = Color.white;
+        private static readonly Color CasualEngineColor = new(0.9f, 0.3f, 0.9f);
+        private static readonly Color PrecisionEngineColor = new(1f, 0.9f, 0f);
+        private static readonly Color SoloTapsEngineColor = new(0.5411765f, 0.1686275f, 0.8862746f);
+        private static readonly Color CustomEngineColor = new(1f, 0.25f, 0.25f);
 
 
         public void SetInfo(ViewType.ScoreInfo scoreInfo)
@@ -29,13 +39,15 @@ namespace YARG.Menu.MusicLibrary
             // Set width
             var rect = GetComponent<RectTransform>();
             var length = SettingsManager.Settings.ShowPercentDecimals.Value ? 150 : 130;
-            GetComponent<RectTransform>().sizeDelta = new Vector2(length, rect.sizeDelta.y);
+            rect.sizeDelta = new Vector2(length, rect.sizeDelta.y);
 
             // Set instrument icon
             _instrumentIcon.sprite = GetSprite($"InstrumentIcons[{scoreInfo.Instrument.ToResourceName()}]");
 
             // Set difficulty icon
             _difficultyIcon.sprite = GetSprite($"DifficultyIcons[{scoreInfo.Difficulty.ToString()}]");
+            _difficultyIcon.color = Color.white;
+            _difficultyRing.color = GetEngineColor(scoreInfo.EnginePresetId);
 
             // Set percent value
             if (SettingsManager.Settings.ShowPercentDecimals.Value)
@@ -60,5 +72,14 @@ namespace YARG.Menu.MusicLibrary
 
             return sprite;
         }
+
+        private static Color GetEngineColor(Guid enginePresetId) => enginePresetId switch
+        {
+            var id when id == Guid.Empty || id == EnginePreset.Default.Id => DefaultEngineColor,
+            var id when id == EnginePreset.Casual.Id => CasualEngineColor,
+            var id when id == EnginePreset.Precision.Id => PrecisionEngineColor,
+            var id when id == EnginePreset.SoloTaps.Id => SoloTapsEngineColor,
+            _ => CustomEngineColor
+        };
     }
 }

--- a/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
+++ b/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
@@ -30,6 +30,7 @@ namespace YARG.Menu.MusicLibrary
         public readonly Guid ProfileId;
         public readonly Instrument Instrument;
         public readonly Difficulty Difficulty;
+        public readonly Guid EnginePresetId;
         public readonly int HumanPlayerCount;
         public readonly HighScoreHistoryMode HighScoreHistoryMode;
 
@@ -37,12 +38,14 @@ namespace YARG.Menu.MusicLibrary
             Guid profileId,
             Instrument instrument,
             Difficulty difficulty,
+            Guid enginePresetId,
             int humanPlayerCount,
             HighScoreHistoryMode highScoreHistoryMode)
         {
             ProfileId = profileId;
             Instrument = instrument;
             Difficulty = difficulty;
+            EnginePresetId = enginePresetId;
             HumanPlayerCount = humanPlayerCount;
             HighScoreHistoryMode = highScoreHistoryMode;
         }
@@ -57,6 +60,7 @@ namespace YARG.Menu.MusicLibrary
                 profile?.Id ?? Guid.Empty,
                 profile?.CurrentInstrument ?? Instrument.FiveFretGuitar,
                 profile?.CurrentDifficulty ?? Difficulty.Expert,
+                profile?.EnginePreset ?? Guid.Empty,
                 PlayerContainer.Players.Count(player => !player.Profile.IsBot),
                 SettingsManager.Settings.HighScoreHistory.Value);
         }
@@ -66,6 +70,7 @@ namespace YARG.Menu.MusicLibrary
             return ProfileId == other.ProfileId &&
                 Instrument == other.Instrument &&
                 Difficulty == other.Difficulty &&
+                EnginePresetId == other.EnginePresetId &&
                 HumanPlayerCount == other.HumanPlayerCount &&
                 HighScoreHistoryMode == other.HighScoreHistoryMode;
         }

--- a/Assets/Script/Menu/MusicLibrary/ViewTypes/SongViewType.cs
+++ b/Assets/Script/Menu/MusicLibrary/ViewTypes/SongViewType.cs
@@ -102,6 +102,7 @@ namespace YARG.Menu.MusicLibrary
                 Difficulty = _playerScoreRecord.Difficulty,
                 Percent = _playerScoreRecord.GetPercent(),
                 Instrument = _playerScoreRecord.Instrument,
+                EnginePresetId = _playerScoreRecord.EnginePresetId,
                 IsFc = _playerScoreRecord.IsFc
             };
         }

--- a/Assets/Script/Menu/MusicLibrary/ViewTypes/ViewType.cs
+++ b/Assets/Script/Menu/MusicLibrary/ViewTypes/ViewType.cs
@@ -1,4 +1,5 @@
 ﻿using Cysharp.Text;
+using System;
 using YARG.Core;
 using YARG.Core.Game;
 using YARG.Helpers;
@@ -25,6 +26,7 @@ namespace YARG.Menu.MusicLibrary
             public int        Score;
             public Difficulty Difficulty;
             public Instrument Instrument;
+            public Guid       EnginePresetId;
             public bool       IsFc;
         }
 

--- a/Assets/Script/Menu/ProfileList/ProfileSidebar.cs
+++ b/Assets/Script/Menu/ProfileList/ProfileSidebar.cs
@@ -447,7 +447,14 @@ namespace YARG.Menu.ProfileList
 
         public void ChangeEngine()
         {
-            _profile.EnginePreset = _enginePresetsByIndex[_engineDropdown.value];
+            var enginePreset = _enginePresetsByIndex[_engineDropdown.value];
+            if (_profile.EnginePreset == enginePreset)
+            {
+                return;
+            }
+
+            _profile.EnginePreset = enginePreset;
+            ScoreContainer.InvalidateScoreCache();
         }
 
         public void ChangeOpenLaneDisplayType()

--- a/Assets/Script/Scores/ScoreContainer.cs
+++ b/Assets/Script/Scores/ScoreContainer.cs
@@ -41,6 +41,7 @@ namespace YARG.Scores
         private static string     _currentInstrumentSetKey = string.Empty;
         private static Difficulty _currentDifficulty = Difficulty.Easy;
         private static HighScoreHistoryMode _currentHighScoreHistoryMode;
+        private static Guid?      _currentPreferredEnginePresetId;
         private static bool       _scoresWereFetched;
 
         private static bool HighestDifficultyOnly
@@ -187,19 +188,21 @@ namespace YARG.Scores
         private static void UpdatePlayerHighScores(HashWrapper songChecksum, PlayerScoreRecord newScore)
         {
             var bestScore = _db.QueryPlayerSongHighScore(
-                songChecksum, newScore.PlayerId, newScore.Instrument, HighestDifficultyOnly, CurrentDifficultyOnly, newScore.Difficulty);
+                songChecksum, newScore.PlayerId, newScore.Instrument, HighestDifficultyOnly, CurrentDifficultyOnly,
+                newScore.Difficulty, _currentPreferredEnginePresetId);
             var bestPercent = _db.QueryPlayerSongHighestPercentage(
-                songChecksum, newScore.PlayerId, newScore.Instrument, HighestDifficultyOnly, CurrentDifficultyOnly, newScore.Difficulty);
+                songChecksum, newScore.PlayerId, newScore.Instrument, HighestDifficultyOnly, CurrentDifficultyOnly,
+                newScore.Difficulty, _currentPreferredEnginePresetId);
 
             if (_scoresWereFetched &&
                 _currentPlayerId == newScore.PlayerId &&
                 InstrumentSetContains(_currentInstrumentSetKey, newScore.Instrument))
             {
                 if (bestScore is not null)
-                    UpdateBestScoreCache(songChecksum, bestScore);
+                    UpdateBestScoreCache(songChecksum, bestScore, _currentPreferredEnginePresetId);
 
                 if (bestPercent is not null)
-                    UpdateBestPercentCache(songChecksum, bestPercent);
+                    UpdateBestPercentCache(songChecksum, bestPercent, _currentPreferredEnginePresetId);
             }
         }
 
@@ -259,16 +262,24 @@ namespace YARG.Scores
         /// <param name="instrument">The instrument to retrieve a high score for.</param>
         /// <param name="allowCacheUpdate">Sets whether all high scores for this player and instrument should be cached. Set this to true when fetching a large number of high scores for the same player and instrument
         /// (such as when displaying high scores on the Music Library). Set this to false when fetching multiple high scores for different players in a row.</param>
+        /// <param name="preferredEnginePresetId">If set, scores using this engine are preferred before applying the high score sort.</param>
         /// <returns>The highest score for the provided song, player and instrument, or null if no high score exists.</returns>
-        public static PlayerScoreRecord GetHighScore(HashWrapper songChecksum, Guid playerId, Instrument instrument, bool allowCacheUpdate = true)
+        public static PlayerScoreRecord GetHighScore(
+            HashWrapper songChecksum,
+            Guid playerId,
+            Instrument instrument,
+            bool allowCacheUpdate = true,
+            Guid? preferredEnginePresetId = null)
         {
             if (allowCacheUpdate)
-                FetchHighScores(playerId, new[] { instrument });
+                FetchHighScores(playerId, new[] { instrument }, preferredEnginePresetId);
 
-            if (_currentPlayerId == playerId && _currentInstrumentSetKey == BuildInstrumentSetKey(instrument))
+            if (_currentPlayerId == playerId &&
+                _currentInstrumentSetKey == BuildInstrumentSetKey(instrument) &&
+                _currentPreferredEnginePresetId == preferredEnginePresetId)
                 return PlayerHighScores.GetValueOrDefault(songChecksum);
 
-            return GetHighScoreFromDatabase(songChecksum, playerId, instrument);
+            return GetHighScoreFromDatabase(songChecksum, playerId, instrument, preferredEnginePresetId);
         }
 
         public static GameRecord GetBandHighScore(HashWrapper songChecksum)
@@ -276,11 +287,18 @@ namespace YARG.Scores
             return BandHighScores.GetValueOrDefault(songChecksum);
         }
 
-        public static PlayerScoreRecord GetPreferredHighScore(HashWrapper songChecksum, Guid playerId, Instrument instrument, bool allowCacheUpdate = true)
+        public static PlayerScoreRecord GetPreferredHighScore(
+            HashWrapper songChecksum,
+            Guid playerId,
+            Instrument instrument,
+            bool allowCacheUpdate = true,
+            Guid? preferredEnginePresetId = null)
         {
             return UseHighestScore
-                ? GetHighScore(songChecksum, playerId, instrument, allowCacheUpdate)
-                : GetBestPercentageScore(songChecksum, playerId, instrument, allowCacheUpdate);
+                ? GetHighScore(
+                    songChecksum, playerId, instrument, allowCacheUpdate, preferredEnginePresetId)
+                : GetBestPercentageScore(
+                    songChecksum, playerId, instrument, allowCacheUpdate, preferredEnginePresetId);
         }
 
         public static bool UseBandHighScoresForCurrentPlayers
@@ -303,18 +321,24 @@ namespace YARG.Scores
             var player = PlayerContainer.Players.First(entry => !entry.Profile.IsBot);
             playerScoreRecord = player.Profile.GameMode == GameMode.EliteDrums
                 ? GetPreferredHighScoreForInstruments(
-                    songChecksum, player.Profile.Id, MidiDrumkitHelper.Instruments)
+                    songChecksum, player.Profile.Id, MidiDrumkitHelper.Instruments,
+                    preferredEnginePresetId: player.Profile.EnginePreset)
                 : GetPreferredHighScore(
-                    songChecksum, player.Profile.Id, player.Profile.CurrentInstrument);
+                    songChecksum, player.Profile.Id, player.Profile.CurrentInstrument,
+                    preferredEnginePresetId: player.Profile.EnginePreset);
         }
 
-        private static PlayerScoreRecord GetHighScoreFromDatabase(HashWrapper songChecksum, Guid playerId, Instrument instrument)
+        private static PlayerScoreRecord GetHighScoreFromDatabase(
+            HashWrapper songChecksum,
+            Guid playerId,
+            Instrument instrument,
+            Guid? preferredEnginePresetId)
         {
             try
             {
                 return _db.QueryPlayerSongHighScore(
                     songChecksum, playerId, instrument, HighestDifficultyOnly, CurrentDifficultyOnly,
-                    PlayerContainer.GetProfileById(playerId).CurrentDifficulty);
+                    PlayerContainer.GetProfileById(playerId).CurrentDifficulty, preferredEnginePresetId);
             }
             catch (Exception e)
             {
@@ -333,25 +357,38 @@ namespace YARG.Scores
         /// <param name="instrument">The instrument to retrieve a high score for.</param>
         /// <param name="allowCacheUpdate">Sets whether all high scores for this player and instrument should be cached. Set this to true when fetching a large number of high scores for the same player and instrument
         /// (such as when displaying high scores on the Music Library). Set this to false when fetching multiple high scores for different players in a row.</param>
+        /// <param name="preferredEnginePresetId">If set, scores using this engine are preferred before applying the high score sort.</param>
         /// <returns>The highest score percentage for the provided song, player and instrument, or null if no high score exists.</returns>
-        public static PlayerScoreRecord GetBestPercentageScore(HashWrapper songChecksum, Guid playerId, Instrument instrument, bool allowCacheUpdate = true)
+        public static PlayerScoreRecord GetBestPercentageScore(
+            HashWrapper songChecksum,
+            Guid playerId,
+            Instrument instrument,
+            bool allowCacheUpdate = true,
+            Guid? preferredEnginePresetId = null)
         {
             if (allowCacheUpdate)
-                FetchHighScores(playerId, new[] { instrument });
+                FetchHighScores(playerId, new[] { instrument }, preferredEnginePresetId);
 
-            if (_currentPlayerId == playerId && _currentInstrumentSetKey == BuildInstrumentSetKey(instrument))
+            if (_currentPlayerId == playerId &&
+                _currentInstrumentSetKey == BuildInstrumentSetKey(instrument) &&
+                _currentPreferredEnginePresetId == preferredEnginePresetId)
                 return PlayerHighPercentages.GetValueOrDefault(songChecksum);
 
-            return GetHighestPercentageFromDatabase(songChecksum, playerId, instrument);
+            return GetHighestPercentageFromDatabase(
+                songChecksum, playerId, instrument, preferredEnginePresetId);
         }
 
-        private static PlayerScoreRecord GetHighestPercentageFromDatabase(HashWrapper songChecksum, Guid playerId, Instrument instrument)
+        private static PlayerScoreRecord GetHighestPercentageFromDatabase(
+            HashWrapper songChecksum,
+            Guid playerId,
+            Instrument instrument,
+            Guid? preferredEnginePresetId)
         {
             try
             {
                 return _db.QueryPlayerSongHighestPercentage(
                     songChecksum, playerId, instrument, HighestDifficultyOnly, CurrentDifficultyOnly,
-                    PlayerContainer.GetProfileById(playerId).CurrentDifficulty);
+                    PlayerContainer.GetProfileById(playerId).CurrentDifficulty, preferredEnginePresetId);
             }
             catch (Exception e)
             {
@@ -360,7 +397,10 @@ namespace YARG.Scores
             }
         }
 
-        private static void FetchHighScores(Guid playerId, IReadOnlyList<Instrument> instruments)
+        private static void FetchHighScores(
+            Guid playerId,
+            IReadOnlyList<Instrument> instruments,
+            Guid? preferredEnginePresetId)
         {
             if (instruments == null || instruments.Count == 0) return;
 
@@ -373,6 +413,7 @@ namespace YARG.Scores
                 _currentInstrumentSetKey == instrumentKey &&
                 _currentDifficulty == currentDifficulty &&
                 _currentHighScoreHistoryMode == currentHighScoreHistoryMode &&
+                _currentPreferredEnginePresetId == preferredEnginePresetId &&
                 _scoresWereFetched)
             {
                 // Already cached. No need to fetch again from the database.
@@ -395,14 +436,14 @@ namespace YARG.Scores
                 {
                      var highScores = _db.QueryPlayerHighScores(
                           playerId, instrument, HighestDifficultyOnly, CurrentDifficultyOnly, currentDifficulty,
-                          SongContainer.SongsByHash.Keys, SongContainer.LibraryRevision);
+                          SongContainer.SongsByHash.Keys, SongContainer.LibraryRevision, preferredEnginePresetId);
                     foreach (var score in highScores)
                     {
                         if (!checksumByRecordId.TryGetValue(score.GameRecordId, out var checksum))
                             continue;
 
                         var hash = HashWrapper.Create(checksum);
-                        UpdateBestScoreCache(hash, score);
+                        UpdateBestScoreCache(hash, score, preferredEnginePresetId);
                     }
                 }
 
@@ -410,14 +451,14 @@ namespace YARG.Scores
                 {
                      var highPercentages = _db.QueryPlayerHighestPercentages(
                           playerId, instrument, HighestDifficultyOnly, CurrentDifficultyOnly, currentDifficulty,
-                          SongContainer.SongsByHash.Keys, SongContainer.LibraryRevision);
+                          SongContainer.SongsByHash.Keys, SongContainer.LibraryRevision, preferredEnginePresetId);
                     foreach (var score in highPercentages)
                     {
                         if (!checksumByRecordId.TryGetValue(score.GameRecordId, out var checksum))
                             continue;
 
                         var hash = HashWrapper.Create(checksum);
-                        UpdateBestPercentCache(hash, score);
+                        UpdateBestPercentCache(hash, score, preferredEnginePresetId);
                     }
                 }
 
@@ -425,6 +466,7 @@ namespace YARG.Scores
                 _currentDifficulty = currentDifficulty;
                 _currentHighScoreHistoryMode = currentHighScoreHistoryMode;
                 _currentInstrumentSetKey = instrumentKey;
+                _currentPreferredEnginePresetId = preferredEnginePresetId;
                 _scoresWereFetched = true;
             }
             catch (Exception e)
@@ -433,28 +475,44 @@ namespace YARG.Scores
             }
         }
 
-        private static void UpdateBestScoreCache(HashWrapper songChecksum, PlayerScoreRecord candidate)
+        private static void UpdateBestScoreCache(
+            HashWrapper songChecksum,
+            PlayerScoreRecord candidate,
+            Guid? preferredEnginePresetId)
         {
             if (!PlayerHighScores.TryGetValue(songChecksum, out var current) ||
-                IsBetterScore(candidate, current))
+                IsBetterScore(candidate, current, preferredEnginePresetId))
             {
                 PlayerHighScores[songChecksum] = candidate;
             }
         }
 
-        private static void UpdateBestPercentCache(HashWrapper songChecksum, PlayerScoreRecord candidate)
+        private static void UpdateBestPercentCache(
+            HashWrapper songChecksum,
+            PlayerScoreRecord candidate,
+            Guid? preferredEnginePresetId)
         {
             if (!PlayerHighPercentages.TryGetValue(songChecksum, out var current) ||
-                IsBetterPercentage(candidate, current))
+                IsBetterPercentage(candidate, current, preferredEnginePresetId))
             {
                 PlayerHighPercentages[songChecksum] = candidate;
             }
         }
 
-        private static bool IsBetterScore(PlayerScoreRecord candidate, PlayerScoreRecord current)
+        private static bool IsBetterScore(
+            PlayerScoreRecord candidate,
+            PlayerScoreRecord current,
+            Guid? preferredEnginePresetId)
         {
             if (current == null)
                 return true;
+
+            bool candidateUsesPreferredEngine = UsesPreferredEngine(
+                candidate.EnginePresetId, preferredEnginePresetId);
+            bool currentUsesPreferredEngine = UsesPreferredEngine(
+                current.EnginePresetId, preferredEnginePresetId);
+            if (candidateUsesPreferredEngine != currentUsesPreferredEngine)
+                return candidateUsesPreferredEngine;
 
             if (HighestDifficultyOnly && candidate.Difficulty != current.Difficulty)
                 return candidate.Difficulty > current.Difficulty;
@@ -462,10 +520,20 @@ namespace YARG.Scores
             return candidate.Score > current.Score;
         }
 
-        private static bool IsBetterPercentage(PlayerScoreRecord candidate, PlayerScoreRecord current)
+        private static bool IsBetterPercentage(
+            PlayerScoreRecord candidate,
+            PlayerScoreRecord current,
+            Guid? preferredEnginePresetId)
         {
             if (current == null)
                 return true;
+
+            bool candidateUsesPreferredEngine = UsesPreferredEngine(
+                candidate.EnginePresetId, preferredEnginePresetId);
+            bool currentUsesPreferredEngine = UsesPreferredEngine(
+                current.EnginePresetId, preferredEnginePresetId);
+            if (candidateUsesPreferredEngine != currentUsesPreferredEngine)
+                return candidateUsesPreferredEngine;
 
             if (HighestDifficultyOnly && candidate.Difficulty != current.Difficulty)
                 return candidate.Difficulty > current.Difficulty;
@@ -476,6 +544,20 @@ namespace YARG.Scores
                 return candidatePercent > currentPercent;
 
             return candidate.IsFc && !current.IsFc;
+        }
+
+        private static bool UsesPreferredEngine(Guid enginePresetId, Guid? preferredEnginePresetId)
+        {
+            if (!preferredEnginePresetId.HasValue)
+                return false;
+
+            if (preferredEnginePresetId.Value == Guid.Empty ||
+                preferredEnginePresetId.Value == EnginePreset.Default.Id)
+            {
+                return enginePresetId == Guid.Empty || enginePresetId == EnginePreset.Default.Id;
+            }
+
+            return enginePresetId == preferredEnginePresetId.Value;
         }
 
         private static string BuildInstrumentSetKey(IReadOnlyList<Instrument> instruments)
@@ -502,6 +584,7 @@ namespace YARG.Scores
             _currentPlayerId = Guid.Empty;
             _currentDifficulty = Difficulty.Easy;
             _currentHighScoreHistoryMode = default;
+            _currentPreferredEnginePresetId = null;
             _scoresWereFetched = false;
             _currentInstrumentSetKey = string.Empty;
             PlayerHighScores.Clear();
@@ -570,10 +653,10 @@ namespace YARG.Scores
                 List<PlayerScoreWithChecksum> records = profile.GameMode == GameMode.EliteDrums
                     ? _db.QueryPlayerBestStarsForInstruments(
                         profile, MidiDrumkitHelper.Instruments, SettingsManager.Settings.HighScoreHistory.Value,
-                        SongContainer.SongsByHash.Keys, SongContainer.LibraryRevision)
+                        SongContainer.SongsByHash.Keys, SongContainer.LibraryRevision, profile.EnginePreset)
                     : _db.QueryPlayerBestStars(
                         profile, SettingsManager.Settings.HighScoreHistory.Value, SongContainer.SongsByHash.Keys,
-                        SongContainer.LibraryRevision);
+                        SongContainer.LibraryRevision, profile.EnginePreset);
                 Dictionary<HashWrapper, StarAmount> result = new Dictionary<HashWrapper, StarAmount>();
 
                 foreach (PlayerScoreWithChecksum record in records)
@@ -607,18 +690,22 @@ namespace YARG.Scores
             HashWrapper songChecksum,
             Guid playerId,
             IReadOnlyList<Instrument> instruments,
-            bool allowCacheUpdate = true)
+            bool allowCacheUpdate = true,
+            Guid? preferredEnginePresetId = null)
         {
             return UseHighestScore
-                ? GetHighScoreForInstruments(songChecksum, playerId, instruments, allowCacheUpdate)
-                : GetBestPercentageScoreForInstruments(songChecksum, playerId, instruments, allowCacheUpdate);
+                ? GetHighScoreForInstruments(
+                    songChecksum, playerId, instruments, allowCacheUpdate, preferredEnginePresetId)
+                : GetBestPercentageScoreForInstruments(
+                    songChecksum, playerId, instruments, allowCacheUpdate, preferredEnginePresetId);
         }
 
         public static PlayerScoreRecord GetHighScoreForInstruments(
             HashWrapper songChecksum,
             Guid playerId,
             IReadOnlyList<Instrument> instruments,
-            bool allowCacheUpdate = true)
+            bool allowCacheUpdate = true,
+            Guid? preferredEnginePresetId = null)
         {
             if (instruments == null || instruments.Count == 0)
             {
@@ -627,15 +714,17 @@ namespace YARG.Scores
 
             if (instruments.Count == 1)
             {
-                return GetHighScore(songChecksum, playerId, instruments[0]);
+                return GetHighScore(
+                    songChecksum, playerId, instruments[0], allowCacheUpdate, preferredEnginePresetId);
             }
 
             if (allowCacheUpdate)
-                FetchHighScores(playerId, instruments);
+                FetchHighScores(playerId, instruments, preferredEnginePresetId);
 
             string instrumentKey = BuildInstrumentSetKey(instruments);
             if (_currentPlayerId == playerId &&
                 _currentInstrumentSetKey == instrumentKey &&
+                _currentPreferredEnginePresetId == preferredEnginePresetId &&
                 _scoresWereFetched)
             {
                 return PlayerHighScores.GetValueOrDefault(songChecksum);
@@ -643,7 +732,8 @@ namespace YARG.Scores
 
             try
             {
-                return _db.QueryPlayerSongHighScoreForInstruments(songChecksum, playerId, instruments, HighestDifficultyOnly);
+                return _db.QueryPlayerSongHighScoreForInstruments(
+                    songChecksum, playerId, instruments, HighestDifficultyOnly, preferredEnginePresetId);
             }
             catch (Exception e)
             {
@@ -656,7 +746,8 @@ namespace YARG.Scores
             HashWrapper songChecksum,
             Guid playerId,
             IReadOnlyList<Instrument> instruments,
-            bool allowCacheUpdate = true)
+            bool allowCacheUpdate = true,
+            Guid? preferredEnginePresetId = null)
         {
             if (instruments == null || instruments.Count == 0)
             {
@@ -665,15 +756,17 @@ namespace YARG.Scores
 
             if (instruments.Count == 1)
             {
-                return GetBestPercentageScore(songChecksum, playerId, instruments[0]);
+                return GetBestPercentageScore(
+                    songChecksum, playerId, instruments[0], allowCacheUpdate, preferredEnginePresetId);
             }
 
             if (allowCacheUpdate)
-                FetchHighScores(playerId, instruments);
+                FetchHighScores(playerId, instruments, preferredEnginePresetId);
 
             string instrumentKey = BuildInstrumentSetKey(instruments);
             if (_currentPlayerId == playerId &&
                 _currentInstrumentSetKey == instrumentKey &&
+                _currentPreferredEnginePresetId == preferredEnginePresetId &&
                 _scoresWereFetched)
             {
                 return PlayerHighPercentages.GetValueOrDefault(songChecksum);
@@ -681,7 +774,8 @@ namespace YARG.Scores
 
             try
             {
-                return _db.QueryPlayerSongHighestPercentageForInstruments(songChecksum, playerId, instruments, HighestDifficultyOnly);
+                return _db.QueryPlayerSongHighestPercentageForInstruments(
+                    songChecksum, playerId, instruments, HighestDifficultyOnly, preferredEnginePresetId);
             }
             catch (Exception e)
             {

--- a/Assets/Script/Scores/ScoreDatabase.cs
+++ b/Assets/Script/Scores/ScoreDatabase.cs
@@ -267,6 +267,29 @@ namespace YARG.Scores
             _currentLibraryHashRevision = libraryRevision;
         }
 
+        private static (string OrderBy, object[] Arguments) GetEnginePreferenceOrderBy(
+            string tableAlias,
+            Guid? preferredEnginePresetId)
+        {
+            if (!preferredEnginePresetId.HasValue)
+            {
+                return (string.Empty, Array.Empty<object>());
+            }
+
+            if (preferredEnginePresetId.Value == Guid.Empty ||
+                preferredEnginePresetId.Value == EnginePreset.Default.Id)
+            {
+                return (
+                    $"CASE WHEN {tableAlias}.EnginePresetId = ? OR {tableAlias}.EnginePresetId = ? " +
+                        $"OR {tableAlias}.EnginePresetId IS NULL THEN 0 ELSE 1 END, ",
+                    new object[] { EnginePreset.Default.Id, Guid.Empty });
+            }
+
+            return (
+                $"CASE WHEN {tableAlias}.EnginePresetId = ? THEN 0 ELSE 1 END, ",
+                new object[] { preferredEnginePresetId.Value });
+        }
+
         public List<GameRecord> QueryAllScores()
         {
             return Query<GameRecord>("SELECT * FROM GameRecords");
@@ -341,14 +364,18 @@ namespace YARG.Scores
             bool currentDifficultyOnly,
             Difficulty currentDifficulty,
             IEnumerable<HashWrapper> currentLibrarySongHashes,
-            int libraryRevision
+            int libraryRevision,
+            Guid? preferredEnginePresetId = null
         )
         {
             SetCurrentLibrarySongHashes(currentLibrarySongHashes, libraryRevision);
+            var enginePreference = GetEnginePreferenceOrderBy("ps", preferredEnginePresetId);
             string orderBy = highestDifficultyOnly
                 ? "ps.Difficulty DESC, ps.Score DESC"
                 : "ps.Score DESC";
             string difficultyFilter = currentDifficultyOnly ? " AND ps.Difficulty = ?" : "";
+
+            orderBy = enginePreference.OrderBy + orderBy;
 
             string query = $@"WITH RankedScores AS (
                     SELECT ps.*,
@@ -367,17 +394,17 @@ namespace YARG.Scores
                 )
                 SELECT * FROM RankedScores WHERE ScoreRank = 1";
 
-            var result = currentDifficultyOnly
-                ? Query<PlayerScoreRecord>(
-                    query,
-                    playerId,
-                    (int) instrument,
-                    (int) currentDifficulty)
-                : Query<PlayerScoreRecord>(
-                    query,
-                    playerId,
-                    (int) instrument);
-            return result;
+            var parameters = new List<object>(enginePreference.Arguments)
+            {
+                playerId,
+                (int) instrument
+            };
+            if (currentDifficultyOnly)
+            {
+                parameters.Add((int) currentDifficulty);
+            }
+
+            return Query<PlayerScoreRecord>(query, parameters.ToArray());
         }
 
         public List<PlayerScoreRecord> QueryPlayerHighestPercentages(
@@ -387,14 +414,18 @@ namespace YARG.Scores
             bool currentDifficultyOnly,
             Difficulty currentDifficulty,
             IEnumerable<HashWrapper> currentLibrarySongHashes,
-            int libraryRevision
+            int libraryRevision,
+            Guid? preferredEnginePresetId = null
         )
         {
             SetCurrentLibrarySongHashes(currentLibrarySongHashes, libraryRevision);
+            var enginePreference = GetEnginePreferenceOrderBy("ps", preferredEnginePresetId);
             string orderBy = highestDifficultyOnly
                 ? "ps.Difficulty DESC, ps.Percent DESC, ps.Score DESC, ps.IsFc DESC"
                 : "ps.Percent DESC, ps.Score DESC, ps.IsFc DESC";
             string difficultyFilter = currentDifficultyOnly ? " AND ps.Difficulty = ?" : "";
+
+            orderBy = enginePreference.OrderBy + orderBy;
 
             string query = $@"WITH RankedScores AS (
                     SELECT ps.*,
@@ -413,18 +444,17 @@ namespace YARG.Scores
                 )
                 SELECT * FROM RankedScores WHERE ScoreRank = 1";
 
-            var result = currentDifficultyOnly
-                ? Query<PlayerScoreRecord>(
-                    query,
-                    playerId,
-                    (int) instrument,
-                    (int) currentDifficulty)
-                : Query<PlayerScoreRecord>(
-                    query,
-                    playerId,
-                    (int) instrument);
+            var parameters = new List<object>(enginePreference.Arguments)
+            {
+                playerId,
+                (int) instrument
+            };
+            if (currentDifficultyOnly)
+            {
+                parameters.Add((int) currentDifficulty);
+            }
 
-            return result;
+            return Query<PlayerScoreRecord>(query, parameters.ToArray());
         }
 
         public PlayerScoreRecord QueryPlayerSongHighScore(
@@ -433,7 +463,8 @@ namespace YARG.Scores
             Instrument instrument,
             bool highestDifficultyOnly,
             bool currentDifficultyOnly,
-            Difficulty currentDifficulty
+            Difficulty currentDifficulty,
+            Guid? preferredEnginePresetId = null
         )
         {
             string query =
@@ -450,29 +481,31 @@ namespace YARG.Scores
                 query += " AND PlayerScores.Difficulty = ?";
             }
 
+            var enginePreference = GetEnginePreferenceOrderBy("PlayerScores", preferredEnginePresetId);
             if (highestDifficultyOnly)
             {
-                query += " ORDER BY PlayerScores.Difficulty DESC, PlayerScores.Score DESC";
+                query += $" ORDER BY {enginePreference.OrderBy}PlayerScores.Difficulty DESC, PlayerScores.Score DESC";
             }
             else
             {
-                query += " ORDER BY PlayerScores.Score DESC";
+                query += $" ORDER BY {enginePreference.OrderBy}PlayerScores.Score DESC";
             }
 
             query += " LIMIT 1";
 
-            return currentDifficultyOnly
-                ? FindWithQuery<PlayerScoreRecord>(
-                    query,
-                    songChecksum.HashBytes,
-                    playerId,
-                    (int) instrument,
-                    (int) currentDifficulty)
-                : FindWithQuery<PlayerScoreRecord>(
-                    query,
-                    songChecksum.HashBytes,
-                    playerId,
-                    (int) instrument);
+            var parameters = new List<object>
+            {
+                songChecksum.HashBytes,
+                playerId,
+                (int) instrument
+            };
+            if (currentDifficultyOnly)
+            {
+                parameters.Add((int) currentDifficulty);
+            }
+            parameters.AddRange(enginePreference.Arguments);
+
+            return FindWithQuery<PlayerScoreRecord>(query, parameters.ToArray());
         }
 
         public PlayerScoreRecord QueryPlayerSongHighestPercentage(
@@ -481,7 +514,8 @@ namespace YARG.Scores
             Instrument instrument,
             bool highestDifficultyOnly,
             bool currentDifficultyOnly,
-            Difficulty currentDifficulty
+            Difficulty currentDifficulty,
+            Guid? preferredEnginePresetId = null
         )
         {
             string query =
@@ -498,29 +532,31 @@ namespace YARG.Scores
                 query += " AND PlayerScores.Difficulty = ?";
             }
 
+            var enginePreference = GetEnginePreferenceOrderBy("PlayerScores", preferredEnginePresetId);
             if (highestDifficultyOnly)
             {
-                query += " ORDER BY PlayerScores.Difficulty DESC, PlayerScores.Percent DESC, PlayerScores.Score DESC, IsFc DESC";
+                query += $" ORDER BY {enginePreference.OrderBy}PlayerScores.Difficulty DESC, PlayerScores.Percent DESC, PlayerScores.Score DESC, IsFc DESC";
             }
             else
             {
-                query += " ORDER BY PlayerScores.Percent DESC, PlayerScores.Score DESC, IsFc DESC";
+                query += $" ORDER BY {enginePreference.OrderBy}PlayerScores.Percent DESC, PlayerScores.Score DESC, IsFc DESC";
             }
 
             query += " LIMIT 1";
 
-            return currentDifficultyOnly
-                ? FindWithQuery<PlayerScoreRecord>(
-                    query,
-                    songChecksum.HashBytes,
-                    playerId,
-                    (int) instrument,
-                    (int) currentDifficulty)
-                : FindWithQuery<PlayerScoreRecord>(
-                    query,
-                    songChecksum.HashBytes,
-                    playerId,
-                    (int) instrument);
+            var parameters = new List<object>
+            {
+                songChecksum.HashBytes,
+                playerId,
+                (int) instrument
+            };
+            if (currentDifficultyOnly)
+            {
+                parameters.Add((int) currentDifficulty);
+            }
+            parameters.AddRange(enginePreference.Arguments);
+
+            return FindWithQuery<PlayerScoreRecord>(query, parameters.ToArray());
         }
 
         public List<SongRecord> QueryMostPlayedSongs(int maxCount)
@@ -587,7 +623,8 @@ namespace YARG.Scores
             YargProfile profile,
             HighScoreHistoryMode mode,
             IEnumerable<HashWrapper> currentLibrarySongHashes,
-            int libraryRevision)
+            int libraryRevision,
+            Guid? preferredEnginePresetId = null)
         {
             SetCurrentLibrarySongHashes(currentLibrarySongHashes, libraryRevision);
 
@@ -596,6 +633,7 @@ namespace YARG.Scores
                 HighScoreHistoryMode.HighestScoreCurrentDifficulty;
 
             string difficultyFilter = currentDifficultyOnly ? " AND ps.Difficulty = ?" : "";
+            var enginePreference = GetEnginePreferenceOrderBy("ps", preferredEnginePresetId);
             string orderBy = mode switch
             {
                 HighScoreHistoryMode.HighestPercentageOverall =>
@@ -612,6 +650,8 @@ namespace YARG.Scores
                     "ps.Score DESC",
                 _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, null)
             };
+
+            orderBy = enginePreference.OrderBy + orderBy;
 
             string query = $@"WITH RankedScores AS (
                     SELECT ps.*, gr.SongChecksum,
@@ -630,17 +670,17 @@ namespace YARG.Scores
                 )
                 SELECT * FROM RankedScores WHERE ScoreRank = 1";
 
-            var result = currentDifficultyOnly
-                ? Query<PlayerScoreWithChecksum>(
-                    query,
-                    profile.Id,
-                    (int) profile.CurrentInstrument,
-                    (int) profile.CurrentDifficulty)
-                : Query<PlayerScoreWithChecksum>(
-                    query,
-                    profile.Id,
-                    (int) profile.CurrentInstrument);
-            return result;
+            var parameters = new List<object>(enginePreference.Arguments)
+            {
+                profile.Id,
+                (int) profile.CurrentInstrument
+            };
+            if (currentDifficultyOnly)
+            {
+                parameters.Add((int) profile.CurrentDifficulty);
+            }
+
+            return Query<PlayerScoreWithChecksum>(query, parameters.ToArray());
         }
 
         public List<PlayerScoreWithChecksum> QueryPlayerBestStarsForInstruments(
@@ -648,7 +688,8 @@ namespace YARG.Scores
             IReadOnlyList<Instrument> instruments,
             HighScoreHistoryMode mode,
             IEnumerable<HashWrapper> currentLibrarySongHashes,
-            int libraryRevision)
+            int libraryRevision,
+            Guid? preferredEnginePresetId = null)
         {
             SetCurrentLibrarySongHashes(currentLibrarySongHashes, libraryRevision);
 
@@ -658,6 +699,7 @@ namespace YARG.Scores
 
             string inClause = BuildInstrumentInClause(instruments);
             string difficultyFilter = currentDifficultyOnly ? " AND ps.Difficulty = ?" : "";
+            var enginePreference = GetEnginePreferenceOrderBy("ps", preferredEnginePresetId);
             string orderBy = mode switch
             {
                 HighScoreHistoryMode.HighestPercentageOverall =>
@@ -674,6 +716,8 @@ namespace YARG.Scores
                     "ps.Score DESC",
                 _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, null)
             };
+
+            orderBy = enginePreference.OrderBy + orderBy;
 
             string query = $@"WITH RankedScores AS (
                     SELECT ps.*, gr.SongChecksum,
@@ -692,7 +736,7 @@ namespace YARG.Scores
                 )
                 SELECT * FROM RankedScores WHERE ScoreRank = 1";
 
-            var parameters = new List<object> { profile.Id };
+            var parameters = new List<object>(enginePreference.Arguments) { profile.Id };
             parameters.AddRange(BuildInstrumentParams(instruments));
             if (currentDifficultyOnly)
             {
@@ -705,7 +749,8 @@ namespace YARG.Scores
             HashWrapper songChecksum,
             Guid playerId,
             IReadOnlyList<Instrument> instruments,
-            bool highestDifficultyOnly)
+            bool highestDifficultyOnly,
+            Guid? preferredEnginePresetId = null)
         {
             string inClause = BuildInstrumentInClause(instruments);
             string query =
@@ -717,19 +762,21 @@ namespace YARG.Scores
                     AND PlayerScores.Instrument {inClause}
                     AND PlayerScores.IsReplay = 0";
 
+            var enginePreference = GetEnginePreferenceOrderBy("PlayerScores", preferredEnginePresetId);
             if (highestDifficultyOnly)
             {
-                query += " ORDER BY PlayerScores.Difficulty DESC, PlayerScores.Score DESC";
+                query += $" ORDER BY {enginePreference.OrderBy}PlayerScores.Difficulty DESC, PlayerScores.Score DESC";
             }
             else
             {
-                query += " ORDER BY PlayerScores.Score DESC";
+                query += $" ORDER BY {enginePreference.OrderBy}PlayerScores.Score DESC";
             }
 
             query += " LIMIT 1";
 
             var parameters = new List<object> { songChecksum.HashBytes, playerId };
             parameters.AddRange(BuildInstrumentParams(instruments));
+            parameters.AddRange(enginePreference.Arguments);
 
             return FindWithQuery<PlayerScoreRecord>(query, parameters.ToArray());
         }
@@ -738,7 +785,8 @@ namespace YARG.Scores
             HashWrapper songChecksum,
             Guid playerId,
             IReadOnlyList<Instrument> instruments,
-            bool highestDifficultyOnly)
+            bool highestDifficultyOnly,
+            Guid? preferredEnginePresetId = null)
         {
             string inClause = BuildInstrumentInClause(instruments);
             string query =
@@ -750,19 +798,21 @@ namespace YARG.Scores
                     AND PlayerScores.Instrument {inClause}
                     AND PlayerScores.IsReplay = 0";
 
+            var enginePreference = GetEnginePreferenceOrderBy("PlayerScores", preferredEnginePresetId);
             if (highestDifficultyOnly)
             {
-                query += " ORDER BY PlayerScores.Difficulty DESC, PlayerScores.Percent DESC, IsFc DESC";
+                query += $" ORDER BY {enginePreference.OrderBy}PlayerScores.Difficulty DESC, PlayerScores.Percent DESC, IsFc DESC";
             }
             else
             {
-                query += " ORDER BY PlayerScores.Percent DESC, IsFc DESC";
+                query += $" ORDER BY {enginePreference.OrderBy}PlayerScores.Percent DESC, IsFc DESC";
             }
 
             query += " LIMIT 1";
 
             var parameters = new List<object> { songChecksum.HashBytes, playerId };
             parameters.AddRange(BuildInstrumentParams(instruments));
+            parameters.AddRange(enginePreference.Arguments);
 
             return FindWithQuery<PlayerScoreRecord>(query, parameters.ToArray());
         }

--- a/Assets/Script/Song/SongContainer.cs
+++ b/Assets/Script/Song/SongContainer.cs
@@ -117,6 +117,7 @@ namespace YARG.Song
         private static Guid _starsCacheProfileId = Guid.Empty;
         private static Instrument _starsCacheInstrument = Instrument.Band;
         private static Difficulty _starsCacheDifficulty = Difficulty.Easy;
+        private static Guid _starsCacheEnginePreset = Guid.Empty;
         private static HighScoreHistoryMode _starsCacheHighScoreHistoryMode;
         private static bool _starsCacheUsesBandScores;
         private static bool _starsCacheValid;
@@ -422,6 +423,7 @@ namespace YARG.Song
 
         public static void InvalidateStarsCache()
         {
+            _starsCacheEnginePreset = Guid.Empty;
             _starsCacheValid = false;
             _sortStars = Array.Empty<SongCategory>();
             _runtimeStars.Clear();
@@ -570,6 +572,7 @@ namespace YARG.Song
                 _starsCacheProfileId == profile.Id &&
                 _starsCacheInstrument == cacheInstrument &&
                 _starsCacheDifficulty == profile.CurrentDifficulty &&
+                _starsCacheEnginePreset == profile.EnginePreset &&
                 _starsCacheHighScoreHistoryMode == SettingsManager.Settings.HighScoreHistory.Value &&
                 _starsCacheUsesBandScores == useBandScores)
             {
@@ -642,6 +645,7 @@ namespace YARG.Song
             _starsCacheProfileId = profile.Id;
             _starsCacheInstrument = cacheInstrument;
             _starsCacheDifficulty = profile.CurrentDifficulty;
+            _starsCacheEnginePreset = profile.EnginePreset;
             _starsCacheHighScoreHistoryMode = SettingsManager.Settings.HighScoreHistory.Value;
             _starsCacheUsesBandScores = useBandScores;
             _starsCacheValid = true;


### PR DESCRIPTION
With this commit we now prefer scores from the active engine preset when querying high scores, percentages, and stars. 

This commit also adds a engine-colored ring around the music library difficulty badge.

In this screenshot we have custom engine, precision engine, and default engine:
<img width="314" height="315" alt="presets" src="https://github.com/user-attachments/assets/cb24349b-b328-413c-b308-f81d72509ea5" />