### PR TITLE
Update PlasticBand-Unity to v0.9.1

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -150,6 +150,11 @@ tab_width = 4
 indent_style = tab
 tab_width = 4
 
+[manifest.json]
+charset = utf-8
+indent_style = space
+indent_size = 2
+
 [*.inputactions]
 indent_style = tab
 tab_width = 4

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -33,7 +33,7 @@
     "com.nobi.roundedcorners": "https://github.com/kirevdokimov/Unity-UI-Rounded-Corners.git",
     "com.starasgames.tmpro-dynamic-data-cleaner": "1.0.0",
     "com.thenathannator.hidrogen": "0.5.3",
-    "com.thenathannator.plasticband": "0.9.0",
+    "com.thenathannator.plasticband": "0.9.1",
     "com.unity.2d.sprite": "1.0.0",
     "com.unity.addressables": "2.8.0",
     "com.unity.ai.navigation": "2.0.9",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -75,7 +75,7 @@
       "url": "https://package.openupm.com"
     },
     "com.thenathannator.plasticband": {
-      "version": "0.9.0",
+      "version": "0.9.1",
       "depth": 0,
       "source": "registry",
       "dependencies": {


### PR DESCRIPTION
Notable changes include:

- Xbox and Playstation CRKD guitars are now supported.
- 4-lane and 5-lane XInput drumkits are now distinguished between more reliably, using a new method that does not require any inputs to be received first.
- Tilt on PS3 GH guitars now fill up the whole -1 to 1 range by default.
- PS4/5 Riffmaster joysticks no longer have up and down swapped.

([Full release notes](https://github.com/TheNathannator/PlasticBand-Unity/releases/tag/v0.9.1))