### PR TITLE
Preserve Playlist Entries when Songs are Updated in Place

### DIFF
--- a/Assets/Script/Playlists/PlaylistContainer.cs
+++ b/Assets/Script/Playlists/PlaylistContainer.cs
@@ -110,6 +110,51 @@ namespace YARG.Playlists
             return removed;
         }
 
+        public static int ReplaceUpdatedSongHashes(IReadOnlyDictionary<HashWrapper, HashWrapper> replacements)
+        {
+            if (replacements == null || replacements.Count == 0)
+            {
+                return 0;
+            }
+
+            int replaced = 0;
+
+            void ReplaceAndSave(Playlist playlist, string path)
+            {
+                if (playlist?.SongHashes == null)
+                {
+                    return;
+                }
+
+                int playlistReplacements = 0;
+                for (int i = 0; i < playlist.SongHashes.Count; i++)
+                {
+                    if (replacements.TryGetValue(playlist.SongHashes[i], out var replacement))
+                    {
+                        playlist.SongHashes[i] = replacement;
+                        playlistReplacements++;
+                    }
+                }
+
+                if (playlistReplacements == 0)
+                {
+                    return;
+                }
+
+                replaced += playlistReplacements;
+                SavePlaylist(playlist, path);
+                YargLogger.LogInfo($"Replaced {playlistReplacements} updated song hashes in playlist '{playlist.Name}'");
+            }
+
+            ReplaceAndSave(FavoritesPlaylist, _favoritesPath);
+            foreach (var playlist in _playlists)
+            {
+                ReplaceAndSave(playlist, Path.Join(PlaylistDirectory, GetFileNameForPlaylist(playlist)));
+            }
+
+            return replaced;
+        }
+
         private static bool RemoveDeadHashesFromPlaylist(Playlist playlist, IReadOnlyDictionary<HashWrapper, List<SongEntry>> songsByHash, ref int removed)
         {
             if (playlist.SongHashes == null || playlist.SongHashes.Count == 0)

--- a/Assets/Script/Song/SongContainer.cs
+++ b/Assets/Script/Song/SongContainer.cs
@@ -14,6 +14,7 @@ using YARG.Helpers.Extensions;
 using YARG.Localization;
 using YARG.Menu.MusicLibrary;
 using YARG.Player;
+using YARG.Playlists;
 using YARG.Scores;
 using YARG.Settings;
 
@@ -154,9 +155,11 @@ namespace YARG.Song
             }
 
             var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+            var previousSongCache = _songCache;
+            SongCache refreshedSongCache = null;
             var task = UniTask.RunOnThreadPool(() =>
             {
-                _songCache =  CacheHandler.RunScan(quick,
+                refreshedSongCache = CacheHandler.RunScan(quick,
                     PathHelper.SongCachePath,
                     PathHelper.BadSongsPath,
                     SettingsManager.Settings.UseFullDirectoryForPlaylists.Value,
@@ -171,6 +174,10 @@ namespace YARG.Song
                 }
                 await UniTask.NextFrame();
             }
+
+            PlaylistContainer.ReplaceUpdatedSongHashes(
+                FindUpdatedSongHashes(previousSongCache, refreshedSongCache));
+            _songCache = refreshedSongCache;
 
             if (SettingsManager.Settings.Genrelizer.Value is GenrelizerMode.Genrelize && !GlobalVariables.OfflineMode)
             {
@@ -191,6 +198,66 @@ namespace YARG.Song
             YargLogger.LogFormatInfo("Scan time: {0}s", stopwatch.Elapsed.TotalSeconds);
             MusicLibraryMenu.SetReload(MusicLibraryReloadState.Full);
             SongSources.LoadSprites(context);
+        }
+
+        private static Dictionary<HashWrapper, HashWrapper> FindUpdatedSongHashes(
+            SongCache previousCache, SongCache refreshedCache)
+        {
+            var previousByLocation = GetSongsByUniqueLocation(previousCache);
+            var refreshedByLocation = GetSongsByUniqueLocation(refreshedCache);
+            var replacements = new Dictionary<HashWrapper, HashWrapper>();
+            var ambiguousHashes = new HashSet<HashWrapper>();
+
+            foreach (var (location, previousSong) in previousByLocation)
+            {
+                if (!refreshedByLocation.TryGetValue(location, out var refreshedSong) ||
+                    previousSong.Hash.Equals(refreshedSong.Hash) ||
+                    refreshedCache.Entries.ContainsKey(previousSong.Hash) ||
+                    ambiguousHashes.Contains(previousSong.Hash))
+                {
+                    continue;
+                }
+
+                // A hash can represent duplicate copies in different directories. If those
+                // copies changed to different hashes, there is no unambiguous replacement.
+                if (replacements.TryGetValue(previousSong.Hash, out var replacement))
+                {
+                    if (!replacement.Equals(refreshedSong.Hash))
+                    {
+                        replacements.Remove(previousSong.Hash);
+                        ambiguousHashes.Add(previousSong.Hash);
+                    }
+                }
+                else
+                {
+                    replacements.Add(previousSong.Hash, refreshedSong.Hash);
+                }
+            }
+
+            return replacements;
+        }
+
+        private static Dictionary<string, SongEntry> GetSongsByUniqueLocation(SongCache songCache)
+        {
+            var songsByLocation = new Dictionary<string, SongEntry>(StringComparer.OrdinalIgnoreCase);
+            var duplicateLocations = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var song in songCache.Entries.Values.SelectMany(entries => entries))
+            {
+                string location = song.ActualLocation;
+                if (duplicateLocations.Contains(location))
+                {
+                    continue;
+                }
+
+                if (!songsByLocation.TryAdd(location, song))
+                {
+                    songsByLocation.Remove(location);
+                    duplicateLocations.Add(location);
+                }
+            }
+
+            return songsByLocation;
         }
 
         public static SongCategory[] GetSortedCategory(SortAttribute sort)


### PR DESCRIPTION
Currently, when a notes.mid file is modified and the library is rescanned, the song receives a new hash.  This is expected behavior and remains unchanged.  However, because playlists identify songs by hash, the song may disappear from any playlists containing it.

With this change, when a song's hash changes during a rescan but its directory remains the same, playlist entries using the old hash are updated to use the new hash.  Ambiguous matches, such as duplicate copies that produce different new hashes, are left unchanged.