### PR TITLE
feat: show built-in preset values read-only in the preset editor

### DIFF
--- a/Assets/Prefabs/Menu/Settings/Presets/PresetDefaultText.prefab
+++ b/Assets/Prefabs/Menu/Settings/Presets/PresetDefaultText.prefab
@@ -66,7 +66,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: '<font-weight=600>You can not modify a built-in preset.</font-weight>
+  m_text: '<font-weight=600>You cannot modify a built-in preset.</font-weight>
 
     In
     order to modify a preset, press on the copy button to make a preset based off

--- a/Assets/Script/Menu/Common/Dialogs/ColorPickerDialog.cs
+++ b/Assets/Script/Menu/Common/Dialogs/ColorPickerDialog.cs
@@ -228,7 +228,6 @@ namespace YARG.Menu.Dialogs
         /// </summary>
         private class SliderRowVisual
         {
-            private const float SELECTED_BAR_DARKEN = 0.7f;
             private const float EDITING_YELLOW_DIM = 0.8f;
 
             private static readonly Color SELECTED_HANDLE_GREY = new(0.82f, 0.82f, 0.82f, 1f);
@@ -304,9 +303,7 @@ namespace YARG.Menu.Dialogs
                         // Desaturated grey at the same brightness as the
                         // previous dim yellow — the switch to saturated
                         // yellow on edit is much more noticeable this way
-                        var dim = RuntimeNavigatable.SelectedTextColor * SELECTED_BAR_DARKEN;
-                        Color.RGBToHSV(dim, out _, out _, out float v);
-                        color = Color.HSVToRGB(0f, 0f, v);
+                        color = RuntimeNavigatable.DimmedSelectionGrey;
                     }
                     else
                     {

--- a/Assets/Script/Menu/Navigation/RuntimeNavigatable.cs
+++ b/Assets/Script/Menu/Navigation/RuntimeNavigatable.cs
@@ -23,6 +23,17 @@ namespace YARG.Menu.Navigation
         /// </summary>
         public static readonly Color SelectedTextColor = new(1f, 0.83137256f, 0.22745098f, 1f);
 
+        /// <summary>
+        /// Desaturated selection color for selected but inert controls.
+        /// </summary>
+        public static readonly Color DimmedSelectionGrey = Desaturated(SelectedTextColor * 0.7f);
+
+        private static Color Desaturated(Color color)
+        {
+            Color.RGBToHSV(color, out _, out _, out float v);
+            return Color.HSVToRGB(0f, 0f, v);
+        }
+
         private static Sprite _selectionGradient;
         private static Sprite _buttonOutline;
 

--- a/Assets/Script/Menu/Settings/Visuals/BaseSettingVisual.cs
+++ b/Assets/Script/Menu/Settings/Visuals/BaseSettingVisual.cs
@@ -82,7 +82,7 @@ namespace YARG.Menu.Settings.Visuals
             }
         }
 
-        public void SetEditable(bool editable)
+        public virtual void SetEditable(bool editable, bool dim = true)
         {
             IsEditable = editable;
             var canvasGroup = gameObject.GetComponent<CanvasGroup>();
@@ -90,7 +90,7 @@ namespace YARG.Menu.Settings.Visuals
             {
                 canvasGroup = gameObject.AddComponent<CanvasGroup>();
             }
-            canvasGroup.alpha = editable ? 1f : 0.5f;
+            canvasGroup.alpha = !editable && dim ? 0.5f : 1f;
             canvasGroup.interactable = editable;
             canvasGroup.blocksRaycasts = true;
 

--- a/Assets/Script/Menu/Settings/Visuals/SliderSettingVisual.cs
+++ b/Assets/Script/Menu/Settings/Visuals/SliderSettingVisual.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using UnityEngine.UI;
 using YARG.Core.Input;
 using YARG.Menu.Navigation;
 using YARG.Settings.Types;
@@ -7,11 +8,59 @@ namespace YARG.Menu.Settings.Visuals
 {
     public class SliderSettingVisual : BaseSettingVisual<SliderSetting>
     {
+        private static readonly Color READONLY_DISABLED_GREY = new(0.6f, 0.6f, 0.6f, 1f);
+
         [SerializeField]
         private ValueSlider _slider;
 
+        private bool _defaultsCaptured;
+        private Color _fillDefault;
+        private Color _disabledColorDefault;
+
         // Unity sucks -_-
         private bool _ignoreCallback;
+
+        public override void SetEditable(bool editable, bool dim = true)
+        {
+            var slider = _slider.GetComponentInChildren<Slider>();
+            if (slider != null)
+            {
+                if (!_defaultsCaptured)
+                {
+                    _defaultsCaptured = true;
+                    _fillDefault = slider.fillRect != null
+                        ? slider.fillRect.GetComponent<Image>().color
+                        : Color.white;
+                    _disabledColorDefault = slider.colors.disabledColor;
+                }
+
+                // Keep the disabled handle opaque so the slider shape stays hidden.
+                var colors = slider.colors;
+                colors.disabledColor = editable
+                    ? _disabledColorDefault
+                    : READONLY_DISABLED_GREY;
+                slider.colors = colors;
+            }
+
+            base.SetEditable(editable, dim);
+
+            if (slider?.fillRect == null)
+            {
+                return;
+            }
+
+            var fill = slider.fillRect.GetComponent<Image>();
+            if (editable)
+            {
+                fill.color = _fillDefault;
+            }
+            else
+            {
+                var fillGrey = RuntimeNavigatable.DimmedSelectionGrey;
+                fillGrey.a = _fillDefault.a;
+                fill.color = fillGrey;
+            }
+        }
 
         protected override void OnSettingInit()
         {

--- a/Assets/Script/Menu/Settings/Visuals/ToggleSettingVisual.cs
+++ b/Assets/Script/Menu/Settings/Visuals/ToggleSettingVisual.cs
@@ -11,9 +11,33 @@ namespace YARG.Menu.Settings.Visuals
         [SerializeField]
         private Toggle _toggle;
 
+        private Color _disabledColorDefault;
+
         public override void RefreshVisual()
         {
             _toggle.SetIsOnWithoutNotify(Setting.Value);
+        }
+
+        /// <summary>
+        /// Keeps read-only toggles legible: the checkmark remains visible while the
+        /// grey base stays opaque.
+        /// </summary>
+        public override void SetEditable(bool editable, bool dim = true)
+        {
+            var colors = _toggle.colors;
+            _disabledColorDefault = colors.disabledColor;
+
+            colors.disabledColor = editable
+                ? _disabledColorDefault
+                : new Color(_disabledColorDefault.r, _disabledColorDefault.g,
+                    _disabledColorDefault.b, 1f);
+            _toggle.colors = colors;
+
+            base.SetEditable(editable, dim);
+
+            _toggle.graphic.color = editable
+                ? Color.white
+                : new Color(0.5f, 0.5f, 0.5f, 1f);
         }
 
         public override NavigationScheme GetNavigationScheme()

--- a/Assets/Script/Settings/Metadata/Tabs/PresetSubTab.Generic.cs
+++ b/Assets/Script/Settings/Metadata/Tabs/PresetSubTab.Generic.cs
@@ -471,26 +471,28 @@ namespace YARG.Settings.Metadata
                 }
                 default:
                 {
-                    if (!HideFields)
+                    if (_subSection is not null
+                        && _presetRef is ColorProfile
+                        && ColorFieldGroups.TryGetValue(_subSection, out var groups))
                     {
-                        if (_subSection is not null
-                            && _presetRef is ColorProfile
-                            && ColorFieldGroups.TryGetValue(_subSection, out var groups))
+                        BuildGroupedFields(settingContainer, navGroup, _presetRef, groups);
+                    }
+                    else
+                    {
+                        foreach (var field in _fields)
                         {
-                            BuildGroupedFields(settingContainer, navGroup, _presetRef, groups);
-                        }
-                        else
-                        {
-                            foreach (var field in _fields)
+                            if (_subSection is not null && field.ParentField.Name != _subSection)
                             {
-                                if (_subSection is not null && field.ParentField.Name != _subSection)
-                                {
-                                    continue;
-                                }
-
-                                BuildField(field, settingContainer, navGroup, _presetRef);
+                                continue;
                             }
+
+                            BuildField(field, settingContainer, navGroup, _presetRef);
                         }
+                    }
+
+                    if (ReadOnlyFields)
+                    {
+                        MakeFieldsReadOnly(settingContainer);
                     }
 
                     break;
@@ -899,9 +901,16 @@ namespace YARG.Settings.Metadata
         /// same as clicking the row's Color Picker button. Keeps the stock row
         /// highlight ("Selected Background").
         /// </summary>
-        private static void UseColorPickerNavigation(BaseSettingVisual visual, NavigationGroup navGroup)
+        private void UseColorPickerNavigation(BaseSettingVisual visual, NavigationGroup navGroup)
         {
             if (visual is not ColorSettingVisual colorVisual)
+            {
+                return;
+            }
+
+            // Keep read-only rows navigable for controller scrolling; confirm no-ops
+            // when IsEditable is false.
+            if (ReadOnlyFields)
             {
                 return;
             }
@@ -1258,6 +1267,11 @@ namespace YARG.Settings.Metadata
             FieldSubGroup fretSub, Dictionary<string, FieldSettingInfo> fieldLookup, T preset,
             NavigationGroup navGroup)
         {
+            // Copying would modify a read-only (default) preset.
+            if (ReadOnlyFields)
+            {
+                return;
+            }
             // The base note is the first color field of the Notes sub-group.
             if (group.SubGroups.Length == 0 || group.SubGroups[0].FieldNames.Length == 0)
             {
@@ -1479,6 +1493,22 @@ namespace YARG.Settings.Metadata
                 _swatchFillSprite = sprite;
             }
             return sprite;
+        }
+
+        // Keep values opaque: CanvasGroup alpha would make colors and sliders
+        // translucent, so only input text is dimmed.
+        private static void MakeFieldsReadOnly(Transform container)
+        {
+            foreach (var visual in container.GetComponentsInChildren<BaseSettingVisual>(false))
+            {
+                visual.SetEditable(false, dim: false);
+
+                foreach (var input in visual.GetComponentsInChildren<TMP_InputField>(false))
+                {
+                    var text = input.textComponent;
+                    text.color = text.color.WithAlpha(0.7f);
+                }
+            }
         }
 
         private void BuildField(FieldSettingInfo field, Transform container, NavigationGroup navGroup, T preset)

--- a/Assets/Script/Settings/Metadata/Tabs/PresetSubTab.cs
+++ b/Assets/Script/Settings/Metadata/Tabs/PresetSubTab.cs
@@ -19,10 +19,9 @@ namespace YARG.Settings.Metadata
 {
     public abstract class PresetSubTab : Tab
     {
-        // When true, BuildSettingTab shows the dropdown and preview toggles but
-        // hides the color/preset editing fields. Used for default/built-in profiles
-        // so the user can still switch instrument previews.
-        public bool HideFields { get; set; }
+        // Keeps default preset fields inspectable without allowing edits; preview
+        // controls remain interactive.
+        public bool ReadOnlyFields { get; set; }
 
         // Shared preview visual state across all preset type tabs (Camera, Color,
         // Engine, Highway, RockMeter). Bundled into one object (rather than a

--- a/Assets/Script/Settings/Metadata/Tabs/PresetsTab.cs
+++ b/Assets/Script/Settings/Metadata/Tabs/PresetsTab.cs
@@ -237,12 +237,13 @@ namespace YARG.Settings.Metadata
             else
             {
                 tab.SetPresetReference(SelectedPreset);
-                tab.HideFields = preset.DefaultPreset;
-                tab.BuildSettingTab(settingContainer, navGroup);
+                tab.ReadOnlyFields = preset.DefaultPreset;
                 if (preset.DefaultPreset)
                 {
+                    // Keep the default-preset notice above its read-only fields.
                     Object.Instantiate(_presetDefaultText, settingContainer);
                 }
+                tab.BuildSettingTab(settingContainer, navGroup);
             }
         }
 


### PR DESCRIPTION
## Summary

Built-in (OOTB) presets now display their values read-only in the standard
preset editor UI instead of hiding them. The "You cannot modify a built-in
preset" notice still leads, with the preset's fields rendered after it, so
users can see what a default preset contains without copying it.

## Why

There was no way to inspect a built-in preset's values without copying it: selecting one showed only the notice and the preview controls. Answering "what does the default camera preset actually set?" required duplicating the preset.

## Design

- Fields build exactly as in edit mode; a read-only pass then disables interaction. Colors, swatches, and slider positions render exactly.
- Interaction is blocked via the `CanvasGroup` with alpha untouched, and control disabled-tints are overridden to opaque greys: sliders get a grey fill and a solid dark handle; an "on" toggle keeps a solid, darkened blue overlay.
- Value text (numeric inputs, hex fields) is gently dimmed to read as inert.
- Rows remain controller-navigable so long lists can be scrolled, but confirm is inert — this reuses the existing `IsEditable` guard in `BaseSettingNavigatable`.
- Color rows keep the stock navigatable (no color picker), and the "Copy from note" button is not created, since both could modify the preset.
- Preview controls (instrument dropdown, preview toggles) stay interactive on built-ins, as before.

## Changes

| File | Change |
|------|--------|
| `PresetsTab.cs` | Show the built-in notice *before* the fields; set the new flag. |
| `PresetSubTab.cs` | `HideFields` → `ReadOnlyFields` (fields render read-only instead of being skipped). |
| `PresetSubTab.Generic.cs` | Always build fields; `MakeFieldsReadOnly` pass; gate color-picker navigation and the copy-from-note button for read-only presets. |
| `BaseSettingVisual.cs` | `SetEditable` is virtual and takes a `dim` parameter (metadata rows keep the existing dimmed behavior). |
| `SliderSettingVisual.cs` | Read-only: grey fill, opaque dark handle (overrides the stock half-transparent disabled tint). |
| `ToggleSettingVisual.cs` | Read-only: opaque disabled tint, darkened blue "on" overlay. |
| `RuntimeNavigatable.cs` | New shared `DimmedSelectionGrey` (the selection color desaturated) so the color picker and read-only sliders use one definition. |
| `ColorPickerDialog.cs` | Slider-row selected grey now uses the shared constant instead of a local derivation. |
| `PresetDefaultText.prefab` | Fix "You can not" → "You cannot". |

## Notes

- Applies to every preset type (Camera, Color, Engine, Highway, Rock Meter) through the single `BuildSettingTab` path.
- `SetEditable`'s existing callers are unaffected; the new parameter defaults to the previous behavior.

## Testing done

- Unity batchmode compilation against the synced runtime: zero `error CS` on 2026-08-17.
- In-game verification on 2026-08-17 across Camera, Color, Engine, Highway, and Rock Meter presets: values visible and exact (colors unmodified, solid slider handles, single-state toggles), notice leading, no copy-from-note button, preview controls interactive, read-only rows inert under confirm and mouse.
