### PR TITLE
Add bind for selecting current artist in music library

### DIFF
--- a/Assets/Script/Input/Bindings/BindingCollection.Templates.cs
+++ b/Assets/Script/Input/Bindings/BindingCollection.Templates.cs
@@ -23,6 +23,7 @@ namespace YARG.Input
             new ButtonBinding("Menu.Right",  (int) MenuAction.Right),
 
             new ButtonBinding("Menu.Search", (int) MenuAction.Search),
+            new ButtonBinding("Menu.SelectArtist", (int) MenuAction.SelectArtist),
         };
 
         public static BindingCollection CreateFiveFretGuitarBindings() => new(GameMode.FiveFretGuitar)

--- a/Assets/Script/Input/Bindings/DefaultKeyboardMenuBindings.cs
+++ b/Assets/Script/Input/Bindings/DefaultKeyboardMenuBindings.cs
@@ -20,6 +20,7 @@ namespace YARG.Input
             (MenuAction.Start,  Key.Space),
             (MenuAction.Select, Key.Backspace),
             (MenuAction.Search, Key.Tab),
+            (MenuAction.SelectArtist, Key.F1),
             (MenuAction.Up,     Key.UpArrow),
             (MenuAction.Down,   Key.DownArrow),
             (MenuAction.Left,   Key.LeftArrow),

--- a/Assets/Script/Input/Bindings/Defaults/BindingCollection.Keyboard.cs
+++ b/Assets/Script/Input/Bindings/Defaults/BindingCollection.Keyboard.cs
@@ -241,6 +241,7 @@ namespace YARG.Input
             AddBinding(MenuAction.Right, keyboard.rightArrowKey);
 
             AddBinding(MenuAction.Search, keyboard.tabKey);
+            AddBinding(MenuAction.SelectArtist, keyboard.f1Key);
 
             return true;
         }

--- a/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
+++ b/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
@@ -398,6 +398,8 @@ namespace YARG.Menu.MusicLibrary
                     OnOrangeHit, OnOrangeRelease),
                 new NavigationScheme.Entry(MenuAction.Search, "Menu.MusicLibrary.Search",
                     _searchField.Focus, hide: true),
+                new NavigationScheme.Entry(MenuAction.SelectArtist, "Menu.MusicLibrary.SelectArtist",
+                    () => CurrentSelection?.SecondaryTextClick(), hide: true),
             };
 
             _ = Navigator.Instance.PushScheme(new NavigationScheme(entries, false));

--- a/Assets/StreamingAssets/lang/en-US.json
+++ b/Assets/StreamingAssets/lang/en-US.json
@@ -368,6 +368,7 @@
             "ExpandHeaderHoldStartSet": "<align=left>Expand Header<br><size=67%>(Hold) Start The Set</size></align>",
             "CollapseHeaderHoldStartSet": "<align=left>Collapse Header<br><size=67%>(Hold) Start The Set</size></align>",
             "Search": "Search",
+            "SelectArtist": "Select Current Artist",
             "ExitSearchHold": "(Hold) Exit Search",
             "SkipSection": "<align=left>Navigate Sections</align>",
             "MoveInPlaylist": "Move Song",
@@ -887,7 +888,8 @@
             "Right": "Right",
             "Start": "Start (Pause)",
             "Select": "Select",
-            "Search": "Search"
+            "Search": "Search",
+            "SelectArtist": "Select Current Artist"
         },
         "FiveFret": {
             "Green": "Green Fret (First)",


### PR DESCRIPTION
With this commit you can press F1 on the music library to show all the songs from the current artist. The binding is configurable.

See #1404 and #1555 for context.

Needs https://github.com/YARC-Official/YARG.Core/pull/432.