### PR TITLE
Add Ctrl+L shortcut to focus music library search

### DIFF
--- a/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
+++ b/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using TMPro;
 using UnityEngine;
+using UnityEngine.InputSystem;
 using YARG.Core;
 using YARG.Core.Audio;
 using YARG.Core.Game;
@@ -740,6 +741,11 @@ namespace YARG.Menu.MusicLibrary
 
         protected void Update()
         {
+            if (Keyboard.current.ctrlKey.isPressed && Keyboard.current.kKey.wasPressedThisFrame)
+            {
+                CurrentSelection?.SecondaryTextClick();
+            }
+
             foreach (var heldInput in _heldInputs)
                 heldInput.Timer -= Time.unscaledDeltaTime;
 

--- a/Assets/Script/Menu/MusicLibrary/SongSearchingField.cs
+++ b/Assets/Script/Menu/MusicLibrary/SongSearchingField.cs
@@ -174,6 +174,11 @@ namespace YARG.Menu.MusicLibrary
 
         private void Update()
         {
+            if (Keyboard.current.ctrlKey.isPressed && Keyboard.current.lKey.wasPressedThisFrame)
+            {
+                Focus();
+            }
+
             if (Keyboard.current.escapeKey.wasPressedThisFrame)
             {
                 ClearFilterQueries();


### PR DESCRIPTION
Sometimes I have my wireless keyboard at hand, but not the mouse. With this commit, I can still easily use the song search.