### PR TITLE
Add KeepLyricBar to HUD settings

### DIFF
--- a/Assets/Scenes/Gameplay.unity
+++ b/Assets/Scenes/Gameplay.unity
@@ -6045,6 +6045,7 @@ MonoBehaviour:
   _transparentBackground: {fileID: 658438231}
   _phrasePrefab: {fileID: 4412832065551153811, guid: b0bc5cdea31af4c188dd572f5efa4a1a, type: 3}
   _canvas: {fileID: 1858185586}
+  _vocalPlayerHudContainer: {fileID: 1338572397}
 --- !u!114 &1047079483
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Script/Gameplay/GameManager.Loading.cs
+++ b/Assets/Script/Gameplay/GameManager.Loading.cs
@@ -495,7 +495,15 @@ namespace YARG.Gameplay
                                 : Chart.Harmony;
                             VocalTrack.Initialize(chart, player, Song.VocalScrollSpeedScalingFactor);
 
-                            _lyricBar.gameObject.SetActive(false);
+                            if (SettingsManager.Settings.KeepLyricBar.Value &&
+                                SettingsManager.Settings.LyricDisplay.Value != LyricDisplayMode.Disabled)
+                            {
+                                _lyricBar.SetVocalPlayerLayout();
+                            }
+                            else
+                            {
+                                _lyricBar.gameObject.SetActive(false);
+                            }
                             vocalTrackInitialized = true;
                         }
 

--- a/Assets/Script/Gameplay/HUD/LyricBar.cs
+++ b/Assets/Script/Gameplay/HUD/LyricBar.cs
@@ -6,6 +6,7 @@ using DG.Tweening;
 using UnityEngine;
 using YARG.Core.Chart;
 using YARG.Core.Logging;
+using YARG.Helpers.Extensions;
 using YARG.Settings;
 
 namespace YARG.Gameplay.HUD
@@ -28,6 +29,8 @@ namespace YARG.Gameplay.HUD
         private LyricBarPhrase _phrasePrefab;
         [SerializeField]
         private CanvasGroup _canvas;
+        [SerializeField]
+        private RectTransform _vocalPlayerHudContainer;
 
         private readonly List<double>     _fadeStartTimings = new();
         private          int              _fadeIndex;
@@ -67,6 +70,13 @@ namespace YARG.Gameplay.HUD
                     _transparentBackground.SetActive(false);
                     break;
             }
+        }
+
+        public void SetVocalPlayerLayout()
+        {
+            var corners = new Vector3[4];
+            _vocalPlayerHudContainer.GetWorldCorners(corners);
+            transform.position = transform.position.WithY(corners[0].y);
         }
 
         protected override void OnChartLoaded(SongChart chart)

--- a/Assets/Script/Settings/SettingsManager.Settings.cs
+++ b/Assets/Script/Settings/SettingsManager.Settings.cs
@@ -506,6 +506,8 @@ namespace YARG.Settings
                     LyricDisplayMode.Disabled
                 };
 
+            public ToggleSetting KeepLyricBar { get; } = new(false);
+
             public DropdownSetting<SongProgressMode> SongTimeOnScoreBox { get; }
                 = new(SongProgressMode.CountUpAndTotal)
                 {

--- a/Assets/Script/Settings/SettingsManager.cs
+++ b/Assets/Script/Settings/SettingsManager.cs
@@ -174,6 +174,7 @@ namespace YARG.Settings
                 nameof(Settings.UnisonDisplay),
                 nameof(Settings.ShowPlayerNameWhenStartingSong),
                 nameof(Settings.LyricDisplay),
+                nameof(Settings.KeepLyricBar),
                 nameof(Settings.SongTimeOnScoreBox),
                 nameof(Settings.GraphicalProgressOnScoreBox),
                 nameof(Settings.GraphicalSongProgressTint),

--- a/Assets/StreamingAssets/lang/en-US.json
+++ b/Assets/StreamingAssets/lang/en-US.json
@@ -1324,6 +1324,10 @@
                     "Transparent": "Translucent Background"
                 }
             },
+            "KeepLyricBar": {
+                "Name": "Keep Lyric Bar",
+                "Description": "Displays the karaoke lyric bar below the vocal track while singers are playing."
+            },
             "MasterMusicVolume": {
                 "Name": "Master Music Volume",
                 "PauseName": "Master",


### PR DESCRIPTION
### Description

This PR implements one of the requested feature in the Discord suggestion's forum channel `Karaoke features: Static Vocals and Auto-mute vocals`.

<img width="1513" height="413" alt="image" src="https://github.com/user-attachments/assets/79ba8f27-646c-4876-b784-988b8de1a808" />


This adds a new `KeepLyricBar` toggle under the HUD settings allowing to keep the lyric bar even if there are singers. I first tried to use a fixed offset approach but finally decided to use an anchor from an existing UI element instead.

While I'm not familiar with YARG codebase, I'm used to git, OSS contribution and C#, so feel free to go hard on me if there is anything I need to adjust to be on par with the project's guideline.

### Rationale

While the lyric bar allows to focus on the words to sing like most karaoke softwares _(e.g. joysound, karafun, ...)_, the vocal track's pitch lanes allow to adjust the pitch, i.e. they both excel in one job but fail on what the other does best. So the addition of this new setting tries to address various frictions such as:
 - Hard to follow/read scrolling lyrics even when static vocals is enabled.
 - Allow to have scrolling lyrics and the "static lyrics" via the lyric bar _(e.g. useful when 2 players singing the same vocal but one prefers the scrolling lyrics but the other does not)_.
 - Unable to read ahead coming lyrics _(i.e. the lyric bar can display 2 sentences unlike the vocal track)_.

BTW, the current static vocals system doesn't help here as you loose the pitch timing and won't be able to catch up lyrics if they're going too fast or are unreadable _(e.g. blurriness, scrolling artifacts?, smaller text, ...)_.

In sum, this new setting doesn't change current defaults/behaviours, allows to keep the best of both worlds, is minimal and can easily be reverted when a better system is implemented.