### PR TITLE
Fix CharacterManager never getting initalised

### DIFF
--- a/Assets/Script/Gameplay/BackgroundManager.cs
+++ b/Assets/Script/Gameplay/BackgroundManager.cs
@@ -365,7 +365,7 @@ namespace YARG.Gameplay
             }
 
             // Initialize CharacterManager, if it exists
-            var characterManager = bgInstance.GetComponent<CharacterManager>();
+            var characterManager = bgInstance.GetComponentInChildren<CharacterManager>();
             if (characterManager != null)
             {
                 characterManager.Initialize();


### PR DESCRIPTION
Characters broke - at least in Axel's venues, the CharacterManager script is on Background > Stage > Band and so is not a component of the background itself