### PR TITLE
Fix bug where engine preset is not set correctly when switching game modes in the Profiles menu

### DIFF
--- a/Assets/Script/Menu/ProfileList/ProfileSidebar.cs
+++ b/Assets/Script/Menu/ProfileList/ProfileSidebar.cs
@@ -251,7 +251,7 @@ namespace YARG.Menu.ProfileList
             _rangeDisabledToggle.isOn = profile.RangeEnabled;
             _openLaneDisplayTypeDropdown.value = _openLaneDisplayTypesByIndex.IndexOf(profile.OpenLaneDisplayType);
             _useCymbalModelsToggle.isOn = profile.UseCymbalModels;
-            
+
             // Update preset dropdowns
             _engineDropdown.SetValueWithoutNotify(
                 _enginePresetsByIndex.IndexOf(profile.EnginePreset));
@@ -269,6 +269,12 @@ namespace YARG.Menu.ProfileList
                 _starPowerActivationTypesByIndex.IndexOf(profile.StarPowerActivationType));
             _rockMeterPresetDropdown.SetValueWithoutNotify(
                 _rockmeterPresetsByIndex.IndexOf(profile.RockMeterPreset));
+
+            // Not all game modes support all engine presets.
+            // If the current engine doesn't exist for the selected instrument, the above _engineDropdown
+            // will be silently set to index 0, but the engine itself will not have been set, so we need
+            // to explicitly set it.
+            ChangeEngine();
 
             // Show the proper name container (hide the editing version)
             _nameContainer.SetActive(true);


### PR DESCRIPTION
Fixes https://discord.com/channels/1086048856678084609/1524788078110179450

How to reproduce:
- Go to profiles menu
- Select game mode Guitar, set engine preset to Casual
- Switch game mode to Keys, engine preset display will say Default which implies to the user that the engine preset has been changed because Casual doesn't exist on Keys, but in reality the Casual engine will still be selected (can verify by switching back to Guitar)
- Play a song on Keys, score card will display Casual despite it not being a thing