### PR TITLE
Percentage and Score Sorting, Resolution Helper

### DIFF
--- a/Assets/Script/Menu/Filters/FiltersMenu.cs
+++ b/Assets/Script/Menu/Filters/FiltersMenu.cs
@@ -650,7 +650,8 @@ namespace YARG.Menu.Filters
                     }
                     else
                     {
-                        if (sort != SortAttribute.Playcount && sort != SortAttribute.Stars)
+                        if (sort != SortAttribute.Playcount && sort != SortAttribute.Stars &&
+                            sort != SortAttribute.Percentage && sort != SortAttribute.Score)
                             SettingsManager.Settings.PreviousLibrarySort = sort;
 
                         SettingsManager.Settings.LibrarySort = sort;

--- a/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
+++ b/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
@@ -1236,7 +1236,8 @@ namespace YARG.Menu.MusicLibrary
 
         private static bool IsDynamicScoreSort(SortAttribute sort)
         {
-            return sort is SortAttribute.Playcount or SortAttribute.Stars;
+            return sort is SortAttribute.Playcount or SortAttribute.Stars or
+                SortAttribute.Percentage or SortAttribute.Score;
         }
 
         private bool SetIndexToStableId(string stableId, int searchStartIndex = 0)

--- a/Assets/Script/Song/SongContainer.cs
+++ b/Assets/Script/Song/SongContainer.cs
@@ -668,10 +668,14 @@ namespace YARG.Song
                     PlayerScoreRecord xRecord = percentageRecords[x];
                     PlayerScoreRecord yRecord = percentageRecords[y];
                     int comparison = yRecord.GetPercent().CompareTo(xRecord.GetPercent());
+
+                    // For equal percentages, show full combos first. Then break
+                    // remaining ties by instrument intensity and title.
                     if (comparison == 0)
                     {
-                        comparison = yRecord.Score.CompareTo(xRecord.Score);
+                        comparison = yRecord.IsFc.CompareTo(xRecord.IsFc);
                     }
+
                     return comparison != 0 ? comparison : comparer.Compare(x, y);
                 });
             }
@@ -750,6 +754,8 @@ namespace YARG.Song
                     categorySongs[i].Sort((x, y) =>
                     {
                         int comparison = scoreRecords[y].Score.CompareTo(scoreRecords[x].Score);
+
+                        // Break equal scores by instrument intensity, then title.
                         return comparison != 0 ? comparison : comparer.Compare(x, y);
                     });
                     string label = Localize.Key($"Menu.MusicLibrary.Sort.Score.{thresholds[i]}");
@@ -1078,6 +1084,8 @@ namespace YARG.Song
 
                 if (intensityX == intensityY)
                 {
+                    // MetadataComparer sorts by title first, with the remaining
+                    // metadata providing a deterministic fallback for duplicate titles.
                     return SongEntrySorting.MetadataComparer.Instance.Compare(x, y);
                 }
                 else if (intensityX == -1)

--- a/Assets/Script/Song/SongContainer.cs
+++ b/Assets/Script/Song/SongContainer.cs
@@ -620,6 +620,7 @@ namespace YARG.Song
             {
                 buckets[i] = new List<SongEntry>();
             }
+            var percentageRecords = new Dictionary<SongEntry, PlayerScoreRecord>();
 
             // Prime the cache once. Its validity criteria include the profile,
             // instrument, difficulty, and High Score History mode.
@@ -631,36 +632,48 @@ namespace YARG.Song
 
             foreach (SongEntry song in _songs)
             {
-                int bucketIndex;
                 if (!song[instrument].IsActive())
                 {
-                    bucketIndex = bucketKeys.Length - 1;
-                }
-                else
-                {
-                    PlayerScoreRecord record = ScoreContainer.GetBestPercentageScore(
-                        song.Hash, profile.Id, instrument, allowCacheUpdate: false);
-                    if (record == null || record.GetPercent() <= 0f)
-                    {
-                        bucketIndex = bucketKeys.Length - 2;
-                    }
-                    else
-                    {
-                        float percent = record.GetPercent() * 100f;
-                        bucketIndex = percent switch
-                        {
-                            >= 100f => 0,
-                            >= 90f  => 1,
-                            >= 80f  => 2,
-                            >= 70f  => 3,
-                            >= 60f  => 4,
-                            >= 50f  => 5,
-                            _       => 6,
-                        };
-                    }
+                    InsertSorted(buckets[^1], song, comparer);
+                    continue;
                 }
 
-                InsertSorted(buckets[bucketIndex], song, comparer);
+                PlayerScoreRecord record = ScoreContainer.GetBestPercentageScore(
+                    song.Hash, profile.Id, instrument, allowCacheUpdate: false);
+                if (record == null || record.GetPercent() <= 0f)
+                {
+                    InsertSorted(buckets[^2], song, comparer);
+                    continue;
+                }
+
+                float percent = record.GetPercent() * 100f;
+                int bucketIndex = percent switch
+                {
+                    >= 100f => 0,
+                    >= 90f  => 1,
+                    >= 80f  => 2,
+                    >= 70f  => 3,
+                    >= 60f  => 4,
+                    >= 50f  => 5,
+                    _       => 6,
+                };
+                percentageRecords[song] = record;
+                buckets[bucketIndex].Add(song);
+            }
+
+            for (int i = 0; i < buckets.Length - 2; i++)
+            {
+                buckets[i].Sort((x, y) =>
+                {
+                    PlayerScoreRecord xRecord = percentageRecords[x];
+                    PlayerScoreRecord yRecord = percentageRecords[y];
+                    int comparison = yRecord.GetPercent().CompareTo(xRecord.GetPercent());
+                    if (comparison == 0)
+                    {
+                        comparison = yRecord.Score.CompareTo(xRecord.Score);
+                    }
+                    return comparison != 0 ? comparison : comparer.Compare(x, y);
+                });
             }
 
             return CreateScoreCategories(bucketKeys, buckets);
@@ -691,6 +704,7 @@ namespace YARG.Song
 
             var unplayed = new List<SongEntry>();
             var noPart = new List<SongEntry>();
+            var scoreRecords = new Dictionary<SongEntry, PlayerScoreRecord>();
 
             if (_songs.Length > 0)
             {
@@ -724,7 +738,8 @@ namespace YARG.Song
                     }
                 }
 
-                InsertSorted(categorySongs[bucketIndex], song, comparer);
+                scoreRecords[song] = record;
+                categorySongs[bucketIndex].Add(song);
             }
 
             var result = new List<SongCategory>();
@@ -732,6 +747,11 @@ namespace YARG.Song
             {
                 if (categorySongs[i].Count > 0)
                 {
+                    categorySongs[i].Sort((x, y) =>
+                    {
+                        int comparison = scoreRecords[y].Score.CompareTo(scoreRecords[x].Score);
+                        return comparison != 0 ? comparison : comparer.Compare(x, y);
+                    });
                     string label = Localize.Key($"Menu.MusicLibrary.Sort.Score.{thresholds[i]}");
                     result.Add(new SongCategory(label, categorySongs[i].ToArray(), label));
                 }

--- a/Assets/Script/Song/SongContainer.cs
+++ b/Assets/Script/Song/SongContainer.cs
@@ -36,6 +36,8 @@ namespace YARG.Song
         DateAdded,
         Playcount,
         Stars,
+        Percentage,
+        Score,
         Playable,
         Random,
 
@@ -216,6 +218,8 @@ namespace YARG.Song
                     SortAttribute.Playcount    => GetPlaycounts(),
                     SortAttribute.Playable     => GetPlayableSongs(),
                     SortAttribute.Stars        => GetStars(),
+                    SortAttribute.Percentage   => GetPercentage(),
+                    SortAttribute.Score        => GetScore(),
                     SortAttribute.Random       => GetRandomSort(),
 
                     SortAttribute.FiveFretGuitar => _sortInstruments[Instrument.FiveFretGuitar],
@@ -581,6 +585,198 @@ namespace YARG.Song
             var shuffled = new List<SongEntry>(_songs);
             shuffled.Shuffle();
             return new[] { new SongCategory(string.Empty, shuffled.ToArray(), null) };
+        }
+
+        private static SongCategory[] GetPercentage()
+        {
+            if (PlayerContainer.OnlyHasBotsActive())
+            {
+                return GetFallbackScoreSort();
+            }
+
+            YargPlayer player = PlayerContainer.Players.FirstOrDefault(e => !e.Profile.IsBot);
+            if (player == null)
+            {
+                return _sortTitles;
+            }
+
+            YargProfile profile = player.Profile;
+            Instrument instrument = profile.CurrentInstrument;
+            IntensityComparer comparer = new(instrument);
+            string[] bucketKeys =
+            {
+                Localize.Key("Menu.MusicLibrary.Sort.Percentage.100"),
+                Localize.Key("Menu.MusicLibrary.Sort.Percentage.90"),
+                Localize.Key("Menu.MusicLibrary.Sort.Percentage.80"),
+                Localize.Key("Menu.MusicLibrary.Sort.Percentage.70"),
+                Localize.Key("Menu.MusicLibrary.Sort.Percentage.60"),
+                Localize.Key("Menu.MusicLibrary.Sort.Percentage.50"),
+                Localize.Key("Menu.MusicLibrary.Sort.Percentage.Below50"),
+                Localize.Key("Menu.MusicLibrary.Sort.Unplayed"),
+                Localize.Key("Menu.MusicLibrary.Sort.NoPart"),
+            };
+            var buckets = new List<SongEntry>[bucketKeys.Length];
+            for (int i = 0; i < buckets.Length; i++)
+            {
+                buckets[i] = new List<SongEntry>();
+            }
+
+            // Prime the cache once. Its validity criteria include the profile,
+            // instrument, difficulty, and High Score History mode.
+            if (_songs.Length > 0)
+            {
+                ScoreContainer.GetBestPercentageScore(
+                    _songs[0].Hash, profile.Id, instrument, allowCacheUpdate: true);
+            }
+
+            foreach (SongEntry song in _songs)
+            {
+                int bucketIndex;
+                if (!song[instrument].IsActive())
+                {
+                    bucketIndex = bucketKeys.Length - 1;
+                }
+                else
+                {
+                    PlayerScoreRecord record = ScoreContainer.GetBestPercentageScore(
+                        song.Hash, profile.Id, instrument, allowCacheUpdate: false);
+                    if (record == null || record.GetPercent() <= 0f)
+                    {
+                        bucketIndex = bucketKeys.Length - 2;
+                    }
+                    else
+                    {
+                        float percent = record.GetPercent() * 100f;
+                        bucketIndex = percent switch
+                        {
+                            >= 100f => 0,
+                            >= 90f  => 1,
+                            >= 80f  => 2,
+                            >= 70f  => 3,
+                            >= 60f  => 4,
+                            >= 50f  => 5,
+                            _       => 6,
+                        };
+                    }
+                }
+
+                InsertSorted(buckets[bucketIndex], song, comparer);
+            }
+
+            return CreateScoreCategories(bucketKeys, buckets);
+        }
+
+        private static SongCategory[] GetScore()
+        {
+            if (PlayerContainer.OnlyHasBotsActive())
+            {
+                return GetFallbackScoreSort();
+            }
+
+            YargPlayer player = PlayerContainer.Players.FirstOrDefault(e => !e.Profile.IsBot);
+            if (player == null)
+            {
+                return _sortTitles;
+            }
+
+            YargProfile profile = player.Profile;
+            Instrument instrument = profile.CurrentInstrument;
+            IntensityComparer comparer = new(instrument);
+            int[] thresholds = { 500000, 400000, 300000, 200000, 150000, 100000, 75000, 50000, 30000, 10000, 1 };
+            var categorySongs = new List<SongEntry>[thresholds.Length];
+            for (int i = 0; i < categorySongs.Length; i++)
+            {
+                categorySongs[i] = new List<SongEntry>();
+            }
+
+            var unplayed = new List<SongEntry>();
+            var noPart = new List<SongEntry>();
+
+            if (_songs.Length > 0)
+            {
+                ScoreContainer.GetHighScore(
+                    _songs[0].Hash, profile.Id, instrument, allowCacheUpdate: true);
+            }
+
+            foreach (SongEntry song in _songs)
+            {
+                if (!song[instrument].IsActive())
+                {
+                    InsertSorted(noPart, song, comparer);
+                    continue;
+                }
+
+                PlayerScoreRecord record = ScoreContainer.GetHighScore(
+                    song.Hash, profile.Id, instrument, allowCacheUpdate: false);
+                if (record == null || record.Score <= 0)
+                {
+                    InsertSorted(unplayed, song, comparer);
+                    continue;
+                }
+
+                int bucketIndex = thresholds.Length - 1;
+                for (int i = 0; i < thresholds.Length; i++)
+                {
+                    if (record.Score >= thresholds[i])
+                    {
+                        bucketIndex = i;
+                        break;
+                    }
+                }
+
+                InsertSorted(categorySongs[bucketIndex], song, comparer);
+            }
+
+            var result = new List<SongCategory>();
+            for (int i = 0; i < thresholds.Length; i++)
+            {
+                if (categorySongs[i].Count > 0)
+                {
+                    string label = Localize.Key($"Menu.MusicLibrary.Sort.Score.{thresholds[i]}");
+                    result.Add(new SongCategory(label, categorySongs[i].ToArray(), label));
+                }
+            }
+
+            AddScoreCategory(result, unplayed, Localize.Key("Menu.MusicLibrary.Sort.Unplayed"));
+            AddScoreCategory(result, noPart, Localize.Key("Menu.MusicLibrary.Sort.NoPart"));
+            return result.ToArray();
+        }
+
+        private static SongCategory[] GetFallbackScoreSort()
+        {
+            SortAttribute previousSort = SettingsManager.Settings.PreviousLibrarySort;
+            if (previousSort != SortAttribute.Stars && previousSort != SortAttribute.Playcount &&
+                previousSort != SortAttribute.Playable && previousSort != SortAttribute.Percentage &&
+                previousSort != SortAttribute.Score)
+            {
+                return GetSortedCategory(previousSort);
+            }
+
+            return _sortTitles;
+        }
+
+        private static SongCategory[] CreateScoreCategories(string[] labels, List<SongEntry>[] buckets)
+        {
+            var result = new List<SongCategory>();
+            for (int i = 0; i < labels.Length; i++)
+            {
+                AddScoreCategory(result, buckets[i], labels[i]);
+            }
+            return result.ToArray();
+        }
+
+        private static void AddScoreCategory(List<SongCategory> result, List<SongEntry> songs, string label)
+        {
+            if (songs.Count > 0)
+            {
+                result.Add(new SongCategory(label, songs.ToArray(), label));
+            }
+        }
+
+        private static void InsertSorted(List<SongEntry> songs, SongEntry song, IntensityComparer comparer)
+        {
+            int index = songs.BinarySearch(song, comparer);
+            songs.Insert(~index, song);
         }
 
         private static void UpdateSongUi(LoadingContext context)

--- a/Assets/StreamingAssets/lang/en-US.json
+++ b/Assets/StreamingAssets/lang/en-US.json
@@ -79,6 +79,8 @@
             "Source": "Source",
 			"Subgenre": "Subgenre",
             "Stars": "Stars",
+            "Percentage": "Percentage",
+            "Score": "Score",
             "Unspecified": "None",
             "Year": "Year",
             "DateAdded": "Date Added",
@@ -327,6 +329,32 @@
             "RecommendedSongsHelp": "Refresh List of Recommended Songs",
             "PlayableSongs": "PLAYABLE SONGS",
             "RandomSong": "RANDOM SONG",
+            "Sort": {
+                "Unplayed": "Unplayed Songs",
+                "NoPart": "No Part",
+                "Percentage": {
+                    "100": "100%",
+                    "90": "90 - 99%",
+                    "80": "80 - 89%",
+                    "70": "70 - 79%",
+                    "60": "60 - 69%",
+                    "50": "50 - 59%",
+                    "Below50": "Below 50%"
+                },
+                "Score": {
+                    "500000": "500,000+ Points",
+                    "400000": "400,000+ Points",
+                    "300000": "300,000+ Points",
+                    "200000": "200,000+ Points",
+                    "150000": "150,000+ Points",
+                    "100000": "100,000+ Points",
+                    "75000": "75,000+ Points",
+                    "50000": "50,000+ Points",
+                    "30000": "30,000+ Points",
+                    "10000": "10,000+ Points",
+                    "1": "1+ Points"
+                }
+            },
             "Playlists": "PLAYLIST MANAGER",
             "PlaylistsHelp": "Create, View, and Edit Custom Playlists",
             "Favorites": "Favorites",


### PR DESCRIPTION
This is a continuation of #1353 by @Nort1346.

Adds two new library sorting options, **Percentage** and **Score**

<img width="367" height="264" alt="image" src="https://github.com/user-attachments/assets/76d9ad41-64a3-4f58-9ded-0e6e6c469958" />

I've made changes so this works with the new **High Score History** options and logic that was already applied to sorting by **Stars**.
<img width="1360" height="510" alt="image" src="https://github.com/user-attachments/assets/c11b8612-1c33-4f42-b203-8e72eaea021a" />

Best percentage across all difficulties, sorted by Percentage:
<img width="1872" height="818" alt="image" src="https://github.com/user-attachments/assets/42351b73-8618-423c-afcb-feee188a3ee4" />

Best percentage on current difficulty (Expert), sorted by Percentage:
<img width="1872" height="818" alt="image" src="https://github.com/user-attachments/assets/beb74930-5843-4902-9e70-6fb1a57d4216" />

I either don't have good examples of other options/sort combinations or they're redundant.

**Feedback Item:** I retained secondary sorts within the groups - first by intensity, then by song title.  This is how sorting by **Stars** works.  Although, with stars, every song within each group is the same.  But with **Percentage**, all songs between 90-99.9% are mixed together.  Likewise, for **Scores**, all songs between 300,000-399,999 points are also mixed together.  Let me know if songs within the groups should be ordered high-to-low.

This fixes: #675.