### PR TITLE
Fix BRE Box behaviour with multiple close together BREs

### DIFF
--- a/Assets/Script/Gameplay/GameManager.cs
+++ b/Assets/Script/Gameplay/GameManager.cs
@@ -166,7 +166,6 @@ namespace YARG.Gameplay
 
         private bool _isReplaySaved;
         private int _originalSleepTimeout;
-        private bool _breBoxActive;
 
         private StemMixer _mixer;
         private MetronomeScheduler _metronomeScheduler;
@@ -1098,25 +1097,18 @@ namespace YARG.Gameplay
 
         public void StartCoda(CodaSection _)
         {
-            if (_breBoxActive)
-            {
-                return;
-            }
-
-            _breBoxActive = true;
             _breBox.StartCoda(EngineManager);
         }
 
         public void EndCoda(CodaSection coda)
         {
             var songEnding = SongTime >= LastNoteTime;
-            _breBox.EndCoda(EngineManager.TotalCodaBonus, songEnding, () => { _breBoxActive = false; });
+            _breBox.EndCoda(EngineManager.TotalCodaBonus, songEnding, null);
         }
 
         public void ResetCoda()
         {
             _breBox.ForceReset();
-            _breBoxActive = false;
         }
     }
 }

--- a/Assets/Script/Gameplay/HUD/BREBox.cs
+++ b/Assets/Script/Gameplay/HUD/BREBox.cs
@@ -5,6 +5,7 @@ using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
 using YARG.Core.Engine;
+using YARG.Core.Logging;
 using YARG.Localization;
 
 namespace YARG.Gameplay.HUD
@@ -61,14 +62,17 @@ namespace YARG.Gameplay.HUD
         {
             if (gameObject.activeSelf)
             {
-                return;
+                YargLogger.LogWarning("BREBox is already active! Forcing a reset.");
+                ForceReset();
+            }
+            else
+            {
+                StopCurrentCoroutine();
             }
 
             _manager = manager;
 
             gameObject.SetActive(true);
-
-            StopCurrentCoroutine();
 
             _currentCoroutine = StartCoroutine(ShowCoroutine());
         }
@@ -113,6 +117,8 @@ namespace YARG.Gameplay.HUD
         public void ForceReset()
         {
             StopCurrentCoroutine();
+
+            _breBoxCanvasGroup.transform.DOKill();
 
             _breBox.gameObject.SetActive(false);
 


### PR DESCRIPTION
Fix for https://discord.com/channels/1086048856678084609/1532493284188885182

We kill the tweens and force a reset if the box is active at the start of another coda.