### PR TITLE
Fix Popup and Difficulty Menu Scrollbar State

### DIFF
--- a/Assets/Script/Menu/DifficultySelect/DifficultySelectMenu.cs
+++ b/Assets/Script/Menu/DifficultySelect/DifficultySelectMenu.cs
@@ -96,6 +96,7 @@ namespace YARG.Menu.DifficultySelect
 
         private YargPlayer CurrentPlayer => PlayerContainer.Players[_playerIndex];
 
+        private ScrollRect _scrollRect;
         private Scrollbar _scrollbar;
 
         private void OnEnable()
@@ -154,7 +155,7 @@ namespace YARG.Menu.DifficultySelect
             _sourceIcon.sprite = SongSources.SourceToIcon(GlobalVariables.State.CurrentSong.Source);
             _sourceIcon.gameObject.SetActive(_sourceIcon.sprite != null);
 
-
+            _scrollRect = GetComponentInChildren<ScrollRect>();
             _scrollbar = GetComponentInChildren<Scrollbar>();
             _navGroup.SelectionChanged += UpdateForSelectionChanged;
         }
@@ -162,27 +163,42 @@ namespace YARG.Menu.DifficultySelect
         private void UpdateForSelectionChanged(NavigatableBehaviour navigatableBehaviour,
             SelectionOrigin selectionOrigin)
         {
+            UpdateScrollbarForSelection();
+        }
+
+        private void UpdateScrollbarForSelection()
+        {
             if (!_scrollbar)
             {
                 return;
             }
 
             int? index = _navGroup.SelectedIndex;
-            if (index is { } i)
+            if (index is not { } i) return;
+
+            int count = _navGroup.Count;
+            if (count <= 0)
             {
-                int count = _navGroup.Count;
-                float highScrollBound = _scrollbar.size + (1 - _scrollbar.size) * _scrollbar.value;
-                float lowScrollBound = (1 - _scrollbar.size) * _scrollbar.value;
-                float indexHighBound = 1 - (1 / (float) count) * i;
-                float indexLowBound = 1 - (1 / (float) count) * (i + 1);
-                if (highScrollBound < indexHighBound)
-                {
-                    _scrollbar.value = (indexHighBound - _scrollbar.size) / (1 - _scrollbar.size);
-                }
-                else if (lowScrollBound > indexLowBound)
-                {
-                    _scrollbar.value = indexLowBound / (1 - _scrollbar.size);
-                }
+                return;
+            }
+
+            if (Mathf.Approximately(_scrollbar.size, 1f))
+            {
+                _scrollbar.value = 1f;
+                return;
+            }
+
+            float highScrollBound = _scrollbar.size + (1 - _scrollbar.size) * _scrollbar.value;
+            float lowScrollBound = (1 - _scrollbar.size) * _scrollbar.value;
+            float indexHighBound = 1 - (1 / (float) count) * i;
+            float indexLowBound = 1 - (1 / (float) count) * (i + 1);
+            if (highScrollBound < indexHighBound)
+            {
+                _scrollbar.value = (indexHighBound - _scrollbar.size) / (1 - _scrollbar.size);
+            }
+            else if (lowScrollBound > indexLowBound)
+            {
+                _scrollbar.value = indexLowBound / (1 - _scrollbar.size);
             }
         }
 
@@ -218,6 +234,27 @@ namespace YARG.Menu.DifficultySelect
             }
 
             _lastMenuState = _menuState;
+            RefreshScrollbar();
+        }
+
+        private void RefreshScrollbar()
+        {
+            if (_scrollRect == null)
+            {
+                UpdateScrollbarForSelection();
+                return;
+            }
+
+            Canvas.ForceUpdateCanvases();
+            _scrollRect.Rebuild(CanvasUpdate.PostLayout);
+
+            if (_scrollRect.ScrollableHeight() <= 0f)
+            {
+                _scrollRect.verticalNormalizedPosition = 1f;
+                return;
+            }
+
+            UpdateScrollbarForSelection();
         }
 
         private void CreateMainMenu()

--- a/Assets/Script/Menu/MusicLibrary/PopupMenu.cs
+++ b/Assets/Script/Menu/MusicLibrary/PopupMenu.cs
@@ -3,6 +3,7 @@ using Cysharp.Threading.Tasks;
 using TMPro;
 using UnityEngine;
 using UnityEngine.Events;
+using UnityEngine.UI;
 using YARG.Core;
 using YARG.Core.Extensions;
 using YARG.Core.Input;
@@ -44,7 +45,14 @@ namespace YARG.Menu.MusicLibrary
         [SerializeField]
         private NavigationGroup _navGroup;
 
+        private ScrollRect _scrollRect;
+
         private State _menuState;
+
+        private void Awake()
+        {
+            _scrollRect = _navGroup.GetComponent<ScrollRect>();
+        }
 
         private void OnEnable()
         {
@@ -81,7 +89,7 @@ namespace YARG.Menu.MusicLibrary
         {
             // Reset content
             _navGroup.ClearNavigatables();
-            _container.DestroyChildren();
+            ClearItems();
 
             // Create the menu
             switch (_menuState)
@@ -100,7 +108,33 @@ namespace YARG.Menu.MusicLibrary
                     break;
             }
 
+            ResetScroll();
             _navGroup.SelectFirst();
+        }
+
+        private void ResetScroll()
+        {
+            if (_scrollRect == null) return;
+
+            Canvas.ForceUpdateCanvases();
+
+            if (_container is RectTransform containerTransform)
+            {
+                LayoutRebuilder.ForceRebuildLayoutImmediate(containerTransform);
+                containerTransform.anchoredPosition = containerTransform.anchoredPosition.WithY(0f);
+            }
+
+            _scrollRect.verticalNormalizedPosition = 1f;
+        }
+
+        private void ClearItems()
+        {
+            for (int i = _container.childCount - 1; i >= 0; i--)
+            {
+                var child = _container.GetChild(i);
+                child.SetParent(null, false);
+                Destroy(child.gameObject);
+            }
         }
 
         private void CreateMainMenu()
@@ -393,7 +427,7 @@ namespace YARG.Menu.MusicLibrary
 
         private void CreateGoToSection()
         {
-            SetLocalizedHeader("GoTo");
+            SetLocalizedHeader("GoToSection");
 
             foreach (var (name, index) in _musicLibrary.Shortcuts)
             {
@@ -407,6 +441,8 @@ namespace YARG.Menu.MusicLibrary
 
         private void CreateAddToPlayList()
         {
+            SetLocalizedHeader("AddToPlaylist");
+
             // Get the list of playlists from PlaylistContainer and create items for each
             foreach (var playlist in PlaylistContainer.Playlists)
             {

--- a/Assets/Script/Menu/Navigation/ScrollViewNavigationUpdater.cs
+++ b/Assets/Script/Menu/Navigation/ScrollViewNavigationUpdater.cs
@@ -1,5 +1,6 @@
-﻿using UnityEngine;
+using UnityEngine;
 using UnityEngine.UI;
+using YARG.Helpers.Extensions;
 
 namespace YARG.Menu.Navigation
 {
@@ -11,13 +12,15 @@ namespace YARG.Menu.Navigation
 
         private NavigationGroup _navigationGroup;
         private ScrollRect _scrollRect;
-        private RectTransform _rectTransform;
+        private RectTransform _viewportTransform;
 
         private void Awake()
         {
             _navigationGroup = GetComponent<NavigationGroup>();
             _scrollRect = GetComponent<ScrollRect>();
-            _rectTransform = GetComponent<RectTransform>();
+            _viewportTransform = _scrollRect.viewport != null
+                ? _scrollRect.viewport
+                : GetComponent<RectTransform>();
 
             _navigationGroup.SelectionChanged += OnSelectionChanged;
         }
@@ -30,11 +33,34 @@ namespace YARG.Menu.Navigation
 
             Canvas.ForceUpdateCanvases();
 
-            var newPos =
-                _scrollRect.transform.InverseTransformPoint(_contentTransform.position).y -
-                _scrollRect.transform.InverseTransformPoint(selected.transform.position).y -
-                _rectTransform.rect.height / 2f;
+            if (_scrollRect.ScrollableHeight() <= 0f)
+            {
+                _scrollRect.verticalNormalizedPosition = 1f;
+                return;
+            }
 
+            var selectedTransform = selected.transform as RectTransform;
+            if (selectedTransform == null) return;
+
+            var viewportBounds = new Bounds(_viewportTransform.rect.center, _viewportTransform.rect.size);
+            var selectedBounds = RectTransformUtility.CalculateRelativeRectTransformBounds(
+                _viewportTransform, selectedTransform);
+
+            var newPos = _contentTransform.anchoredPosition.y;
+            if (selectedBounds.max.y > viewportBounds.max.y)
+            {
+                newPos -= selectedBounds.max.y - viewportBounds.max.y;
+            }
+            else if (selectedBounds.min.y < viewportBounds.min.y)
+            {
+                newPos += viewportBounds.min.y - selectedBounds.min.y;
+            }
+            else
+            {
+                return;
+            }
+
+            newPos = Mathf.Clamp(newPos, 0f, _scrollRect.ScrollableHeight());
             _contentTransform.anchoredPosition = _contentTransform.anchoredPosition.WithY(newPos);
         }
 

--- a/Assets/StreamingAssets/lang/en-US.json
+++ b/Assets/StreamingAssets/lang/en-US.json
@@ -321,8 +321,8 @@
             "Popup": {
                 "Header": {
                     "SortBy": "Sort By...",
-                    "GoTo": "Go To...",
-                    "SelectPlaylists": "Select Playlists"
+                    "GoToSection": "Go To Section...",
+                    "AddToPlaylist": "Add To Playlist..."
                 },
                 "Item": {
                     "RandomSong": "Random Song",


### PR DESCRIPTION
Fixes several scrollbar state issues in the Music Library popup menus and Difficulty Select menu.
- Keeps popup menu scrolling tied to the visible viewport instead of recentering on the selected option.
- Resets popup scroll position when rebuilding or reopening More Options submenus, preventing stale offsets from previous menu states.
- Refreshes Difficulty Select scrollbar after switching between option lists, so short lists show a full-height scrollbar again. _(i.e. going from main Difficulty Select to Modifiers and back to Difficulty)_

Verbiage changes:
- Adds an "Add To Playlist..." submenu header to match "Sort By..." and "Go To Section...".
- Changes the "Go To..." submenu header to "Go To Section..." for clearer context.  Verified it was only used here.

This fixes: https://discord.com/channels/1086048856678084609/1514618627008237599 and #803.