### PR TITLE
Add Current Difficulty Score Display Options and Sync Star Sorting

### DIFF
--- a/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
+++ b/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
@@ -261,13 +261,20 @@ namespace YARG.Menu.MusicLibrary
             }
             Instrument currentInstrument = profile?.CurrentInstrument ?? Instrument.FiveFretGuitar;
             Difficulty currentDifficulty = profile?.CurrentDifficulty ?? Difficulty.Expert;
-            if (_needsReload ||
+            bool profileSortContextChanged =
                 currentInstrument != _lastInstrument ||
-                currentDifficulty != _lastDifficulty)
+                currentDifficulty != _lastDifficulty;
+
+            if (_needsReload || profileSortContextChanged)
             {
                 _lastInstrument = currentInstrument;
                 _lastDifficulty = currentDifficulty;
                 _needsReload = false;
+
+                if (profileSortContextChanged && SettingsManager.Settings.LibrarySort == SortAttribute.Stars)
+                {
+                    _searchField.Reset();
+                }
 
                 if (_reloadState != MusicLibraryReloadState.Full)
                 {

--- a/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
+++ b/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
@@ -115,6 +115,9 @@ namespace YARG.Menu.MusicLibrary
 
         private static Instrument _lastInstrument;
         private static Difficulty _lastDifficulty;
+        private static Guid _lastProfileId;
+        private static int _lastHumanPlayerCount;
+        private static HighScoreHistoryMode _lastHighScoreHistoryMode;
 
         private static bool _needsReload = false;
         private bool _needsNavigationSchemeRefresh = false;
@@ -261,17 +264,26 @@ namespace YARG.Menu.MusicLibrary
             }
             Instrument currentInstrument = profile?.CurrentInstrument ?? Instrument.FiveFretGuitar;
             Difficulty currentDifficulty = profile?.CurrentDifficulty ?? Difficulty.Expert;
-            bool profileSortContextChanged =
+            Guid currentProfileId = profile?.Id ?? Guid.Empty;
+            int currentHumanPlayerCount = PlayerContainer.Players.Count(player => !player.Profile.IsBot);
+            HighScoreHistoryMode currentHighScoreHistoryMode = SettingsManager.Settings.HighScoreHistory.Value;
+            bool scoreSortContextChanged =
+                currentProfileId != _lastProfileId ||
+                currentHumanPlayerCount != _lastHumanPlayerCount ||
                 currentInstrument != _lastInstrument ||
-                currentDifficulty != _lastDifficulty;
+                currentDifficulty != _lastDifficulty ||
+                currentHighScoreHistoryMode != _lastHighScoreHistoryMode;
 
-            if (_needsReload || profileSortContextChanged)
+            if (_needsReload || scoreSortContextChanged)
             {
+                _lastProfileId = currentProfileId;
+                _lastHumanPlayerCount = currentHumanPlayerCount;
                 _lastInstrument = currentInstrument;
                 _lastDifficulty = currentDifficulty;
+                _lastHighScoreHistoryMode = currentHighScoreHistoryMode;
                 _needsReload = false;
 
-                if (profileSortContextChanged && SettingsManager.Settings.LibrarySort == SortAttribute.Stars)
+                if (scoreSortContextChanged && SettingsManager.Settings.LibrarySort == SortAttribute.Stars)
                 {
                     _searchField.Reset();
                 }
@@ -1277,11 +1289,13 @@ namespace YARG.Menu.MusicLibrary
         private void OnPlayerAdded(YargPlayer player)
         {
             _noPlayerWarning.SetActive(PlayerContainer.Players.Count <= 0);
+            _needsReload = true;
         }
 
         private void OnPlayerRemoved(YargPlayer player)
         {
             _noPlayerWarning.SetActive(PlayerContainer.Players.Count <= 0);
+            _needsReload = true;
         }
 
         public static void ResetMainLibraryIndex()

--- a/Assets/Script/Menu/MusicLibrary/ViewTypes/SongViewType.cs
+++ b/Assets/Script/Menu/MusicLibrary/ViewTypes/SongViewType.cs
@@ -1,11 +1,14 @@
+using System;
 using System.Linq;
 using Cysharp.Text;
 using UnityEngine;
+using YARG.Core;
 using YARG.Core.Game;
 using YARG.Core.Song;
 using YARG.Player;
 using YARG.Playlists;
 using YARG.Scores;
+using YARG.Settings;
 using YARG.Song;
 
 namespace YARG.Menu.MusicLibrary
@@ -34,6 +37,11 @@ namespace YARG.Menu.MusicLibrary
         private bool _fetchedScores;
         private PlayerScoreRecord _playerScoreRecord;
         private GameRecord _bandScoreRecord;
+        private int _fetchedHumanCount;
+        private Guid _fetchedPlayerId;
+        private Instrument _fetchedInstrument;
+        private Difficulty _fetchedDifficulty;
+        private HighScoreHistoryMode _fetchedHighScoreHistoryMode;
 
         public SongViewType(MusicLibraryMenu musicLibrary, SongEntry songEntry, string context = "library")
         {
@@ -211,30 +219,63 @@ namespace YARG.Menu.MusicLibrary
 
         private void FetchHighScores()
         {
-            if (_fetchedScores)
+            var context = GetCurrentScoreContext();
+            if (_fetchedScores &&
+                _fetchedHumanCount == context.HumanCount &&
+                _fetchedPlayerId == context.PlayerId &&
+                _fetchedInstrument == context.Instrument &&
+                _fetchedDifficulty == context.Difficulty &&
+                _fetchedHighScoreHistoryMode == context.HighScoreHistoryMode)
             {
                 return;
             }
 
             FetchHighScores(SongEntry, out _playerScoreRecord, out _bandScoreRecord);
+            _fetchedHumanCount = context.HumanCount;
+            _fetchedPlayerId = context.PlayerId;
+            _fetchedInstrument = context.Instrument;
+            _fetchedDifficulty = context.Difficulty;
+            _fetchedHighScoreHistoryMode = context.HighScoreHistoryMode;
             _fetchedScores = true;
+        }
+
+        private static ScoreContext GetCurrentScoreContext()
+        {
+            var player = PlayerContainer.Players.FirstOrDefault(e => !e.Profile.IsBot);
+            return new ScoreContext(
+                PlayerContainer.Players.Count(p => !p.Profile.IsBot),
+                player?.Profile.Id ?? Guid.Empty,
+                player?.Profile.CurrentInstrument ?? Instrument.Band,
+                player?.Profile.CurrentDifficulty ?? Difficulty.Easy,
+                SettingsManager.Settings.HighScoreHistory.Value);
         }
 
         private static void FetchHighScores(SongEntry songEntry, out PlayerScoreRecord playerScoreRecord, out GameRecord bandScoreRecord)
         {
-            playerScoreRecord = null;
-            bandScoreRecord = null;
+            ScoreContainer.GetPreferredHighScoresForCurrentPlayers(
+                songEntry.Hash, out playerScoreRecord, out bandScoreRecord);
+        }
 
-            var humanCount = PlayerContainer.Players.Count(p => !p.Profile.IsBot);
-            if (humanCount == 1)
+        private readonly struct ScoreContext
+        {
+            public readonly int HumanCount;
+            public readonly Guid PlayerId;
+            public readonly Instrument Instrument;
+            public readonly Difficulty Difficulty;
+            public readonly HighScoreHistoryMode HighScoreHistoryMode;
+
+            public ScoreContext(
+                int humanCount,
+                Guid playerId,
+                Instrument instrument,
+                Difficulty difficulty,
+                HighScoreHistoryMode highScoreHistoryMode)
             {
-                var player = PlayerContainer.Players.First(e => !e.Profile.IsBot);
-                playerScoreRecord = ScoreContainer.GetPreferredHighScore(
-                    songEntry.Hash, player.Profile.Id, player.Profile.CurrentInstrument);
-            }
-            else
-            {
-                bandScoreRecord = ScoreContainer.GetBandHighScore(songEntry.Hash);
+                HumanCount = humanCount;
+                PlayerId = playerId;
+                Instrument = instrument;
+                Difficulty = difficulty;
+                HighScoreHistoryMode = highScoreHistoryMode;
             }
         }
     }

--- a/Assets/Script/Scores/ScoreContainer.cs
+++ b/Assets/Script/Scores/ScoreContainer.cs
@@ -18,8 +18,10 @@ namespace YARG.Scores
     {
         HighestPercentageOverall = 0,
         HighestPercentageDifficulty = 1,
-        HighestScoreOverall = 2,
-        HighestScoreDifficulty = 3,
+        HighestPercentageCurrentDifficulty = 2,
+        HighestScoreOverall = 3,
+        HighestScoreDifficulty = 4,
+        HighestScoreCurrentDifficulty = 5,
     }
 
     public static partial class ScoreContainer
@@ -37,6 +39,8 @@ namespace YARG.Scores
 
         private static Instrument _currentInstrument = Instrument.Band;
         private static Guid       _currentPlayerId;
+        private static Difficulty _currentDifficulty = Difficulty.Easy;
+        private static HighScoreHistoryMode _currentHighScoreHistoryMode;
         private static bool       _scoresWereFetched;
 
         private static bool HighestDifficultyOnly
@@ -44,10 +48,16 @@ namespace YARG.Scores
                 HighScoreHistoryMode.HighestPercentageDifficulty or
                 HighScoreHistoryMode.HighestScoreDifficulty;
 
+        private static bool CurrentDifficultyOnly
+            => SettingsManager.Settings.HighScoreHistory.Value is
+                HighScoreHistoryMode.HighestPercentageCurrentDifficulty or
+                HighScoreHistoryMode.HighestScoreCurrentDifficulty;
+
         private static bool UseHighestScore
             => SettingsManager.Settings.HighScoreHistory.Value is
                 HighScoreHistoryMode.HighestScoreOverall or
-                HighScoreHistoryMode.HighestScoreDifficulty;
+                HighScoreHistoryMode.HighestScoreDifficulty or
+                HighScoreHistoryMode.HighestScoreCurrentDifficulty;
 
         private static bool AllowScoresWithBots => SettingsManager.Settings.SaveScoresWithBots.Value;
 
@@ -177,9 +187,9 @@ namespace YARG.Scores
         private static void UpdatePlayerHighScores(HashWrapper songChecksum, PlayerScoreRecord newScore)
         {
             PlayerHighScores[songChecksum] = _db.QueryPlayerSongHighScore(
-                songChecksum, newScore.PlayerId, newScore.Instrument, HighestDifficultyOnly);
+                songChecksum, newScore.PlayerId, newScore.Instrument, HighestDifficultyOnly, CurrentDifficultyOnly, newScore.Difficulty);
             PlayerHighPercentages[songChecksum] = _db.QueryPlayerSongHighestPercentage(
-                songChecksum, newScore.PlayerId, newScore.Instrument, HighestDifficultyOnly);
+                songChecksum, newScore.PlayerId, newScore.Instrument, HighestDifficultyOnly, CurrentDifficultyOnly, newScore.Difficulty);
         }
 
         public static void RecordPlayerInfo(Guid id, string name)
@@ -266,11 +276,35 @@ namespace YARG.Scores
                 : GetBestPercentageScore(songChecksum, playerId, instrument, allowCacheUpdate);
         }
 
+        public static bool UseBandHighScoresForCurrentPlayers
+            => PlayerContainer.Players.Count(player => !player.Profile.IsBot) != 1;
+
+        public static void GetPreferredHighScoresForCurrentPlayers(
+            HashWrapper songChecksum,
+            out PlayerScoreRecord playerScoreRecord,
+            out GameRecord bandScoreRecord)
+        {
+            playerScoreRecord = null;
+            bandScoreRecord = null;
+
+            if (UseBandHighScoresForCurrentPlayers)
+            {
+                bandScoreRecord = GetBandHighScore(songChecksum);
+                return;
+            }
+
+            var player = PlayerContainer.Players.First(entry => !entry.Profile.IsBot);
+            playerScoreRecord = GetPreferredHighScore(
+                songChecksum, player.Profile.Id, player.Profile.CurrentInstrument);
+        }
+
         private static PlayerScoreRecord GetHighScoreFromDatabase(HashWrapper songChecksum, Guid playerId, Instrument instrument)
         {
             try
             {
-                return _db.QueryPlayerSongHighScore(songChecksum, playerId, instrument, HighestDifficultyOnly);
+                return _db.QueryPlayerSongHighScore(
+                    songChecksum, playerId, instrument, HighestDifficultyOnly, CurrentDifficultyOnly,
+                    PlayerContainer.GetProfileById(playerId).CurrentDifficulty);
             }
             catch (Exception e)
             {
@@ -309,7 +343,9 @@ namespace YARG.Scores
         {
             try
             {
-                return _db.QueryPlayerSongHighestPercentage(songChecksum, playerId, instrument, HighestDifficultyOnly);
+                return _db.QueryPlayerSongHighestPercentage(
+                    songChecksum, playerId, instrument, HighestDifficultyOnly, CurrentDifficultyOnly,
+                    PlayerContainer.GetProfileById(playerId).CurrentDifficulty);
             }
             catch (Exception e)
             {
@@ -320,7 +356,15 @@ namespace YARG.Scores
 
         private static void FetchHighScores(Guid playerId, Instrument instrument)
         {
-            if (_currentPlayerId == playerId && _currentInstrument == instrument && _scoresWereFetched)
+            var profile = PlayerContainer.GetProfileById(playerId);
+            var currentDifficulty = profile?.CurrentDifficulty ?? Difficulty.Expert;
+            var currentHighScoreHistoryMode = SettingsManager.Settings.HighScoreHistory.Value;
+
+            if (_currentPlayerId == playerId &&
+                _currentInstrument == instrument &&
+                _currentDifficulty == currentDifficulty &&
+                _currentHighScoreHistoryMode == currentHighScoreHistoryMode &&
+                _scoresWereFetched)
             {
                 // Already cached. No need to fetch again from the database.
                 return;
@@ -333,7 +377,8 @@ namespace YARG.Scores
 
                 var checksums = _db.QuerySongChecksums();
 
-                var highScores = _db.QueryPlayerHighScores(playerId, instrument, HighestDifficultyOnly);
+                var highScores = _db.QueryPlayerHighScores(
+                    playerId, instrument, HighestDifficultyOnly, CurrentDifficultyOnly, currentDifficulty);
                 foreach (var score in highScores)
                 {
                     var (_, checksum) = checksums.FirstOrDefault(x => x.RecordId == score.GameRecordId);
@@ -345,7 +390,8 @@ namespace YARG.Scores
                     PlayerHighScores.Add(HashWrapper.Create(checksum), score);
                 }
 
-                var highPercentages = _db.QueryPlayerHighestPercentages(playerId, instrument, HighestDifficultyOnly);
+                var highPercentages = _db.QueryPlayerHighestPercentages(
+                    playerId, instrument, HighestDifficultyOnly, CurrentDifficultyOnly, currentDifficulty);
                 foreach (var score in highPercentages)
                 {
                     var (_, checksum) = checksums.FirstOrDefault(x => x.RecordId == score.GameRecordId);
@@ -359,6 +405,8 @@ namespace YARG.Scores
 
                 _currentInstrument = instrument;
                 _currentPlayerId = playerId;
+                _currentDifficulty = currentDifficulty;
+                _currentHighScoreHistoryMode = currentHighScoreHistoryMode;
                 _scoresWereFetched = true;
             }
             catch (Exception e)
@@ -371,6 +419,8 @@ namespace YARG.Scores
         {
             _currentPlayerId = Guid.Empty;
             _currentInstrument = Instrument.Band;
+            _currentDifficulty = Difficulty.Easy;
+            _currentHighScoreHistoryMode = default;
             _scoresWereFetched = false;
         }
 
@@ -433,7 +483,8 @@ namespace YARG.Scores
         {
             try
             {
-                List<PlayerScoreWithChecksum> records = _db.QueryPlayerBestStars(profile, false);
+                List<PlayerScoreWithChecksum> records = _db.QueryPlayerBestStars(
+                    profile, SettingsManager.Settings.HighScoreHistory.Value);
                 Dictionary<HashWrapper, StarAmount> result = new Dictionary<HashWrapper, StarAmount>();
 
                 foreach (PlayerScoreWithChecksum record in records)
@@ -449,6 +500,18 @@ namespace YARG.Scores
                 YargLogger.LogException(e, "Failed to fetch best star value from database.");
             }
             return new Dictionary<HashWrapper, StarAmount>();
+        }
+
+        public static Dictionary<HashWrapper, StarAmount> GetBestStarsForCurrentPlayers(YargProfile profile)
+        {
+            if (!UseBandHighScoresForCurrentPlayers)
+            {
+                return GetBestStarsForSong(profile);
+            }
+
+            return BandHighScores.ToDictionary(
+                record => record.Key,
+                record => record.Value.BandStars);
         }
     }
 }

--- a/Assets/Script/Scores/ScoreDatabase.cs
+++ b/Assets/Script/Scores/ScoreDatabase.cs
@@ -276,18 +276,23 @@ namespace YARG.Scores
         public List<PlayerScoreRecord> QueryPlayerHighScores(
             Guid playerId,
             Instrument instrument,
-            bool highestDifficultyOnly
+            bool highestDifficultyOnly,
+            bool currentDifficultyOnly,
+            Difficulty currentDifficulty
         )
         {
             string orderBy = highestDifficultyOnly
                 ? "ps2.Difficulty DESC, ps2.Score DESC"
                 : "ps2.Score DESC";
+            string difficultyFilter = currentDifficultyOnly ? " AND ps.Difficulty = ?" : "";
+            string subDifficultyFilter = currentDifficultyOnly ? " AND ps2.Difficulty = ps.Difficulty" : "";
 
             string query = $@"SELECT ps.* FROM PlayerScores ps
                 INNER JOIN GameRecords gr
                     ON ps.GameRecordId = gr.Id
                 WHERE ps.PlayerId = ?
                     AND ps.Instrument = ?
+                    {difficultyFilter}
                     AND ps.IsReplay = 0
                     AND ps.Id = (
                         SELECT ps2.Id FROM PlayerScores ps2
@@ -295,34 +300,45 @@ namespace YARG.Scores
                                 ON ps2.GameRecordId = gr2.Id
                         WHERE ps2.PlayerId = ps.PlayerId
                             AND ps2.Instrument = ps.Instrument
+                            {subDifficultyFilter}
                             AND ps2.IsReplay = 0
                             AND gr2.SongChecksum = gr.SongChecksum
                         ORDER BY {orderBy}
                         LIMIT 1
                     )";
 
-            return Query<PlayerScoreRecord>(
-                query,
-                playerId,
-                (int) instrument
-            );
+            return currentDifficultyOnly
+                ? Query<PlayerScoreRecord>(
+                    query,
+                    playerId,
+                    (int) instrument,
+                    (int) currentDifficulty)
+                : Query<PlayerScoreRecord>(
+                    query,
+                    playerId,
+                    (int) instrument);
         }
 
         public List<PlayerScoreRecord> QueryPlayerHighestPercentages(
             Guid playerId,
             Instrument instrument,
-            bool highestDifficultyOnly
+            bool highestDifficultyOnly,
+            bool currentDifficultyOnly,
+            Difficulty currentDifficulty
         )
         {
             string orderBy = highestDifficultyOnly
                 ? "ps2.Difficulty DESC, ps2.Percent DESC, ps2.IsFc DESC"
                 : "ps2.Percent DESC, ps2.IsFc DESC";
+            string difficultyFilter = currentDifficultyOnly ? " AND ps.Difficulty = ?" : "";
+            string subDifficultyFilter = currentDifficultyOnly ? " AND ps2.Difficulty = ps.Difficulty" : "";
 
             string query = $@"SELECT ps.* FROM PlayerScores ps
                 INNER JOIN GameRecords gr
                     ON ps.GameRecordId = gr.Id
                 WHERE ps.PlayerId = ?
                     AND ps.Instrument = ?
+                    {difficultyFilter}
                     AND ps.IsReplay = 0
                     AND ps.Id = (
                         SELECT ps2.Id FROM PlayerScores ps2
@@ -330,17 +346,23 @@ namespace YARG.Scores
                                 ON ps2.GameRecordId = gr2.Id
                         WHERE ps2.PlayerId = ps.PlayerId
                             AND ps2.Instrument = ps.Instrument
+                            {subDifficultyFilter}
                             AND ps2.IsReplay = 0
                             AND gr2.SongChecksum = gr.SongChecksum
                         ORDER BY {orderBy}
                         LIMIT 1
                     )";
 
-            var result = Query<PlayerScoreRecord>(
-                query,
-                playerId,
-                (int) instrument
-            );
+            var result = currentDifficultyOnly
+                ? Query<PlayerScoreRecord>(
+                    query,
+                    playerId,
+                    (int) instrument,
+                    (int) currentDifficulty)
+                : Query<PlayerScoreRecord>(
+                    query,
+                    playerId,
+                    (int) instrument);
             return result;
         }
 
@@ -348,7 +370,9 @@ namespace YARG.Scores
             HashWrapper songChecksum,
             Guid playerId,
             Instrument instrument,
-            bool highestDifficultyOnly
+            bool highestDifficultyOnly,
+            bool currentDifficultyOnly,
+            Difficulty currentDifficulty
         )
         {
             string query =
@@ -359,6 +383,11 @@ namespace YARG.Scores
                     AND PlayerScores.PlayerId = ?
                     AND PlayerScores.Instrument = ?
                     AND PlayerScores.IsReplay = 0";
+
+            if (currentDifficultyOnly)
+            {
+                query += " AND PlayerScores.Difficulty = ?";
+            }
 
             if (highestDifficultyOnly)
             {
@@ -371,19 +400,27 @@ namespace YARG.Scores
 
             query += " LIMIT 1";
 
-            return FindWithQuery<PlayerScoreRecord>(
-                query,
-                songChecksum.HashBytes,
-                playerId,
-                (int) instrument
-            );
+            return currentDifficultyOnly
+                ? FindWithQuery<PlayerScoreRecord>(
+                    query,
+                    songChecksum.HashBytes,
+                    playerId,
+                    (int) instrument,
+                    (int) currentDifficulty)
+                : FindWithQuery<PlayerScoreRecord>(
+                    query,
+                    songChecksum.HashBytes,
+                    playerId,
+                    (int) instrument);
         }
 
         public PlayerScoreRecord QueryPlayerSongHighestPercentage(
             HashWrapper songChecksum,
             Guid playerId,
             Instrument instrument,
-            bool highestDifficultyOnly
+            bool highestDifficultyOnly,
+            bool currentDifficultyOnly,
+            Difficulty currentDifficulty
         )
         {
             string query =
@@ -394,6 +431,11 @@ namespace YARG.Scores
                     AND PlayerScores.PlayerId = ?
                     AND PlayerScores.Instrument = ?
                     AND PlayerScores.IsReplay = 0";
+
+            if (currentDifficultyOnly)
+            {
+                query += " AND PlayerScores.Difficulty = ?";
+            }
 
             if (highestDifficultyOnly)
             {
@@ -406,12 +448,18 @@ namespace YARG.Scores
 
             query += " LIMIT 1";
 
-            return FindWithQuery<PlayerScoreRecord>(
-                query,
-                songChecksum.HashBytes,
-                playerId,
-                (int) instrument
-            );
+            return currentDifficultyOnly
+                ? FindWithQuery<PlayerScoreRecord>(
+                    query,
+                    songChecksum.HashBytes,
+                    playerId,
+                    (int) instrument,
+                    (int) currentDifficulty)
+                : FindWithQuery<PlayerScoreRecord>(
+                    query,
+                    songChecksum.HashBytes,
+                    playerId,
+                    (int) instrument);
         }
 
         public List<SongRecord> QueryMostPlayedSongs(int maxCount)
@@ -453,37 +501,59 @@ namespace YARG.Scores
             );
         }
 
-        public List<PlayerScoreWithChecksum> QueryPlayerBestStars(YargProfile profile, bool highestDifficultyOnly)
+        public List<PlayerScoreWithChecksum> QueryPlayerBestStars(YargProfile profile, HighScoreHistoryMode mode)
         {
-            string difficultyFilter = highestDifficultyOnly ? "" : " AND ps.Difficulty = ?";
-            string subDifficultyFilter = highestDifficultyOnly ? "" : " AND ps2.Difficulty = ps.Difficulty";
+            bool currentDifficultyOnly = mode is
+                HighScoreHistoryMode.HighestPercentageCurrentDifficulty or
+                HighScoreHistoryMode.HighestScoreCurrentDifficulty;
+
+            string difficultyFilter = currentDifficultyOnly ? " AND ps.Difficulty = ?" : "";
+            string subDifficultyFilter = currentDifficultyOnly ? " AND ps2.Difficulty = ps.Difficulty" : "";
+            string orderBy = mode switch
+            {
+                HighScoreHistoryMode.HighestPercentageOverall =>
+                    "ps2.Percent DESC, ps2.IsFc DESC",
+                HighScoreHistoryMode.HighestPercentageDifficulty =>
+                    "ps2.Difficulty DESC, ps2.Percent DESC, ps2.IsFc DESC",
+                HighScoreHistoryMode.HighestScoreOverall =>
+                    "ps2.Score DESC",
+                HighScoreHistoryMode.HighestScoreDifficulty =>
+                    "ps2.Difficulty DESC, ps2.Score DESC",
+                HighScoreHistoryMode.HighestPercentageCurrentDifficulty =>
+                    "ps2.Percent DESC, ps2.IsFc DESC",
+                HighScoreHistoryMode.HighestScoreCurrentDifficulty =>
+                    "ps2.Score DESC",
+                _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, null)
+            };
 
             string query = $@"SELECT ps.*, gr.SongChecksum FROM PlayerScores ps
                 INNER JOIN GameRecords gr
                     ON ps.GameRecordId = gr.Id
                 WHERE ps.PlayerId = ?
                     AND ps.Instrument = ?{difficultyFilter}
+                    AND ps.IsReplay = 0
                     AND ps.Id = (
                         SELECT ps2.Id FROM PlayerScores ps2
                             INNER JOIN GameRecords gr2
                                 ON ps2.GameRecordId = gr2.Id
                         WHERE ps2.PlayerId = ps.PlayerId
                             AND ps2.Instrument = ps.Instrument{subDifficultyFilter}
+                            AND ps2.IsReplay = 0
                             AND gr2.SongChecksum = gr.SongChecksum
-                        ORDER BY ps2.Stars DESC
+                        ORDER BY {orderBy}
                         LIMIT 1
                     )";
 
-            return highestDifficultyOnly
+            return currentDifficultyOnly
                 ? Query<PlayerScoreWithChecksum>(
                     query,
                     profile.Id,
-                    (int) profile.CurrentInstrument)
+                    (int) profile.CurrentInstrument,
+                    (int) profile.CurrentDifficulty)
                 : Query<PlayerScoreWithChecksum>(
                     query,
                     profile.Id,
-                    (int) profile.CurrentInstrument,
-                    (int) profile.CurrentDifficulty);
+                    (int) profile.CurrentInstrument);
         }
 
         #endregion

--- a/Assets/Script/Settings/SettingsManager.Settings.cs
+++ b/Assets/Script/Settings/SettingsManager.Settings.cs
@@ -266,12 +266,19 @@ namespace YARG.Settings
                 };
 
             public DropdownSetting<HighScoreHistoryMode> HighScoreHistory { get; }
-                = new(HighScoreHistoryMode.HighestPercentageDifficulty, _ => ScoreContainer.InvalidateScoreCache())
+                = new(HighScoreHistoryMode.HighestPercentageDifficulty, _ =>
+                {
+                    ScoreContainer.InvalidateScoreCache();
+                    SongContainer.InvalidateStarsCache();
+                    MusicLibraryMenu.SetReload(MusicLibraryReloadState.Partial);
+                })
                 {
                     HighScoreHistoryMode.HighestPercentageOverall,
                     HighScoreHistoryMode.HighestPercentageDifficulty,
+                    HighScoreHistoryMode.HighestPercentageCurrentDifficulty,
                     HighScoreHistoryMode.HighestScoreOverall,
                     HighScoreHistoryMode.HighestScoreDifficulty,
+                    HighScoreHistoryMode.HighestScoreCurrentDifficulty,
                 };
 
             public ToggleSetting ShowPercentDecimals { get; } = new(false);

--- a/Assets/Script/Song/SongContainer.cs
+++ b/Assets/Script/Song/SongContainer.cs
@@ -112,6 +112,8 @@ namespace YARG.Song
         private static Guid _starsCacheProfileId = Guid.Empty;
         private static Instrument _starsCacheInstrument = Instrument.Band;
         private static Difficulty _starsCacheDifficulty = Difficulty.Easy;
+        private static HighScoreHistoryMode _starsCacheHighScoreHistoryMode;
+        private static bool _starsCacheUsesBandScores;
         private static bool _starsCacheValid;
 
         public static IReadOnlyDictionary<string, List<SongEntry>> Titles => _sortedSongs.Titles;
@@ -484,16 +486,20 @@ namespace YARG.Song
             }
 
             var profile = player.Profile;
+            bool useBandScores = ScoreContainer.UseBandHighScoresForCurrentPlayers;
             if (_starsCacheValid &&
                 _starsCacheProfileId == profile.Id &&
                 _starsCacheInstrument == profile.CurrentInstrument &&
-                _starsCacheDifficulty == profile.CurrentDifficulty)
+                _starsCacheDifficulty == profile.CurrentDifficulty &&
+                _starsCacheHighScoreHistoryMode == SettingsManager.Settings.HighScoreHistory.Value &&
+                _starsCacheUsesBandScores == useBandScores)
             {
                 return _sortStars;
             }
 
             _runtimeStars.Clear();
-            Dictionary<HashWrapper, StarAmount> bestStars = ScoreContainer.GetBestStarsForSong(profile);
+            Dictionary<HashWrapper, StarAmount> bestStars =
+                ScoreContainer.GetBestStarsForCurrentPlayers(profile);
             foreach (var song in _songs)
             {
                 if (!bestStars.TryGetValue(song.Hash, out StarAmount stars))
@@ -543,6 +549,8 @@ namespace YARG.Song
             _starsCacheProfileId = profile.Id;
             _starsCacheInstrument = profile.CurrentInstrument;
             _starsCacheDifficulty = profile.CurrentDifficulty;
+            _starsCacheHighScoreHistoryMode = SettingsManager.Settings.HighScoreHistory.Value;
+            _starsCacheUsesBandScores = useBandScores;
             _starsCacheValid = true;
             return _sortStars;
         }

--- a/Assets/StreamingAssets/lang/en-US.json
+++ b/Assets/StreamingAssets/lang/en-US.json
@@ -1275,8 +1275,10 @@
                 "Dropdown": {
                     "HighestPercentageOverall": "Best percentage across all difficulties",
                     "HighestPercentageDifficulty": "Best percentage on highest-played difficulty",
+                    "HighestPercentageCurrentDifficulty": "Best percentage on current difficulty",
                     "HighestScoreOverall": "Highest score across all difficulties",
-                    "HighestScoreDifficulty": "Highest score on highest-played difficulty"
+                    "HighestScoreDifficulty": "Highest score on highest-played difficulty",
+                    "HighestScoreCurrentDifficulty": "Highest score on current difficulty"
                 }
             },
             "HighwayTiltMultiplier": {


### PR DESCRIPTION
**Current Difficulty Display**
- Added **Best percentage on current difficulty** and **Highest score on current difficulty options** to the **High Score History** setting.
- When selected, these options only show stars, score, and percentage for the current difficulty.
- "Current difficulty" is the difficulty most recently selected from the Select Instrument menu after choosing a song.
- Like the four existing options, these solo high-score display modes are ignored unless exactly one human player is connected.
<img width="1392" height="510" alt="image" src="https://github.com/user-attachments/assets/1578b8a7-971e-43df-987d-42e6ba4c4ddb" />

**Star Sorting and Display**
- Based on feedback from #1353, adjusted the initial Sort by Stars behavior. That PR may now have conflicts with this one.
- Previously, the score display and star grouping could use different difficulty scopes. For example, the display could consider all difficulties while star grouping only considered the current difficulty.
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/c6f17cd4-b616-4da3-90db-7ec2821ffd4c" />

- In the example above, I earned 4 stars on Easy and 5 stars on Hard for Therefore I Am. The display correctly shows the best stars from Hard, but the song was grouped by the 4-star Easy score because Easy was the current/last-selected difficulty.
- Updated star sorting so songs are grouped by the stars from the same score record selected by **High Score History**.
- Added refresh handling so displayed stars and star sorting update when profiles are added/removed, the selected difficulty or instrument changes, or the **High Score History** setting changes. This avoids stale display or grouping data.

_Note:_ This is built on top of #1548, which includes similar changes around reapplying filters. That PR should either be merged first, or both PRs should be merged together.