### PR TITLE
Preserve Music Library Song Selection Instead of Scroll Position when Score Context Changes

### DIFF
--- a/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.SortFilter.cs
+++ b/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.SortFilter.cs
@@ -331,7 +331,7 @@ namespace YARG.Menu.MusicLibrary
 
             // Keep the previous sort attribute, too, so it can be used to
             // sort the list of unplayed songs and possibly for other things
-            if (sort != SortAttribute.Playcount && sort != SortAttribute.Stars)
+            if (!IsDynamicScoreSort(sort))
             {
                 SettingsManager.Settings.PreviousLibrarySort = sort;
             }

--- a/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
+++ b/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -25,6 +25,52 @@ using Random = UnityEngine.Random;
 
 namespace YARG.Menu.MusicLibrary
 {
+    internal readonly struct ScoreContext : IEquatable<ScoreContext>
+    {
+        public readonly Guid ProfileId;
+        public readonly Instrument Instrument;
+        public readonly Difficulty Difficulty;
+        public readonly int HumanPlayerCount;
+        public readonly HighScoreHistoryMode HighScoreHistoryMode;
+
+        private ScoreContext(
+            Guid profileId,
+            Instrument instrument,
+            Difficulty difficulty,
+            int humanPlayerCount,
+            HighScoreHistoryMode highScoreHistoryMode)
+        {
+            ProfileId = profileId;
+            Instrument = instrument;
+            Difficulty = difficulty;
+            HumanPlayerCount = humanPlayerCount;
+            HighScoreHistoryMode = highScoreHistoryMode;
+        }
+
+        public static ScoreContext Capture()
+        {
+            YargProfile profile = PlayerContainer.Players
+                .Select(player => player.Profile)
+                .FirstOrDefault(profile => !profile.IsBot);
+
+            return new ScoreContext(
+                profile?.Id ?? Guid.Empty,
+                profile?.CurrentInstrument ?? Instrument.FiveFretGuitar,
+                profile?.CurrentDifficulty ?? Difficulty.Expert,
+                PlayerContainer.Players.Count(player => !player.Profile.IsBot),
+                SettingsManager.Settings.HighScoreHistory.Value);
+        }
+
+        public bool Equals(ScoreContext other)
+        {
+            return ProfileId == other.ProfileId &&
+                Instrument == other.Instrument &&
+                Difficulty == other.Difficulty &&
+                HumanPlayerCount == other.HumanPlayerCount &&
+                HighScoreHistoryMode == other.HighScoreHistoryMode;
+        }
+    }
+
     public enum MusicLibraryMode
     {
         QuickPlay,
@@ -113,11 +159,7 @@ namespace YARG.Menu.MusicLibrary
 
         // Doesn't go through PlaylistContainer because it is ephemeral
 
-        private static Instrument _lastInstrument;
-        private static Difficulty _lastDifficulty;
-        private static Guid _lastProfileId;
-        private static int _lastHumanPlayerCount;
-        private static HighScoreHistoryMode _lastHighScoreHistoryMode;
+        private static ScoreContext _lastScoreContext;
 
         private static bool _needsReload = false;
         private bool _needsNavigationSchemeRefresh = false;
@@ -253,34 +295,12 @@ namespace YARG.Menu.MusicLibrary
 
         private void SetRefreshIfNeeded()
         {
-            YargProfile profile = null;
-            foreach (YargPlayer p in PlayerContainer.Players)
-            {
-                if (!p.Profile.IsBot)
-                {
-                    profile = p.Profile;
-                    break;
-                }
-            }
-            Instrument currentInstrument = profile?.CurrentInstrument ?? Instrument.FiveFretGuitar;
-            Difficulty currentDifficulty = profile?.CurrentDifficulty ?? Difficulty.Expert;
-            Guid currentProfileId = profile?.Id ?? Guid.Empty;
-            int currentHumanPlayerCount = PlayerContainer.Players.Count(player => !player.Profile.IsBot);
-            HighScoreHistoryMode currentHighScoreHistoryMode = SettingsManager.Settings.HighScoreHistory.Value;
-            bool scoreSortContextChanged =
-                currentProfileId != _lastProfileId ||
-                currentHumanPlayerCount != _lastHumanPlayerCount ||
-                currentInstrument != _lastInstrument ||
-                currentDifficulty != _lastDifficulty ||
-                currentHighScoreHistoryMode != _lastHighScoreHistoryMode;
+            var scoreContext = ScoreContext.Capture();
+            bool scoreSortContextChanged = !scoreContext.Equals(_lastScoreContext);
 
             if (_needsReload || scoreSortContextChanged)
             {
-                _lastProfileId = currentProfileId;
-                _lastHumanPlayerCount = currentHumanPlayerCount;
-                _lastInstrument = currentInstrument;
-                _lastDifficulty = currentDifficulty;
-                _lastHighScoreHistoryMode = currentHighScoreHistoryMode;
+                _lastScoreContext = scoreContext;
                 _needsReload = false;
 
                 if (scoreSortContextChanged && SettingsManager.Settings.LibrarySort == SortAttribute.Stars)
@@ -1072,6 +1092,7 @@ namespace YARG.Menu.MusicLibrary
             public readonly string HeaderFirstSongContentStableId;
             public readonly string HeaderPreviousSongContentStableId;
             public readonly bool PreserveIndexOnDynamicSort; // Sorted by Playcount or Stars
+            public readonly ScoreContext ScoreContext;
 
             public SelectionSnapshot(
                 int selectedIndex,
@@ -1080,7 +1101,8 @@ namespace YARG.Menu.MusicLibrary
                 string headerStableId,
                 string headerFirstSongContentStableId,
                 string headerPreviousSongContentStableId,
-                bool preserveIndexOnDynamicSort)
+                bool preserveIndexOnDynamicSort,
+                ScoreContext scoreContext)
             {
                 SelectedIndex = selectedIndex;
                 SelectedStableId = selectedStableId;
@@ -1089,6 +1111,7 @@ namespace YARG.Menu.MusicLibrary
                 HeaderFirstSongContentStableId = headerFirstSongContentStableId;
                 HeaderPreviousSongContentStableId = headerPreviousSongContentStableId;
                 PreserveIndexOnDynamicSort = preserveIndexOnDynamicSort;
+                ScoreContext = scoreContext;
             }
         }
 
@@ -1154,12 +1177,18 @@ namespace YARG.Menu.MusicLibrary
                 headerStableId,
                 headerFirstSongContentStableId,
                 headerPreviousSongContentStableId,
-                preserveIndexOnDynamicSort);
+                preserveIndexOnDynamicSort,
+                ScoreContext.Capture());
         }
 
         private void RestoreSelectionSnapshot(SelectionSnapshot snapshot)
         {
+            bool scoreSortContextChanged =
+                SettingsManager.Settings.LibrarySort == SortAttribute.Stars &&
+                !snapshot.ScoreContext.Equals(ScoreContext.Capture());
+
             if (snapshot.PreserveIndexOnDynamicSort &&
+                !scoreSortContextChanged &&
                 (SettingsManager.Settings.LibrarySort == SortAttribute.Playcount ||
                     SettingsManager.Settings.LibrarySort == SortAttribute.Stars))
             {

--- a/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
+++ b/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
@@ -276,8 +276,7 @@ namespace YARG.Menu.MusicLibrary
 
             // Make sure sort is not by play count if there are only bots
             if (PlayerContainer.OnlyHasBotsActive() &&
-                (SettingsManager.Settings.LibrarySort == SortAttribute.Playcount ||
-                    SettingsManager.Settings.LibrarySort == SortAttribute.Stars))
+                IsDynamicScoreSort(SettingsManager.Settings.LibrarySort))
             {
                 // Name makes a good fallback?
                 ChangeSort(SortAttribute.Name);
@@ -303,7 +302,7 @@ namespace YARG.Menu.MusicLibrary
                 _lastScoreContext = scoreContext;
                 _needsReload = false;
 
-                if (scoreSortContextChanged && SettingsManager.Settings.LibrarySort == SortAttribute.Stars)
+                if (scoreSortContextChanged && IsDynamicScoreSort(SettingsManager.Settings.LibrarySort))
                 {
                     _searchField.Reset();
                 }
@@ -844,8 +843,7 @@ namespace YARG.Menu.MusicLibrary
             _savedPlaylist = SelectedPlaylist;
             if (MenuState == MenuState.Library && !PlaylistMode)
             {
-                bool preserveIndexOnDynamicSort = SettingsManager.Settings.LibrarySort == SortAttribute.Playcount ||
-                    SettingsManager.Settings.LibrarySort == SortAttribute.Stars;
+                bool preserveIndexOnDynamicSort = IsDynamicScoreSort(SettingsManager.Settings.LibrarySort);
                 _savedSelectionSnapshot = CaptureSelectionSnapshot(preserveIndexOnDynamicSort);
                 _hasSavedSelectionSnapshot = true;
             }
@@ -1183,14 +1181,13 @@ namespace YARG.Menu.MusicLibrary
 
         private void RestoreSelectionSnapshot(SelectionSnapshot snapshot)
         {
-            bool scoreSortContextChanged =
-                SettingsManager.Settings.LibrarySort == SortAttribute.Stars &&
+            bool dynamicSortContextChanged =
+                IsDynamicScoreSort(SettingsManager.Settings.LibrarySort) &&
                 !snapshot.ScoreContext.Equals(ScoreContext.Capture());
 
             if (snapshot.PreserveIndexOnDynamicSort &&
-                !scoreSortContextChanged &&
-                (SettingsManager.Settings.LibrarySort == SortAttribute.Playcount ||
-                    SettingsManager.Settings.LibrarySort == SortAttribute.Stars))
+                !dynamicSortContextChanged &&
+                IsDynamicScoreSort(SettingsManager.Settings.LibrarySort))
             {
                 if (ViewList.Count == 0) return;
 
@@ -1235,6 +1232,11 @@ namespace YARG.Menu.MusicLibrary
             }
 
             SelectedIndex = snapshot.SelectedIndex;
+        }
+
+        private static bool IsDynamicScoreSort(SortAttribute sort)
+        {
+            return sort is SortAttribute.Playcount or SortAttribute.Stars;
         }
 
         private bool SetIndexToStableId(string stableId, int searchStartIndex = 0)

--- a/Assets/Script/Menu/MusicLibrary/ViewTypes/SongViewType.cs
+++ b/Assets/Script/Menu/MusicLibrary/ViewTypes/SongViewType.cs
@@ -1,15 +1,11 @@
-using System;
-using System.Linq;
 using Cysharp.Text;
 using UnityEngine;
-using YARG.Core;
 using YARG.Core.Game;
 using YARG.Core.Song;
 using YARG.Helpers;
 using YARG.Player;
 using YARG.Playlists;
 using YARG.Scores;
-using YARG.Settings;
 using YARG.Song;
 
 namespace YARG.Menu.MusicLibrary
@@ -38,11 +34,7 @@ namespace YARG.Menu.MusicLibrary
         private bool _fetchedScores;
         private PlayerScoreRecord _playerScoreRecord;
         private GameRecord _bandScoreRecord;
-        private int _fetchedHumanCount;
-        private Guid _fetchedPlayerId;
-        private Instrument _fetchedInstrument;
-        private Difficulty _fetchedDifficulty;
-        private HighScoreHistoryMode _fetchedHighScoreHistoryMode;
+        private ScoreContext _fetchedScoreContext;
 
         public SongViewType(MusicLibraryMenu musicLibrary, SongEntry songEntry, string context = "library")
         {
@@ -220,64 +212,21 @@ namespace YARG.Menu.MusicLibrary
 
         private void FetchHighScores()
         {
-            var context = GetCurrentScoreContext();
-            if (_fetchedScores &&
-                _fetchedHumanCount == context.HumanCount &&
-                _fetchedPlayerId == context.PlayerId &&
-                _fetchedInstrument == context.Instrument &&
-                _fetchedDifficulty == context.Difficulty &&
-                _fetchedHighScoreHistoryMode == context.HighScoreHistoryMode)
+            var context = ScoreContext.Capture();
+            if (_fetchedScores && _fetchedScoreContext.Equals(context))
             {
                 return;
             }
 
             FetchHighScores(SongEntry, out _playerScoreRecord, out _bandScoreRecord);
-            _fetchedHumanCount = context.HumanCount;
-            _fetchedPlayerId = context.PlayerId;
-            _fetchedInstrument = context.Instrument;
-            _fetchedDifficulty = context.Difficulty;
-            _fetchedHighScoreHistoryMode = context.HighScoreHistoryMode;
+            _fetchedScoreContext = context;
             _fetchedScores = true;
-        }
-
-        private static ScoreContext GetCurrentScoreContext()
-        {
-            var player = PlayerContainer.Players.FirstOrDefault(e => !e.Profile.IsBot);
-            return new ScoreContext(
-                PlayerContainer.Players.Count(p => !p.Profile.IsBot),
-                player?.Profile.Id ?? Guid.Empty,
-                player?.Profile.CurrentInstrument ?? Instrument.Band,
-                player?.Profile.CurrentDifficulty ?? Difficulty.Easy,
-                SettingsManager.Settings.HighScoreHistory.Value);
         }
 
         private static void FetchHighScores(SongEntry songEntry, out PlayerScoreRecord playerScoreRecord, out GameRecord bandScoreRecord)
         {
             ScoreContainer.GetPreferredHighScoresForCurrentPlayers(
                 songEntry.Hash, out playerScoreRecord, out bandScoreRecord);
-        }
-
-        private readonly struct ScoreContext
-        {
-            public readonly int HumanCount;
-            public readonly Guid PlayerId;
-            public readonly Instrument Instrument;
-            public readonly Difficulty Difficulty;
-            public readonly HighScoreHistoryMode HighScoreHistoryMode;
-
-            public ScoreContext(
-                int humanCount,
-                Guid playerId,
-                Instrument instrument,
-                Difficulty difficulty,
-                HighScoreHistoryMode highScoreHistoryMode)
-            {
-                HumanCount = humanCount;
-                PlayerId = playerId;
-                Instrument = instrument;
-                Difficulty = difficulty;
-                HighScoreHistoryMode = highScoreHistoryMode;
-            }
         }
     }
 }


### PR DESCRIPTION
Right now, when sorted by something dependent on score context (e.g. **Stars**), selecting a song, changing instrument or difficulty (depending on **High Score History** setting), and returning to the Music Library Menu, your scroll position will be maintained, having the selection be on a completely different song.

This change makes the Music Library prefer the song selection instead of the scroll position when you change score context like Instrument.
<img width="1893" height="1127" alt="image" src="https://github.com/user-attachments/assets/9e53147a-c1e1-4f12-9aa0-3849cddeaddd" />
<img width="1893" height="1127" alt="image" src="https://github.com/user-attachments/assets/9cd6cec3-3e63-4d0c-aedf-9975830ecf2b" />

Also, put a tangentially related fix for sort by **Play Count** when changing score context in a similar way.  Right now, the Music Library will stay sorted by the stale context.  For example, switching from Guitar to Bass will keep the library sorted by **Play Count** on Guitar instead of updating to Bass.

This change will update the sort so **Play Count** reflects the latest selected instrument.
