### PR TITLE
Setting Best Percent Ties with Highest Score

### DIFF
--- a/Assets/Script/Scores/ScoreDatabase.cs
+++ b/Assets/Script/Scores/ScoreDatabase.cs
@@ -328,8 +328,8 @@ namespace YARG.Scores
         )
         {
             string orderBy = highestDifficultyOnly
-                ? "ps2.Difficulty DESC, ps2.Percent DESC, ps2.IsFc DESC"
-                : "ps2.Percent DESC, ps2.IsFc DESC";
+                ? "ps2.Difficulty DESC, ps2.Percent DESC, ps2.Score DESC, ps2.IsFc DESC"
+                : "ps2.Percent DESC, ps2.Score DESC, ps2.IsFc DESC";
             string difficultyFilter = currentDifficultyOnly ? " AND ps.Difficulty = ?" : "";
             string subDifficultyFilter = currentDifficultyOnly ? " AND ps2.Difficulty = ps.Difficulty" : "";
 
@@ -439,11 +439,11 @@ namespace YARG.Scores
 
             if (highestDifficultyOnly)
             {
-                query += " ORDER BY PlayerScores.Difficulty DESC, PlayerScores.Percent DESC, IsFc DESC";
+                query += " ORDER BY PlayerScores.Difficulty DESC, PlayerScores.Percent DESC, PlayerScores.Score DESC, IsFc DESC";
             }
             else
             {
-                query += " ORDER BY PlayerScores.Percent DESC, IsFc DESC";
+                query += " ORDER BY PlayerScores.Percent DESC, PlayerScores.Score DESC, IsFc DESC";
             }
 
             query += " LIMIT 1";
@@ -512,15 +512,15 @@ namespace YARG.Scores
             string orderBy = mode switch
             {
                 HighScoreHistoryMode.HighestPercentageOverall =>
-                    "ps2.Percent DESC, ps2.IsFc DESC",
+                    "ps2.Percent DESC, ps2.Score DESC, ps2.IsFc DESC",
                 HighScoreHistoryMode.HighestPercentageDifficulty =>
-                    "ps2.Difficulty DESC, ps2.Percent DESC, ps2.IsFc DESC",
+                    "ps2.Difficulty DESC, ps2.Percent DESC, ps2.Score DESC, ps2.IsFc DESC",
                 HighScoreHistoryMode.HighestScoreOverall =>
                     "ps2.Score DESC",
                 HighScoreHistoryMode.HighestScoreDifficulty =>
                     "ps2.Difficulty DESC, ps2.Score DESC",
                 HighScoreHistoryMode.HighestPercentageCurrentDifficulty =>
-                    "ps2.Percent DESC, ps2.IsFc DESC",
+                    "ps2.Percent DESC, ps2.Score DESC, ps2.IsFc DESC",
                 HighScoreHistoryMode.HighestScoreCurrentDifficulty =>
                     "ps2.Score DESC",
                 _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, null)


### PR DESCRIPTION
Right now, when you set the **High Score History** setting to one of the "Best percent ..." options, if you got the same percent on two playthroughs, the Music Library will show stars/score for the _first_ playthrough, instead of the _best_ playthrough.  This change will settle tied percent playthroughs and prefer the one with the highest score (and by extension, stars).

<img width="1364" height="514" alt="image" src="https://github.com/user-attachments/assets/8ee51e1a-c6a3-470b-8434-e08472cc3e00" />

First Playthrough:
<img width="1873" height="94" alt="image" src="https://github.com/user-attachments/assets/8ea987fe-b61f-4fc3-9470-78021011529a" />
<img width="1873" height="94" alt="image" src="https://github.com/user-attachments/assets/2263714b-07a4-40c8-a0cb-0600b4a53f92" />

Best Score Playthrough:
<img width="1873" height="94" alt="image" src="https://github.com/user-attachments/assets/77bc5aa0-7b1a-4c92-b0a9-09f1826d833d" />
<img width="1873" height="94" alt="image" src="https://github.com/user-attachments/assets/e22c602e-624b-46f4-b806-ef1807ff7a27" />

This fixes: https://discord.com/channels/1086048856678084609/1528023618687205376