### PR TITLE
Fix Persistent UI Layering Regression a Third Time

### DIFF
--- a/Assets/Prefabs/Menu/MusicLibrary/PlayAShow/ShowDialog.prefab
+++ b/Assets/Prefabs/Menu/MusicLibrary/PlayAShow/ShowDialog.prefab
@@ -667,7 +667,7 @@ Canvas:
   m_AdditionalShaderChannelsFlag: 0
   m_UpdateRectTransformForStandalone: 0
   m_SortingLayerID: 0
-  m_SortingOrder: 102
+  m_SortingOrder: 107
   m_TargetDisplay: 0
 --- !u!114 &4182839957287432121
 MonoBehaviour:


### PR DESCRIPTION
Regression caused by #1601.  The difficulty rings container was moved in front of the **Play a Show** dialog, causing the orange button and part of the timer to be obstructed.  This fixes that by bringing the **Play a Show** dialog in front.

Before:
<img width="1588" height="851" alt="image" src="https://github.com/user-attachments/assets/c95aad40-3844-4cbe-83d8-1b9a39b16c87" />
