### PR TITLE
feat: clarify recommended preset dismissal

### DIFF
--- a/Assets/Script/Menu/ProfileList/ProfileSidebar.cs
+++ b/Assets/Script/Menu/ProfileList/ProfileSidebar.cs
@@ -500,7 +500,7 @@ namespace YARG.Menu.ProfileList
 
             // Add buttons
 
-            dialog.AddDialogButton("Menu.Common.Cancel", MenuData.Colors.CancelButton,
+            dialog.AddDialogButton("Menu.Common.DontApply", MenuData.Colors.CancelButton,
                 () => DialogManager.Instance.ClearDialog());
 
             dialog.AddDialogButton("Menu.Common.Apply", MenuData.Colors.ConfirmButton, () =>

--- a/Assets/StreamingAssets/lang/en-US.json
+++ b/Assets/StreamingAssets/lang/en-US.json
@@ -129,6 +129,7 @@
             "Apply": "Apply",
             "Back": "Back",
             "Cancel": "Cancel",
+            "DontApply": "Don't Apply",
             "Close": "Close",
             "Confirm": "Confirm",
             "Continue": "Continue",


### PR DESCRIPTION
## Summary

Renames the negative action in the recommended-presets dialog from **Cancel**
to **Don't Apply**. The action only dismisses the recommendation; changing the
profile's theme has already taken effect.

## Why

When a user changes a profile's theme, the theme may offer recommended camera
and color presets. The dialog's negative button was labeled **Cancel**, which
could imply that it would undo the theme change. **Don't Apply** describes the
actual behavior: keep the new theme, but retain the current camera and color
profiles.

## Steps to reproduce

1. Open Profiles and select a profile.
2. Change the profile's Theme to another built-in theme, such as `Circular (Beta)` or `YARG on Fire`.
3. The **Apply Recommended Presets?** dialog appears.
4. Confirm that the negative button reads **Don't Apply**.
5. Select **Don't Apply** and verify that the theme changes while the existing camera and color profiles remain selected.

## Root cause

`ProfileSidebar.ChangeTheme` uses the shared `Menu.Common.Cancel` localization
key for the dialog's dismiss action. That action calls `ClearDialog()` only;
the theme assignment occurs before the dialog is shown.

## Fix

Add a dedicated `Menu.Common.DontApply` localization key and use it only for
this dialog. The shared `Menu.Common.Cancel` key remains unchanged for dialogs
where Cancel represents an actual cancellation.

## Changes

| File | Change |
|------|--------|
| `Assets/Script/Menu/ProfileList/ProfileSidebar.cs` | Use `Menu.Common.DontApply` for the recommended-presets dialog's negative button. |
| `Assets/StreamingAssets/lang/en-US.json` | Add the English `DontApply` label: `Don't Apply`. |

## Testing done

- Unity batchmode compile on the synced runtime exited successfully with no `error CS` entries.
- JSON parsing and `git diff --check` passed.
- In-game verification 2026-07-17: triggered the dialog by changing a profile theme, confirmed the new label, and confirmed that **Don't Apply** preserves the existing camera and color profiles while **Apply** continues to apply the recommendations.

## Notes

- Unity-side only; no Core changes or submodule pointer update are required.
- Only the English localization table changes. Other languages fall back to the default English table until translations are added through the normal localization workflow.
