### PR TITLE
Fix Persistent UI Layering Regression

### DIFF
--- a/Assets/Prefabs/Menu/MusicLibrary/MusicLibraryMenu.prefab
+++ b/Assets/Prefabs/Menu/MusicLibrary/MusicLibraryMenu.prefab
@@ -997,7 +997,7 @@ Canvas:
   m_AdditionalShaderChannelsFlag: 25
   m_UpdateRectTransformForStandalone: 0
   m_SortingLayerID: 0
-  m_SortingOrder: 101
+  m_SortingOrder: 106
   m_TargetDisplay: 0
 --- !u!114 &6708243923115141855
 MonoBehaviour:
@@ -5822,6 +5822,7 @@ MonoBehaviour:
   _favoriteButton: {fileID: 7245200975423601239}
   _favoriteButtonImage: {fileID: 2342133780687937856}
   _sidebarContents: {fileID: 5958352450756398038}
+  _difficultiesContainer: {fileID: 1075743806509257609}
   _difficultiesDisplay: {fileID: 5958352450117307646}
   _albumTitleContainer: {fileID: 5180982014109557589}
   _timeContainer: {fileID: 5958352449830330596}

--- a/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
+++ b/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
@@ -187,6 +187,7 @@ namespace YARG.Menu.MusicLibrary
         protected override void OnEnable()
         {
             base.OnEnable();
+            SetSidebarDifficultiesVisible(true);
 
             _heldInputs.Clear();
 

--- a/Assets/Script/Menu/MusicLibrary/Sidebar.cs
+++ b/Assets/Script/Menu/MusicLibrary/Sidebar.cs
@@ -57,6 +57,8 @@ namespace YARG.Menu.MusicLibrary
         [SerializeField]
         private GameObject _sidebarContents;
         [SerializeField]
+        private GameObject _difficultiesContainer;
+        [SerializeField]
         private GameObject _difficultiesDisplay;
         [SerializeField]
         private GameObject _albumTitleContainer;
@@ -83,7 +85,7 @@ namespace YARG.Menu.MusicLibrary
 
         public void SetDifficultiesVisible(bool visible)
         {
-            _difficultiesDisplay.SetActive(visible);
+            _difficultiesContainer.SetActive(visible);
         }
 
         private readonly List<DifficultyRing> _difficultyRings = new();


### PR DESCRIPTION
With #1601, there is a regression that the `HelpBar` will appear in-front of the `DifficultiesContainer`, cutting off the bottom row of difficulty rings.

Because `DifficultiesContainer` needs to be in-front of `HelpBar`, and `HelpBar` needs to be in-front of `FiltersMenu` and `FiltersMenu` needs to be in-front of `DifficultiesContainer`, I've decided to hide the `DifficultiesContainer` when you open the `FiltersMenu` and show `DifficultiesContainer` when you close the `FiltersMenu`.