### PR TITLE
Black key glissandos

### DIFF
--- a/Assets/Art/Materials/Gameplay/Notes/Rectangular/KeysWhiteMiddle.mat
+++ b/Assets/Art/Materials/Gameplay/Notes/Rectangular/KeysWhiteMiddle.mat
@@ -8,8 +8,7 @@ Material:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: KeysWhiteMiddle
-  m_Shader: {fileID: -6465566751694194690, guid: f234a0dbfe313d94697e5acc4c227a98,
-    type: 3}
+  m_Shader: {fileID: -6465566751694194690, guid: f234a0dbfe313d94697e5acc4c227a98, type: 3}
   m_Parent: {fileID: 0}
   m_ModifiedSerializedProperties: 0
   m_ValidKeywords: []

--- a/Assets/Art/Meshes/Gameplay/Notes/Rectangular/KeysBlackGlissandoNote.fbx
+++ b/Assets/Art/Meshes/Gameplay/Notes/Rectangular/KeysBlackGlissandoNote.fbx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1f821372e3c75b80e2e71a5960d4cad99ce063430e8f0556dee50cca44706b91
+size 29036

--- a/Assets/Art/Meshes/Gameplay/Notes/Rectangular/KeysBlackGlissandoNote.fbx.meta
+++ b/Assets/Art/Meshes/Gameplay/Notes/Rectangular/KeysBlackGlissandoNote.fbx.meta
@@ -1,0 +1,107 @@
+fileFormatVersion: 2
+guid: 4d32ed36c7b559a499145650aae53378
+ModelImporter:
+  serializedVersion: 21300
+  internalIDToNameTable: []
+  externalObjects: {}
+  materials:
+    materialImportMode: 0
+    materialName: 0
+    materialSearch: 1
+    materialLocation: 1
+  animations:
+    legacyGenerateAnimations: 4
+    bakeSimulation: 0
+    resampleCurves: 1
+    optimizeGameObjects: 0
+    removeConstantScaleCurves: 1
+    motionNodeName: 
+    rigImportErrors: 
+    rigImportWarnings: 
+    animationImportErrors: 
+    animationImportWarnings: 
+    animationRetargetingWarnings: 
+    animationDoRetargetingWarnings: 0
+    importAnimatedCustomProperties: 0
+    importConstraints: 0
+    animationCompression: 1
+    animationRotationError: 0.5
+    animationPositionError: 0.5
+    animationScaleError: 0.5
+    animationWrapMode: 0
+    extraExposedTransformPaths: []
+    extraUserProperties: []
+    clipAnimations: []
+    isReadable: 0
+  meshes:
+    lODScreenPercentages: []
+    globalScale: 1
+    meshCompression: 0
+    addColliders: 0
+    useSRGBMaterialColor: 1
+    sortHierarchyByName: 1
+    importVisibility: 1
+    importBlendShapes: 1
+    importCameras: 0
+    importLights: 0
+    nodeNameCollisionStrategy: 1
+    fileIdsGeneration: 2
+    swapUVChannels: 0
+    generateSecondaryUV: 0
+    useFileUnits: 1
+    keepQuads: 0
+    weldVertices: 1
+    bakeAxisConversion: 0
+    preserveHierarchy: 0
+    skinWeightsMode: 0
+    maxBonesPerVertex: 4
+    minBoneWeight: 0.001
+    optimizeBones: 1
+    meshOptimizationFlags: -1
+    indexFormat: 0
+    secondaryUVAngleDistortion: 8
+    secondaryUVAreaDistortion: 15.000001
+    secondaryUVHardAngle: 88
+    secondaryUVMarginMethod: 1
+    secondaryUVMinLightmapResolution: 40
+    secondaryUVMinObjectScale: 1
+    secondaryUVPackMargin: 4
+    useFileScale: 1
+    strictVertexDataChecks: 0
+  tangentSpace:
+    normalSmoothAngle: 60
+    normalImportMode: 0
+    tangentImportMode: 3
+    normalCalculationMode: 4
+    legacyComputeAllNormalsFromSmoothingGroupsWhenMeshHasBlendShapes: 0
+    blendShapeNormalImportMode: 1
+    normalSmoothingSource: 0
+  referencedClips: []
+  importAnimation: 1
+  humanDescription:
+    serializedVersion: 3
+    human: []
+    skeleton: []
+    armTwist: 0.5
+    foreArmTwist: 0.5
+    upperLegTwist: 0.5
+    legTwist: 0.5
+    armStretch: 0.05
+    legStretch: 0.05
+    feetSpacing: 0
+    globalScale: 1
+    rootMotionBoneName: 
+    hasTranslationDoF: 0
+    hasExtraRoot: 0
+    skeletonHasParents: 1
+  lastHumanDescriptionAvatarSource: {instanceID: 0}
+  autoGenerateAvatarMappingIfUnspecified: 1
+  animationType: 2
+  humanoidOversampling: 1
+  avatarSetup: 0
+  addHumanoidExtraRootOnlyWhenUsingAvatar: 1
+  remapMaterialsIfMaterialImportModeIsNone: 0
+  additionalBone: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Gameplay/Visual/Themes/RectangularTheme.prefab
+++ b/Assets/Prefabs/Gameplay/Visual/Themes/RectangularTheme.prefab
@@ -155,7 +155,7 @@ Transform:
   m_GameObject: {fileID: 470677965324328071}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: -0.333, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -31450,6 +31450,7 @@ Transform:
   m_Children:
   - {fileID: 4103504954580991531}
   - {fileID: 4391319547939344646}
+  - {fileID: 3016523649137376562}
   - {fileID: 8202880826653267939}
   m_Father: {fileID: 4500990497932702555}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -41314,6 +41315,68 @@ ParticleSystemRenderer:
   m_MeshWeighting1: 1
   m_MeshWeighting2: 1
   m_MeshWeighting3: 1
+--- !u!1 &6004324031140085193
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3016523649137376562}
+  - component: {fileID: 2152464703777078585}
+  m_Layer: 0
+  m_Name: Black Glissando Note
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3016523649137376562
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6004324031140085193}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.333, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7215419732793792015}
+  m_Father: {fileID: 2431635785390195220}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2152464703777078585
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6004324031140085193}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e38531c1d86248efb38659cc5e64a2cc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  <NoteType>k__BackingField: 16
+  <StarPowerVariant>k__BackingField: 0
+  _coloredMaterials:
+  - Mesh: {fileID: 8388375247981342048}
+    MaterialIndex: 2
+    EmissionMultiplier: 8
+    EmissionAddition: 0
+  _coloredMaterialsNoStarPower: []
+  _coloredMetalMaterials:
+  - Mesh: {fileID: 8388375247981342048}
+    MaterialIndex: 0
+    EmissionMultiplier: 0
+    EmissionAddition: 0
+  - Mesh: {fileID: 8388375247981342048}
+    MaterialIndex: 1
+    EmissionMultiplier: 0
+    EmissionAddition: 0
 --- !u!1 &6012213803221084217
 GameObject:
   m_ObjectHideFlags: 0
@@ -46276,7 +46339,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6135506318367116900}
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 1, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
@@ -74362,6 +74425,97 @@ MeshRenderer:
 Transform:
   m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: c58cec31fa674ce43a64f4fff3bb71b4, type: 3}
   m_PrefabInstance: {fileID: 6430475190486820274}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &7181248514527719908
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 3016523649137376562}
+    m_Modifications:
+    - target: {fileID: -8679921383154817045, guid: 4d32ed36c7b559a499145650aae53378, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 2.8
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 4d32ed36c7b559a499145650aae53378, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 3.75
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 4d32ed36c7b559a499145650aae53378, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 4d32ed36c7b559a499145650aae53378, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 4d32ed36c7b559a499145650aae53378, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.0666
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 4d32ed36c7b559a499145650aae53378, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0.055
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 4d32ed36c7b559a499145650aae53378, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 4d32ed36c7b559a499145650aae53378, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 4d32ed36c7b559a499145650aae53378, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 4d32ed36c7b559a499145650aae53378, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 4d32ed36c7b559a499145650aae53378, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: -90
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 4d32ed36c7b559a499145650aae53378, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -8679921383154817045, guid: 4d32ed36c7b559a499145650aae53378, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: -7511558181221131132, guid: 4d32ed36c7b559a499145650aae53378, type: 3}
+      propertyPath: 'm_Materials.Array.data[0]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 4d4a54b04f5b07c45a8de58f3bae1527, type: 2}
+    - target: {fileID: -7511558181221131132, guid: 4d32ed36c7b559a499145650aae53378, type: 3}
+      propertyPath: 'm_Materials.Array.data[1]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 4f16b31c50c947444a8d68c0c930610d, type: 2}
+    - target: {fileID: -7511558181221131132, guid: 4d32ed36c7b559a499145650aae53378, type: 3}
+      propertyPath: 'm_Materials.Array.data[2]'
+      value: 
+      objectReference: {fileID: 2100000, guid: 9b5f31b36b0afbe4a9597a38d8f3d61d, type: 2}
+    - target: {fileID: 919132149155446097, guid: 4d32ed36c7b559a499145650aae53378, type: 3}
+      propertyPath: m_Name
+      value: KeysBlackGlissandoNote
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 4d32ed36c7b559a499145650aae53378, type: 3}
+--- !u!4 &7215419732793792015 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 4d32ed36c7b559a499145650aae53378, type: 3}
+  m_PrefabInstance: {fileID: 7181248514527719908}
+  m_PrefabAsset: {fileID: 0}
+--- !u!23 &8388375247981342048 stripped
+MeshRenderer:
+  m_CorrespondingSourceObject: {fileID: -7511558181221131132, guid: 4d32ed36c7b559a499145650aae53378, type: 3}
+  m_PrefabInstance: {fileID: 7181248514527719908}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &7571871479518514372
 PrefabInstance:

--- a/Assets/Script/Gameplay/Visuals/TrackElements/ProKeys/ProKeysNoteElement.cs
+++ b/Assets/Script/Gameplay/Visuals/TrackElements/ProKeys/ProKeysNoteElement.cs
@@ -12,9 +12,10 @@ namespace YARG.Gameplay.Visuals
     {
         private enum NoteType
         {
-            White     = 0,
-            Black     = 1,
-            Glissando = 2,
+            White          = 0,
+            Black          = 1,
+            Glissando      = 2,
+            BlackGlissando = 3,
 
             Count
         }
@@ -31,9 +32,10 @@ namespace YARG.Gameplay.Visuals
             Dictionary<ThemeNoteType, GameObject> starPowerModels)
         {
             CreateNoteGroupArrays((int) NoteType.Count);
-            AssignNoteGroup(models, starPowerModels, (int) NoteType.White,     ThemeNoteType.White);
-            AssignNoteGroup(models, starPowerModels, (int) NoteType.Black,     ThemeNoteType.Black);
-            AssignNoteGroup(models, starPowerModels, (int) NoteType.Glissando, ThemeNoteType.Glissando);
+            AssignNoteGroup(models, starPowerModels, (int) NoteType.White,          ThemeNoteType.White);
+            AssignNoteGroup(models, starPowerModels, (int) NoteType.Black,          ThemeNoteType.Black);
+            AssignNoteGroup(models, starPowerModels, (int) NoteType.Glissando,      ThemeNoteType.Glissando);
+            AssignNoteGroup(models, starPowerModels, (int) NoteType.BlackGlissando, ThemeNoteType.BlackGlissando);
         }
 
         protected override void InitializeElement()
@@ -41,6 +43,7 @@ namespace YARG.Gameplay.Visuals
             base.InitializeElement();
 
             var noteGroups = IsStarPowerVisible ? StarPowerNoteGroups : NoteGroups;
+            var isGlissando = (NoteRef.ProKeysFlags & ProKeysNoteFlags.Glissando) != 0;
 
             // Set the position
             transform.localPosition = Vector3.zero;
@@ -50,18 +53,12 @@ namespace YARG.Gameplay.Visuals
             NoteType noteType;
             if (ProKeysUtilities.IsWhiteKey(NoteRef.Key % 12))
             {
-                if ((NoteRef.ProKeysFlags & ProKeysNoteFlags.Glissando) != 0)
-                {
-                    noteType = NoteType.Glissando;
-                }
-                else
-                {
-                    noteType = NoteType.White;
-                }
+                noteType = isGlissando ? NoteType.Glissando : NoteType.White;
+             
             }
             else
             {
-                noteType = NoteType.Black;
+                noteType = isGlissando ? NoteType.BlackGlissando : NoteType.Black;
             }
 
             // Initialize the note group

--- a/Assets/Script/Themes/Authoring/ThemeNote.cs
+++ b/Assets/Script/Themes/Authoring/ThemeNote.cs
@@ -30,7 +30,9 @@ namespace YARG.Themes
 
         Wildcard = 14,
 
-        DedicatedLaneKick = 15
+        DedicatedLaneKick = 15,
+
+        BlackGlissando = 16,
     }
 
     public class ThemeNote : MonoBehaviour


### PR DESCRIPTION
Conventionally, glissandos are used only for white keys. It's certainly not a good idea to chart a glissando that intermixes white keys and black keys, but there's really no reason why an all-black-key glissando shouldn't be charted if that's what the original keyboardist did.

This PR adds a new gem model for black keys in glissandos. Mechanically, glissandos are completely agnostic to specific keys - they accept all inputs and autohit all notes - so there's no need for a Core PR; they already work.

I took heed of the comment in `ThemeNote.cs` and inserted the new `BlackGlissando` type at `16` rather than pushing `Wildcard` and `DedicatedLaneKick` down to let it sit with the other PK types. However, I'm not really sure the warning needs to be heeded yet, since custom note themes aren't yet supported - if we can still get away with shuffling things around, I'd be happier putting it at `14` and bumping those other two down.

I also wasn't sure if renaming `Glissando` to `WhiteGlissando` would cause any serialization issues, so I left that alone, but would be happier to rename it if possible.

Test chart: 
[BlackKeyGlissandoTest.zip](https://github.com/user-attachments/files/30877362/BlackKeyGlissandoTest.zip)

The test chart contains glissando and nonglissando sequences of both white and black keys, both with and without OD, to test all aspects of the visuals and engine.