### PR TITLE
Make practice mode handle EngineManager state better

### DIFF
--- a/Assets/Script/Gameplay/HUD/ReplayViewer/ReplayController.cs
+++ b/Assets/Script/Gameplay/HUD/ReplayViewer/ReplayController.cs
@@ -267,7 +267,7 @@ namespace YARG.Gameplay.HUD
             GameManager.SetSongTime(time, 0);
 
             // EngineManager's state will get fixed when the players play up to time
-            GameManager.EngineManager.Reset();
+            GameManager.EngineManager.ResetState();
 
             foreach (var player in GameManager.Players)
             {

--- a/Assets/Script/Gameplay/Player/TrackPlayer.cs
+++ b/Assets/Script/Gameplay/Player/TrackPlayer.cs
@@ -391,6 +391,8 @@ namespace YARG.Gameplay.Player
             BeatlineIndex = 0;
             ResetNoteCounters();
 
+            ResetTrackEffectOverlay(0);
+
             CurrentCoda = null;
             _breIndex = 0;
             _unisonStartIndex = 0;
@@ -959,6 +961,9 @@ namespace YARG.Gameplay.Player
             ResetNoteCounters();
 
             BeatlineIndex = 0;
+
+            // Removed by EngineManager
+            EngineContainer = null;
 
             Engine = CreateEngine();
 

--- a/Assets/Script/Gameplay/Player/VocalsPlayer.cs
+++ b/Assets/Script/Gameplay/Player/VocalsPlayer.cs
@@ -595,6 +595,9 @@ namespace YARG.Gameplay.Player
 
             _phraseIndex = -1;
 
+            // Removed by EngineManager
+            EngineContainer = null;
+
             Engine = CreateEngine();
             Engine.SetSpeed(GameManager.SongSpeed >= 1 ? GameManager.SongSpeed : 1);
             ResetPracticeSection();

--- a/Assets/Script/Gameplay/PracticeManager.cs
+++ b/Assets/Script/Gameplay/PracticeManager.cs
@@ -170,6 +170,9 @@ namespace YARG.Gameplay
             TimeStart = timeStart;
             TimeEnd = timeEnd;
 
+            // Engines are all recreated, so reset everything here
+            GameManager.EngineManager.Reset();
+
             bool allowPracticeSP = SettingsManager.Settings.EnablePracticeSP.Value;
             foreach (var player in GameManager.Players)
             {
@@ -244,6 +247,8 @@ namespace YARG.Gameplay
                 HasUpdatedAbPositions = false;
                 return;
             }
+
+            GameManager.EngineManager.ResetState();
 
             foreach (var player in GameManager.Players)
             {


### PR DESCRIPTION
Now we totally reset engine manager when changing sections, since the engines are recreated anyway, and reset the state of EngineManager when practice sections are reset. Also includes a fix for track effects in practice mode.

Requires YARC-Official/YARG.Core#435