### PR TITLE
ci: add workflow to auto-label PRs needing rebase

### DIFF
--- a/.github/workflows/label-conflicts.yml
+++ b/.github/workflows/label-conflicts.yml
@@ -14,7 +14,7 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: eps1lon/actions-label-merge-conflict@204c3e8006e8b4e768e146743b5936bc93297a78 # v3.0.2
+      - uses: eps1lon/actions-label-merge-conflict@0273be72a0bbd58fcd71d0d6c02c209b50d1e5e1 # v3.1.0
         with:
           dirtyLabel: "Needs Rebase"
           repoToken: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/label-conflicts.yml
+++ b/.github/workflows/label-conflicts.yml
@@ -1,0 +1,22 @@
+name: Auto Label Merge Conflicts
+
+on:
+  push:
+    branches:
+      - dev
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  label-conflicts:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: eps1lon/actions-label-merge-conflict@204c3e8006e8b4e768e146743b5936bc93297a78 # v3.0.2
+        with:
+          dirtyLabel: "Needs Rebase"
+          repoToken: "${{ secrets.GITHUB_TOKEN }}"
+          retryAfterMinutes: 1
+          retryMaxIterations: 5


### PR DESCRIPTION
### Description
Adds a GitHub Actions workflow to automatically apply and remove the `Needs Rebase` label on open PRs when merge conflicts occur.