### PR TITLE
Better mic gain handling, reverb pipeline

### DIFF
--- a/Assets/Script/Audio/Bass/BassHelpers.cs
+++ b/Assets/Script/Audio/Bass/BassHelpers.cs
@@ -28,9 +28,6 @@ namespace YARG.Audio.BASS
 #pragma warning disable CS0649
         public int CompressorFX;
         public int PitchFX;
-        public int LowEQ;
-        public int MidEQ;
-        public int HighEQ;
 #pragma warning restore CS0649
     }
 

--- a/Assets/Script/Audio/Bass/BassMicSignal.cs
+++ b/Assets/Script/Audio/Bass/BassMicSignal.cs
@@ -27,6 +27,45 @@ namespace YARG.Audio.BASS
             fCenter = 10_000f,
             fGain = -10f,
         };
+
+        private static readonly BQFParameters MonitorHighPassParams = new()
+        {
+            lFilter = BQFType.HighPass,
+            fCenter = 90f,
+            fQ = 0.707f,
+            lChannel = FXChannelFlags.All,
+        };
+
+        private static readonly DampParameters MonitorLevelerParams = new()
+        {
+            fTarget = 0.20f,
+            fQuiet = 0.02f,
+            fRate = 0.02f,
+            fGain = 3.0f,
+            fDelay = 0.2f,
+            lChannel = FXChannelFlags.All,
+        };
+
+        private static readonly CompressorParameters MonitorCompressorParams = new()
+        {
+            fThreshold = -18.0f,
+            fRatio = 3.0f,
+            fAttack = 10.0f,
+            fRelease = 100.0f,
+            fGain = 0.0f,
+            lChannel = FXChannelFlags.All,
+        };
+
+        private static readonly CompressorParameters MonitorLimiterParams = new()
+        {
+            fThreshold = -1.0f,
+            fRatio = 20.0f,
+            fAttack = 0.1f,
+            fRelease = 30.0f,
+            fGain = 0.0f,
+            lChannel = FXChannelFlags.All,
+        };
+
         private readonly string          _name;
         private readonly BassFreeverbDsp _reverb;
 
@@ -146,7 +185,14 @@ namespace YARG.Audio.BASS
                     return null;
                 }
 
-                reverb = BassFreeverbDsp.Create(monitorHandle, 0.3f, 1f, 0.4f, 0.7f, 0f, 1);
+                if (!AddMonitoringEffects(monitorHandle))
+                {
+                    YargLogger.LogFormatError("Failed to add dynamics to mic '{0}' monitor split: {1}", name,
+                        Bass.LastError);
+                    return null;
+                }
+
+                reverb = BassFreeverbDsp.Create(monitorHandle, 0.3f, 1f, 0.4f, 0.7f, 0f);
                 if (reverb == null)
                 {
                     YargLogger.LogError($"Failed to add reverb to mic '{name}' monitor split");
@@ -193,6 +239,26 @@ namespace YARG.Audio.BASS
         }
 
         public void SetMonitoringLevel(double volume) => _monitor?.SetVolume(volume);
+
+        private static bool AddMonitoringEffects(int handle)
+        {
+            if (BassHelpers.FXAddParameters(handle, EffectType.BQF, MonitorHighPassParams, priority: 4) == 0)
+            {
+                return false;
+            }
+
+            if (BassHelpers.FXAddParameters(handle, EffectType.Damp, MonitorLevelerParams, priority: 3) == 0)
+            {
+                return false;
+            }
+
+            if (BassHelpers.FXAddParameters(handle, EffectType.Compressor, MonitorCompressorParams, priority: 2) == 0)
+            {
+                return false;
+            }
+
+            return BassHelpers.FXAddParameters(handle, EffectType.Compressor, MonitorLimiterParams, priority: 1) != 0;
+        }
 
         private static void FreeStream(ref int handle)
         {

--- a/Assets/Script/Audio/Bass/BassStemChannel.cs
+++ b/Assets/Script/Audio/Bass/BassStemChannel.cs
@@ -1,7 +1,6 @@
 using ManagedBass;
 using ManagedBass.Mix;
 using UnityEngine;
-using YARG.Audio.BASS.Effects;
 using YARG.Core.Audio;
 using YARG.Core.Logging;
 
@@ -9,11 +8,10 @@ namespace YARG.Audio.BASS
 {
     public sealed class BassStemChannel : StemChannel
     {
-        private readonly int                        _sourceHandle;
-        private          StreamHandle               _streamHandles;
-        private          StreamHandle               _reverbHandles;
-        private          PitchShiftParametersStruct _pitchParams;
-        private          BassFreeverbDsp             _reverbDsp;
+        private readonly int                         _sourceHandle;
+        private readonly StreamHandle                _streamHandles;
+        private readonly StreamHandle                _reverbHandles;
+        private          PitchShiftParametersStruct  _pitchParams;
 
         private          double _volume;
         private          bool   _isReverbing;
@@ -101,7 +99,6 @@ namespace YARG.Audio.BASS
             }
 
             // Publish after the mixer seek so the next DSP callback cannot retain pre-seek tail.
-            _reverbDsp?.RequestReset();
         }
 
         protected override void SetVolume_Internal(double volume)
@@ -129,33 +126,6 @@ namespace YARG.Audio.BASS
             if (reverb)
             {
                 // Set reverb FX
-                if (_reverbDsp == null)
-                {
-                    _reverbHandles.LowEQ = BassHelpers.AddEqToChannel(_reverbHandles.Stream, BassHelpers.LowEqParams);
-                    _reverbHandles.MidEQ = BassHelpers.AddEqToChannel(_reverbHandles.Stream, BassHelpers.MidEqParams);
-                    _reverbHandles.HighEQ = BassHelpers.AddEqToChannel(_reverbHandles.Stream, BassHelpers.HighEqParams);
-                    if (_reverbHandles.LowEQ == 0 || _reverbHandles.MidEQ == 0 ||
-                        _reverbHandles.HighEQ == 0)
-                    {
-                        _isReverbing = false;
-                        RemoveReverbEq();
-                        return;
-                    }
-
-                    _reverbDsp = BassFreeverbDsp.Create(_reverbHandles.Stream,
-                        dryMix: 0.0f,
-                        wetMix: 1.0f,
-                        roomSize: 0.8f,
-                        damp: 0.5f,
-                        width: 1.0f);
-                    if (_reverbDsp == null)
-                    {
-                        _isReverbing = false;
-                        RemoveReverbEq();
-                        return;
-                    }
-                }
-
                 float volume = (float) (_volume * BassHelpers.REVERB_VOLUME_MULTIPLIER);
                 if (!Bass.ChannelSlideAttribute(_reverbHandles.Stream, ChannelAttribute.Volume, volume, BassHelpers.REVERB_SLIDE_IN_MILLISECONDS))
                 {
@@ -164,9 +134,7 @@ namespace YARG.Audio.BASS
             }
             else
             {
-                // No reverb is applied, but let the reverb stream slide out/fade out naturally
-                if (_reverbDsp == null) return;
-
+                // No new reverb is sent, but let the reverb stream slide out/fade out naturally
                 if (!Bass.ChannelSlideAttribute(_reverbHandles.Stream, ChannelAttribute.Volume, 0, BassHelpers.REVERB_SLIDE_OUT_MILLISECONDS))
                 {
                     YargLogger.LogFormatError("Failed to set reverb volume: {0}!", Bass.LastError);
@@ -174,31 +142,5 @@ namespace YARG.Audio.BASS
             }
         }
 
-        protected override void DisposeUnmanagedResources()
-        {
-            _reverbDsp?.Dispose();
-            _reverbDsp = null;
-        }
-
-        private void RemoveReverbEq()
-        {
-            RemoveFx(ref _reverbHandles.LowEQ);
-            RemoveFx(ref _reverbHandles.MidEQ);
-            RemoveFx(ref _reverbHandles.HighEQ);
-        }
-
-        private void RemoveFx(ref int fxHandle)
-        {
-            if (fxHandle == 0)
-            {
-                return;
-            }
-
-            if (!Bass.ChannelRemoveFX(_reverbHandles.Stream, fxHandle))
-            {
-                YargLogger.LogFormatError("Failed to remove reverb EQ effect: {0}!", Bass.LastError);
-            }
-            fxHandle = 0;
-        }
     }
 }

--- a/Assets/Script/Audio/Bass/BassStemPipeline.cs
+++ b/Assets/Script/Audio/Bass/BassStemPipeline.cs
@@ -40,24 +40,18 @@ namespace YARG.Audio.BASS
         private readonly BassNormalizer?  _normalizer;
         private readonly BassMixer        _reverbMixer;
         private readonly BassFreeverbDsp  _reverbDsp;
-        private readonly int              _reverbHighEq;
-        private readonly int              _reverbLowEq;
-        private readonly int              _reverbMidEq;
         private readonly List<StemData>   _stemDatas = new();
         private readonly BassTempoStream  _tempoStream;
         private          bool             _disposed;
         private          bool             _normalizationEnabled;
 
         private BassStemPipeline(BassMixer mixer, BassMixer reverbMixer, BassFreeverbDsp reverbDsp,
-            int reverbLowEq, int reverbMidEq, int reverbHighEq, BassTempoStream tempoStream,
+            BassTempoStream tempoStream,
             BassNormalizer? normalizer, BassGainDsp? gainDsp)
         {
             _mixer = mixer;
             _reverbMixer = reverbMixer;
             _reverbDsp = reverbDsp;
-            _reverbLowEq = reverbLowEq;
-            _reverbMidEq = reverbMidEq;
-            _reverbHighEq = reverbHighEq;
             _tempoStream = tempoStream;
             _normalizer = normalizer;
             _gainDsp = gainDsp;
@@ -94,7 +88,7 @@ namespace YARG.Audio.BASS
             int reverbHighEq = BassHelpers.AddEqToChannel(reverbMixer.Handle, BassHelpers.HighEqParams);
             if (reverbLowEq == 0 || reverbMidEq == 0 || reverbHighEq == 0)
             {
-                DisposeReverbBus(reverbMixer, null, reverbLowEq, reverbMidEq, reverbHighEq);
+                DisposeReverbBus(reverbMixer, null);
                 mixer.Dispose();
                 return null;
             }
@@ -107,14 +101,14 @@ namespace YARG.Audio.BASS
                 width: 1.0f);
             if (reverbDsp == null)
             {
-                DisposeReverbBus(reverbMixer, null, reverbLowEq, reverbMidEq, reverbHighEq);
+                DisposeReverbBus(reverbMixer, null);
                 mixer.Dispose();
                 return null;
             }
 
             if (!mixer.AddChannel(reverbMixer.Handle))
             {
-                DisposeReverbBus(reverbMixer, reverbDsp, reverbLowEq, reverbMidEq, reverbHighEq);
+                DisposeReverbBus(reverbMixer, reverbDsp);
                 mixer.Dispose();
                 return null;
             }
@@ -129,7 +123,7 @@ namespace YARG.Audio.BASS
             {
                 YargLogger.LogError(exception.Message);
                 mixer.RemoveChannel(reverbMixer.Handle);
-                DisposeReverbBus(reverbMixer, reverbDsp, reverbLowEq, reverbMidEq, reverbHighEq);
+                DisposeReverbBus(reverbMixer, reverbDsp);
                 mixer.Dispose();
                 return null;
             }
@@ -145,8 +139,7 @@ namespace YARG.Audio.BASS
                 }
             }
 
-            return new BassStemPipeline(mixer, reverbMixer, reverbDsp, reverbLowEq, reverbMidEq, reverbHighEq,
-                tempoStream, normalizer, gainDsp);
+            return new BassStemPipeline(mixer, reverbMixer, reverbDsp, tempoStream, normalizer, gainDsp);
         }
 
         public bool AddStems(Stream stream, IEnumerable<StemMixer.StemInfo> stemInfos,
@@ -204,22 +197,21 @@ namespace YARG.Audio.BASS
             _mixer.RemoveAllChannels();
             _reverbMixer.RemoveAllChannels();
 
-            double requiredAlignment = 0;
+            alignmentDelay = 0;
             foreach (var data in _stemDatas)
             {
-                if (data.PitchFxDelay > requiredAlignment)
+                if (data.PitchFxDelay > alignmentDelay)
                 {
-                    requiredAlignment = data.PitchFxDelay;
+                    alignmentDelay = data.PitchFxDelay;
                 }
             }
 
-            alignmentDelay = requiredAlignment;
             var dryChannels = new List<BassMixerChannel>(_stemDatas.Count);
             var reverbChannels = new List<BassMixerChannel>(_stemDatas.Count);
 
             foreach (var data in _stemDatas)
             {
-                double delay = playbackDelay + requiredAlignment - data.PitchFxDelay;
+                double delay = playbackDelay + alignmentDelay - data.PitchFxDelay;
                 dryChannels.Add(new BassMixerChannel(data.StreamHandles.Stream, data.VolumeMatrix, delay));
                 reverbChannels.Add(new BassMixerChannel(data.ReverbHandles.Stream, data.VolumeMatrix, delay));
             }
@@ -304,31 +296,14 @@ namespace YARG.Audio.BASS
             _tempoStream.Dispose();
             _mixer.RemoveChannel(_reverbMixer.Handle);
             _reverbMixer.RemoveAllChannels();
-            DisposeReverbBus(_reverbMixer, _reverbDsp, _reverbLowEq, _reverbMidEq, _reverbHighEq);
+            DisposeReverbBus(_reverbMixer, _reverbDsp);
             _mixer.Dispose();
         }
 
-        private static void DisposeReverbBus(BassMixer mixer, BassFreeverbDsp? reverbDsp,
-            int lowEq, int midEq, int highEq)
+        private static void DisposeReverbBus(BassMixer mixer, BassFreeverbDsp? reverbDsp)
         {
             reverbDsp?.Dispose();
-            RemoveEffect(mixer.Handle, lowEq);
-            RemoveEffect(mixer.Handle, midEq);
-            RemoveEffect(mixer.Handle, highEq);
             mixer.Dispose();
-        }
-
-        private static void RemoveEffect(int streamHandle, int effectHandle)
-        {
-            if (effectHandle == 0)
-            {
-                return;
-            }
-
-            if (!Bass.ChannelRemoveFX(streamHandle, effectHandle) && Bass.LastError != Errors.Handle)
-            {
-                YargLogger.LogFormatError("Failed to remove reverb effect: {0}", Bass.LastError);
-            }
         }
 
         private static bool BuildStemData(BassMixerSource source, IEnumerable<StemMixer.StemInfo> stemInfos,

--- a/Assets/Script/Audio/Bass/BassStemPipeline.cs
+++ b/Assets/Script/Audio/Bass/BassStemPipeline.cs
@@ -35,18 +35,29 @@ namespace YARG.Audio.BASS
     /// </summary>
     internal sealed class BassStemPipeline : IDisposable
     {
-        private readonly BassGainDsp?    _gainDsp;
-        private readonly BassMixer       _mixer;
-        private readonly BassNormalizer? _normalizer;
-        private readonly List<StemData>  _stemDatas = new();
-        private readonly BassTempoStream _tempoStream;
-        private          bool            _disposed;
-        private          bool            _normalizationEnabled;
+        private readonly BassGainDsp?     _gainDsp;
+        private readonly BassMixer        _mixer;
+        private readonly BassNormalizer?  _normalizer;
+        private readonly BassMixer        _reverbMixer;
+        private readonly BassFreeverbDsp  _reverbDsp;
+        private readonly int              _reverbHighEq;
+        private readonly int              _reverbLowEq;
+        private readonly int              _reverbMidEq;
+        private readonly List<StemData>   _stemDatas = new();
+        private readonly BassTempoStream  _tempoStream;
+        private          bool             _disposed;
+        private          bool             _normalizationEnabled;
 
-        private BassStemPipeline(BassMixer mixer, BassTempoStream tempoStream,
+        private BassStemPipeline(BassMixer mixer, BassMixer reverbMixer, BassFreeverbDsp reverbDsp,
+            int reverbLowEq, int reverbMidEq, int reverbHighEq, BassTempoStream tempoStream,
             BassNormalizer? normalizer, BassGainDsp? gainDsp)
         {
             _mixer = mixer;
+            _reverbMixer = reverbMixer;
+            _reverbDsp = reverbDsp;
+            _reverbLowEq = reverbLowEq;
+            _reverbMidEq = reverbMidEq;
+            _reverbHighEq = reverbHighEq;
             _tempoStream = tempoStream;
             _normalizer = normalizer;
             _gainDsp = gainDsp;
@@ -71,6 +82,43 @@ namespace YARG.Audio.BASS
                 return null;
             }
 
+            var reverbMixer = BassMixer.Create(sampleRate, channelCount, flags, processingThreads);
+            if (reverbMixer == null)
+            {
+                mixer.Dispose();
+                return null;
+            }
+
+            int reverbLowEq = BassHelpers.AddEqToChannel(reverbMixer.Handle, BassHelpers.LowEqParams);
+            int reverbMidEq = BassHelpers.AddEqToChannel(reverbMixer.Handle, BassHelpers.MidEqParams);
+            int reverbHighEq = BassHelpers.AddEqToChannel(reverbMixer.Handle, BassHelpers.HighEqParams);
+            if (reverbLowEq == 0 || reverbMidEq == 0 || reverbHighEq == 0)
+            {
+                DisposeReverbBus(reverbMixer, null, reverbLowEq, reverbMidEq, reverbHighEq);
+                mixer.Dispose();
+                return null;
+            }
+
+            var reverbDsp = BassFreeverbDsp.Create(reverbMixer.Handle,
+                dryMix: 0.0f,
+                wetMix: 1.0f,
+                roomSize: 0.8f,
+                damp: 0.5f,
+                width: 1.0f);
+            if (reverbDsp == null)
+            {
+                DisposeReverbBus(reverbMixer, null, reverbLowEq, reverbMidEq, reverbHighEq);
+                mixer.Dispose();
+                return null;
+            }
+
+            if (!mixer.AddChannel(reverbMixer.Handle))
+            {
+                DisposeReverbBus(reverbMixer, reverbDsp, reverbLowEq, reverbMidEq, reverbHighEq);
+                mixer.Dispose();
+                return null;
+            }
+
             BassTempoStream tempoStream;
             try
             {
@@ -80,6 +128,8 @@ namespace YARG.Audio.BASS
             catch (BassX.BassOperationException exception)
             {
                 YargLogger.LogError(exception.Message);
+                mixer.RemoveChannel(reverbMixer.Handle);
+                DisposeReverbBus(reverbMixer, reverbDsp, reverbLowEq, reverbMidEq, reverbHighEq);
                 mixer.Dispose();
                 return null;
             }
@@ -95,7 +145,8 @@ namespace YARG.Audio.BASS
                 }
             }
 
-            return new BassStemPipeline(mixer, tempoStream, normalizer, gainDsp);
+            return new BassStemPipeline(mixer, reverbMixer, reverbDsp, reverbLowEq, reverbMidEq, reverbHighEq,
+                tempoStream, normalizer, gainDsp);
         }
 
         public bool AddStems(Stream stream, IEnumerable<StemMixer.StemInfo> stemInfos,
@@ -151,6 +202,7 @@ namespace YARG.Audio.BASS
         public bool RealignChannels(double playbackDelay, out double alignmentDelay)
         {
             _mixer.RemoveAllChannels();
+            _reverbMixer.RemoveAllChannels();
 
             double requiredAlignment = 0;
             foreach (var data in _stemDatas)
@@ -162,18 +214,28 @@ namespace YARG.Audio.BASS
             }
 
             alignmentDelay = requiredAlignment;
-            var channels = new List<BassMixerChannel>(_stemDatas.Count * 2);
+            var dryChannels = new List<BassMixerChannel>(_stemDatas.Count);
+            var reverbChannels = new List<BassMixerChannel>(_stemDatas.Count);
 
             foreach (var data in _stemDatas)
             {
                 double delay = playbackDelay + requiredAlignment - data.PitchFxDelay;
-                channels.Add(new BassMixerChannel(data.StreamHandles.Stream, data.VolumeMatrix, delay));
-                channels.Add(new BassMixerChannel(data.ReverbHandles.Stream, data.VolumeMatrix, delay));
+                dryChannels.Add(new BassMixerChannel(data.StreamHandles.Stream, data.VolumeMatrix, delay));
+                reverbChannels.Add(new BassMixerChannel(data.ReverbHandles.Stream, data.VolumeMatrix, delay));
             }
 
-            bool added = _mixer.AddChannels(channels);
+            bool added = _reverbMixer.AddChannels(reverbChannels) && _mixer.AddChannels(dryChannels) &&
+                _mixer.AddChannel(_reverbMixer.Handle);
+            if (!added)
+            {
+                _mixer.RemoveAllChannels();
+                _reverbMixer.RemoveAllChannels();
+                return false;
+            }
+
             _tempoStream.ResetPosition();
-            return added;
+            _reverbDsp.RequestReset();
+            return true;
         }
 
         public bool RemoveStem(SongStem stemToRemove)
@@ -185,7 +247,7 @@ namespace YARG.Audio.BASS
                 if (data.Stem == stemToRemove)
                 {
                     _mixer.RemoveChannel(data.StreamHandles.Stream);
-                    _mixer.RemoveChannel(data.ReverbHandles.Stream);
+                    _reverbMixer.RemoveChannel(data.ReverbHandles.Stream);
                     data.Source.Release(data.StreamHandles);
                     data.Source.Release(data.ReverbHandles);
                     _stemDatas.RemoveAt(i);
@@ -209,6 +271,7 @@ namespace YARG.Audio.BASS
         public void SetDevice(int deviceId)
         {
             StopNormalization();
+            _reverbMixer.SetDevice(deviceId);
             _mixer.SetDevice(deviceId);
             _tempoStream.SetDevice(deviceId);
         }
@@ -239,7 +302,33 @@ namespace YARG.Audio.BASS
             _normalizer?.Dispose();
             _gainDsp?.Dispose();
             _tempoStream.Dispose();
+            _mixer.RemoveChannel(_reverbMixer.Handle);
+            _reverbMixer.RemoveAllChannels();
+            DisposeReverbBus(_reverbMixer, _reverbDsp, _reverbLowEq, _reverbMidEq, _reverbHighEq);
             _mixer.Dispose();
+        }
+
+        private static void DisposeReverbBus(BassMixer mixer, BassFreeverbDsp? reverbDsp,
+            int lowEq, int midEq, int highEq)
+        {
+            reverbDsp?.Dispose();
+            RemoveEffect(mixer.Handle, lowEq);
+            RemoveEffect(mixer.Handle, midEq);
+            RemoveEffect(mixer.Handle, highEq);
+            mixer.Dispose();
+        }
+
+        private static void RemoveEffect(int streamHandle, int effectHandle)
+        {
+            if (effectHandle == 0)
+            {
+                return;
+            }
+
+            if (!Bass.ChannelRemoveFX(streamHandle, effectHandle) && Bass.LastError != Errors.Handle)
+            {
+                YargLogger.LogFormatError("Failed to remove reverb effect: {0}", Bass.LastError);
+            }
         }
 
         private static bool BuildStemData(BassMixerSource source, IEnumerable<StemMixer.StemInfo> stemInfos,
@@ -260,6 +349,13 @@ namespace YARG.Audio.BASS
                 }
 
                 var (streamHandle, reverbHandle) = handles.Value;
+                if (!Bass.ChannelSlideAttribute(reverbHandle.Stream, ChannelAttribute.Volume, 0, 0))
+                {
+                    YargLogger.LogFormatError("Failed to initialize reverb volume for stem {0}: {1}!", stem,
+                        Bass.LastError);
+                    return false;
+                }
+
                 double pitchFxDelay = GetPitchDelay(stem, streamHandle);
                 if (pitchFxDelay < 0)
                 {
@@ -302,6 +398,7 @@ namespace YARG.Audio.BASS
                 return;
             }
 
+            _reverbMixer.SetProcessingThreads(_stemDatas.Count);
             _mixer.SetProcessingThreads(_stemDatas.Count);
         }
 


### PR DESCRIPTION
Some updates to mic monitoring to fix issues with different volume levels per device

New chain:
- 90 Hz high-pass filter
- automatic level control
- compressor
- limiter

This should provider steadier mic volume and less rumble

We also improve our reverb handling for multi stem scenarios, where we use a single reverb bus instead of multiple reverbs per stem