### PR TITLE
Alias Magma's "Country > Traditional Folk" to Traditional instead of Folk

### DIFF
--- a/Assets/Script/Song/Genrelizer.Lists.cs
+++ b/Assets/Script/Song/Genrelizer.Lists.cs
@@ -219,8 +219,8 @@ namespace YARG.Song
             { (COUNTRY, "contemporary"),                (COUNTRY, "Contemporary Country") },
             //(COUNTRY, "honky tonk")                   unchanged
             { (COUNTRY, "outlaw"),                      (COUNTRY, "Outlaw Country") },
-            { (COUNTRY, "traditional folk"),            (FOLK, "Traditional Folk") },
-            { (COUNTRY, "traditionalfolk"),             (FOLK, "Traditional Folk") },
+            { (COUNTRY, "traditional folk"),            (TRADITIONAL, "Traditional Folk") },
+            { (COUNTRY, "traditionalfolk"),             (TRADITIONAL, "Traditional Folk") },
             { (COUNTRY, "other"),                       (COUNTRY, null) },
 
             //(GLAM, "goth")                            unchanged


### PR DESCRIPTION
A little while ago, we introduced the `Traditional` genre to YARG and Genrelizer, establishing a split between two different meanings of "folk music". `Traditional` represents genuine, often anonymous folk music from long ago while `Folk` represents modern, rock-influenced folk music by contemporary artists.

It occurred to me that Magma's subgenres also acknowledged this distinction by having both `Contemporary Folk` (under `Other`) and `Traditional Folk` (under `Country`) as subgenres. We previously aliased both under `Folk`, but this PR updates the latter to the `Traditional` genre to honor that distinction.