### PR TITLE
Add the option to adjust the tint on the song progress overlay

### DIFF
--- a/Assets/Script/Gameplay/HUD/ScoreBox/ScoreBox.cs
+++ b/Assets/Script/Gameplay/HUD/ScoreBox/ScoreBox.cs
@@ -111,6 +111,7 @@ namespace YARG.Gameplay.HUD
             _displayedCountDownSeconds = -1;
 
             _songProgressBar.SetProgress(0f);
+            _overlayImage.color = SettingsManager.Settings.GraphicalSongProgressTint.Value;
         }
 
         protected override void OnChartLoaded(SongChart chart)

--- a/Assets/Script/Helpers/JsonUnityColorConverter.cs
+++ b/Assets/Script/Helpers/JsonUnityColorConverter.cs
@@ -1,0 +1,22 @@
+using System;
+using Newtonsoft.Json;
+using UnityEngine;
+using YARG.Helpers.Extensions;
+
+namespace YARG.Helpers
+{
+    public class JsonUnityColorConverter : JsonConverter<Color>
+    {
+        public override void WriteJson(JsonWriter writer, Color value, JsonSerializer serializer)
+        {
+            serializer.Serialize(writer, value.ToSystemColor());
+        }
+
+        public override Color ReadJson(JsonReader reader, Type objectType, Color existingValue,
+            bool hasExistingValue, JsonSerializer serializer)
+        {
+            var systemColor = serializer.Deserialize<System.Drawing.Color>(reader);
+            return systemColor.ToUnityColor();
+        }
+    }
+}

--- a/Assets/Script/Helpers/JsonUnityColorConverter.cs.meta
+++ b/Assets/Script/Helpers/JsonUnityColorConverter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c5d2d9d306d8a1ca093f9b5d065af55d

--- a/Assets/Script/Settings/SettingsManager.Settings.cs
+++ b/Assets/Script/Settings/SettingsManager.Settings.cs
@@ -456,6 +456,9 @@ namespace YARG.Settings
 
             public ToggleSetting GraphicalProgressOnScoreBox { get; } = new(true);
 
+            public ColorSetting GraphicalSongProgressTint { get; }
+                = new ColorSetting(Color.white, false);
+
             public ToggleSetting KeepSongInfoVisible { get; } = new(false);
 
             #endregion

--- a/Assets/Script/Settings/SettingsManager.cs
+++ b/Assets/Script/Settings/SettingsManager.cs
@@ -174,6 +174,7 @@ namespace YARG.Settings
                 nameof(Settings.LyricDisplay),
                 nameof(Settings.SongTimeOnScoreBox),
                 nameof(Settings.GraphicalProgressOnScoreBox),
+                nameof(Settings.GraphicalSongProgressTint),
                 nameof(Settings.KeepSongInfoVisible),
             },
             new PresetsTab("Presets", icon: "Customization"),

--- a/Assets/Script/Settings/SettingsManager.cs
+++ b/Assets/Script/Settings/SettingsManager.cs
@@ -19,6 +19,7 @@ namespace YARG.Settings
             Formatting = Formatting.Indented,
             Converters = new List<JsonConverter>
             {
+                new JsonUnityColorConverter(),
                 new JsonColorConverter(),
                 new JsonVector2Converter()
             }

--- a/Assets/StreamingAssets/lang/en-US.json
+++ b/Assets/StreamingAssets/lang/en-US.json
@@ -1216,6 +1216,10 @@
                 "Name": "Graphical Progress On Score Box",
                 "Description": "Enables and disables the graphical blue outline on the score box that displays the song's progress."
             },
+            "GraphicalSongProgressTint": {
+                "Name": "Graphical Progress Tint",
+                "Description": "Adjust the tint on the song progress, if enabled."
+            },
             "GuitarVolume": {
                 "Name": "Guitar Volume",
                 "PauseName": "Guitar",


### PR DESCRIPTION
Added a color-selection option to add a tint to the song progress overlay around the score counter.

I am colorblind and have had difficulty seeing this at a glance with the default blue. This just allows a player to customize to something with higher contrast. 