### PR TITLE
Fix: Song progress overlay desynced from actual song progress

### DIFF
--- a/Assets/Scenes/Gameplay.unity
+++ b/Assets/Scenes/Gameplay.unity
@@ -1835,6 +1835,10 @@ PrefabInstance:
       propertyPath: m_AspectRatio
       value: 1.6326531
       objectReference: {fileID: 0}
+    - target: {fileID: 4228396685661071210, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
+      propertyPath: useCustomPosition
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 4345241489645973008, guid: 039fee0ec42345d4f88c0625255415d4, type: 3}
       propertyPath: m_LocalScale.x
       value: 0


### PR DESCRIPTION
Really noticeable with a high contrast song progress overlay but the custom position in the mask was causing the bar to be offset, so songs would end with the bar having about 5% left to show. 