### PR TITLE
Reapply Active Filters when Opening Music Library

### DIFF
--- a/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
+++ b/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
@@ -160,6 +160,7 @@ namespace YARG.Menu.MusicLibrary
                 _currentSong = CurrentlyPlaying;
             }
 
+            FiltersMenu.RefreshActiveFilterPredicate();
             SetRefreshIfNeeded();
 
             StemSettings.ApplySettings = SettingsManager.Settings.ApplyVolumesInMusicLibrary.Value;

--- a/Assets/Script/Player/PlayerContainer.cs
+++ b/Assets/Script/Player/PlayerContainer.cs
@@ -188,7 +188,6 @@ namespace YARG.Player
                 MusicLibraryMenu.SetReload(MusicLibraryReloadState.Full);
             }
 
-            FiltersMenu.RefreshActiveFilterPredicate();
             MusicLibraryMenu.NeedsReload();
 
             StatsManager.Instance?.UpdateActivePlayers();


### PR DESCRIPTION
When profiles or instruments changed, Music Library could show songs that no longer matched the previous Filters menu state.  The Filters menu still showed the selections as active, but the library list was rebuilt without applying them.

Previously, active filters were refreshed from profile-change handling, which covered returning from Difficulty Select but missed other Music Library entry paths like Score Results.  This updates Music Library to rebuild the active filter predicate in `MusicLibraryMenu.OnEnable()` before refreshing the song list, so saved filters are consistently reapplied whenever the library opens.

This fixes: https://discord.com/channels/1086048856678084609/1514015970740666429

**Potential Feedback Item:**
I removed re-applying the filters from `PlayerContainer.ActiveProfilesChanged()` because I couldn't find a way to change profiles/instruments without then triggering `MusicLibraryMenu.OnEnable()` so it seemed redundant.  Let me know if I missed something.  Otherwise, this might still need to be added back with upcoming profile/controller "Overshell" changes.