### PR TITLE
Fix Persistent UI Layering in Filters Menu

### DIFF
--- a/Assets/Scenes/PersistentScene.unity
+++ b/Assets/Scenes/PersistentScene.unity
@@ -414,7 +414,7 @@ Canvas:
   m_AdditionalShaderChannelsFlag: 25
   m_UpdateRectTransformForStandalone: 0
   m_SortingLayerID: 0
-  m_SortingOrder: 101
+  m_SortingOrder: 105
   m_TargetDisplay: 0
 --- !u!224 &237507930
 RectTransform:
@@ -2308,7 +2308,7 @@ Canvas:
   m_AdditionalShaderChannelsFlag: 25
   m_UpdateRectTransformForStandalone: 0
   m_SortingLayerID: 0
-  m_SortingOrder: 104
+  m_SortingOrder: 106
   m_TargetDisplay: 0
 --- !u!1 &787126830
 GameObject:
@@ -4473,7 +4473,7 @@ Canvas:
   m_AdditionalShaderChannelsFlag: 25
   m_UpdateRectTransformForStandalone: 0
   m_SortingLayerID: 0
-  m_SortingOrder: 100
+  m_SortingOrder: 105
   m_TargetDisplay: 0
 --- !u!224 &1694016463
 RectTransform:

--- a/Assets/Script/Menu/Filters/FiltersMenu.cs
+++ b/Assets/Script/Menu/Filters/FiltersMenu.cs
@@ -183,6 +183,7 @@ namespace YARG.Menu.Filters
         private FilterHelpBarState _lastHelpBarState;
         private bool _pendingHelpBarRefresh;
         private bool _showRecommendationsOnOpen;
+        private readonly List<(Canvas Canvas, int SortingOrder)> _elevatedCanvases = new();
 
         protected override void SingletonAwake()
         {
@@ -194,6 +195,8 @@ namespace YARG.Menu.Filters
         private void OnEnable()
         {
             if (!_ready) return;
+
+            SetPersistentUiElevated(true);
 
             _leftNavGroup.SelectionChanged += OnSelectionChanged;
                 _rightNavGroup.SelectionChanged += OnRightSelectionChanged;
@@ -217,6 +220,32 @@ namespace YARG.Menu.Filters
             SaveFilters();
             _showRecommendationsOnOpen = SettingsManager.Settings.ShowRecommendedSongs.Value;
             RefreshHelpBar();
+        }
+
+        private void SetPersistentUiElevated(bool elevated)
+        {
+            if (!elevated)
+            {
+                foreach (var (canvas, originalOrder) in _elevatedCanvases)
+                    canvas.sortingOrder = originalOrder;
+
+                _elevatedCanvases.Clear();
+                return;
+            }
+
+            int sortingOrder = GetComponent<Canvas>().sortingOrder + 1;
+            var statsCanvas = Resources.FindObjectsOfTypeAll<Canvas>()
+                .FirstOrDefault(canvas => canvas.gameObject.name == "Stat Canvas" &&
+                    canvas.gameObject.scene.IsValid());
+
+            foreach (var canvas in new[] { HelpBar.Instance.GetComponentInParent<Canvas>(), statsCanvas })
+            {
+                if (canvas == null)
+                    continue;
+
+                _elevatedCanvases.Add((canvas, canvas.sortingOrder));
+                canvas.sortingOrder = sortingOrder;
+            }
         }
 
         private void HandleConfirm()
@@ -1831,6 +1860,8 @@ namespace YARG.Menu.Filters
         private void OnDisable()
         {
             if (!_ready) return;
+
+            SetPersistentUiElevated(false);
 
             bool showRecommendationsChanged = _showRecommendationsOnOpen !=
                 SettingsManager.Settings.ShowRecommendedSongs.Value;

--- a/Assets/Script/Menu/Filters/FiltersMenu.cs
+++ b/Assets/Script/Menu/Filters/FiltersMenu.cs
@@ -183,7 +183,6 @@ namespace YARG.Menu.Filters
         private FilterHelpBarState _lastHelpBarState;
         private bool _pendingHelpBarRefresh;
         private bool _showRecommendationsOnOpen;
-        private readonly List<(Canvas Canvas, int SortingOrder)> _elevatedCanvases = new();
 
         protected override void SingletonAwake()
         {
@@ -195,8 +194,6 @@ namespace YARG.Menu.Filters
         private void OnEnable()
         {
             if (!_ready) return;
-
-            SetPersistentUiElevated(true);
 
             _leftNavGroup.SelectionChanged += OnSelectionChanged;
                 _rightNavGroup.SelectionChanged += OnRightSelectionChanged;
@@ -220,32 +217,6 @@ namespace YARG.Menu.Filters
             SaveFilters();
             _showRecommendationsOnOpen = SettingsManager.Settings.ShowRecommendedSongs.Value;
             RefreshHelpBar();
-        }
-
-        private void SetPersistentUiElevated(bool elevated)
-        {
-            if (!elevated)
-            {
-                foreach (var (canvas, originalOrder) in _elevatedCanvases)
-                    canvas.sortingOrder = originalOrder;
-
-                _elevatedCanvases.Clear();
-                return;
-            }
-
-            int sortingOrder = GetComponent<Canvas>().sortingOrder + 1;
-            var statsCanvas = Resources.FindObjectsOfTypeAll<Canvas>()
-                .FirstOrDefault(canvas => canvas.gameObject.name == "Stat Canvas" &&
-                    canvas.gameObject.scene.IsValid());
-
-            foreach (var canvas in new[] { HelpBar.Instance.GetComponentInParent<Canvas>(), statsCanvas })
-            {
-                if (canvas == null)
-                    continue;
-
-                _elevatedCanvases.Add((canvas, canvas.sortingOrder));
-                canvas.sortingOrder = sortingOrder;
-            }
         }
 
         private void HandleConfirm()
@@ -1860,8 +1831,6 @@ namespace YARG.Menu.Filters
         private void OnDisable()
         {
             if (!_ready) return;
-
-            SetPersistentUiElevated(false);
 
             bool showRecommendationsChanged = _showRecommendationsOnOpen !=
                 SettingsManager.Settings.ShowRecommendedSongs.Value;


### PR DESCRIPTION
Bring the Status Bar and Now Playing controls z-index if front of the Filters Menu.

Before:
<img width="2560" height="1440" alt="User attachment" src="https://github.com/user-attachments/assets/62c49f06-0b15-42e3-b9c1-c3a6f1738663" />

After:
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/d907aacc-c570-4c8b-b891-1c0dfb3b557c" />
