### PR TITLE
Add Options for Song Duration Groups in Sort and Filter

### DIFF
--- a/Assets/Script/Menu/Filters/FiltersMenu.cs
+++ b/Assets/Script/Menu/Filters/FiltersMenu.cs
@@ -153,6 +153,7 @@ namespace YARG.Menu.Filters
         private static int _cachedPlaylistCountsSignature = -1;
         private static int _cachedCharterSongCount = -1;
         private static int _cachedLengthSongCount = -1;
+        private static SongLengthLabelMode? _cachedLengthLabelMode;
         private static int _cachedIntensitySongCount = -1;
 
 
@@ -1477,17 +1478,26 @@ namespace YARG.Menu.Filters
 #region Song Lengths
         private static IReadOnlyList<string> GetAllLengthsCached()
         {
-            return GetAllCached(ref _cachedLengths, ref _cachedLengthSongCount, () =>
+            var labelMode = SettingsManager.Settings.SongLengthLabels.Value;
+            if (_cachedLengths != null &&
+                _cachedLengthSongCount == SongContainer.Count &&
+                _cachedLengthLabelMode == labelMode)
             {
-                var counts = GetLengthCounts();
-                var ordered = new List<string>(LengthLabels.Count);
-                foreach (var label in LengthLabels)
-                {
-                    if (counts.TryGetValue(label, out int count) && count > 0)
-                        ordered.Add(label);
-                }
-                return ordered;
-            });
+                return _cachedLengths;
+            }
+
+            _cachedLengthSongCount = SongContainer.Count;
+            _cachedLengthLabelMode = labelMode;
+
+            var counts = GetLengthCounts();
+            var ordered = new List<string>(LengthLabels.Count);
+            foreach (var label in LengthLabels)
+            {
+                if (counts.TryGetValue(label, out int count) && count > 0)
+                    ordered.Add(label);
+            }
+
+            return _cachedLengths = ordered;
         }
 
         private static Dictionary<string, int> GetLengthCounts()
@@ -1506,11 +1516,6 @@ namespace YARG.Menu.Filters
             return dict;
         }
 
-        // Toggle which length buckets to use by switching this flag.
-        // - true  -> Legacy labels (Short/Medium/Long/Epic)
-        // - false -> Range labels (0-2, 2-5, 5-10, 10-15, 15-20, 20+)
-        private const bool UseLegacyLengthLabels = true;
-
         private static readonly string[] LegacyLengthLabelKeys =
         {
             "Menu.Filters.Length.Short",
@@ -1528,6 +1533,9 @@ namespace YARG.Menu.Filters
             "15:00 - 20:00",
             "20:00+",
         };
+
+        private static bool UseLegacyLengthLabels =>
+            SettingsManager.Settings.SongLengthLabels.Value == SongLengthLabelMode.LegacyLabels;
 
         private static IReadOnlyList<string> LengthLabels =>
             UseLegacyLengthLabels ? GetLegacyLengthLabels() : RangeLengthLabels;
@@ -1560,8 +1568,6 @@ namespace YARG.Menu.Filters
                 };
             }
 
-            // Left for possible future use
-#pragma warning disable CS0162 // Unreachable code detected
             return lengthMilliseconds switch
             {
                 < 120000  => RangeLengthLabels[0],
@@ -1571,7 +1577,6 @@ namespace YARG.Menu.Filters
                 < 1200000 => RangeLengthLabels[4],
                 _         => RangeLengthLabels[5],
             };
-#pragma warning restore CS0162 // Unreachable code detected
         }
 #endregion
 

--- a/Assets/Script/Settings/SettingsManager.Settings.cs
+++ b/Assets/Script/Settings/SettingsManager.Settings.cs
@@ -34,6 +34,12 @@ using Object = UnityEngine.Object;
 
 namespace YARG.Settings
 {
+    public enum SongLengthLabelMode
+    {
+        RangeLabels,
+        LegacyLabels,
+    }
+
     public enum QualityMode
     {
         NativeAA = 0,
@@ -251,6 +257,13 @@ namespace YARG.Settings
 
             public ToggleSetting ShowFavoriteButton { get; } = new(true);
             public ToggleSetting ShowRecommendedSongs { get; } = new(true, ShowRecommendedSongsCallback);
+
+            public DropdownSetting<SongLengthLabelMode> SongLengthLabels { get; }
+                = new(SongLengthLabelMode.RangeLabels, _ => RefreshSongs())
+                {
+                    SongLengthLabelMode.RangeLabels,
+                    SongLengthLabelMode.LegacyLabels,
+                };
 
             public ToggleSetting EnablePlayAShow { get; } = new(true);
             public SliderSetting PlayAShowTimeout { get; } = new (10.0f, 1.0f, 30.0f);

--- a/Assets/Script/Settings/SettingsManager.cs
+++ b/Assets/Script/Settings/SettingsManager.cs
@@ -100,6 +100,7 @@ namespace YARG.Settings
                 nameof(Settings.HighScoreInfo),
                 new FieldMetadata(nameof(Settings.ShowPercentDecimals), isAdvanced: true),
                 nameof(Settings.HighScoreHistory),
+                new FieldMetadata(nameof(Settings.SongLengthLabels), isAdvanced: true),
                 new HeaderMetadata("PlayAShow"),
                 nameof(Settings.EnablePlayAShow),
                 nameof(Settings.PlayAShowTimeout),

--- a/Assets/Script/Song/SongContainer.cs
+++ b/Assets/Script/Song/SongContainer.cs
@@ -807,10 +807,7 @@ namespace YARG.Song
                     return Cast(_sortedSongs.SongLengths);
                 }
 
-                var groups = new List<SongEntry>[4]
-                {
-                    new(), new(), new(), new(),
-                };
+                var groups = new SortedDictionary<int, List<SongEntry>>();
 
                 // The range categories and their contents are already ordered by duration.
                 foreach (var range in _sortedSongs.SongLengths.Values)
@@ -824,7 +821,12 @@ namespace YARG.Song
                             < 420000 => 2,
                             _        => 3,
                         };
-                        groups[groupIndex].Add(song);
+
+                        if (!groups.TryGetValue(groupIndex, out var group))
+                        {
+                            groups.Add(groupIndex, group = new List<SongEntry>());
+                        }
+                        group.Add(song);
                     }
                 }
 
@@ -836,18 +838,14 @@ namespace YARG.Song
                     "Menu.Filters.Length.Epic",
                 };
 
-                var sections = new List<SongCategory>(groups.Length);
-                for (int i = 0; i < groups.Length; i++)
+                var sections = new SongCategory[groups.Count];
+                int index = 0;
+                foreach (var (groupIndex, songs) in groups)
                 {
-                    if (groups[i].Count == 0)
-                    {
-                        continue;
-                    }
-
-                    string label = Localize.Key(labelKeys[i]);
-                    sections.Add(new SongCategory(label, groups[i].ToArray(), label));
+                    string label = Localize.Key(labelKeys[groupIndex]);
+                    sections[index++] = new SongCategory(label, songs.ToArray(), label);
                 }
-                return sections.ToArray();
+                return sections;
             }
 
             static SongCategory[] Cast(SortedDictionary<string, List<SongEntry>> list)

--- a/Assets/Script/Song/SongContainer.cs
+++ b/Assets/Script/Song/SongContainer.cs
@@ -635,7 +635,7 @@ namespace YARG.Song
 
             _sortTitles       = Cast(_sortedSongs.Titles);
             _sortYears        = Cast(_sortedSongs.Years);
-            _sortSongLengths  = Cast(_sortedSongs.SongLengths);
+            _sortSongLengths  = GetSongLengthSort();
             _playables = null;
 
             _sortDatesAdded = new SongCategory[_sortedSongs.DatesAdded.Count];
@@ -798,6 +798,56 @@ namespace YARG.Song
                     sections[index++] = new SongCategory(key, node.Value.ToArray(), categoryGroupName);
                 }
                 return sections;
+            }
+
+            static SongCategory[] GetSongLengthSort()
+            {
+                if (SettingsManager.Settings.SongLengthLabels.Value == SongLengthLabelMode.RangeLabels)
+                {
+                    return Cast(_sortedSongs.SongLengths);
+                }
+
+                var groups = new List<SongEntry>[4]
+                {
+                    new(), new(), new(), new(),
+                };
+
+                // The range categories and their contents are already ordered by duration.
+                foreach (var range in _sortedSongs.SongLengths.Values)
+                {
+                    foreach (var song in range)
+                    {
+                        int groupIndex = song.SongLengthMilliseconds switch
+                        {
+                            < 180000 => 0,
+                            < 300000 => 1,
+                            < 420000 => 2,
+                            _        => 3,
+                        };
+                        groups[groupIndex].Add(song);
+                    }
+                }
+
+                string[] labelKeys =
+                {
+                    "Menu.Filters.Length.Short",
+                    "Menu.Filters.Length.Medium",
+                    "Menu.Filters.Length.Long",
+                    "Menu.Filters.Length.Epic",
+                };
+
+                var sections = new List<SongCategory>(groups.Length);
+                for (int i = 0; i < groups.Length; i++)
+                {
+                    if (groups[i].Count == 0)
+                    {
+                        continue;
+                    }
+
+                    string label = Localize.Key(labelKeys[i]);
+                    sections.Add(new SongCategory(label, groups[i].ToArray(), label));
+                }
+                return sections.ToArray();
             }
 
             static SongCategory[] Cast(SortedDictionary<string, List<SongEntry>> list)

--- a/Assets/StreamingAssets/lang/en-US.json
+++ b/Assets/StreamingAssets/lang/en-US.json
@@ -1286,6 +1286,14 @@
                     "HighestScoreCurrentDifficulty": "Highest score on current difficulty"
                 }
             },
+            "SongLengthLabels": {
+                "Name": "Song Duration Labels",
+                "Description": "Choose how song durations are grouped in the music library and filters menu.",
+                "Dropdown": {
+                    "RangeLabels": "2:00, 5:00, 10:00, 15:00, 20:00",
+                    "LegacyLabels": "Short, Medium, Long, Epic"
+                }
+            },
             "HighwayTiltMultiplier": {
                 "Name": "Highway Tilt Multiplier",
                 "Description": "Controls the amount that the tracks should tilt inward during multiplayer gameplay only."


### PR DESCRIPTION
## Description
The Music Library's "Sort by Duration" and the Filters menu's "Song Lengths" currently use different groups.  This change synchronizes them and adds an advanced setting for selecting between:
- Range Labels: under 2, 2–5, 5–10, 10–15, 15–20, and 20+ minutes
- Legacy Labels: under 3, 3–5, 5–7, and 7+ minutes
Range Labels are the default.

This fixes: https://discord.com/channels/1086048856678084609/1528258447701971015

## Screenshots or Video

### Default Range Labels
Settings:
<img width="1393" height="131" alt="image" src="https://github.com/user-attachments/assets/c083b7c4-97d4-4706-ad0a-7524eb6156b2" />

Music Library Menu:
<img width="1873" height="562" alt="image" src="https://github.com/user-attachments/assets/a124ae2e-2e19-40c7-bf7d-359cdd724290" />

Filters Menu:
<img width="1127" height="802" alt="image" src="https://github.com/user-attachments/assets/712b4624-ad31-426c-981e-6c5f5ff203f3" />

### Optional Legacy Labels
Settings:
<img width="1393" height="131" alt="image" src="https://github.com/user-attachments/assets/f8b1df93-e973-491d-9753-2f0ab0907c06" />

Music Library Menu:
<img width="1873" height="401" alt="image" src="https://github.com/user-attachments/assets/b5cbce08-9a28-4c4a-9874-3f51874f6993" />

Filters Menu:
<img width="1127" height="535" alt="image" src="https://github.com/user-attachments/assets/2c9c41d9-ba1e-43bd-9592-b0c464a51da7" />