### PR TITLE
Support lanes on Medium, Easy, and Beginner

### DIFF
--- a/Assets/Art/Animations/Gameplay/SpBarIdle.anim
+++ b/Assets/Art/Animations/Gameplay/SpBarIdle.anim
@@ -1,4 +1,4 @@
-﻿%YAML 1.1
+%YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
 --- !u!74 &7400000
 AnimationClip:

--- a/Assets/Art/Animations/Gameplay/SpBarSustaining.anim
+++ b/Assets/Art/Animations/Gameplay/SpBarSustaining.anim
@@ -1,4 +1,4 @@
-﻿%YAML 1.1
+%YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
 --- !u!74 &7400000
 AnimationClip:

--- a/Assets/Script/Gameplay/Player/DrumsPlayer.cs
+++ b/Assets/Script/Gameplay/Player/DrumsPlayer.cs
@@ -40,7 +40,7 @@ namespace YARG.Gameplay.Player
         private bool _greenCymbalHasLane = false;
 
         public int NumberOfDedicatedKickLanes { get; private set; } = 0;
-
+        public int CenteredPosition => (LaneCount - 1) / 2;
 
         public float NoteScaleFactor = 1f;
         private float _baselineLaneCount => _fiveLaneMode ? 5f : 4f;
@@ -386,7 +386,20 @@ namespace YARG.Gameplay.Player
 
         protected override void InitializeSpawnedLane(LaneElement lane, DrumNote note)
         {
-            var highwayOrderingInfo = _highwayOrdering[note.Pad];
+            HighwayOrderingInfo highwayOrderingInfo;
+
+            if (_fiveLaneMode && note.Pad is (int)FiveLaneDrumPad.Wildcard)
+            {
+                highwayOrderingInfo = new(CenteredPosition, (int) FiveLaneDrumPad.Wildcard);
+            }
+            else if (!_fiveLaneMode && note.Pad is (int) FourLaneDrumPad.Wildcard)
+            {
+                highwayOrderingInfo = new(CenteredPosition, (int) FourLaneDrumPad.Wildcard);
+            }
+            else
+            {
+                highwayOrderingInfo = _highwayOrdering[note.Pad];
+            }
 
             var laneColor = (_fiveLaneMode ?
                 Player.ColorProfile.FiveLaneDrums.GetNoteColor(highwayOrderingInfo.ColorIndex) :
@@ -440,9 +453,12 @@ namespace YARG.Gameplay.Player
 
         protected override void ModifyLaneFromNote(LaneElement lane, DrumNote note)
         {
-            if (note.Pad == 0)
+            if (_fiveLaneMode ?
+                (note.Pad is (int)FiveLaneDrumPad.Kick or (int)FiveLaneDrumPad.Wildcard) :
+                (note.Pad is (int)FourLaneDrumPad.Kick or (int)FourLaneDrumPad.Wildcard)
+            )
             {
-                lane.ToggleOpen(true);
+                lane.ToggleFullWidth(true);
             }
             else
             {

--- a/Assets/Script/Gameplay/Player/FiveFretGuitarPlayer.cs
+++ b/Assets/Script/Gameplay/Player/FiveFretGuitarPlayer.cs
@@ -468,9 +468,9 @@ namespace YARG.Gameplay.Player
 
         protected override void ModifyLaneFromNote(LaneElement lane, GuitarNote note)
         {
-            if (note.Fret == (int) FiveFretGuitarFret.Open)
+            if (note.Fret is (int) FiveFretGuitarFret.Open or (int) FiveFretGuitarFret.Wildcard)
             {
-                lane.ToggleOpen(true);
+                lane.ToggleFullWidth(true);
             }
             else
             {

--- a/Assets/Script/Gameplay/Player/FiveLaneKeysPlayer.cs
+++ b/Assets/Script/Gameplay/Player/FiveLaneKeysPlayer.cs
@@ -479,9 +479,12 @@ public override bool ShouldUpdateInputsOnResume => true;
 
         protected override void ModifyLaneFromNote(LaneElement lane, GuitarNote note)
         {
-            if (note.Fret == (int) FiveFretGuitarFret.Open && !UsingOpenLane)
+            if (
+                (note.Fret is (int) FiveFretGuitarFret.Open && !UsingOpenLane) ||
+                (note.Fret is (int) FiveFretGuitarFret.Wildcard)
+            )
             {
-                lane.ToggleOpen(true);
+                lane.ToggleFullWidth(true);
             }
             else
             {

--- a/Assets/Script/Gameplay/Visuals/TrackElements/LaneElement.cs
+++ b/Assets/Script/Gameplay/Visuals/TrackElements/LaneElement.cs
@@ -18,7 +18,7 @@ namespace YARG.Gameplay.Visuals
         // Conversion rate from end cap bone movement units to 1 TrackElement.GetZPositionAtTime unit
         private const float LANE_LENGTH_RATIO = 0.02f;
 
-        private const float OPEN_LANE_SCALE = 0.5f;
+        private const float FULL_WIDTH_LANE_SCALE = 0.5f;
 
         private static readonly int EmissionColor = Shader.PropertyToID("_EmissionColor");
 
@@ -83,7 +83,7 @@ namespace YARG.Gameplay.Visuals
 
         private Color _color;
 
-        private bool _isOpen = false;
+        private bool _isFullWidth = false;
 
         public void SetAppearance(Instrument instrument, int index, float lateralPosition, int subdivisions, Color color)
         {
@@ -194,27 +194,27 @@ namespace YARG.Gameplay.Visuals
             }
         }
 
-        public void ToggleOpen(bool state)
+        public void ToggleFullWidth(bool state)
         {
-            if (state == _isOpen)
+            if (state == _isFullWidth)
             {
                 return;
             }
 
-            _isOpen = state;
+            _isFullWidth = state;
 
-            //_meshRenderer.sortingOrder += _isOpen ? -50 : 50;
-            _meshTransform.localPosition = _meshTransform.localPosition.WithY(_isOpen ? -0.01f : 0);
+            //_meshRenderer.sortingOrder += _isFullWidth ? -50 : 50;
+            _meshTransform.localPosition = _meshTransform.localPosition.WithY(_isFullWidth ? -0.01f : 0);
 
             if (Initialized)
             {
-                RenderOpen();
+                RenderFullWidth();
             }
         }
 
         protected override void InitializeElement()
         {
-            RenderOpen();
+            RenderFullWidth();
             RenderScale();
 
             // Set position
@@ -233,7 +233,7 @@ namespace YARG.Gameplay.Visuals
 
         protected override void HideElement()
         {
-            ToggleOpen(false);
+            ToggleFullWidth(false);
         }
 
         private void RenderLength()
@@ -250,16 +250,16 @@ namespace YARG.Gameplay.Visuals
             RenderLength();
         }
 
-        private void RenderOpen()
+        private void RenderFullWidth()
         {
             // This is the only shape key on the mesh, has an index of 0
-            _meshRenderer.SetBlendShapeWeight(0, _isOpen ? 100 : 0);
+            _meshRenderer.SetBlendShapeWeight(0, _isFullWidth ? 100 : 0);
 
-            if (_isOpen == true)
+            if (_isFullWidth == true)
             {
                 SetXPosition(0);
 
-                _scale = OPEN_LANE_SCALE;
+                _scale = FULL_WIDTH_LANE_SCALE;
 
                 if (Initialized)
                 {


### PR DESCRIPTION
[Corresponding YARG.Core PR](https://github.com/YARC-Official/YARG.Core/pull/413)

Previously, `.MID` only supported lanes on X and H (other than on PK). Non-PK lanes in `.MID` are X-only by default, and can be configured to XH by setting the lane marker's velocity in the range `[41,50]`. This behavior is inherited from RB3.

CH introduced an extension to this system, whereby the range `[31,40]` applies a lane to XHM and `[21,30]` applies it to XHME. In theory, introducing this without hiding it behind a text event feature flag could cause issues with legacy charts, but in practice this doesn't seem to have happened, so the cat's out of the bag as far as I'm concerned.

In addition to implementing those two new velocity ranges, this PR also implements wildcard lanes on Beginner. These were already theoretically possible due to `.CHART` supporting per-difficulty lanes on drums, but I considered them an incidental edge case and [previously introduced logic to strip them out of Beginner charts](https://github.com/YARC-Official/YARG.Core/pull/375). Now that we have more robust and intentional support for lanes on Easy across all parts and formats, I'd like to properly support Beginner lanes.

In gameplay, wildcard lanes act as you would expect - any input counts toward keeping the lane going, and it's completely impossible to overhit during them (and during the little proximity forgiveness windows, for that matter). On the parsing side, I introduced a little new logic to turn E trills into B tremolos, since B is all wildcards and a trill of all one note isn't valid.

Wildcard lanes use the default color profile value (a pale green). Could be cool to make them pulse in rainbow colors, but that would require a whole new shader and extra logic, which is beyond both my capabilities and what's worth doing for such a niche feature.

Architecturally, this isn't the cleanest thing I've ever written, so feel free to nitpick my encapsulation and inheritance. I've thoroughly tested all of the gameplay logic though, and everything seems to be in order.