### PR TITLE
Extend track effects to cover the end of a sustain

### DIFF
--- a/Assets/Script/Gameplay/Player/TrackPlayer.cs
+++ b/Assets/Script/Gameplay/Player/TrackPlayer.cs
@@ -336,7 +336,7 @@ namespace YARG.Gameplay.Player
 
             phrases.AddRange(EngineContainer.UnisonPhrases);
 
-            var effects = TrackEffect.PhrasesToEffects(phrases);
+            var effects = TrackEffect.PhrasesToEffects(Notes, phrases);
             _trackEffects.AddRange(effects);
         }
 

--- a/Assets/Script/Gameplay/Visuals/TrackEffect.cs
+++ b/Assets/Script/Gameplay/Visuals/TrackEffect.cs
@@ -292,11 +292,14 @@ namespace YARG.Gameplay.Visuals
 
         // Give me a list of chart phrases, I give you a list of corresponding track effects
         // I only ask that the phrases you give me are all the same kind
-        public static List<TrackEffect> PhrasesToEffects(params List<Phrase>[] arrayOfPhraseLists)
+        public static List<TrackEffect> PhrasesToEffects<TNote>(List<TNote> notes, params List<Phrase>[] arrayOfPhraseLists)
+            where TNote : Note<TNote>
         {
             var effects = new List<TrackEffect>();
             foreach (var phrases in arrayOfPhraseLists)
             {
+                phrases.Sort((x, y) => x.Time.CompareTo(y.Time));
+                int noteIndex = 0;
                 for (var i = 0; i < phrases.Count; i++)
                 {
                     var type = phrases[i].Type;
@@ -319,10 +322,48 @@ namespace YARG.Gameplay.Visuals
                     var transitionState = true;
 
                     effects.Add(
-                        new TrackEffect(phrases[i].Time, phrases[i].TimeEnd, (TrackEffectType) kind, transitionState, transitionState));
+                        new TrackEffect(phrases[i].Time, GetVisualTimeEndOfPhrase(notes, ref noteIndex, phrases[i]), (TrackEffectType) kind, transitionState, transitionState));
                 }
             }
             return effects;
+        }
+
+        private static double GetVisualTimeEndOfPhrase<TNote>(List<TNote> notes, ref int currentNoteIndex, Phrase phrase)
+            where TNote : Note<TNote>
+        {
+            if (
+                notes is List<DrumNote> ||
+                notes is null ||
+                notes.Count == 0 ||
+                notes.Count <= currentNoteIndex
+            )
+            {
+                return phrase.TimeEnd;
+            }
+
+            while (currentNoteIndex < notes.Count && notes[currentNoteIndex].Tick < phrase.Tick)
+            {
+                currentNoteIndex++;
+            }
+
+            double endTime = phrase.TimeEnd;
+
+            // We intentionally don't increase currentNoteIndex here by making a copy into i,
+            // Since phrases of different types can overlap
+            for (int i = currentNoteIndex; i < notes.Count; i++)
+            {
+                var note = notes[i];
+
+                if (note.Tick >= phrase.TickEnd)
+                {
+                    endTime = Math.Min(endTime, note.Time);
+                    break;
+                }
+
+                endTime = Math.Max(endTime, note.TimeEnd);
+            }
+
+            return endTime;
         }
     }
 }


### PR DESCRIPTION
Hooray, minor visual polish! In terms of implementation, in order to pass the notes list so we could get when the sustain actually ended, I had to make the `PhrasesToEffects` method use the generic `TNote` and take a list of notes from the track player. Mildly unwieldy, but I can't think of a scenario where it would actually cause a problem. `currentNoteIndex` is passed by ref for performance, so we don't need to iterate over the list of notes for each track effect, but this means the list of phrases needs to be sorted first.

Before:

https://github.com/user-attachments/assets/d7bea8e7-14f0-4833-af62-029a1599dc02

After:

https://github.com/user-attachments/assets/c7e63e25-6c4f-4bcf-907b-b80a5cfc0a39

