### PR TITLE
Rescale lanes based on lane count

### DIFF
--- a/Assets/Script/Gameplay/Player/DrumsPlayer.cs
+++ b/Assets/Script/Gameplay/Player/DrumsPlayer.cs
@@ -462,8 +462,8 @@ namespace YARG.Gameplay.Player
             }
             else
             {
-                // Correct size of lane slightly for padding in fret array
-                lane.MultiplyScale(0.97f);
+                // Adjust width of lane, correcting slightly for padding in fret array
+                lane.MultiplyScale(0.97f * 5 / LaneCount);
             }
         }
 

--- a/Assets/Script/Gameplay/Player/FiveLaneKeysPlayer.cs
+++ b/Assets/Script/Gameplay/Player/FiveLaneKeysPlayer.cs
@@ -488,7 +488,7 @@ public override bool ShouldUpdateInputsOnResume => true;
             }
             else
             {
-                lane.MultiplyScale(0.85f);
+                lane.MultiplyScale(0.85f * 5 / LaneCount);
             }
         }
 


### PR DESCRIPTION
For highways with variable numbers of lanes (5LK with its optional open lane, and all drum highways), rescales trill and tremolo lanes to match the narrower notes. We already do this for BRE lanes

Note - I don't really understand the origins of the `0.97f` and `0.85f` magic numbers here or why they're different between drums and 5LK, but I went ahead and left them in as scalars for the conversions