### PR TITLE
Add auto downcharts feature

### DIFF
--- a/Assets/Script/Gameplay/GameManager.Loading.cs
+++ b/Assets/Script/Gameplay/GameManager.Loading.cs
@@ -318,10 +318,7 @@ namespace YARG.Gameplay
         {
             try
             {
-                var downchartMode = SettingsManager.Settings.UseGeneratedDowncharts.Value
-                    ? DownchartGenerationMode.ReplaceExistingDifficulties
-                    : DownchartGenerationMode.MissingDifficulties;
-                Chart = Song.LoadChart(downchartMode);
+                Chart = Song.LoadChart(DownchartGenerationMode.MissingDifficulties);
                 if (Chart != null)
                 {
                     GenerateVenueTrack();

--- a/Assets/Script/Gameplay/GameManager.Loading.cs
+++ b/Assets/Script/Gameplay/GameManager.Loading.cs
@@ -318,7 +318,10 @@ namespace YARG.Gameplay
         {
             try
             {
-                Chart = Song.LoadChart();
+                var downchartMode = SettingsManager.Settings.UseGeneratedDowncharts.Value
+                    ? DownchartGenerationMode.ReplaceExistingDifficulties
+                    : DownchartGenerationMode.MissingDifficulties;
+                Chart = Song.LoadChart(downchartMode);
                 if (Chart != null)
                 {
                     GenerateVenueTrack();

--- a/Assets/Script/Gameplay/Player/FiveFretGuitarPlayer.cs
+++ b/Assets/Script/Gameplay/Player/FiveFretGuitarPlayer.cs
@@ -162,6 +162,13 @@ namespace YARG.Gameplay.Player
 
         protected override InstrumentDifficulty<GuitarNote> GetNotes(SongChart chart)
         {
+            if (Player.UseGeneratedChart)
+            {
+                return chart.GenerateFiveFretDownchart(
+                    Player.Profile.CurrentInstrument,
+                    Player.Profile.CurrentDifficulty);
+            }
+
             var track = chart.GetFiveFretTrack(Player.Profile.CurrentInstrument).Clone();
             return track.GetDifficulty(Player.Profile.CurrentDifficulty);
         }

--- a/Assets/Script/Gameplay/Player/FiveLaneKeysPlayer.cs
+++ b/Assets/Script/Gameplay/Player/FiveLaneKeysPlayer.cs
@@ -151,6 +151,13 @@ public override bool ShouldUpdateInputsOnResume => true;
 
         protected override InstrumentDifficulty<GuitarNote> GetNotes(SongChart chart)
         {
+            if (Player.UseGeneratedChart)
+            {
+                return chart.GenerateFiveFretDownchart(
+                    Player.Profile.CurrentInstrument,
+                    Player.Profile.CurrentDifficulty);
+            }
+
             var track = chart.GetFiveFretTrack(Player.Profile.CurrentInstrument).Clone();
             return track.GetDifficulty(Player.Profile.CurrentDifficulty);
         }

--- a/Assets/Script/Menu/DifficultySelect/DifficultySelectMenu.cs
+++ b/Assets/Script/Menu/DifficultySelect/DifficultySelectMenu.cs
@@ -7,6 +7,7 @@ using UnityEngine;
 using UnityEngine.Events;
 using UnityEngine.UI;
 using YARG.Core;
+using YARG.Core.Chart;
 using YARG.Core.Extensions;
 using YARG.Core.Game;
 using YARG.Core.Input;
@@ -808,6 +809,15 @@ namespace YARG.Menu.DifficultySelect
             if (instrument is Instrument.ProKeys && difficulty is Difficulty.Beginner)
             {
                 return false;
+            }
+
+            // Missing Easy/Medium/Hard five-fret charts can be generated from Expert when gameplay loads.
+            if (difficulty is (Difficulty.Easy or Difficulty.Medium or Difficulty.Hard) &&
+                instrument is (Instrument.FiveFretGuitar or Instrument.FiveFretBass or
+                    Instrument.FiveFretRhythm or Instrument.FiveFretCoopGuitar or Instrument.Keys) &&
+                entry[instrument][Difficulty.Expert])
+            {
+                return true;
             }
 
             // Otherwise, we can do this

--- a/Assets/Script/Menu/DifficultySelect/DifficultySelectMenu.cs
+++ b/Assets/Script/Menu/DifficultySelect/DifficultySelectMenu.cs
@@ -19,6 +19,7 @@ using YARG.Menu.Navigation;
 using YARG.Menu.Persistent;
 using YARG.Menu.Filters;
 using YARG.Player;
+using YARG.Settings;
 using YARG.Song;
 
 namespace YARG.Menu.DifficultySelect
@@ -300,7 +301,7 @@ namespace YARG.Menu.DifficultySelect
                 });
 
                 CreateItem(LocalizeHeader("Difficulty"),
-                    player.Profile.CurrentDifficulty.ToLocalizedName(),
+                    GetDifficultyName(player.Profile.CurrentDifficulty, player.UseGeneratedChart),
                     _lastMenuState == State.Difficulty, () =>
                 {
                     _menuState = State.Difficulty;
@@ -411,6 +412,7 @@ namespace YARG.Menu.DifficultySelect
                 {
                     var preferredInstrument = CurrentPlayer.Profile.PreferredInstrument;
                     CurrentPlayer.Profile.CurrentInstrument = instrument;
+                    CurrentPlayer.UseGeneratedChart = false;
 
                     // Re-resolve after an instrument switch in case the raw harmony index is out
                     // of range for this song (ChangePlayer's check can be masked by the
@@ -439,16 +441,34 @@ namespace YARG.Menu.DifficultySelect
         {
             foreach (var difficulty in _possibleDifficulties)
             {
-                bool selected = CurrentPlayer.Profile.CurrentDifficulty == difficulty;
+                bool selected = CurrentPlayer.Profile.CurrentDifficulty == difficulty &&
+                    !CurrentPlayer.UseGeneratedChart;
                 CreateItem(difficulty.ToLocalizedName(), selected, () =>
                 {
                     CurrentPlayer.Profile.CurrentDifficulty
                         = CurrentPlayer.Profile.DifficultyFallback
                         = difficulty;
+                    CurrentPlayer.UseGeneratedChart = false;
 
                     _menuState = State.Main;
                     UpdateForPlayer();
                 });
+
+                if (CanUseGeneratedDifficulty(CurrentPlayer.Profile.CurrentInstrument, difficulty))
+                {
+                    bool generatedSelected = CurrentPlayer.Profile.CurrentDifficulty == difficulty &&
+                        CurrentPlayer.UseGeneratedChart;
+                    CreateItem(GetDifficultyName(difficulty, true), generatedSelected, () =>
+                    {
+                        CurrentPlayer.Profile.CurrentDifficulty
+                            = CurrentPlayer.Profile.DifficultyFallback
+                            = difficulty;
+                        CurrentPlayer.UseGeneratedChart = true;
+
+                        _menuState = State.Main;
+                        UpdateForPlayer();
+                    });
+                }
             }
         }
 
@@ -715,6 +735,10 @@ namespace YARG.Menu.DifficultySelect
                 }
             }
             profile.CurrentDifficulty = (Difficulty) diff;
+            if (!CanUseGeneratedDifficulty(profile.CurrentInstrument, profile.CurrentDifficulty))
+            {
+                CurrentPlayer.UseGeneratedChart = false;
+            }
         }
 
         private void OnDisable()
@@ -813,8 +837,7 @@ namespace YARG.Menu.DifficultySelect
 
             // Missing Easy/Medium/Hard five-fret charts can be generated from Expert when gameplay loads.
             if (difficulty is (Difficulty.Easy or Difficulty.Medium or Difficulty.Hard) &&
-                instrument is (Instrument.FiveFretGuitar or Instrument.FiveFretBass or
-                    Instrument.FiveFretRhythm or Instrument.FiveFretCoopGuitar or Instrument.Keys) &&
+                instrument.ToNativeGameMode() == GameMode.FiveFretGuitar &&
                 entry[instrument][Difficulty.Expert])
             {
                 return true;
@@ -830,6 +853,25 @@ namespace YARG.Menu.DifficultySelect
                 Instrument.FiveLaneDrums => entry[Instrument.ProDrums][difficulty],
                 _ => false
             };
+        }
+
+        private bool CanUseGeneratedDifficulty(Instrument instrument, Difficulty difficulty)
+        {
+            if (!SettingsManager.Settings.UseGeneratedDowncharts.Value ||
+                difficulty is not (Difficulty.Easy or Difficulty.Medium or Difficulty.Hard) ||
+                instrument.ToNativeGameMode() != GameMode.FiveFretGuitar)
+            {
+                return false;
+            }
+
+            return _songList.All(entry =>
+                entry[instrument][difficulty] && entry[instrument][Difficulty.Expert]);
+        }
+
+        private string GetDifficultyName(Difficulty difficulty, bool generated)
+        {
+            string name = difficulty.ToLocalizedName();
+            return generated ? $"{name} ({LocalizeHeader("Generated")})" : name;
         }
 
         public void SongSpeedEndEdit(string text)

--- a/Assets/Script/Player/YargPlayer.cs
+++ b/Assets/Script/Player/YargPlayer.cs
@@ -22,6 +22,8 @@ namespace YARG.Player
         /// </summary>
         public bool SittingOut;
 
+        public bool UseGeneratedChart { get; set; }
+
         public bool InputsEnabled { get; private set; }
         public ProfileBindings Bindings { get; private set; }
 
@@ -54,6 +56,7 @@ namespace YARG.Player
         {
             Profile = profile;
             Bindings = bindings;
+            UseGeneratedChart = false;
             IsReplay = false;
         }
 
@@ -92,6 +95,7 @@ namespace YARG.Player
             Bindings?.Dispose();
             Profile = profile;
             Bindings = bindings;
+            UseGeneratedChart = false;
 
             // Resolve bindings
             if (resolveDevices)

--- a/Assets/Script/Settings/SettingsManager.Settings.cs
+++ b/Assets/Script/Settings/SettingsManager.Settings.cs
@@ -192,7 +192,6 @@ namespace YARG.Settings
             public ToggleSetting AutoCreateProfiles { get; } = new(true);
 
             public ToggleSetting ReduceNoteSpeedByDifficulty { get; } = new(true);
-            public ToggleSetting UseGeneratedDowncharts { get; } = new(false);
 
             public ToggleSetting LearningGuides { get; } = new(false);
 
@@ -688,6 +687,7 @@ namespace YARG.Settings
 
             #region Experimental
 
+            public ToggleSetting UseGeneratedDowncharts { get; } = new(false);
             public ToggleSetting DataStreamEnable { get; } = new(false, DataStreamEnableCallback );
             public DropdownSetting<BandComboType> BandComboTypeSetting { get; } = new(BandComboType.Off)
             {

--- a/Assets/Script/Settings/SettingsManager.Settings.cs
+++ b/Assets/Script/Settings/SettingsManager.Settings.cs
@@ -192,6 +192,7 @@ namespace YARG.Settings
             public ToggleSetting AutoCreateProfiles { get; } = new(true);
 
             public ToggleSetting ReduceNoteSpeedByDifficulty { get; } = new(true);
+            public ToggleSetting UseGeneratedDowncharts { get; } = new(false);
 
             public ToggleSetting LearningGuides { get; } = new(false);
 

--- a/Assets/Script/Settings/SettingsManager.cs
+++ b/Assets/Script/Settings/SettingsManager.cs
@@ -53,6 +53,7 @@ namespace YARG.Settings
                 nameof(Settings.NoFail),
                 nameof(Settings.LearningGuides),
                 new FieldMetadata(nameof(Settings.ReduceNoteSpeedByDifficulty)),
+                new FieldMetadata(nameof(Settings.UseGeneratedDowncharts)),
 
                 new HeaderMetadata("StatusBar"),
                 nameof(Settings.ShowBattery),

--- a/Assets/Script/Settings/SettingsManager.cs
+++ b/Assets/Script/Settings/SettingsManager.cs
@@ -53,7 +53,6 @@ namespace YARG.Settings
                 nameof(Settings.NoFail),
                 nameof(Settings.LearningGuides),
                 new FieldMetadata(nameof(Settings.ReduceNoteSpeedByDifficulty)),
-                new FieldMetadata(nameof(Settings.UseGeneratedDowncharts)),
 
                 new HeaderMetadata("StatusBar"),
                 nameof(Settings.ShowBattery),
@@ -252,6 +251,7 @@ namespace YARG.Settings
             new MetadataTab("Experimental", icon: "Beaker", new CharacterPreviewBuilder())
             {
                 new HeaderMetadata("Other"),
+                nameof(Settings.UseGeneratedDowncharts),
                 nameof(Settings.BandComboTypeSetting),
                 nameof(Settings.DataStreamEnable),
                 nameof(Settings.SaveScoresWithBots),

--- a/Assets/StreamingAssets/lang/en-US.json
+++ b/Assets/StreamingAssets/lang/en-US.json
@@ -275,6 +275,7 @@
         "DifficultySelect": {
             "Instrument": "Instrument",
             "Difficulty": "Difficulty",
+            "Generated": "Generated",
             "Harmony": "Harmony",
             "Modifiers": "Modifiers",
             "Ready": "Ready",
@@ -1785,8 +1786,8 @@
                 "Description": "Reduces the note speed if playing on a lower difficulty than Expert. The specified note speed is applied to Expert, and lower difficulties receive a reduction in speed. This setting does not affect vocal tracks."
             },
             "UseGeneratedDowncharts": {
-                "Name": "Use Generated Downcharts",
-                "Description": "Replace authored Easy, Medium, and Hard five-fret charts with versions generated from Expert. Disable this setting to use authored charts while still generating any missing difficulties."
+                "Name": "Show Generated Downcharts",
+                "Description": "Shows generated Easy, Medium, and Hard five-fret charts alongside authored difficulties in the difficulty select menu."
             },
             "LearningGuides": {
                 "Name": "Learning Guides",

--- a/Assets/StreamingAssets/lang/en-US.json
+++ b/Assets/StreamingAssets/lang/en-US.json
@@ -1784,6 +1784,10 @@
                 "Name": "Reduce Note Speed by Difficulty",
                 "Description": "Reduces the note speed if playing on a lower difficulty than Expert. The specified note speed is applied to Expert, and lower difficulties receive a reduction in speed. This setting does not affect vocal tracks."
             },
+            "UseGeneratedDowncharts": {
+                "Name": "Use Generated Downcharts",
+                "Description": "Replace authored Easy, Medium, and Hard five-fret charts with versions generated from Expert. Disable this setting to use authored charts while still generating any missing difficulties."
+            },
             "LearningGuides": {
                 "Name": "Learning Guides",
                 "Description": "Adds some musical theory guides for Pro Keys to help learn the instrument."


### PR DESCRIPTION
This is pure "programmer art" implementation of the feature but it will allow for both the hand authored and generated charts to be accessible in the game simultaneously while we tweak the generation algorithm.

Depends on https://github.com/YARC-Official/YARG.Core/pull/415