### PR TITLE
Fix loading screen appearing underneath Music Library search field + reduce dimming on search field focus

### DIFF
--- a/Assets/Prefabs/Menu/MusicLibrary/MusicLibraryMenu.prefab
+++ b/Assets/Prefabs/Menu/MusicLibrary/MusicLibraryMenu.prefab
@@ -9426,7 +9426,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.Image
   m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 0.9019608}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.6666667}
   m_RaycastTarget: 1
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1

--- a/Assets/Scenes/PersistentScene.unity
+++ b/Assets/Scenes/PersistentScene.unity
@@ -2191,6 +2191,7 @@ GameObject:
   - component: {fileID: 782876830}
   - component: {fileID: 782876832}
   - component: {fileID: 782876833}
+  - component: {fileID: 782876834}
   m_Layer: 5
   m_Name: Loading Screen
   m_TagString: Untagged
@@ -2286,6 +2287,29 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_AspectMode: 4
   m_AspectRatio: 1.7777778
+--- !u!223 &782876834
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 782876828}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 2
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 1
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_VertexColorAlwaysGammaSpace: 0
+  m_AdditionalShaderChannelsFlag: 25
+  m_UpdateRectTransformForStandalone: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 104
+  m_TargetDisplay: 0
 --- !u!1 &787126830
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
Fixes this bug:
https://discord.com/channels/1086048856678084609/1532100226138247259

Additionally, reduce the alpha on the background dimmer on search focus in Music Library.