### PR TITLE
Multichannel mic handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,7 @@ reload_lock~.meta
 
 # Unity crash dumps
 mono_crash.mem.*.blob
+
+# dotnet tool build output
+Tools/**/[Bb]in/
+Tools/**/[Oo]bj/

--- a/Assets/Script/Audio/Bass/BassAudioManager.cs
+++ b/Assets/Script/Audio/Bass/BassAudioManager.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading;
+using Cysharp.Threading.Tasks;
 using ManagedBass;
 using ManagedBass.Fx;
 using ManagedBass.Mix;
@@ -265,6 +267,11 @@ namespace YARG.Audio.BASS
         protected override List<InputDeviceInfo> GetAllInputDevices()
         {
             return _micManager.GetAllDevices();
+        }
+
+        public UniTask<List<InputDeviceInfo>> GetAllInputDevicesAsync(CancellationToken cancellationToken = default)
+        {
+            return _micManager.GetAllDevicesAsync(cancellationToken);
         }
 
 #nullable enable

--- a/Assets/Script/Audio/Bass/BassAudioManager.cs
+++ b/Assets/Script/Audio/Bass/BassAudioManager.cs
@@ -97,6 +97,8 @@ namespace YARG.Audio.BASS
         private readonly int _opusHandle = 0;
         private BassOutputDevice _currentDevice;
 
+        private readonly BassMicManager _micManager = new();
+
         public BassAudioManager()
         {
             YargLogger.LogInfo("Initializing BASS...");
@@ -251,86 +253,25 @@ namespace YARG.Audio.BASS
 
         protected override MicDevice? GetInputDevice(string name)
         {
-            for (int deviceIndex = 0; Bass.RecordGetDeviceInfo(deviceIndex, out var info); deviceIndex++)
+            if (!InputDeviceInfo.TryParseDisplayName(name, out var parsed))
             {
-                // Ignore disabled/claimed devices
-                if (!info.IsEnabled || info.IsInitialized)
-                {
-                    continue;
-                }
-
-                // Ignore loopback devices, they're potentially confusing and can cause feedback loops
-                if (info.IsLoopback)
-                {
-                    continue;
-                }
-
-                // Check if type is in whitelist
-                // The "Default" device is also excluded here since we want the user to explicitly pick which microphone to use
-                // if (!typeWhitelist.Contains(info.Type) || info.Name == "Default") continue;
-                if (info.Name == "Default" || info.Name != name)
-                {
-                    continue;
-                }
-
-                return CreateInputDevice(deviceIndex, name);
+                return null;
             }
 
-            return null;
+            return _micManager.CreateMic(parsed);
         }
 #nullable disable
 
-        protected override List<(int id, string name)> GetAllInputDevices()
+        protected override List<InputDeviceInfo> GetAllInputDevices()
         {
-            var mics = new List<(int id, string name)>();
-
-            // Ignored for now since it causes issues on Linux, BASS must not report device info correctly there
-            // TODO: allow configuring this at runtime?
-            // Also put into a static variable instead of instantiating every time
-            // var typeWhitelist = new List<DeviceType>()
-            // {
-            //     DeviceType.Headset,
-            //     DeviceType.Digital,
-            //     DeviceType.Line,
-            //     DeviceType.Headphones,
-            //     DeviceType.Microphone,
-            // };
-
-            for (int deviceIndex = 0; Bass.RecordGetDeviceInfo(deviceIndex, out var info); deviceIndex++)
-            {
-                // Ignore disabled/claimed devices
-                if (!info.IsEnabled || info.IsInitialized)
-                {
-                    continue;
-                }
-
-                // Ignore loopback devices, they're potentially confusing and can cause feedback loops
-                if (info.IsLoopback)
-                {
-                    continue;
-                }
-
-                // Check if type is in whitelist
-                // The "Default" device is also excluded here since we want the user to explicitly pick which microphone to use
-                // if (!typeWhitelist.Contains(info.Type) || info.Name == "Default") continue;
-                if (info.Name == "Default")
-                {
-                    continue;
-                }
-
-                mics.Add((deviceIndex, info.Name));
-            }
-
-            return mics;
+            return _micManager.GetAllDevices();
         }
 
 #nullable enable
-        protected override MicDevice? CreateInputDevice(int deviceId, string name)
+        protected override MicDevice? CreateInputDevice(InputDeviceInfo device)
 #nullable disable
         {
-            var device = BassMicDevice.Create(deviceId, name);
-            device?.SetMonitoringLevel(SettingsManager.Settings.VocalMonitoring.Value);
-            return device;
+            return _micManager.CreateMic(device);
         }
 
 #nullable enable

--- a/Assets/Script/Audio/Bass/BassAudioManager.cs
+++ b/Assets/Script/Audio/Bass/BassAudioManager.cs
@@ -255,12 +255,18 @@ namespace YARG.Audio.BASS
 
         protected override MicDevice? GetInputDevice(string name)
         {
-            if (!InputDeviceInfo.TryParseDisplayName(name, out var parsed))
+            if (!InputDeviceInfo.TryParseDisplayName(name, out var baseName, out var channel))
             {
                 return null;
             }
 
-            return _micManager.CreateMic(parsed);
+            return GetInputDevice(baseName, channel);
+        }
+
+        protected override MicDevice? GetInputDevice(string baseName, int channel)
+        {
+            var info = new InputDeviceInfo(-1, baseName, channel, channel + 1);
+            return _micManager.CreateMic(info);
         }
 #nullable disable
 

--- a/Assets/Script/Audio/Bass/BassHelpers.cs
+++ b/Assets/Script/Audio/Bass/BassHelpers.cs
@@ -9,6 +9,8 @@ namespace YARG.Audio.BASS
 {
     public static class BassHelpers
     {
+        public const uint YARG_AUDIO_ABI_VERSION = 1;
+
         public const int PLAYBACK_BUFFER_LENGTH = 75;
         public const double PLAYBACK_BUFFER_DESYNC = PLAYBACK_BUFFER_LENGTH / 1000.0;
 

--- a/Assets/Script/Audio/Bass/BassMicDevice.cs
+++ b/Assets/Script/Audio/Bass/BassMicDevice.cs
@@ -206,18 +206,19 @@ namespace YARG.Audio.BASS
         private const float MIC_HIT_INPUT_THRESHOLD = 25f;
 
 #nullable enable
-        internal static BassMicDevice? Create(int deviceId, string name, RecordingSession session,
+        internal static BassMicDevice? Create(int deviceId, string baseName, RecordingSession session,
             int captureChannel = 0)
 #nullable disable
         {
-            var device = new BassMicDevice(deviceId, name, session, captureChannel);
+            string displayName = session.Channels > 1 ? $"{baseName} - Channel {captureChannel + 1}" : baseName;
+            var device = new BassMicDevice(deviceId, baseName, displayName, session, captureChannel);
 
             device._processedHandle =
                 Bass.CreateStream(session.SampleRate, 1, BassFlags.Decode, StreamProcedureType.Push);
             if (device._processedHandle == 0)
             {
                 YargLogger.LogFormatError("Failed to create processed recording stream for mic '{0}': {1}!",
-                    name, Bass.LastError);
+                    displayName, Bass.LastError);
                 return null;
             }
 
@@ -270,6 +271,7 @@ namespace YARG.Audio.BASS
 
         private MonitorPlaybackHandle _monitorHandle;
 
+        private readonly string           _baseName;
         private readonly int              _deviceId;
         private readonly int              _captureChannel;
         private readonly RecordingSession _session;
@@ -342,12 +344,13 @@ namespace YARG.Audio.BASS
 
         public override SerializedMic Serialize()
         {
-            return new SerializedMic(DisplayName);
+            return new SerializedMic(_baseName, _captureChannel);
         }
 
-        private BassMicDevice(int deviceId, string name, RecordingSession session, int captureChannel)
-            : base(name)
+        private BassMicDevice(int deviceId, string baseName, string displayName, RecordingSession session, int captureChannel)
+            : base(displayName)
         {
+            _baseName = baseName;
             _deviceId = deviceId;
             _captureChannel = captureChannel;
             _session = session;

--- a/Assets/Script/Audio/Bass/BassMicDevice.cs
+++ b/Assets/Script/Audio/Bass/BassMicDevice.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Concurrent;
-using System.Runtime.InteropServices;
 using ManagedBass;
 using ManagedBass.Fx;
 using UnityEngine;
@@ -8,13 +7,11 @@ using YARG.Audio.BASS.Effects;
 using YARG.Audio.PitchDetection;
 using YARG.Core.Logging;
 using YARG.Core.Audio;
-using YARG.Core.IO;
 using YARG.Input;
 using YARG.Settings;
 
 namespace YARG.Audio.BASS
 {
-
     internal class MonitorPlaybackHandle : IDisposable
     {
 #nullable enable
@@ -67,9 +64,9 @@ namespace YARG.Audio.BASS
             return new MonitorPlaybackHandle(monitorPlaybackHandle, reverb, gain);
         }
 
-        public readonly int Handle;
+        public readonly  int             Handle;
         private readonly BassFreeverbDsp _reverb;
-        private readonly BassGainDsp _gain;
+        private readonly BassGainDsp     _gain;
 
         private bool _disposed;
 
@@ -121,39 +118,35 @@ namespace YARG.Audio.BASS
             ResetReverb();
             return 0;
         }
-
     }
 
     internal class RecordingHandle : IDisposable
     {
-        private static readonly int[] _sampleRates = { 48000, 44100, 96000, 16000 };
+        private static readonly int[] _sampleRates =
+        {
+            48000,
+            44100,
+            96000,
+            16000
+        };
 
 #nullable enable
-        public static RecordingHandle? CreateRecordingHandle(RecordProcedure procedure)
+        public static RecordingHandle? CreateRecordingHandle(RecordProcedure procedure, int channels = 1)
 #nullable disable
         {
             var devPeriod = Bass.GetConfig(Configuration.DevicePeriod);
             foreach (int sampleRate in _sampleRates)
             {
-                // Keep callbacks from running until the owner has installed this handle and
-                // finished creating the monitor/processing streams.
-                int handle = Bass.RecordStart(sampleRate, 1, BassFlags.RecordPause, devPeriod, procedure, IntPtr.Zero);
+                int handle = Bass.RecordStart(sampleRate, channels, BassFlags.RecordPause, devPeriod, procedure,
+                    IntPtr.Zero);
                 if (handle == 0)
                 {
-                    YargLogger.LogFormatTrace("Failed to start clean recording at {0} Hz: {1}!", sampleRate, Bass.LastError);
+                    YargLogger.LogFormatTrace("Failed to start clean recording at {0} Hz / {1} ch: {2}!", sampleRate,
+                        channels, Bass.LastError);
                     continue;
                 }
 
-                int processedHandle = Bass.CreateStream(sampleRate, 1, BassFlags.Decode, StreamProcedureType.Push);
-                if (processedHandle == 0)
-                {
-                    YargLogger.LogFormatError("Failed to create processed recording stream at {0} Hz: {1}!", sampleRate, Bass.LastError);
-                    Bass.ChannelStop(handle);
-                    Bass.StreamFree(handle);
-                    continue;
-                }
-
-                return new RecordingHandle(handle, processedHandle, devPeriod, sampleRate);
+                return new RecordingHandle(handle, devPeriod, sampleRate, channels);
             }
 
             YargLogger.LogError("Failed to start recording at any supported sample rate!");
@@ -161,19 +154,19 @@ namespace YARG.Audio.BASS
         }
 
         public readonly int Handle;
-        public readonly int ProcessedHandle;
-
         public readonly int RecordPeriod;
         public readonly int SampleRate;
 
+        public readonly int Channels;
+
         private bool _disposed;
 
-        private RecordingHandle(int handle, int processedHandle, int period, int sampleRate)
+        private RecordingHandle(int handle, int period, int sampleRate, int channels)
         {
             Handle = handle;
-            ProcessedHandle = processedHandle;
             RecordPeriod = period;
             SampleRate = sampleRate;
+            Channels = channels;
         }
 
         public bool Start()
@@ -192,9 +185,6 @@ namespace YARG.Audio.BASS
             {
                 Bass.ChannelStop(Handle);
                 Bass.StreamFree(Handle);
-
-                Bass.ChannelStop(ProcessedHandle);
-                Bass.StreamFree(ProcessedHandle);
                 _disposed = true;
             }
         }
@@ -216,73 +206,59 @@ namespace YARG.Audio.BASS
         private const float MIC_HIT_INPUT_THRESHOLD = 25f;
 
 #nullable enable
-        internal static BassMicDevice? Create(int deviceId, string name)
+        internal static BassMicDevice? Create(int deviceId, string name, RecordingSession session,
+            int captureChannel = 0)
 #nullable disable
         {
-            // Must initialise device before recording
-            if (!Bass.RecordInit(deviceId))
+            var device = new BassMicDevice(deviceId, name, session, captureChannel);
+
+            device._processedHandle =
+                Bass.CreateStream(session.SampleRate, 1, BassFlags.Decode, StreamProcedureType.Push);
+            if (device._processedHandle == 0)
             {
-                YargLogger.LogError(
-                    $"Failed to initialize BASS recording device [{deviceId}] '{name}': {Bass.LastError}!");
+                YargLogger.LogFormatError("Failed to create processed recording stream for mic '{0}': {1}!",
+                    name, Bass.LastError);
                 return null;
             }
 
-            var device = new BassMicDevice(deviceId, name);
-            device._recordHandle = RecordingHandle.CreateRecordingHandle(device.ProcessRecordData);
-            if (device._recordHandle == null)
-            {
-                FreeDevice(deviceId);
-                return null;
-            }
+            device._pitchDetector = new PitchTracker(sampleRate: session.SampleRate);
 
-            device._sampleRate = device._recordHandle.SampleRate;
-            device._recordPeriod = device._recordHandle.RecordPeriod;
-
-            device._pitchDetector = new PitchTracker(sampleRate: device._sampleRate);
-
-            var monitorPlayback = MonitorPlaybackHandle.Create(device._sampleRate);
+            var monitorPlayback = MonitorPlaybackHandle.Create(session.SampleRate);
             if (monitorPlayback == null)
             {
-                device._recordHandle.Dispose();
-                FreeDevice(deviceId);
+                Bass.StreamFree(device._processedHandle);
                 return null;
             }
+
             device._monitorHandle = monitorPlayback;
 
-            int lowEqHandle = BassHelpers.AddEqToChannel(device._recordHandle.ProcessedHandle, _lowEqParameters);
-            int highEqHandle = BassHelpers.AddEqToChannel(device._recordHandle.ProcessedHandle, _highEqParameters);
+            int lowEqHandle = BassHelpers.AddEqToChannel(device._processedHandle, _lowEqParameters);
+            int highEqHandle = BassHelpers.AddEqToChannel(device._processedHandle, _highEqParameters);
             if (lowEqHandle == 0 || highEqHandle == 0)
             {
                 YargLogger.LogFormatError("Failed to add EQ to processed recording stream: {0}!", Bass.LastError);
                 device.Dispose();
                 return null;
             }
-            if (!device._recordHandle.Start())
-            {
-                YargLogger.LogFormatError("Failed to start recording stream: {0}!", Bass.LastError);
-                device.Dispose();
-                return null;
-            }
+
+            session.AddMic(device);
             return device;
         }
 
-        private static void FreeDevice(int deviceId)
-        {
-            Bass.CurrentRecordingDevice = deviceId;
-            if (!Bass.RecordFree())
-            {
-                YargLogger.LogFormatWarning("Failed to free recording device after initialization failure: {0}!", Bass.LastError);
-            }
-        }
+        internal event Action Disposed;
 
         private static readonly PeakEQParameters _lowEqParameters = new()
         {
-            fBandwidth = 2.5f, fCenter = 20f, fGain = -10f
+            fBandwidth = 2.5f,
+            fCenter = 20f,
+            fGain = -10f
         };
 
         private static readonly PeakEQParameters _highEqParameters = new()
         {
-            fBandwidth = 2.5f, fCenter = 10_000f, fGain = -10f
+            fBandwidth = 2.5f,
+            fCenter = 10_000f,
+            fGain = -10f
         };
 
         private float? _lastPitch;
@@ -294,35 +270,20 @@ namespace YARG.Audio.BASS
 
         private MonitorPlaybackHandle _monitorHandle;
 
-        private readonly int _deviceId;
+        private readonly int              _deviceId;
+        private readonly int              _captureChannel;
+        private readonly RecordingSession _session;
 
-        private RecordingHandle _recordHandle;
-
-        private int _sampleRate;
-        private int _recordPeriod;
+        private int _processedHandle;
 
         private int _timeAccumulated;
         private int _processedBufferLength;
 
+        internal int CaptureChannel => _captureChannel;
 
         public override int Reset()
         {
             _frameQueue.Clear();
-
-            var recordHandle = _recordHandle;
-            if (recordHandle == null)
-            {
-                return 0;
-            }
-
-            // Query number of bytes in the recording buffer
-            int available = Bass.ChannelGetData(recordHandle.Handle, IntPtr.Zero, (int) DataFlags.Available);
-
-            // Getting channel data removes it from the buffer (clearing it)
-            if (Bass.ChannelGetData(recordHandle.Handle, IntPtr.Zero, available) == -1)
-            {
-                return (int) Bass.LastError;
-            }
 
             // This is a little bit ugly but I think this is the only way to clear the processing buffer.
             // You can't request the available bytes from a decoding channel so there's no way to know how much data is available.
@@ -336,12 +297,12 @@ namespace YARG.Audio.BASS
                 int bytesRead;
                 do
                 {
-                    bytesRead = Bass.ChannelGetData(recordHandle.ProcessedHandle, (IntPtr) buffer, bufferLength);
+                    bytesRead = Bass.ChannelGetData(_processedHandle, (IntPtr) buffer, bufferLength);
                     if (bytesRead >= 0)
                     {
                         YargLogger.LogFormatTrace("Cleared {0} bytes from processed recording buffer", bytesRead);
                     }
-                } while(bytesRead > 0);
+                } while (bytesRead > 0);
 
                 if (bytesRead == -1)
                 {
@@ -355,6 +316,8 @@ namespace YARG.Audio.BASS
             {
                 return monitorError;
             }
+
+            _session.FlushRecordBuffer();
 
             return 0;
         }
@@ -377,67 +340,133 @@ namespace YARG.Audio.BASS
             }
         }
 
-
         public override SerializedMic Serialize()
         {
             return new SerializedMic(DisplayName);
         }
 
-        private BassMicDevice(int deviceId, string name)
+        private BassMicDevice(int deviceId, string name, RecordingSession session, int captureChannel)
             : base(name)
         {
             _deviceId = deviceId;
+            _captureChannel = captureChannel;
+            _session = session;
         }
 
-        private bool ProcessRecordData(int handle, IntPtr buffer, int length, IntPtr user)
+        /// <summary>
+        /// Handles incoming audio from the BASS recording callback.
+        /// </summary>
+        /// <remarks>
+        /// Most mics are mono. But a single physical device
+        /// (like a USB audio interface with 2 XLR inputs) can appear as one stereo device.
+        /// BASS then delivers interleaved 16-bit samples: [mic1, mic2, mic1, mic2...].
+        /// <para>
+        /// Each mic is assigned its own channel index (<see cref="_captureChannel"/>).
+        /// This method extracts just the selected channel from the interleaved frame and converts it to mono
+        /// </para>
+        /// <para>
+        /// If the device is already mono, no copy is made. Otherwise a temporary mono buffer
+        /// is allocated on the stack (no garbage collection) for the current callback only.
+        /// This is safe because the stack memory lives until this method returns, is wrapped
+        /// in a <see cref="Span{T}"/> so the compiler prevents it from escaping, and is
+        /// passed immediately to <see cref="PushMonoData"/> via <c>fixed</c> without being
+        /// stored. The size is also tiny — roughly 1 KB per callback (e.g. at 48 kHz
+        /// with the default 10 ms BASS device period: 48,000 * 0.01 s = 480 frames,
+        /// 480 * 2 bytes = 960 bytes) — so it will not overflow the thread stack (~256 KB–1 MB).
+        /// </para>
+        /// </remarks>
+        /// <param name="buffer">Pointer to the interleaved 16-bit PCM data from BASS.</param>
+        /// <param name="length">Size of <paramref name="buffer"/> in bytes.</param>
+        internal void ProcessData(IntPtr buffer, int length)
         {
+            if (length <= 0)
+            {
+                return;
+            }
 
+            int channels = _session.Channels;
+            if (channels <= 1)
+            {
+                PushMonoData(buffer, length);
+                return;
+            }
+
+            int frames = length / (channels * sizeof(short));
+            if (frames <= 0)
+            {
+                return;
+            }
+
+            Span<short> mono = stackalloc short[frames];
+            unsafe
+            {
+                short* src = (short*) buffer;
+                if (_captureChannel >= channels)
+                {
+                    YargLogger.LogFormatError(
+                        "Mic '{0}' capture channel {1} exceeds session channel count {2}",
+                        DisplayName, _captureChannel, channels);
+                    return;
+                }
+
+                for (int i = 0; i < frames; ++i)
+                {
+                    mono[i] = src[i * channels + _captureChannel];
+                }
+            }
+
+            unsafe
+            {
+                fixed (short* ptr = mono)
+                {
+                    PushMonoData((IntPtr) ptr, frames * sizeof(short));
+                }
+            }
+        }
+
+        /// <summary>
+        /// Sends mono audio to the monitor stream and to the processing stream.
+        /// Buffers audio until enough time has passed to run pitch detection.
+        /// </summary>
+        private void PushMonoData(IntPtr monoBuffer, int monoLength)
+        {
             // Copies the data from the recording buffer to the monitor playback buffer.
-            if (Bass.StreamPutData(_monitorHandle.Handle, buffer, length) == -1)
+            if (Bass.StreamPutData(_monitorHandle.Handle, monoBuffer, monoLength) == -1)
             {
                 YargLogger.LogFormatError("Error pushing data to monitor stream: {0}", Bass.LastError);
             }
 
-
             // Wait for initialization to complete before processing data
             if (!IsRecordingOutput)
             {
-                return true;
-            }
-
-            var recordHandle = _recordHandle;
-            if (recordHandle == null)
-            {
-                return true;
+                return;
             }
 
             // Copy the data to the batch handle to apply FX
-            Bass.StreamPutData(recordHandle.ProcessedHandle, buffer, length);
+            Bass.StreamPutData(_processedHandle, monoBuffer, monoLength);
 
-            _timeAccumulated += _recordPeriod;
+            _timeAccumulated += _session.RecordPeriod;
 
-            _processedBufferLength += length;
+            _processedBufferLength += monoLength;
 
             // Enough time has passed for pitch detection
-            if(_timeAccumulated >= RECORD_PERIOD_MS)
+            if (_timeAccumulated >= RECORD_PERIOD_MS)
             {
                 unsafe
                 {
-                    byte* procBuff = stackalloc byte[_processedBufferLength];
-
-                    Bass.ChannelGetData(recordHandle.ProcessedHandle, (IntPtr) procBuff, _processedBufferLength);
-
-                    var shortLength = _processedBufferLength / sizeof(short);
-                    var readOnlySpan = new ReadOnlySpan<short>(procBuff, shortLength);
-
-                    CalculatePitchAndAmplitude(readOnlySpan);
+                    Span<byte> procBuff = stackalloc byte[_processedBufferLength];
+                    fixed (byte* ptr = procBuff)
+                    {
+                        Bass.ChannelGetData(_processedHandle, (IntPtr) ptr, _processedBufferLength);
+                        int shortLength = _processedBufferLength / sizeof(short);
+                        var readOnlySpan = new ReadOnlySpan<short>(ptr, shortLength);
+                        CalculatePitchAndAmplitude(readOnlySpan);
+                    }
                 }
 
                 _timeAccumulated = 0;
                 _processedBufferLength = 0;
             }
-
-            return true;
         }
 
         private void CalculatePitchAndAmplitude(ReadOnlySpan<short> buffer)
@@ -504,61 +533,6 @@ namespace YARG.Audio.BASS
             _frameQueue.Enqueue(frame);
         }
 
-        public void StopRecording()
-        {
-            if (_recordHandle != null)
-            {
-                var recordHandle = _recordHandle;
-                _recordHandle = null;
-                recordHandle.Dispose();
-                ResetProcessingState();
-            }
-        }
-
-        public void StartRecording()
-        {
-            if (_recordHandle == null)
-            {
-                // Recording-device selection is thread-local in BASS. Creation and restarts
-                // are not guaranteed to run in the same device context.
-                Bass.CurrentRecordingDevice = _deviceId;
-
-                var recordHandle = RecordingHandle.CreateRecordingHandle(ProcessRecordData);
-                if (recordHandle == null)
-                {
-                    YargLogger.LogError($"Failed to start BASS recording stream for mic '{DisplayName}'!");
-                    return;
-                }
-
-                _recordHandle = recordHandle;
-                if (_sampleRate != recordHandle.SampleRate)
-                {
-                    _pitchDetector = new PitchTracker(recordHandle.SampleRate);
-                }
-                _sampleRate = recordHandle.SampleRate;
-                _recordPeriod = recordHandle.RecordPeriod;
-                ResetProcessingState();
-
-                // Re-apply EQs
-                int lowEqHandle = BassHelpers.AddEqToChannel(recordHandle.ProcessedHandle, _lowEqParameters);
-                int highEqHandle = BassHelpers.AddEqToChannel(recordHandle.ProcessedHandle, _highEqParameters);
-                if (lowEqHandle == 0 || highEqHandle == 0)
-                {
-                    YargLogger.LogFormatError("Failed to re-add EQ to processed recording stream: {0}!", Bass.LastError);
-                    StopRecording();
-                    return;
-                }
-
-                if (!recordHandle.Start())
-                {
-                    YargLogger.LogFormatError("Failed to resume BASS recording stream for mic '{0}': {1}!",
-                        DisplayName, Bass.LastError);
-                    StopRecording();
-                    return;
-                }
-            }
-        }
-
         private void ResetProcessingState()
         {
             _timeAccumulated = 0;
@@ -571,18 +545,11 @@ namespace YARG.Audio.BASS
 
         public void RestartRecording()
         {
-            var recordHandle = _recordHandle;
-            if (recordHandle == null)
-            {
-                StartRecording();
-                return;
-            }
-
             // Keep the native recording channel alive across scene/song transitions.
             // Rapidly closing and reopening the capture device can succeed without the
             // backend delivering any callbacks. Pausing also prevents new monitor data
             // from arriving while its queue and processing state are reset.
-            if (!recordHandle.Pause())
+            if (!_session.Pause())
             {
                 YargLogger.LogFormatError("Failed to pause BASS recording stream for mic '{0}': {1}!",
                     DisplayName, Bass.LastError);
@@ -590,6 +557,7 @@ namespace YARG.Audio.BASS
             }
 
             ResetProcessingState();
+            _session.FlushRecordBuffer();
 
             int monitorError = _monitorHandle.ResetBuffer();
             if (monitorError != 0)
@@ -598,7 +566,7 @@ namespace YARG.Audio.BASS
                     DisplayName, (Errors) monitorError);
             }
 
-            if (!recordHandle.Start())
+            if (!_session.Start())
             {
                 YargLogger.LogFormatError("Failed to resume BASS recording stream for mic '{0}': {1}!",
                     DisplayName, Bass.LastError);
@@ -608,13 +576,14 @@ namespace YARG.Audio.BASS
 
         protected override void DisposeUnmanagedResources()
         {
-            _monitorHandle.Dispose();
-            StopRecording();
-            Bass.CurrentRecordingDevice = _deviceId;
-            if (!Bass.RecordFree())
+            _session.RemoveMic(this);
+            Disposed?.Invoke();
+
+            _monitorHandle?.Dispose();
+            if (_processedHandle != 0)
             {
-                YargLogger.LogWarning(
-                    $"Failed to free BASS recording device [{_deviceId}] '{DisplayName}': {Bass.LastError}");
+                Bass.StreamFree(_processedHandle);
+                _processedHandle = 0;
             }
         }
     }

--- a/Assets/Script/Audio/Bass/BassMicManager.cs
+++ b/Assets/Script/Audio/Bass/BassMicManager.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading;
+using Cysharp.Threading.Tasks;
 using ManagedBass;
 using YARG.Core.Audio;
 using YARG.Core.Logging;
@@ -80,6 +81,11 @@ namespace YARG.Audio.BASS
                 mic.SetMonitoringLevel(SettingsManager.Settings.VocalMonitoring.Value);
                 return mic;
             }
+        }
+
+        public UniTask<List<InputDeviceInfo>> GetAllDevicesAsync(CancellationToken cancellationToken = default)
+        {
+            return UniTask.RunOnThreadPool(() => GetAllDevices(), cancellationToken: cancellationToken);
         }
 
         /// <summary>

--- a/Assets/Script/Audio/Bass/BassMicManager.cs
+++ b/Assets/Script/Audio/Bass/BassMicManager.cs
@@ -34,7 +34,6 @@ namespace YARG.Audio.BASS
         {
             if (device.DeviceId < 0)
             {
-                // Id from saved settings can be stale; resolve by name instead.
                 int resolved = FindDeviceIndexByName(device.Name);
                 if (resolved < 0)
                 {
@@ -52,8 +51,6 @@ namespace YARG.Audio.BASS
 
             lock (_lock)
             {
-                // Check inside the lock: the claim happens in BassMicDevice.Create
-                // (session.AddMic), so checking earlier would be a TOCTOU race.
                 if (IsChannelClaimed(device.DeviceId, device.Channel))
                 {
                     return null;
@@ -209,10 +206,6 @@ namespace YARG.Audio.BASS
                 channels = ChannelProbe.Probe(deviceId, name);
                 if (channels == null)
                 {
-                    // Assume one channel so the device stays usable. Cache the
-                    // failure too: re-probing every time the mic menu opens
-                    // stalls the UI for ~1.5 s per dead device. A device list
-                    // change (RefreshCache) re-probes after a replug.
                     _channelCache[name] = 1;
                     return 1;
                 }
@@ -225,8 +218,6 @@ namespace YARG.Audio.BASS
 
         private void ProbeChannels(List<DeviceEntry> devices)
         {
-            // GetChannelCount locks per device; a probe can block for ~1.5s, so
-            // don't hold the lock across the whole sweep.
             foreach (var device in devices)
             {
                 GetChannelCount(device.Id, device.Info.Name);
@@ -326,17 +317,6 @@ namespace YARG.Audio.BASS
         {
             private const int TIMEOUT_MS = 400;
 
-            // Driver-reported channel counts are unreliable, and RecordStart
-            // success proves nothing on Linux (ALSA plug converts to whatever
-            // you ask for). So probe the actual frame layout instead:
-            //   - 8ch: catches true multi-input devices (>2). Only trusted
-            //     when it finds 3+ distinct channels; on a stereo device the
-            //     plug upmix just repeats L/R, so smaller results are
-            //     ambiguous and fall through to the 2ch probe.
-            //   - 2ch: ground truth for mono vs stereo. A mono source is
-            //     upmixed to identical L/R, while a real stereo stream has
-            //     distinct channels -- even when one input is silent.
-            //   - 1ch: last resort for devices that refuse 2ch.
             private static readonly (int Channels, int Rate)[] PROBE_CONFIGS =
             {
                 (8, 48000),
@@ -389,23 +369,15 @@ namespace YARG.Audio.BASS
                         }
                         finally
                         {
-                            // Stop the handle before disposing the waiter: the device may
-                            // already be initialized by a live session, in which case
-                            // RecordFree below is skipped and the recording would otherwise
-                            // keep firing callbacks into a disposed probe.
                             Bass.ChannelStop(handle);
                             probe.Dispose();
                         }
 
                         if (channelCount == 0)
                         {
-                            // No frame within the timeout; try the next config.
                             continue;
                         }
 
-                        // The 8ch upmix of a stereo device just repeats L/R, so
-                        // a small count there only means "stereo". Trust the 2ch
-                        // probe for anything below 3 channels.
                         if (channels == 8 && channelCount < 3)
                         {
                             continue;
@@ -422,9 +394,6 @@ namespace YARG.Audio.BASS
                     }
                 }
 
-                // Expected for devices with no active input (e.g. a motherboard
-                // codec subdevice with nothing plugged in). They still fall back
-                // to a single mono channel, so this is diagnostic, not an error.
                 YargLogger.LogTrace($"Channel probe: no usable frame from [{deviceId}] '{name}'");
                 return null;
             }
@@ -461,8 +430,6 @@ namespace YARG.Audio.BASS
 
                     short[][] deinterleaved = Deinterleave(_frame, _reportedChannels, frameCount);
 
-                    // If input 1 is zeroes and input 2 has stuff → 2ch, extend to all:
-                    // silent before last active counts, tail silence does not.
                     int lastActive = -1;
                     for (int ch = 0; ch < _reportedChannels; ch++)
                     {
@@ -530,13 +497,33 @@ namespace YARG.Audio.BASS
             {
                 for (int i = 0; i < channel; i++)
                 {
-                    if (bufs[channel].AsSpan().SequenceEqual(bufs[i]))
+                    if (ChannelsEquivalent(bufs[channel], bufs[i]))
                     {
                         return true;
                     }
                 }
 
                 return false;
+            }
+
+            /// <summary>
+            ///     Checks whether two channels carry the same signal, tolerating a few
+            ///     glitched samples. Mono devices are upmixed to identical channels,
+            ///     but USB capture can corrupt a handful of samples per stream.
+            /// </summary>
+            private static bool ChannelsEquivalent(short[] a, short[] b)
+            {
+                int maxDiffering = a.Length / 100;
+                int differing = 0;
+                for (int i = 0; i < a.Length; i++)
+                {
+                    if (a[i] != b[i] && ++differing > maxDiffering)
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
             }
         }
     }

--- a/Assets/Script/Audio/Bass/BassMicManager.cs
+++ b/Assets/Script/Audio/Bass/BassMicManager.cs
@@ -1,0 +1,544 @@
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using ManagedBass;
+using YARG.Core.Audio;
+using YARG.Core.Logging;
+using YARG.Settings;
+
+namespace YARG.Audio.BASS
+{
+    // Manages all recording devices and the mics opened on them. Each physical device
+    // is captured once and shared by every mic on it, so multi-input devices (e.g. a
+    // USB audio interface with several inputs) only open the device a single time.
+    // The manager probes devices to discover their real channel count, caches the
+    // results, tracks which channels are already claimed, and handles
+    // RecordingSession instances as mics are added and removed. BASS recording
+    // calls act on the current recording device; _lock serializes all of them.
+    internal sealed class BassMicManager
+    {
+        private readonly List<ActiveMic>         _activeMics   = new();
+        private readonly Dictionary<string, int> _channelCache = new(StringComparer.Ordinal);
+        private readonly object                  _lock         = new();
+        private          List<string>            _deviceNames  = new();
+
+        /// <summary>
+        ///     Opens a mic on a physical device and claims its capture channel. All mics on
+        ///     the same device share one <see cref="RecordingSession" />. Returns null if the
+        ///     channel is already claimed or the device can't be opened.
+        /// </summary>
+        public MicDevice? CreateMic(InputDeviceInfo device)
+        {
+            if (device.DeviceId < 0)
+            {
+                // Id from saved settings can be stale; resolve by name instead.
+                int resolved = FindDeviceIndexByName(device.Name);
+                if (resolved < 0)
+                {
+                    return null;
+                }
+
+                device = new InputDeviceInfo(resolved, device.Name, device.Channel, device.ChannelCount);
+            }
+
+            int captureChannels = GetChannelCount(device.DeviceId, device.Name);
+            if (device.Channel >= captureChannels)
+            {
+                return null;
+            }
+
+            lock (_lock)
+            {
+                // Check inside the lock: the claim happens in BassMicDevice.Create
+                // (session.AddMic), so checking earlier would be a TOCTOU race.
+                if (IsChannelClaimed(device.DeviceId, device.Channel))
+                {
+                    return null;
+                }
+
+                var session = GetOrCreateSession(device.DeviceId, device.Name, captureChannels);
+                if (session == null)
+                {
+                    return null;
+                }
+
+                var mic = BassMicDevice.Create(device.DeviceId, device.DisplayName, session, device.Channel);
+                if (mic == null)
+                {
+                    if (FindActive(device.DeviceId) == null)
+                    {
+                        session.Dispose();
+                        FreeDevice(device.DeviceId);
+                    }
+
+                    return null;
+                }
+
+                var entry = new ActiveMic(device.DeviceId, session);
+                _activeMics.Add(entry);
+                mic.Disposed += () => ReleaseMic(entry);
+                mic.SetMonitoringLevel(SettingsManager.Settings.VocalMonitoring.Value);
+                return mic;
+            }
+        }
+
+        /// <summary>
+        ///     Returns every usable input device and the unclaimed channels on each
+        /// </summary>
+        public List<InputDeviceInfo> GetAllDevices()
+        {
+            var usable = GetDevices()
+                .Where(d => IsUsable(d.Info))
+                .ToList();
+
+            RefreshCache(usable);
+
+            ProbeChannels(usable);
+
+            var result = new List<InputDeviceInfo>();
+            foreach (var device in usable)
+            {
+                result.AddRange(GetUnclaimedInputs(device.Id, device.Info.Name));
+            }
+
+            return result;
+        }
+
+        private void RefreshCache(List<DeviceEntry> devices)
+        {
+            var names = new List<string>(devices.Count);
+            foreach (var device in devices)
+            {
+                names.Add(device.Info.Name);
+            }
+
+            lock (_lock)
+            {
+                if (!names.SequenceEqual(_deviceNames))
+                {
+                    _channelCache.Clear();
+                    _deviceNames = names;
+                }
+            }
+        }
+
+        private static List<DeviceEntry> GetDevices()
+        {
+            var devices = new List<DeviceEntry>();
+            for (int i = 0; Bass.RecordGetDeviceInfo(i, out var info); i++)
+            {
+                devices.Add(new DeviceEntry(i, info));
+            }
+
+            return devices;
+        }
+
+        private static bool IsUsable(DeviceInfo info)
+        {
+            if (!info.IsEnabled || info.IsLoopback)
+            {
+                return false;
+            }
+
+            if (info.Name == "Default")
+            {
+                return false;
+            }
+
+            if (info.Name.StartsWith("Loopback", StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        private static int FindDeviceIndexByName(string name)
+        {
+            foreach (var device in GetDevices())
+            {
+                if (IsUsable(device.Info) && device.Info.Name == name)
+                {
+                    return device.Id;
+                }
+            }
+
+            return -1;
+        }
+
+        private List<InputDeviceInfo> GetUnclaimedInputs(int deviceId, string name)
+        {
+            int channels = GetChannelCount(deviceId, name);
+            var list = new List<InputDeviceInfo>(channels);
+
+            for (int ch = 0; ch < channels; ch++)
+            {
+                if (IsChannelClaimed(deviceId, ch))
+                {
+                    continue;
+                }
+
+                list.Add(new InputDeviceInfo(deviceId, name, ch, channels));
+            }
+
+            return list;
+        }
+
+        private int GetChannelCount(int deviceId, string name)
+        {
+            lock (_lock)
+            {
+                var active = FindActive(deviceId);
+                if (active != null)
+                {
+                    return active.Session.Channels;
+                }
+
+                if (_channelCache.TryGetValue(name, out int cached))
+                {
+                    return cached;
+                }
+            }
+
+            int? channels;
+            lock (_lock)
+            {
+                channels = ChannelProbe.Probe(deviceId, name);
+                if (channels == null)
+                {
+                    // Assume one channel so the device stays usable. Cache the
+                    // failure too: re-probing every time the mic menu opens
+                    // stalls the UI for ~1.5 s per dead device. A device list
+                    // change (RefreshCache) re-probes after a replug.
+                    _channelCache[name] = 1;
+                    return 1;
+                }
+
+                _channelCache[name] = channels.Value;
+            }
+
+            return channels.Value;
+        }
+
+        private void ProbeChannels(List<DeviceEntry> devices)
+        {
+            // GetChannelCount locks per device; a probe can block for ~1.5s, so
+            // don't hold the lock across the whole sweep.
+            foreach (var device in devices)
+            {
+                GetChannelCount(device.Id, device.Info.Name);
+            }
+        }
+
+        private bool IsChannelClaimed(int deviceId, int channel)
+        {
+            lock (_lock)
+            {
+                return FindActive(deviceId)?.Session.IsChannelClaimed(channel) ?? false;
+            }
+        }
+
+        private RecordingSession? GetOrCreateSession(int deviceId, string name, int channels)
+        {
+            var active = FindActive(deviceId);
+            if (active != null)
+            {
+                return active.Session;
+            }
+
+            if (!Bass.RecordInit(deviceId) && Bass.LastError != Errors.Already)
+            {
+                YargLogger.LogFormatError("Failed to init recording device [{0}] '{1}': {2}", deviceId, name,
+                    Bass.LastError);
+                return null;
+            }
+
+            Bass.CurrentRecordingDevice = deviceId;
+            var session = RecordingSession.Create(deviceId, channels);
+            if (session == null)
+            {
+                FreeDevice(deviceId);
+                return null;
+            }
+
+            return session;
+        }
+
+        private void ReleaseMic(ActiveMic mic)
+        {
+            lock (_lock)
+            {
+                _activeMics.Remove(mic);
+                if (FindActive(mic.DeviceId) != null)
+                {
+                    return;
+                }
+
+                mic.Session.Dispose();
+                FreeDevice(mic.DeviceId);
+            }
+        }
+
+        private static void FreeDevice(int deviceId)
+        {
+            if (!Bass.RecordGetDeviceInfo(deviceId, out var info) || !info.IsInitialized)
+            {
+                return;
+            }
+
+            Bass.CurrentRecordingDevice = deviceId;
+            if (!Bass.RecordFree())
+            {
+                YargLogger.LogFormatWarning("Failed to free recording device [{0}]: {1}", deviceId, Bass.LastError);
+            }
+        }
+
+        private ActiveMic? FindActive(int deviceId) => _activeMics.FirstOrDefault(m => m.DeviceId == deviceId);
+
+        private readonly struct DeviceEntry
+        {
+            public readonly int        Id;
+            public readonly DeviceInfo Info;
+
+            public DeviceEntry(int id, DeviceInfo info)
+            {
+                Id = id;
+                Info = info;
+            }
+        }
+
+        private sealed class ActiveMic
+        {
+            public ActiveMic(int deviceId, RecordingSession session)
+            {
+                DeviceId = deviceId;
+                Session = session;
+            }
+
+            public int              DeviceId { get; }
+            public RecordingSession Session  { get; }
+        }
+
+        private sealed class ChannelProbe : IDisposable
+        {
+            private const int TIMEOUT_MS = 400;
+
+            // Driver-reported channel counts are unreliable, and RecordStart
+            // success proves nothing on Linux (ALSA plug converts to whatever
+            // you ask for). So probe the actual frame layout instead:
+            //   - 8ch: catches true multi-input devices (>2). Only trusted
+            //     when it finds 3+ distinct channels; on a stereo device the
+            //     plug upmix just repeats L/R, so smaller results are
+            //     ambiguous and fall through to the 2ch probe.
+            //   - 2ch: ground truth for mono vs stereo. A mono source is
+            //     upmixed to identical L/R, while a real stereo stream has
+            //     distinct channels -- even when one input is silent.
+            //   - 1ch: last resort for devices that refuse 2ch.
+            private static readonly (int Channels, int Rate)[] PROBE_CONFIGS =
+            {
+                (8, 48000),
+                (8, 44100),
+                (2, 48000),
+                (2, 44100),
+                (1, 48000),
+                (1, 44100),
+            };
+
+            private readonly ManualResetEventSlim _gotFrame = new(false);
+            private readonly int                  _reportedChannels;
+            private          short[]              _frame = Array.Empty<short>();
+
+            private ChannelProbe(int reportedChannels)
+            {
+                _reportedChannels = reportedChannels;
+            }
+
+            public void Dispose() => _gotFrame.Dispose();
+
+            public static int? Probe(int deviceId, string name)
+            {
+                bool initialized = Bass.RecordInit(deviceId);
+                if (!initialized && Bass.LastError != Errors.Already)
+                {
+                    return null;
+                }
+
+                Bass.CurrentRecordingDevice = deviceId;
+                int devicePeriod = Bass.GetConfig(Configuration.DevicePeriod);
+                try
+                {
+                    foreach ((int channels, int rate) in PROBE_CONFIGS)
+                    {
+                        var probe = new ChannelProbe(channels);
+                        int handle = Bass.RecordStart(rate, channels, BassFlags.Default,
+                            devicePeriod, probe.Callback, IntPtr.Zero);
+
+                        if (handle == 0)
+                        {
+                            probe.Dispose();
+                            continue;
+                        }
+
+                        int channelCount;
+                        try
+                        {
+                            channelCount = probe.CountChannels();
+                        }
+                        finally
+                        {
+                            // Stop the handle before disposing the waiter: the device may
+                            // already be initialized by a live session, in which case
+                            // RecordFree below is skipped and the recording would otherwise
+                            // keep firing callbacks into a disposed probe.
+                            Bass.ChannelStop(handle);
+                            probe.Dispose();
+                        }
+
+                        if (channelCount == 0)
+                        {
+                            // No frame within the timeout; try the next config.
+                            continue;
+                        }
+
+                        // The 8ch upmix of a stereo device just repeats L/R, so
+                        // a small count there only means "stereo". Trust the 2ch
+                        // probe for anything below 3 channels.
+                        if (channels == 8 && channelCount < 3)
+                        {
+                            continue;
+                        }
+
+                        return channelCount;
+                    }
+                }
+                finally
+                {
+                    if (initialized)
+                    {
+                        Bass.RecordFree();
+                    }
+                }
+
+                // Expected for devices with no active input (e.g. a motherboard
+                // codec subdevice with nothing plugged in). They still fall back
+                // to a single mono channel, so this is diagnostic, not an error.
+                YargLogger.LogTrace($"Channel probe: no usable frame from [{deviceId}] '{name}'");
+                return null;
+            }
+
+            private int CountChannels()
+            {
+                int deadline = Environment.TickCount + TIMEOUT_MS;
+                while (true)
+                {
+                    int remaining = deadline - Environment.TickCount;
+                    if (remaining <= 0)
+                    {
+                        return 0;
+                    }
+
+                    bool received = _gotFrame.Wait(remaining);
+                    if (!received)
+                    {
+                        return 0;
+                    }
+
+                    _gotFrame.Reset();
+
+                    if (_frame.Length == 0 || IsFrameSilent(_frame))
+                    {
+                        continue;
+                    }
+
+                    int frameCount = _frame.Length / _reportedChannels;
+                    if (frameCount == 0)
+                    {
+                        return 0;
+                    }
+
+                    short[][] deinterleaved = Deinterleave(_frame, _reportedChannels, frameCount);
+
+                    // If input 1 is zeroes and input 2 has stuff → 2ch, extend to all:
+                    // silent before last active counts, tail silence does not.
+                    int lastActive = -1;
+                    for (int ch = 0; ch < _reportedChannels; ch++)
+                    {
+                        if (IsSilent(deinterleaved[ch]))
+                        {
+                            continue;
+                        }
+
+                        if (IsDuplicate(deinterleaved, ch))
+                        {
+                            continue;
+                        }
+
+                        lastActive = ch;
+                    }
+
+                    if (lastActive < 0)
+                    {
+                        return 0;
+                    }
+
+                    return lastActive + 1;
+                }
+            }
+
+            private bool Callback(int handle, IntPtr buffer, int length, IntPtr user)
+            {
+                if (length <= 0)
+                {
+                    return true;
+                }
+
+                unsafe
+                {
+                    var span = new Span<short>((short*) buffer, length / sizeof(short));
+                    _frame = span.ToArray();
+                    _gotFrame.Set();
+                }
+
+                return true;
+            }
+
+            private static short[][] Deinterleave(short[] interleaved, int channels, int frameCount)
+            {
+                short[][] outBufs = new short[channels][];
+                for (int ch = 0; ch < channels; ch++)
+                {
+                    short[] buf = new short[frameCount];
+                    for (int i = 0; i < frameCount; i++)
+                    {
+                        buf[i] = interleaved[i * channels + ch];
+                    }
+
+                    outBufs[ch] = buf;
+                }
+
+                return outBufs;
+            }
+
+            private static bool IsSilent(short[] samples) => Array.TrueForAll(samples, s => s == 0);
+
+            private static bool IsFrameSilent(short[] samples) => Array.TrueForAll(samples, s => s == 0);
+
+            private static bool IsDuplicate(short[][] bufs, int channel)
+            {
+                for (int i = 0; i < channel; i++)
+                {
+                    if (bufs[channel].AsSpan().SequenceEqual(bufs[i]))
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
+            }
+        }
+    }
+}
+

--- a/Assets/Script/Audio/Bass/BassMicManager.cs
+++ b/Assets/Script/Audio/Bass/BassMicManager.cs
@@ -63,7 +63,7 @@ namespace YARG.Audio.BASS
                     return null;
                 }
 
-                var mic = BassMicDevice.Create(device.DeviceId, device.DisplayName, session, device.Channel);
+                var mic = BassMicDevice.Create(device.DeviceId, device.Name, session, device.Channel);
                 if (mic == null)
                 {
                     if (FindActive(device.DeviceId) == null)

--- a/Assets/Script/Audio/Bass/BassMicManager.cs.meta
+++ b/Assets/Script/Audio/Bass/BassMicManager.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 42fbfe24839346659d05948891ec5fc5
+timeCreated: 1786045616

--- a/Assets/Script/Audio/Bass/Effects/BassFreeverbDsp.cs
+++ b/Assets/Script/Audio/Bass/Effects/BassFreeverbDsp.cs
@@ -12,7 +12,6 @@ namespace YARG.Audio.BASS.Effects
     /// </summary>
     public sealed class BassFreeverbDsp : SafeHandleZeroOrMinusOneIsInvalid
     {
-        private const uint ABI_VERSION = 1;
         private const string EFFECT_NAME = "native Freeverb DSP";
 
         private BassFreeverbDsp() : base(true)
@@ -45,10 +44,10 @@ namespace YARG.Audio.BASS.Effects
             try
             {
                 uint nativeVersion = Native.GetAbiVersion();
-                if (nativeVersion != ABI_VERSION)
+                if (nativeVersion != BassHelpers.YARG_AUDIO_ABI_VERSION)
                 {
                     YargLogger.LogError(
-                        $"Cannot attach {EFFECT_NAME}: ABI mismatch managed={ABI_VERSION}, " +
+                        $"Cannot attach {EFFECT_NAME}: ABI mismatch managed={BassHelpers.YARG_AUDIO_ABI_VERSION}, " +
                         $"native={nativeVersion}, channel={streamHandle}, " +
                         $"platform={PlatformDescription}.");
                     return null;

--- a/Assets/Script/Audio/Bass/Effects/BassGainDsp.cs
+++ b/Assets/Script/Audio/Bass/Effects/BassGainDsp.cs
@@ -12,7 +12,6 @@ namespace YARG.Audio.BASS.Effects
     /// </summary>
     internal sealed class BassGainDsp : SafeHandleZeroOrMinusOneIsInvalid
     {
-        private const uint ABI_VERSION = 1;
         private const string EFFECT_NAME = "native Gain DSP";
 
         private BassGainDsp() : base(true)
@@ -32,10 +31,10 @@ namespace YARG.Audio.BASS.Effects
             try
             {
                 uint nativeVersion = Native.GetAbiVersion();
-                if (nativeVersion != ABI_VERSION)
+                if (nativeVersion != BassHelpers.YARG_AUDIO_ABI_VERSION)
                 {
                     YargLogger.LogError(
-                        $"Cannot attach {EFFECT_NAME}: ABI mismatch managed={ABI_VERSION}, " +
+                        $"Cannot attach {EFFECT_NAME}: ABI mismatch managed={BassHelpers.YARG_AUDIO_ABI_VERSION}, " +
                         $"native={nativeVersion}, channel={channelHandle}, " +
                         $"platform={PlatformDescription}.");
                     return null;

--- a/Assets/Script/Audio/Bass/RecordingSession.cs
+++ b/Assets/Script/Audio/Bass/RecordingSession.cs
@@ -1,0 +1,153 @@
+using System;
+using System.Collections.Generic;
+using ManagedBass;
+using YARG.Core.Logging;
+
+namespace YARG.Audio.BASS
+{
+    /// <summary>
+    ///     The capture for one physical mic device, shared by every mic on that device.
+    ///     Some devices have multiple inputs (Channel 1, Channel 2, etc.) but we only
+    ///     open the device once — each mic just reads its own channel from that one capture.
+    /// </summary>
+    internal sealed class RecordingSession : IDisposable
+    {
+        private readonly object              _lock = new();
+        private readonly List<BassMicDevice> _mics = new();
+
+        private readonly int             _deviceId;
+        private          RecordingHandle _recordHandle;
+
+        private bool _disposed;
+
+        public int SampleRate   => _recordHandle.SampleRate;
+        public int RecordPeriod => _recordHandle.RecordPeriod;
+        public int Channels     => _recordHandle.Channels;
+
+        private RecordingSession(int deviceId, RecordingHandle recordHandle)
+        {
+            _deviceId = deviceId;
+            _recordHandle = recordHandle;
+        }
+
+#nullable enable
+        public static RecordingSession? Create(int deviceId, int captureChannels)
+#nullable disable
+        {
+            var session = new RecordingSession(deviceId, null);
+            session._recordHandle = RecordingHandle.CreateRecordingHandle(session.OnRecordData, captureChannels);
+            if (session._recordHandle == null)
+            {
+                return null;
+            }
+
+            if (!session._recordHandle.Start())
+            {
+                YargLogger.LogFormatError("Failed to start recording session for device [{0}]: {1}!",
+                    deviceId, Bass.LastError);
+                session._recordHandle.Dispose();
+                return null;
+            }
+
+            return session;
+        }
+
+        public void AddMic(BassMicDevice mic)
+        {
+            lock (_lock)
+            {
+                _mics.Add(mic);
+            }
+        }
+
+        public void RemoveMic(BassMicDevice mic)
+        {
+            lock (_lock)
+            {
+                _mics.Remove(mic);
+            }
+        }
+
+        public bool IsChannelClaimed(int channel)
+        {
+            lock (_lock)
+            {
+                return AnyMicOnChannel(channel);
+            }
+        }
+
+        private bool AnyMicOnChannel(int channel)
+        {
+            for (int i = 0; i < _mics.Count; ++i)
+            {
+                if (_mics[i].CaptureChannel == channel)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        public bool Pause()
+        {
+            return _recordHandle.Pause();
+        }
+
+        public bool Start()
+        {
+            return _recordHandle.Start();
+        }
+
+        public void FlushRecordBuffer()
+        {
+            int available = Bass.ChannelGetData(_recordHandle.Handle, IntPtr.Zero, (int) DataFlags.Available);
+
+            if (Bass.ChannelGetData(_recordHandle.Handle, IntPtr.Zero, available) == -1)
+            {
+                YargLogger.LogFormatError("Failed to clear recording buffer for device [{0}]: {1}!",
+                    _deviceId, Bass.LastError);
+            }
+        }
+
+        private bool OnRecordData(int handle, IntPtr buffer, int length, IntPtr user)
+        {
+            lock (_lock)
+            {
+                for (int i = 0; i < _mics.Count; ++i)
+                {
+                    _mics[i].ProcessData(buffer, length);
+                }
+            }
+
+            return true;
+        }
+
+        private void Dispose(bool disposing)
+        {
+            lock (_lock)
+            {
+                if (_disposed)
+                {
+                    return;
+                }
+
+                _disposed = true;
+                _mics.Clear();
+            }
+
+            _recordHandle?.Dispose();
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        ~RecordingSession()
+        {
+            Dispose(false);
+        }
+    }
+}

--- a/Assets/Script/Audio/Bass/RecordingSession.cs.meta
+++ b/Assets/Script/Audio/Bass/RecordingSession.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a843034a958844cb900c2a6b2beafcdf

--- a/Assets/Script/Gameplay/GameManager.Loading.cs
+++ b/Assets/Script/Gameplay/GameManager.Loading.cs
@@ -425,9 +425,12 @@ namespace YARG.Gameplay
 
                     if (!player.IsReplay)
                     {
-                        // Reset microphone (resets channel buffers)
+                        // Reset microphones (resets channel buffers)
                         // We probably wanna do this no matter what, so put it up here
-                        player.Bindings.Microphone?.Reset();
+                        foreach (var mic in player.Bindings.Microphones)
+                        {
+                            mic.Reset();
+                        }
                     }
 
                     // Skip if the player is sitting out

--- a/Assets/Script/Gameplay/Player/VocalsPlayer.cs
+++ b/Assets/Script/Gameplay/Player/VocalsPlayer.cs
@@ -134,10 +134,10 @@ namespace YARG.Gameplay.Player
 
             _hud.ShowPlayerName(player, needleIndex);
 
-            // Create and start an input context for the mic
-            if (!Player.IsReplay && player.Bindings.Microphone != null)
+            // Create and start an input context for the mics
+            if (!Player.IsReplay && player.Bindings.Microphones.Count > 0)
             {
-                _inputContext = new MicInputContext(player.Bindings.Microphone, GameManager);
+                _inputContext = new MicInputContext(player.Bindings.Microphones, GameManager);
                 _inputContext.Start();
             }
 

--- a/Assets/Script/Input/Bindings/ProfileBindings.cs
+++ b/Assets/Script/Input/Bindings/ProfileBindings.cs
@@ -196,7 +196,8 @@ namespace YARG.Input
 
             for (int i = _unresolvedMics.Count - 1; i >= 0; i--)
             {
-                var device = GlobalAudioHandler.GetInputDevice(_unresolvedMics[i].Name);
+                var mic = _unresolvedMics[i];
+                var device = GlobalAudioHandler.GetInputDevice(mic.BaseName, mic.Channel);
                 if (device != null)
                 {
                     _unresolvedMics.RemoveAt(i);
@@ -435,10 +436,10 @@ namespace YARG.Input
 
             _microphones.Add(microphone);
 
-            // Remove corresponding serialized entry, if any
+            var serialized = microphone.Serialize();
             for (int i = _unresolvedMics.Count - 1; i >= 0; i--)
             {
-                if (_unresolvedMics[i].Name == microphone.DisplayName)
+                if (_unresolvedMics[i].BaseName == serialized.BaseName && _unresolvedMics[i].Channel == serialized.Channel)
                 {
                     _unresolvedMics.RemoveAt(i);
                 }

--- a/Assets/Script/Input/Bindings/ProfileBindings.cs
+++ b/Assets/Script/Input/Bindings/ProfileBindings.cs
@@ -18,8 +18,19 @@ namespace YARG.Input
     {
         public YargProfile Profile { get; }
 
-        private SerializedMic _unresolvedMic;
-        public MicDevice Microphone { get; private set; }
+        private readonly List<SerializedMic> _unresolvedMics = new();
+        private readonly List<MicDevice> _microphones = new();
+
+        /// <summary>
+        ///     The first microphone, for gameplay that only supports one at a time.
+        /// </summary>
+        public MicDevice Microphone => _microphones.Count > 0 ? _microphones[0] : null;
+
+        /// <summary>
+        ///     Every microphone assigned to this profile.
+        /// </summary>
+        public List<MicDevice> Microphones => _microphones;
+
         public List<InputDevice> InputDevices => _devices;
 
         private readonly List<SerializedInputDevice> _unresolvedDevices = new();
@@ -29,7 +40,7 @@ namespace YARG.Input
         public readonly BindingCollection MenuBindings;
 
         public bool HasDeviceAssigned => _devices.Count > 0;
-        public bool Empty => !HasDeviceAssigned && Microphone is null;
+        public bool Empty => !HasDeviceAssigned && _microphones.Count == 0;
 
         public BindingCollection this[GameMode mode] => _bindsByGameMode[mode];
 
@@ -98,7 +109,21 @@ namespace YARG.Input
                 }
             }
 
-            _unresolvedMic = bindings.Microphone;
+            if (bindings.Microphones.Count > 0)
+            {
+                foreach (var mic in bindings.Microphones)
+                {
+                    if (mic is not null)
+                    {
+                        _unresolvedMics.Add(mic);
+                    }
+                }
+            }
+            else if (bindings.Microphone is not null)
+            {
+                // Legacy files (v0-v2) only had a single microphone
+                _unresolvedMics.Add(bindings.Microphone);
+            }
 
             if (bindings.ModeMappings is not null)
             {
@@ -131,7 +156,15 @@ namespace YARG.Input
                 serialized.Devices.Add(device);
             }
 
-            serialized.Microphone = _unresolvedMic;
+            foreach (var mic in _microphones)
+            {
+                serialized.Microphones.Add(mic.Serialize());
+            }
+
+            foreach (var mic in _unresolvedMics)
+            {
+                serialized.Microphones.Add(mic);
+            }
 
             foreach (var (mode, bindings) in _bindsByGameMode)
             {
@@ -161,11 +194,12 @@ namespace YARG.Input
                     OnDeviceAdded(device);
             }
 
-            if (_unresolvedMic is not null)
+            for (int i = _unresolvedMics.Count - 1; i >= 0; i--)
             {
-                var device = GlobalAudioHandler.GetInputDevice(_unresolvedMic.Name);
+                var device = GlobalAudioHandler.GetInputDevice(_unresolvedMics[i].Name);
                 if (device != null)
                 {
+                    _unresolvedMics.RemoveAt(i);
                     AddMicrophone(device);
                 }
             }
@@ -394,15 +428,42 @@ namespace YARG.Input
 
         public void AddMicrophone(MicDevice microphone)
         {
-            Microphone = microphone;
-            _unresolvedMic = microphone.Serialize();
+            if (_microphones.Contains(microphone))
+            {
+                return;
+            }
+
+            _microphones.Add(microphone);
+
+            // Remove corresponding serialized entry, if any
+            for (int i = _unresolvedMics.Count - 1; i >= 0; i--)
+            {
+                if (_unresolvedMics[i].Name == microphone.DisplayName)
+                {
+                    _unresolvedMics.RemoveAt(i);
+                }
+            }
         }
 
-        public void RemoveMicrophone()
+        public void RemoveMicrophone(MicDevice microphone)
         {
-            Microphone?.Dispose();
-            Microphone = null;
-            _unresolvedMic = null;
+            if (!_microphones.Remove(microphone))
+            {
+                return;
+            }
+
+            microphone.Dispose();
+        }
+
+        public void RemoveAllMicrophones()
+        {
+            foreach (var mic in _microphones)
+            {
+                mic.Dispose();
+            }
+
+            _microphones.Clear();
+            _unresolvedMics.Clear();
         }
 
         public void Dispose()
@@ -412,7 +473,7 @@ namespace YARG.Input
                 OnDeviceRemoved(device);
             }
 
-            RemoveMicrophone();
+            RemoveAllMicrophones();
         }
     }
 }

--- a/Assets/Script/Input/Bindings/Serialization/BindingSerialization.cs
+++ b/Assets/Script/Input/Bindings/Serialization/BindingSerialization.cs
@@ -37,6 +37,9 @@ namespace YARG.Input.Serialization
     public class SerializedProfileBindings
     {
         public List<SerializedInputDevice> Devices = new();
+        public List<SerializedMic> Microphones = new();
+
+        // Legacy single microphone, only filled when loading v0-v2 files
         public SerializedMic? Microphone;
 
         public Dictionary<GameMode, SerializedBindingCollection> ModeMappings = new();
@@ -129,7 +132,7 @@ namespace YARG.Input.Serialization
         {
             try
             {
-                var serialized = SerializeBindingsV2(bindings);
+                var serialized = SerializeBindingsV3(bindings);
                 string bindingsJson = JsonConvert.SerializeObject(serialized, Formatting.Indented);
                 File.WriteAllText(bindingsPath, bindingsJson);
             }
@@ -161,6 +164,7 @@ namespace YARG.Input.Serialization
                     0 => DeserializeBindingsV0(jObject),
                     1 => DeserializeBindingsV1(jObject),
                     2 => DeserializeBindingsV2(jObject),
+                    3 => DeserializeBindingsV3(jObject),
                     _ => throw new NotImplementedException($"Unhandled bindings version {version}!")
                 };
 

--- a/Assets/Script/Input/Bindings/Serialization/BindingSerialization.v3.cs
+++ b/Assets/Script/Input/Bindings/Serialization/BindingSerialization.v3.cs
@@ -260,9 +260,9 @@ namespace YARG.Input.Serialization
 
             if (!string.IsNullOrEmpty(DisplayName))
             {
-                if (InputDeviceInfo.TryParseDisplayName(DisplayName, out var b, out var c))
+                if (InputDeviceInfo.TryParseDisplayName(DisplayName, out var parsedBaseName, out var parsedChannel))
                 {
-                    return new SerializedMic(b, c);
+                    return new SerializedMic(parsedBaseName, parsedChannel);
                 }
 
                 return new SerializedMic(DisplayName, 0);

--- a/Assets/Script/Input/Bindings/Serialization/BindingSerialization.v3.cs
+++ b/Assets/Script/Input/Bindings/Serialization/BindingSerialization.v3.cs
@@ -1,0 +1,250 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using UnityEngine;
+using YARG.Core;
+using YARG.Core.Logging;
+
+#nullable enable
+
+namespace YARG.Input.Serialization
+{
+    // Version 3: Supports multiple microphones per profile.
+
+    // Unchanged data types
+    using SerializedInputDeviceV3 = SerializedInputDeviceV0;
+    using SerializedMicV3 = SerializedMicV0;
+
+    public class SerializedBindingsV3
+    {
+        public const int VERSION = 3;
+
+        public int Version = VERSION;
+        public Dictionary<Guid, SerializedProfileBindingsV3> Profiles = new();
+
+        [JsonConstructor]
+        public SerializedBindingsV3() { }
+
+        public SerializedBindingsV3(SerializedBindings serialized)
+        {
+            foreach (var (id, bind) in serialized.Profiles)
+            {
+                Profiles[id] = new SerializedProfileBindingsV3(bind);
+            }
+        }
+
+        public SerializedBindings Deserialize()
+        {
+            var deserialized = new SerializedBindings();
+            foreach (var (id, bind) in Profiles)
+            {
+                deserialized.Profiles[id] = bind.Deserialize();
+            }
+
+            return deserialized;
+        }
+    }
+
+    public class SerializedProfileBindingsV3
+    {
+        public List<SerializedInputDeviceV3> Devices = new();
+        public List<SerializedMicV3> Microphones = new();
+
+        public Dictionary<GameMode, SerializedBindingCollectionV3> ModeMappings = new();
+        public SerializedBindingCollectionV3? MenuMappings;
+
+        [JsonConstructor]
+        public SerializedProfileBindingsV3() { }
+
+        public SerializedProfileBindingsV3(SerializedProfileBindings serialized)
+        {
+            Devices.AddRange(serialized.Devices.Select((device) => new SerializedInputDeviceV3(device)));
+
+            foreach (var mic in serialized.Microphones)
+            {
+                if (mic is not null)
+                {
+                    Microphones.Add(new SerializedMicV3(mic));
+                }
+            }
+
+            foreach (var (gameMode, bindings) in serialized.ModeMappings)
+            {
+                ModeMappings[gameMode] = new SerializedBindingCollectionV3(this, bindings);
+            }
+
+            if (serialized.MenuMappings is not null)
+                MenuMappings = new SerializedBindingCollectionV3(this, serialized.MenuMappings);
+        }
+
+        public SerializedProfileBindings Deserialize()
+        {
+            var deserialized = new SerializedProfileBindings();
+
+            foreach (var mic in Microphones)
+            {
+                if (mic is not null)
+                {
+                    deserialized.Microphones.Add(mic.Deserialize());
+                }
+            }
+
+            deserialized.Devices.AddRange(Devices.Select((device) => device.Deserialize()));
+
+            foreach (var (gameMode, bindings) in ModeMappings)
+            {
+                deserialized.ModeMappings[gameMode] = bindings.Deserialize(this);
+            }
+
+            if (MenuMappings is not null)
+                deserialized.MenuMappings = MenuMappings.Deserialize(this);
+
+            return deserialized;
+        }
+    }
+
+    public class SerializedBindingCollectionV3
+    {
+        public Dictionary<string, SerializedControlBindingV3> Bindings = new();
+
+        [JsonConstructor]
+        public SerializedBindingCollectionV3() { }
+
+        public SerializedBindingCollectionV3(SerializedProfileBindingsV3 binds, SerializedBindingCollection serialized)
+        {
+            foreach (var (id, serializedBinds) in serialized.Bindings)
+            {
+                Bindings[id] = new SerializedControlBindingV3(binds, serializedBinds);
+            }
+        }
+
+        public SerializedBindingCollection Deserialize(SerializedProfileBindingsV3 binds)
+        {
+            var converted = new SerializedBindingCollection();
+            foreach (var (id, serializedBinds) in Bindings)
+            {
+                converted.Bindings[id] = serializedBinds.Deserialize(binds);
+            }
+
+            return converted;
+        }
+    }
+
+    public class SerializedControlBindingV3
+    {
+        public Dictionary<string, string> Parameters = new();
+        public List<SerializedInputControlV3> Controls = new();
+
+        [JsonConstructor]
+        public SerializedControlBindingV3() { }
+
+        public SerializedControlBindingV3(SerializedProfileBindingsV3 binds, SerializedControlBinding serialized)
+        {
+            foreach (var (name, value) in serialized.Parameters)
+            {
+                Parameters.Add(name, value);
+            }
+
+            Controls.AddRange(serialized.Controls.Select((bind) => new SerializedInputControlV3(binds, bind)));
+        }
+
+        public SerializedControlBinding Deserialize(SerializedProfileBindingsV3 binds)
+        {
+            var control = new SerializedControlBinding();
+
+            foreach (var (name, value) in Parameters)
+            {
+                control.Parameters.Add(name, value);
+            }
+
+            foreach (var bind in Controls)
+            {
+                var deserialized = bind.Deserialize(binds);
+                if (deserialized is null)
+                    continue;
+
+                control.Controls.Add(deserialized);
+            }
+
+            return control;
+        }
+
+        public bool ShouldSerializeParameters() => Parameters.Count > 0;
+    }
+
+    public class SerializedInputControlV3
+    {
+        public int DeviceIndex = -1;
+        public SerializedInputDeviceV3? Device;
+
+        public string ControlPath;
+        public Dictionary<string, string> Parameters = new();
+
+        [JsonConstructor]
+        public SerializedInputControlV3()
+        {
+            ControlPath = string.Empty;
+        }
+
+        public SerializedInputControlV3(SerializedProfileBindingsV3 binds, SerializedInputControl serialized)
+        {
+            int deviceIndex = binds.Devices.FindIndex(
+                (device) => device.Layout == serialized.Device.Layout && device.Hash == serialized.Device.Hash);
+            if (deviceIndex < 0)
+                Device = new(serialized.Device);
+            else
+                DeviceIndex = deviceIndex;
+
+            ControlPath = serialized.ControlPath;
+            Parameters = serialized.Parameters;
+        }
+
+        public SerializedInputControl? Deserialize(SerializedProfileBindingsV3 binds)
+        {
+            if (DeviceIndex >= 0)
+            {
+                if (DeviceIndex >= binds.Devices.Count)
+                {
+                    YargLogger.LogFormatWarning("Device at list index {0} is not present!", DeviceIndex);
+                    return null;
+                }
+
+                Device = binds.Devices[DeviceIndex];
+            }
+            else if (Device is null)
+            {
+                YargLogger.LogFormatWarning("No device specified for binding '{0}'!", ControlPath);
+                return null;
+            }
+
+            return new(Device.Deserialize(), ControlPath)
+            {
+                Parameters = Parameters,
+            };
+        }
+
+        // For conditional serialization
+        public bool ShouldSerializeDeviceIndex() => DeviceIndex >= 0;
+        public bool ShouldSerializeDevice() => !ShouldSerializeDeviceIndex();
+        public bool ShouldSerializeParameters() => Parameters.Count > 0;
+    }
+
+    public static partial class BindingSerialization
+    {
+        private static SerializedBindingsV3 SerializeBindingsV3(SerializedBindings serialized)
+        {
+            return new SerializedBindingsV3(serialized);
+        }
+
+        private static SerializedBindings? DeserializeBindingsV3(JObject obj)
+        {
+            var serialized = obj.ToObject<SerializedBindingsV3>();
+            if (serialized is null || serialized.Version != SerializedBindingsV3.VERSION)
+                return null;
+
+            return serialized.Deserialize();
+        }
+    }
+}

--- a/Assets/Script/Input/Bindings/Serialization/BindingSerialization.v3.cs
+++ b/Assets/Script/Input/Bindings/Serialization/BindingSerialization.v3.cs
@@ -5,6 +5,7 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using UnityEngine;
 using YARG.Core;
+using YARG.Core.Audio;
 using YARG.Core.Logging;
 
 #nullable enable
@@ -15,7 +16,6 @@ namespace YARG.Input.Serialization
 
     // Unchanged data types
     using SerializedInputDeviceV3 = SerializedInputDeviceV0;
-    using SerializedMicV3 = SerializedMicV0;
 
     public class SerializedBindingsV3
     {
@@ -229,6 +229,51 @@ namespace YARG.Input.Serialization
         public bool ShouldSerializeDeviceIndex() => DeviceIndex >= 0;
         public bool ShouldSerializeDevice() => !ShouldSerializeDeviceIndex();
         public bool ShouldSerializeParameters() => Parameters.Count > 0;
+    }
+
+    public class SerializedMicV3
+    {
+        public string BaseName;
+        public int Channel;
+
+        public string DisplayName;
+
+        [JsonConstructor]
+        public SerializedMicV3()
+        {
+            BaseName = string.Empty;
+            DisplayName = string.Empty;
+        }
+
+        public SerializedMicV3(SerializedMic serialized)
+        {
+            BaseName = serialized.BaseName;
+            Channel = serialized.Channel;
+        }
+
+        public SerializedMic Deserialize()
+        {
+            if (!string.IsNullOrEmpty(BaseName))
+            {
+                return new SerializedMic(BaseName, Channel);
+            }
+
+            if (!string.IsNullOrEmpty(DisplayName))
+            {
+                if (InputDeviceInfo.TryParseDisplayName(DisplayName, out var b, out var c))
+                {
+                    return new SerializedMic(b, c);
+                }
+
+                return new SerializedMic(DisplayName, 0);
+            }
+
+            return new SerializedMic(BaseName ?? string.Empty, Channel);
+        }
+
+        public bool ShouldSerializeDisplayName() => string.IsNullOrEmpty(BaseName);
+        public bool ShouldSerializeBaseName() => !string.IsNullOrEmpty(BaseName);
+        public bool ShouldSerializeChannel() => !string.IsNullOrEmpty(BaseName);
     }
 
     public static partial class BindingSerialization

--- a/Assets/Script/Input/Bindings/Serialization/BindingSerialization.v3.cs.meta
+++ b/Assets/Script/Input/Bindings/Serialization/BindingSerialization.v3.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3f8c1b9d4e2a6c5b8f7d0a1e9c4b2d3f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Script/Input/MicInputContext.cs
+++ b/Assets/Script/Input/MicInputContext.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using YARG.Audio;
 using YARG.Core.Audio;
 using YARG.Core.Input;
@@ -8,13 +8,13 @@ namespace YARG.Input
 {
     public class MicInputContext
     {
-        public readonly MicDevice Device;
+        private readonly List<MicDevice> _devices;
 
         private readonly GameManager _gameManager;
 
-        public MicInputContext(MicDevice device, GameManager gameManager)
+        public MicInputContext(List<MicDevice> devices, GameManager gameManager)
         {
-            Device = device;
+            _devices = devices;
 
             _gameManager = gameManager;
         }
@@ -24,8 +24,11 @@ namespace YARG.Input
         /// </summary>
         public void Start()
         {
-            Device.ClearOutputQueue();
-            Device.IsRecordingOutput = true;
+            foreach (var device in _devices)
+            {
+                device.ClearOutputQueue();
+                device.IsRecordingOutput = true;
+            }
         }
 
         /// <summary>
@@ -34,22 +37,25 @@ namespace YARG.Input
         /// </summary>
         public IEnumerable<GameInput> GetInputsFromMic()
         {
-            while (Device.DequeueOutputFrame(out var frame))
+            foreach (var device in _devices)
             {
-                // frame.VoiceDetected will ALWAYS be true here, as it wouldn't be queued otherwise
-
-                // Queue it up!
-                GameInput gameInput;
-                if (!frame.IsHit)
+                while (device.DequeueOutputFrame(out var frame))
                 {
-                    gameInput = GameInput.Create(frame.Time, VocalsAction.Pitch, frame.PitchAsMidiNote);
-                }
-                else
-                {
-                    gameInput = GameInput.Create(frame.Time, VocalsAction.Hit, true);
-                }
+                    // frame.VoiceDetected will ALWAYS be true here, as it wouldn't be queued otherwise
 
-                yield return gameInput;
+                    // Queue it up!
+                    GameInput gameInput;
+                    if (!frame.IsHit)
+                    {
+                        gameInput = GameInput.Create(frame.Time, VocalsAction.Pitch, frame.PitchAsMidiNote);
+                    }
+                    else
+                    {
+                        gameInput = GameInput.Create(frame.Time, VocalsAction.Hit, true);
+                    }
+
+                    yield return gameInput;
+                }
             }
         }
 
@@ -58,8 +64,11 @@ namespace YARG.Input
         /// </summary>
         public void Stop()
         {
-            Device.IsRecordingOutput = false;
-            Device.Reset();
+            foreach (var device in _devices)
+            {
+                device.IsRecordingOutput = false;
+                device.Reset();
+            }
         }
     }
 }

--- a/Assets/Script/Menu/Common/Dialogs/Dialog.cs
+++ b/Assets/Script/Menu/Common/Dialogs/Dialog.cs
@@ -101,9 +101,11 @@ namespace YARG.Menu.Dialogs
         {
         }
 
+        public bool IsOpen => this != null && gameObject.activeSelf;
+
         public UniTask WaitUntilClosed()
         {
-            return UniTask.WaitUntil(() => this == null || !gameObject.activeSelf);
+            return UniTask.WaitUntil(() => !IsOpen);
         }
     }
 }

--- a/Assets/Script/Menu/Common/Dialogs/ListDialog.cs
+++ b/Assets/Script/Menu/Common/Dialogs/ListDialog.cs
@@ -13,20 +13,27 @@ namespace YARG.Menu.Dialogs
         [SerializeField]
         private ColoredButton _listButtonPrefab;
 
-        public ColoredButton AddListButton(string text, UnityAction handler, bool closeOnClick = true)
+        public ColoredButton AddListButton(string text, UnityAction handler = null, bool closeOnClick = true)
         {
             var button = AddListEntry(_listButtonPrefab);
 
             button.Text.text = text;
             if (closeOnClick)
             {
-                button.OnClick.AddListener(() =>
+                if (handler != null)
                 {
-                    handler();
-                    DialogManager.Instance.ClearDialog();
-                });
+                    button.OnClick.AddListener(() =>
+                    {
+                        handler();
+                        DialogManager.Instance.ClearDialog();
+                    });
+                }
+                else
+                {
+                    button.OnClick.AddListener(() => DialogManager.Instance.ClearDialog());
+                }
             }
-            else
+            else if (handler != null)
             {
                 button.OnClick.AddListener(handler);
             }

--- a/Assets/Script/Menu/ProfileList/ProfileView.cs
+++ b/Assets/Script/Menu/ProfileList/ProfileView.cs
@@ -341,14 +341,13 @@ namespace YARG.Menu.ProfileList
                 });
             }
 
-            // Add the microphone (there should be only one or zero)
-            var mic = player.Bindings.Microphone;
-            if (mic is not null)
+            // Add the microphones
+            foreach (var mic in player.Bindings.Microphones)
             {
                 devicesAvailable = true;
                 dialog.AddListButton(mic.DisplayName, () =>
                 {
-                    player.Bindings.RemoveMicrophone();
+                    player.Bindings.RemoveMicrophone(mic);
                     selectedDevice = true;
                 });
             }

--- a/Assets/Script/Menu/ProfileList/ProfileView.cs
+++ b/Assets/Script/Menu/ProfileList/ProfileView.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
 using Cysharp.Threading.Tasks;
 using TMPro;
 using UnityEngine;
@@ -9,6 +11,8 @@ using YARG.Core.Audio;
 using YARG.Core.Game;
 using YARG.Core.Logging;
 using YARG.Input;
+using YARG.Menu;
+using YARG.Menu.Dialogs;
 using YARG.Menu.Navigation;
 using YARG.Menu.Persistent;
 using YARG.Player;
@@ -47,8 +51,7 @@ namespace YARG.Menu.ProfileList
         public YargProfile Profile { get; private set; }
 
         private ProfileListMenu _profileListMenu;
-        private ProfileSidebar _profileSidebar;
-
+        private ProfileSidebar  _profileSidebar;
 
         public void Init(ProfileListMenu menu, YargProfile profile, ProfileSidebar sidebar)
         {
@@ -118,10 +121,7 @@ namespace YARG.Menu.ProfileList
             {
                 var dialog = DialogManager.Instance.ShowConfirmDeleteDialog(
                     "Deleting this profile is permanent and you will lose all stats and binds. Play history will " +
-                    "remain and can be accessed in the <b>History</b> tab.", () =>
-                    {
-                        remove = true;
-                    }, Profile.Name);
+                    "remain and can be accessed in the <b>History</b> tab.", () => { remove = true; }, Profile.Name);
 
                 // Wait...
                 await dialog.WaitUntilClosed();
@@ -153,30 +153,27 @@ namespace YARG.Menu.ProfileList
                 "it first, and then retry.</size>");
             var player = PlayerContainer.GetPlayerFromProfile(Profile);
 
-            bool devicesAvailable = false;
             bool selectedDevice = false;
             bool xinputDialogShowing = false;
+            int inputDeviceCount = 0;
 
-            // Add available devices
+            // Add InputSystem devices immediately — fast, no probe
             foreach (var device in InputSystem.devices)
             {
                 if (!device.enabled) continue;
                 if (PlayerContainer.IsDeviceTaken(device)) continue;
 
-                devicesAvailable = true;
+                inputDeviceCount++;
                 dialog.AddListButton(device.displayName, async () =>
                 {
                     player.Bindings.AddDevice(device);
                     if (!player.Bindings.ContainsBindingsForDevice(device))
                     {
 #if UNITY_STANDALONE_WIN || UNITY_EDITOR_WIN
-                        // Some remappers and non-gamepad devices show up as XInput gamepads
                         if (device is XInputController xinput)
                         {
                             xinputDialogShowing = true;
-                            // Prompt user for what kind of device this is
                             var mode = await PromptGamepadMode(xinput);
-                            // Skip if the gamepad is no longer present
                             if (!mode.HasValue || !xinput.added)
                             {
                                 return;
@@ -195,51 +192,83 @@ namespace YARG.Menu.ProfileList
                 });
             }
 
-            // Add available microphones
-            foreach (var microphone in GlobalAudioHandler.GetAllInputDevices())
+            bool TryAddMicrophone(InputDeviceInfo device)
             {
-                devicesAvailable = true;
-                dialog.AddListButton(microphone.name, () =>
+                var created = GlobalAudioHandler.CreateInputDevice(device);
+                if (created is null)
                 {
-                    var device = GlobalAudioHandler.CreateInputDevice(microphone.id, microphone.name);
-                    if (device is null)
-                    {
-                        YargLogger.LogFormatWarning("Failed to initialize microphone `{0}`.", microphone.name);
-                        DialogManager.Instance.ClearDialog();
-                        DialogManager.Instance.ShowMessage("Microphone Error",
-                            $"Failed to initialize microphone:\n\n{microphone.name}\n\nPlease try again or choose a different microphone.");
-                        return;
-                    }
-
-                    player.Bindings.AddMicrophone(device);
-                    selectedDevice = true;
+                    YargLogger.LogFormatWarning("Failed to initialize microphone `{0}`.", device.DisplayName);
                     DialogManager.Instance.ClearDialog();
-                }, closeOnClick: false);
-            }
-
-            if (devicesAvailable)
-            {
-                await dialog.WaitUntilClosed();
-                // We may be showing the xinput selection dialog, in which case we need to wait for that, too
-
-                if (xinputDialogShowing)
-                {
-                    // The dialog isn't actually showing yet, so we yield for a frame
-                    await UniTask.Yield();
-                    await DialogManager.Instance.WaitUntilCurrentClosed();
-                    // And we have to wait one more frame after it closed so that selectedDevice will actually be set
-                    await UniTask.Yield();
+                    DialogManager.Instance.ShowMessage("Microphone Error",
+                        $"Failed to initialize microphone:\n\n{device.DisplayName}\n\nPlease try again or choose a different microphone.");
+                    return false;
                 }
 
-                // Update active players to hide the "No input device" icons if appropriate.
-                StatsManager.Instance.UpdateActivePlayers();
-            }
-            else
-            {
-                DialogManager.Instance.ClearDialog();
+                player.Bindings.AddMicrophone(created);
+                return true;
             }
 
+            PopulateMicsAsync(dialog, inputDeviceCount, mic =>
+            {
+                if (TryAddMicrophone(mic))
+                {
+                    selectedDevice = true;
+                }
+            }).Forget();
+
+            await dialog.WaitUntilClosed();
+
+            if (xinputDialogShowing)
+            {
+                await UniTask.Yield();
+                await DialogManager.Instance.WaitUntilCurrentClosed();
+                await UniTask.Yield();
+            }
+
+            StatsManager.Instance.UpdateActivePlayers();
+
             return selectedDevice;
+        }
+
+        private static async UniTask PopulateMicsAsync(
+            ListDialog dialog,
+            int inputDeviceCount,
+            Action<InputDeviceInfo> onMicSelected)
+        {
+            var placeholderButton = dialog.AddListButton("Scanning microphones...", () => { }, false);
+            placeholderButton.DisableButton();
+            var ct = dialog.GetCancellationTokenOnDestroy();
+
+            List<InputDeviceInfo> mics;
+            try
+            {
+                mics = await GlobalAudioHandler.GetAllInputDevicesAsync(ct);
+            }
+            catch (OperationCanceledException)
+            {
+                return;
+            }
+
+            await UniTask.SwitchToMainThread();
+            Destroy(placeholderButton.gameObject);
+
+            // Dialog may have been closed while microphones were being probed
+            if (!dialog.IsOpen)
+            {
+                return;
+            }
+
+            foreach (var mic in mics)
+            {
+                var localMic = mic;
+                dialog.AddListButton(localMic.DisplayName, () => onMicSelected(localMic));
+            }
+
+            if (inputDeviceCount == 0 && mics.Count == 0)
+            {
+                var btn = dialog.AddListButton("No devices found", () => { }, false);
+                btn.DisableButton();
+            }
         }
 
         private static async UniTask<GamepadBindingMode?> PromptGamepadMode(XInputController xinput)
@@ -260,9 +289,12 @@ namespace YARG.Menu.ProfileList
             dialog.AddListButton("CRKD Guitar (Mode 1, FW3.0+)", () => mode = GamepadBindingMode.CrkdGuitar_Mode1_Fw30);
             dialog.AddListButton("WiitarThing Guitar", () => mode = GamepadBindingMode.WiitarThing_Guitar);
             dialog.AddListButton("WiitarThing Drumkit", () => mode = GamepadBindingMode.WiitarThing_Drums);
-            dialog.AddListButton("RB4InstrumentMapper Guitar", () => mode = GamepadBindingMode.RB4InstrumentMapper_Guitar);
-            dialog.AddListButton("RB4InstrumentMapper GHL Guitar", () => mode = GamepadBindingMode.RB4InstrumentMapper_GHLGuitar);
-            dialog.AddListButton("RB4InstrumentMapper Drumkit", () => mode = GamepadBindingMode.RB4InstrumentMapper_Drums);
+            dialog.AddListButton("RB4InstrumentMapper Guitar",
+                () => mode = GamepadBindingMode.RB4InstrumentMapper_Guitar);
+            dialog.AddListButton("RB4InstrumentMapper GHL Guitar",
+                () => mode = GamepadBindingMode.RB4InstrumentMapper_GHLGuitar);
+            dialog.AddListButton("RB4InstrumentMapper Drumkit",
+                () => mode = GamepadBindingMode.RB4InstrumentMapper_Drums);
             await dialog.WaitUntilClosed();
 
             if (mode.HasValue)

--- a/Assets/Script/Menu/ProfileList/ProfileView.cs
+++ b/Assets/Script/Menu/ProfileList/ProfileView.cs
@@ -242,15 +242,19 @@ namespace YARG.Menu.ProfileList
             List<InputDeviceInfo> mics;
             try
             {
-                mics = await GlobalAudioHandler.GetAllInputDevicesAsync(ct);
+                mics = await UniTask.RunOnThreadPool(() => GlobalAudioHandler.GetAllInputDevices(),
+                    cancellationToken: ct);
+                await UniTask.SwitchToMainThread(cancellationToken: ct);
             }
             catch (OperationCanceledException)
             {
                 return;
             }
 
-            await UniTask.SwitchToMainThread();
-            Destroy(placeholderButton.gameObject);
+            if (placeholderButton != null)
+            {
+                Destroy(placeholderButton.gameObject);
+            }
 
             // Dialog may have been closed while microphones were being probed
             if (!dialog.IsOpen)

--- a/Assets/Script/Persistent/GlobalVariables.cs
+++ b/Assets/Script/Persistent/GlobalVariables.cs
@@ -199,9 +199,15 @@ namespace YARG
             foreach (var profile in PlayerContainer.Profiles)
             {
                 var bindings = BindingsContainer.GetBindingsForProfile(profile);
-                if (bindings?.Microphone is BassMicDevice microphone)
+                if (bindings is not null)
                 {
-                    microphones.Add(microphone);
+                    foreach (var mic in bindings.Microphones)
+                    {
+                        if (mic is BassMicDevice microphone)
+                        {
+                            microphones.Add(microphone);
+                        }
+                    }
                 }
             }
 

--- a/Assets/Script/Settings/SettingsManager.Settings.cs
+++ b/Assets/Script/Settings/SettingsManager.Settings.cs
@@ -923,7 +923,10 @@ namespace YARG.Settings
             {
                 foreach (var player in PlayerContainer.Players)
                 {
-                    player.Bindings.Microphone?.SetMonitoringLevel(volume);
+                    foreach (var mic in player.Bindings.Microphones)
+                    {
+                        mic.SetMonitoringLevel(volume);
+                    }
                 }
             }
 


### PR DESCRIPTION
YARG.Core PR: https://github.com/YARC-Official/YARG.Core/pull/440

The issue:

YARG would sometimes see devices that have 2 inputs as a single device, meaning it was impossible to select input 1 or 2. For example, SingStar mics or usb audio interfaces with multiple inputs

This PR resolves those issues by probing all input devices to determine their appropriate channel count, then allowing the user to select individual channels of the device.

The probe works by starting a recording session and listening for the input frames. We try different combinations of channels / frequency until a successful session is opened. The input frames then are expected to be received interleaved, ie c1 - c2 - c1 - c2 where each is 2 bytes.

We can then determine the true channel count by comparing:

- Are c1 and c2 byte identical? This is a mono device outputting stereo, so report as mono
- Is c2 all 0's? This is a mono device
- Are c1 and c2 different values? This is assumed to be a stereo device with 2 inputs.
- c1 is all 0's, and c2 has input?  This is stereo

Because USB causes some frames to not be bit exact on a mono mic reporting as stereo, we allow a certain percentage of input to differ between channels when making this determination

This logic also applies to up to 8 channel input devices.

Once we have determined channel count, we can display devices as "Device - Channel 1" and "Device - Channel 2" and similar.

The probe runs asynchronously on a background thread while the add devices dialog shows a "Scanning microphones..." message, so the user doesn't have to wait for the dialog to pop up.

We also fix a bug:
1. Add two microphones to single profile
2. First microphone disappears from list

We fix this by allowing multiple microphones per profile now

Tested on:
Linux
MacOS
[PENDING] Windows


Video:

[Kooha-2026-08-07-11-48-38.webm](https://github.com/user-attachments/assets/b548ac3d-656c-4ef1-b76c-391bd934813d)
