### PR TITLE
Minor UnisonDisplay fixes

### DIFF
--- a/Assets/Script/Gameplay/HUD/UnisonBonus/UnisonDisplay.cs
+++ b/Assets/Script/Gameplay/HUD/UnisonBonus/UnisonDisplay.cs
@@ -88,15 +88,14 @@ namespace YARG.Gameplay.HUD
 
             _lastVisualTime = time;
 
+            UpdateScale(currentPhrase, time);
+
             if (time > currentPhrase.TransitionOut.TimeEnd)
             {
                 _currentPhraseIndex++;
                 YargLogger.LogFormatTrace("Advancing to unison phrase {0}", _currentPhraseIndex);
                 ResetState();
-                return;
             }
-
-            UpdateScale(currentPhrase, time);
         }
 
         protected override void OnSongStarted()

--- a/Assets/Script/Gameplay/HUD/UnisonBonus/UnisonDisplay.cs
+++ b/Assets/Script/Gameplay/HUD/UnisonBonus/UnisonDisplay.cs
@@ -100,6 +100,12 @@ namespace YARG.Gameplay.HUD
 
         protected override void OnSongStarted()
         {
+            if (GameManager.IsPractice)
+            {
+                gameObject.SetActive(false);
+                return;
+            }
+
             int minPlayers = SettingsManager.Settings.UnisonDisplay.Value switch
             {
                 UnisonDisplaySetting.Always          => 1,
@@ -107,11 +113,12 @@ namespace YARG.Gameplay.HUD
                 UnisonDisplaySetting.Disabled        => int.MaxValue,
                 _                                    => throw new ArgumentOutOfRangeException(),
             };
+            var maxParticipants = GameManager.EngineManager.UnisonEvents.Max(e => e.PartCount);
 
             if (SettingsManager.Settings.UnisonDisplay.Value == UnisonDisplaySetting.Disabled ||
-                GameManager.EngineManager.Engines.Count(e =>
-                    e.Instrument is not Instrument.Vocals and not Instrument.Harmony) < minPlayers)
+                maxParticipants < minPlayers)
             {
+                // Disable display now if there would never be enough participants to show the display
                 gameObject.SetActive(false);
                 return;
             }
@@ -132,8 +139,11 @@ namespace YARG.Gameplay.HUD
 
             _parent.SetActive(false);
 
+            // We need to use engineCount here since we use lists indexed by engineId,
+            // which *should* be in the range [0, engineCount - 1] in normal gameplay.
             int engineCount = GameManager.EngineManager.Engines.Count;
-            if (engineCount > MAX_PARTICIPANTS_FOR_ICON_DISPLAY)
+
+            if (maxParticipants > MAX_PARTICIPANTS_FOR_ICON_DISPLAY)
             {
                 _unisonBar.Initialize(engineCount);
             }

--- a/Assets/Script/Gameplay/HUD/UnisonBonus/UnisonIcon.cs
+++ b/Assets/Script/Gameplay/HUD/UnisonBonus/UnisonIcon.cs
@@ -81,6 +81,10 @@ namespace YARG.Gameplay.HUD
 
         private void SetTween()
         {
+            if (_seekTween == null)
+            {
+                return;
+            }
             // Lerp to new progress
             _seekTween.ChangeEndValue(_progress, true);
             _seekTween.Play();


### PR DESCRIPTION
This fixes two bugs in UnisonDisplay
- Display would sometimes stay on screen when FPS is low
- Extremely low FPS or extreme lag could cause the UI to freeze up as a tween is not initialised (somehow?)

This does not fix the practice mode bug. That will come later once I actually figure out how I want to fix it