### PR TITLE
bug/web-export-sorting: Articles were not ignored in Artist/Song/Album sort.

### DIFF
--- a/Assets/Script/Song/Exporters/WebBrowserTemplate.cs
+++ b/Assets/Script/Song/Exporters/WebBrowserTemplate.cs
@@ -660,18 +660,34 @@ namespace YARG.Song.Exporters
             return true;
         }
 
+        // Sort metadata without changing the displayed values: ignore one leading
+        // English article when it is followed by whitespace.
+        function normalizeSortValue(value) {
+            const normalized = (value || '').trim().toLowerCase();
+            // The whitespace terminator makes the alternation safe and order-independent.
+            return normalized.replace(/^(the|an|a)\s+/i, '');
+        }
+
         function sortFiltered() {
             if (!state.sortCol) return;
             const col = state.sortCol;
             const dir = state.sortAsc ? 1 : -1;
             const numericCols = new Set(['l', 'y']);
+            const articleInsensitiveCols = new Set(['a', 't', 'al']);
             if (numericCols.has(col)) {
                 filtered.sort((a, b) => ((a[col] || 0) - (b[col] || 0)) * dir);
             } else {
                 filtered.sort((a, b) => {
-                    const va = (a[col] || '').toLowerCase();
-                    const vb = (b[col] || '').toLowerCase();
-                    return va < vb ? -dir : va > vb ? dir : 0;
+                    const rawA = (a[col] || '').toLowerCase();
+                    const rawB = (b[col] || '').toLowerCase();
+                    const va = articleInsensitiveCols.has(col) ? normalizeSortValue(rawA) : rawA;
+                    const vb = articleInsensitiveCols.has(col) ? normalizeSortValue(rawB) : rawB;
+                    if (va < vb) return -dir;
+                    if (va > vb) return dir;
+                    if (articleInsensitiveCols.has(col) && rawA !== rawB) {
+                        return rawA < rawB ? -dir : dir;
+                    }
+                    return 0;
                 });
             }
         }


### PR DESCRIPTION
## Summary

Make the exported song-library page sort Artist, Title, and Album using keys that ignore one leading English article (`The`, `An`, or `A`) while preserving the original displayed metadata.

For example, `The Beatles`, `The Eagles`, `A Perfect Circle`, and `An Example` sort under `B`, `E`, `P`, and `E` respectively instead of under `T` or `A`.

## Why

The web exporter already presents sortable Artist, Title, and Album columns, but its JavaScript comparator lowercased the complete field. Leading articles therefore controlled the sort position, which differs from YARG's intended metadata sorting behavior and makes artist/title browsing less useful.

## Steps to reproduce

1. Open the exported `songs.html` page containing records such as `The Beatles`, `The Eagles`, `A Perfect Circle`, and `An Example`.
2. Click the **Artist** header to sort ascending.
3. Observe the incorrect behavior before this fix: entries beginning with `The` appear in the `T` section and entries beginning with `A`/`An` appear under `A`.
4. Repeat with the **Title** and **Album** headers.

## Root cause

`sortFiltered()` used the complete lowercased field as the comparison key for every non-numeric column:

```javascript
const va = (a[col] || '').toLowerCase();
const vb = (b[col] || '').toLowerCase();
return va < vb ? -dir : va > vb ? dir : 0;
```

The exporter had no separate sort key for leading-article-insensitive metadata. Search haystacks intentionally contain the original lowercased metadata and must not be changed for this fix.

## Fix

`WebBrowserTemplate.cs` now adds a small `normalizeSortValue()` helper that trims and lowercases a value, then removes at most one leading `the`, `an`, or `a` when followed by whitespace:

```javascript
function normalizeSortValue(value) {
    const normalized = (value || '').trim().toLowerCase();
    return normalized.replace(/^(the|an|a)\s+/i, '');
}
```

The helper is applied only to the explicit metadata columns `{ a, t, al }`. Length and Year remain numeric, Instruments keeps its original plain lowercased behavior, and all displayed values/search haystacks remain unchanged.

When normalized keys compare equal, the comparator falls back to the lowercased raw value using the same ascending/descending direction. This keeps entries such as `Beatles` and `The Beatles` deterministic.

## Changes

| File | Change |
|------|--------|
| `YARG/Assets/Script/Song/Exporters/WebBrowserTemplate.cs` | Normalize leading English articles for Artist, Title, and Album sort keys; retain raw-value tie-breaking and existing behavior for all other columns |
| `tests/web-browser-sort.test.js` | Dependency-free Node regression tests that extract and execute the actual embedded helper/comparator |

The external scratch template was also updated to keep its sorter block aligned with the embedded template; it is outside the YARG/workspace repositories and is not part of the upstream PR.

## Testing done

- **Node regression test:** `node --test tests/web-browser-sort.test.js` — **4 passed, 0 failed** on Node `v24.18.0`. Covers normalization boundaries (`Achtung Baby`, standalone `A`/`An`, `The.Beatles`, middle-of-field articles, tab/newline whitespace), ascending/descending Artist, Title/Album, raw tie-breaking, Instruments, numeric Length, and unchanged displayed values.
- **In-game/browser verification (2026-07-26):** The operator tested the runtime synced to `52200385`, exported the song-library web page, and confirmed the updated Artist/Title/Album sorting behavior works while displayed metadata remains unchanged.
- **Runtime synchronization:** YARG runtime is on `52200385`; `YARG.Core` matches its pinned SHA `76fb4f264c107b2da1725a2c220fc81af365e075`.
- **Source checks:** `git diff --check` passed; no YARG.Core source changes were introduced.

## Notes

- Unity-side only; no YARG.Core changes are required.
- The HTML export's visible Artist, Title, and Album strings are not normalized or rewritten.
- Article removal is intentionally limited to one leading English article followed by whitespace. Forms such as `Meet the Beatles`, `Achtung Baby`, standalone `A`, and `The.Beatles` retain their normal comparison semantics.
