### PR TITLE
dmx: Add configurable local sACN IP address

### DIFF
--- a/Assets/Prefabs/Menu/Settings/Visuals/IPv4Setting.prefab
+++ b/Assets/Prefabs/Menu/Settings/Visuals/IPv4Setting.prefab
@@ -165,17 +165,6 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 7665614177142481491, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
   m_PrefabInstance: {fileID: 6609846725191865157}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &4376046301004112940 stripped
-MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 7421987709479303017, guid: 8f25b12de267d7544aa2ff7993247fcd, type: 3}
-  m_PrefabInstance: {fileID: 6609846725191865157}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &8095148824242519626
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -288,6 +277,17 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 8331225728328382101, guid: 6f46741e648c07044852bd3391146600, type: 3}
   m_PrefabInstance: {fileID: 8095148824242519626}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &3424729177075475668 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 6904207334484646558, guid: 6f46741e648c07044852bd3391146600, type: 3}
+  m_PrefabInstance: {fileID: 8095148824242519626}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
 --- !u!1 &3786693973871400430 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 4961476867242781604, guid: 6f46741e648c07044852bd3391146600, type: 3}
@@ -310,7 +310,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a836d42a330f95f409ae40738d33f68c, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _settingLabel: {fileID: 4376046301004112940}
+  _settingLabel: {fileID: 3424729177075475668}
   _evenBackground: {fileID: 3786693973871400430}
   _advancedMarker: {fileID: 9042856458688905155}
   _inputField: {fileID: 1887982916101165759}

--- a/Assets/Script/Integration/Sacn/SacnHardware.cs
+++ b/Assets/Script/Integration/Sacn/SacnHardware.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Net;
 using Haukcode.sACN;
 using UnityEngine;
 using YARG.Core.Logging;
@@ -37,9 +38,12 @@ namespace YARG.Integration.Sacn
             {
                 if (_sendClient != null) return;
 
-                var IPAddress = SACNCommon.GetFirstBindAddress().IPAddress;
+                string configuredAddress = SettingsManager.Settings.DMXLocalIP.Value;
+                IPAddress ipAddress = string.IsNullOrEmpty(configuredAddress)
+                    ? SACNCommon.GetFirstBindAddress().IPAddress
+                    : IPAddress.Parse(configuredAddress);
 
-                if (IPAddress == null)
+                if (ipAddress == null)
                 {
                     if (!_toastShown)
                     {
@@ -56,7 +60,7 @@ namespace YARG.Integration.Sacn
                 SacnInterpreter.OnChannelSet += HandleChannelEvent;
 
                 _sendClient = new SACNClient(senderId: _acnSourceId, senderName: ACN_SOURCE_NAME,
-                    localAddress: IPAddress);
+                    localAddress: ipAddress);
 
                 _timer = 0f;
             }

--- a/Assets/Script/Menu/Settings/Visuals/IPv4SettingVisual.cs
+++ b/Assets/Script/Menu/Settings/Visuals/IPv4SettingVisual.cs
@@ -28,7 +28,11 @@ namespace YARG.Menu.Settings.Visuals
         {
             try
             {
-                if (IPAddress.TryParse(_inputField.text, out var ipAddress))
+                if (Setting.AllowEmpty && string.IsNullOrEmpty(_inputField.text))
+                {
+                    Setting.Value = string.Empty;
+                }
+                else if (IPAddress.TryParse(_inputField.text, out var ipAddress))
                 {
                     if (IPv4Setting.IsValidIPv4(ipAddress))
                     {

--- a/Assets/Script/Settings/SettingsManager.Settings.cs
+++ b/Assets/Script/Settings/SettingsManager.Settings.cs
@@ -630,6 +630,8 @@ namespace YARG.Settings
 
             public IntSetting DMXKeysChannel { get; } = new(32, 1, 512, v => SacnInterpreter.Instance.KeysChannel = v);
 
+            public IPv4Setting DMXLocalIP { get; } = new(defaultValue: string.Empty, allowEmpty: true);
+
             public IntSetting DMXUniverseChannel { get; } = new(1, 1, 65535);
 
             public IntSetting DMXTargetFPS { get; } = new(44, 10, 60);

--- a/Assets/Script/Settings/SettingsManager.cs
+++ b/Assets/Script/Settings/SettingsManager.cs
@@ -230,6 +230,7 @@ namespace YARG.Settings
                 nameof(Settings.DMXBassChannel),
                 nameof(Settings.DMXKeysChannel),
                 new HeaderMetadata("AdvancedDMXSettings"),
+                nameof(Settings.DMXLocalIP),
                 nameof(Settings.DMXUniverseChannel),
                 nameof(Settings.DMXDimmerValues),
                 nameof(Settings.DMXTargetFPS),

--- a/Assets/Script/Settings/Types/IPv4Setting.cs
+++ b/Assets/Script/Settings/Types/IPv4Setting.cs
@@ -8,17 +8,28 @@ namespace YARG.Settings.Types
     {
         public override string AddressableName => "Setting/IPv4";
 
-        public IPv4Setting(string value, Action<string> onChange = null) : base(onChange)
+        private readonly string _defaultValue;
+
+        public bool AllowEmpty { get; }
+
+        public IPv4Setting(string defaultValue, Action<string> onChange = null, bool allowEmpty = false) : base(onChange)
         {
-            _value = value;
+            _defaultValue = defaultValue;
+            AllowEmpty = allowEmpty;
+            _value = defaultValue;
         }
 
         protected override void SetValue(string value)
         {
+            if (AllowEmpty && string.IsNullOrEmpty(value))
+            {
+                _value = string.Empty;
+                return;
+            }
+
             if (!IsValidIPv4(value))
             {
-                // If it's invalid, just default to this
-                _value = "255.255.255.255";
+                _value = _defaultValue;
             }
             else
             {

--- a/Assets/StreamingAssets/lang/en-US.json
+++ b/Assets/StreamingAssets/lang/en-US.json
@@ -1744,6 +1744,10 @@
                 "Name": "DMX Broadcast Universe",
                 "Description": "This is the universe that YARG will send the sACN packet to. Default is \"1\". Maximum is \"65535\"."
             },
+            "DMXLocalIP": {
+                "Name": "sACN Local IP",
+                "Description": "The local IPv4 address used to send sACN packets. Leave blank to automatically select the first available Ethernet or Wi-Fi address."
+            },
             "ReconnectProfiles": {
                 "Name": "Reconnect Profiles",
                 "Description": "At startup, reconnect previously connected profiles."


### PR DESCRIPTION
The default behavior of automatic interface selection remains, but now you can override it if it didn't choose the correct network.