### PR TITLE
Fix Persistent UI Layering Regression Again

### DIFF
--- a/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
+++ b/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
@@ -1316,6 +1316,7 @@ namespace YARG.Menu.MusicLibrary
             {
                 // Ensure difficulty rings are restored even if the scan fails or is canceled
                 _sidebar.gameObject.SetActive(true);
+                SetSidebarDifficultiesVisible(true);
                 _sidebar.UpdateSidebar(true);
             }
         }


### PR DESCRIPTION
Regression caused by #1601.  Scanning songs from the Music Library > More Options menu hides the difficulty rings container but does not bring it back after the scan finishes.

This fixes https://discord.com/channels/1086048856678084609/1535543331050754129