### PR TITLE
Unify Play a Show and Setlist Behavior in the Music Library

### DIFF
--- a/Assets/Script/Menu/Common/Dialogs/SongPickerListDialog.cs
+++ b/Assets/Script/Menu/Common/Dialogs/SongPickerListDialog.cs
@@ -276,7 +276,7 @@ namespace YARG.Menu.Dialogs
         public override void Submit()
         {
             _timerSequence.Kill();
-            MusicLibrary.RefreshAndReselect();
+            MusicLibrary.RefreshAndReselect(selectTopOfList: true);
             DialogManager.Instance.ClearDialog();
         }
 

--- a/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.Playlist.cs
+++ b/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.Playlist.cs
@@ -235,16 +235,24 @@ namespace YARG.Menu.MusicLibrary
 
         private List<ViewType> CreateShowViewList()
         {
+            _totalSongCount = 0;
+            _totalStarCount = 0;
+
             var list = new List<ViewType>
             {
-                new ButtonViewType(Localize.Key("Menu.MusicLibrary.Back"),
-                    "MusicLibraryIcons[Back]", LeaveShowMode, BACK_ID),
-                new ButtonViewType("Show Setlist", "MusicLibraryIcons[Playlists]", () => { })
+                new ButtonViewType(
+                    Localize.Key("Menu.MusicLibrary.Popup.Item.DeleteSetlist"),
+                    "MusicLibraryIcons[Playlists]", DeleteShowSetlist)
             };
 
             foreach (var song in ShowPlaylist.ToList())
             {
-                list.Add(new SongViewType(this, song));
+                var songView = new SongViewType(this, song);
+                list.Add(songView);
+
+                _totalSongCount++;
+                var starAmount = songView.GetStarAmount();
+                _totalStarCount += starAmount is null ? 0 : StarAmountHelper.GetStarCount(starAmount.Value);
             }
 
             return list;
@@ -285,11 +293,25 @@ namespace YARG.Menu.MusicLibrary
                             SelectedIndex++;
                         }
                     }),
-                new NavigationScheme.Entry(MenuAction.Green, "Menu.Common.Confirm",
-                    () => CurrentSelection?.PrimaryButtonClick()),
-                new NavigationScheme.Entry(MenuAction.Red, "Menu.Common.Back", LeaveShowMode),
-                new NavigationScheme.Entry(MenuAction.Blue, "Menu.MusicLibrary.StartShow",
-                    OnPlayShowHit),
+                new NavigationScheme.Entry(MenuAction.Left, "Menu.MusicLibrary.MoveInPlaylist",
+                    MovePlaylistEntryUp),
+                new NavigationScheme.Entry(MenuAction.Right, "Menu.MusicLibrary.MoveInPlaylist",
+                    MovePlaylistEntryDown),
+                new NavigationScheme.Entry(
+                    MenuAction.Green,
+                    "Menu.MusicLibrary.AddHoldStartSet",
+                    OnGreenTap,
+                    holdSeconds: GREEN_HOLD_SECONDS,
+                    onHoldHandler: OnGreenHold,
+                    hide: true),
+                new NavigationScheme.Entry(MenuAction.Red, "Menu.Common.Back", LeaveShowMode, hide: true),
+                new NavigationScheme.Entry(
+                    MenuAction.Yellow,
+                    "Menu.MusicLibrary.HoldPlayShow",
+                    () => { },
+                    holdSeconds: GREEN_HOLD_SECONDS,
+                    onHoldHandler: OpenShowPicker),
+                new NavigationScheme.Entry(MenuAction.Blue, "Menu.MusicLibrary.Filters", OpenFilters),
                 new NavigationScheme.Entry(MenuAction.Orange, "Menu.MusicLibrary.MoreOptions",
                     OnOrangeHit, OnOrangeRelease),
             }, false));
@@ -329,13 +351,20 @@ namespace YARG.Menu.MusicLibrary
             MenuState = MenuState.Show;
             Refresh();
 
+            if (!SetIndexTo(i => i is SongViewType))
+                SelectedIndex = 0;
+
+            OpenShowPicker();
+        }
+
+        private void OpenShowPicker()
+        {
+            SelectedIndex = 0;
             DialogManager.Instance.ShowSongPickerDialog("Pick Your Poison", this);
         }
 
         private void LeaveShowMode()
         {
-            ShowPlaylist.Clear();
-
             // Pop the navigation scheme
             Navigator.Instance.PopScheme();
             // We have to reset the navigation scheme so the help bar has the correct yellow button text
@@ -344,6 +373,9 @@ namespace YARG.Menu.MusicLibrary
 
             // Back to library
             MenuState = MenuState.Library;
+            // Show mode can be entered from a saved playlist. Do not carry that playlist's
+            // filtering context back into the main library.
+            SelectedPlaylist = null;
             Refresh();
 
             // Restore the main library index if it is valid
@@ -355,6 +387,14 @@ namespace YARG.Menu.MusicLibrary
             {
                 SetIndexTo(i => i is ButtonViewType { ID: RANDOM_SONG_ID });
             }
+        }
+
+        private void DeleteShowSetlist()
+        {
+            string setlistName = ShowPlaylist.Name;
+            ShowPlaylist.Clear();
+            LeaveShowMode();
+            ToastManager.ToastSuccess($"Deleted '{setlistName}'");
         }
 
         private void StartSetlist()
@@ -434,31 +474,16 @@ namespace YARG.Menu.MusicLibrary
             }
         }
 
-        private void OnPlayShowHit()
-        {
-            if (ShowPlaylist.Count > 0 && PlayerContainer.Players.Count > 0)
-            {
-                GlobalVariables.State.PlayingAShow = true;
-                GlobalVariables.State.ShowSongs = ShowPlaylist.ToList();
-                GlobalVariables.State.CurrentSong = GlobalVariables.State.ShowSongs.First();
-                GlobalVariables.State.ShowIndex = 0;
-
-                // Make sure we don't come back to play a show after show has been played
-                LeaveShowMode();
-
-                MenuManager.Instance.PushMenu(MenuManager.Menu.DifficultySelect);
-            }
-        }
-
         private void MovePlaylistEntryUp()
         {
-            if (SelectedPlaylist == null) return;
+            var playlist = MenuState == MenuState.Show ? ShowPlaylist : SelectedPlaylist;
+            if (playlist == null) return;
 
             if (CurrentSelection is SongViewType selection)
             {
                 var song = selection.SongEntry;
                 int previousIndex = SelectedIndex;
-                SelectedPlaylist.MoveSongUp(song);
+                playlist.MoveSongUp(song);
                 Refresh();
                 if (!SetIndexTo(i => i is SongViewType view && view.SongEntry == song))
                 {
@@ -470,13 +495,14 @@ namespace YARG.Menu.MusicLibrary
 
         private void MovePlaylistEntryDown()
         {
-            if (SelectedPlaylist == null) return;
+            var playlist = MenuState == MenuState.Show ? ShowPlaylist : SelectedPlaylist;
+            if (playlist == null) return;
 
             if (CurrentSelection is SongViewType selection)
             {
                 var song = selection.SongEntry;
                 int previousIndex = SelectedIndex;
-                SelectedPlaylist.MoveSongDown(song);
+                playlist.MoveSongDown(song);
                 Refresh();
                 if (!SetIndexTo(i => i is SongViewType view && view.SongEntry == song))
                 {

--- a/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.Playlist.cs
+++ b/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.Playlist.cs
@@ -100,24 +100,18 @@ namespace YARG.Menu.MusicLibrary
             SetNavigationScheme(true);
             var list = new List<ViewType>{};
 
-            // Only allow rename if not Favorites or Current Setlist
-            if (SelectedPlaylist != PlaylistContainer.FavoritesPlaylist && !SelectedPlaylist.Ephemeral)
+            if (SelectedPlaylist.Ephemeral)
             {
                 list.Add(new ButtonViewType(
-                    Localize.Key("Menu.MusicLibrary.Popup.Item.RenamePlaylist"),
-                    "MusicLibraryIcons[Playlists]", RenamePlaylist)
+                    Localize.Key("Menu.MusicLibrary.StartSet"),
+                    "MusicLibraryIcons[Playlists]", StartSetlist)
                 );
             }
-
-            // Only allow delete if not Favorites
-            if (SelectedPlaylist != PlaylistContainer.FavoritesPlaylist)
+            else
             {
-                var deleteLabel = SelectedPlaylist == ShowPlaylist
-                    ? Localize.Key("Menu.MusicLibrary.Popup.Item.DeleteSetlist")
-                    : Localize.Key("Menu.MusicLibrary.Popup.Item.DeletePlaylist");
                 list.Add(new ButtonViewType(
-                    deleteLabel,
-                    "MusicLibraryIcons[Playlists]", DeletePlaylist)
+                    Localize.Key("Menu.MusicLibrary.Popup.Item.AddPlaylistToSetlist"),
+                    "MusicLibraryIcons[Playlists]", () => AddPlaylistToSetlist(SelectedPlaylist))
                 );
             }
 
@@ -125,6 +119,7 @@ namespace YARG.Menu.MusicLibrary
             // which means the song list hasn't been constructed yet.
             if (_sortedSongs is null || SongContainer.Count <= 0)
             {
+                AddPlaylistManagementButtons(list);
                 return list;
             }
 
@@ -149,7 +144,52 @@ namespace YARG.Menu.MusicLibrary
                 }
             }
 
+            AddPlaylistManagementButtons(list);
             return list;
+        }
+
+        private void AddPlaylistManagementButtons(List<ViewType> list)
+        {
+            if (SelectedPlaylist.Ephemeral)
+            {
+                AddSetlistManagementButtons(list, DeletePlaylist);
+                return;
+            }
+
+            // Only allow rename if not Favorites or Current Setlist
+            if (SelectedPlaylist != PlaylistContainer.FavoritesPlaylist)
+            {
+                list.Add(new ButtonViewType(
+                    Localize.Key("Menu.MusicLibrary.Popup.Item.RenamePlaylist"),
+                    "MusicLibraryIcons[Playlists]", RenamePlaylist)
+                );
+            }
+
+            // Only allow delete if not Favorites
+            if (SelectedPlaylist != PlaylistContainer.FavoritesPlaylist)
+            {
+                list.Add(new ButtonViewType(
+                    Localize.Key("Menu.MusicLibrary.Popup.Item.DeletePlaylist"),
+                    "MusicLibraryIcons[Playlists]", DeletePlaylist)
+                );
+            }
+        }
+
+        private void AddSetlistManagementButtons(List<ViewType> list, Action deleteAction)
+        {
+            list.Add(new ButtonViewType(
+                Localize.Key("Menu.MusicLibrary.Popup.Item.SaveSetlistToPlaylist"),
+                "MusicLibraryIcons[Playlists]", SaveSetlistToPlaylist)
+            );
+            list.Add(new ButtonViewType(
+                Localize.Key("Menu.MusicLibrary.Popup.Item.DeleteSetlist"),
+                "MusicLibraryIcons[Playlists]", deleteAction)
+            );
+        }
+
+        private void SaveSetlistToPlaylist()
+        {
+            _popupMenu.OpenAddToPlaylist(ShowPlaylist);
         }
 
         private void RenamePlaylist()
@@ -241,8 +281,8 @@ namespace YARG.Menu.MusicLibrary
             var list = new List<ViewType>
             {
                 new ButtonViewType(
-                    Localize.Key("Menu.MusicLibrary.Popup.Item.DeleteSetlist"),
-                    "MusicLibraryIcons[Playlists]", DeleteShowSetlist)
+                    Localize.Key("Menu.MusicLibrary.StartSet"),
+                    "MusicLibraryIcons[Playlists]", StartSetlist)
             };
 
             foreach (var song in ShowPlaylist.ToList())
@@ -254,6 +294,8 @@ namespace YARG.Menu.MusicLibrary
                 var starAmount = songView.GetStarAmount();
                 _totalStarCount += starAmount is null ? 0 : StarAmountHelper.GetStarCount(starAmount.Value);
             }
+
+            AddSetlistManagementButtons(list, DeleteShowSetlist);
 
             return list;
         }
@@ -419,45 +461,7 @@ namespace YARG.Menu.MusicLibrary
         {
             if (CurrentSelection is PlaylistViewType playlist)
             {
-                if (playlist.Playlist.SongHashes.Count == 0)
-                {
-                    ToastManager.ToastError(Localize.Key("Menu.MusicLibrary.EmptyPlaylist"));
-                    return;
-                }
-
-                if (playlist.Playlist.Ephemeral)
-                {
-                    // No, we won't add the setlist to itself, thanks
-                    ToastManager.ToastError(Localize.Key("Menu.MusicLibrary.CannotAddToSelf"));
-                    return;
-                }
-
-                var i = 0;
-
-                foreach (var song in playlist.Playlist.ToList())
-                {
-                    ShowPlaylist.AddSong(song);
-                    i++;
-                }
-
-                if (i > 0)
-                {
-                    ToastManager.ToastSuccess(Localize.KeyFormat("Menu.MusicLibrary.PlaylistAddedToSet", i));
-                }
-                else
-                {
-                    ToastManager.ToastWarning(Localize.Key("Menu.MusicLibrary.NoSongsInPlaylist"));
-                }
-
-                if (i > 0 && ShowPlaylist.Count == i)
-                {
-                    // We need to rebuild the navigation scheme the first time we add song(s)
-                    SetNavigationScheme(true);
-                }
-
-                // Refresh view if needed
-                RefreshAndReselect();
-
+                AddPlaylistToSetlist(playlist.Playlist);
                 return;
             }
 
@@ -472,6 +476,47 @@ namespace YARG.Menu.MusicLibrary
 
                 ToastManager.ToastSuccess(Localize.Key("Menu.MusicLibrary.AddedToSet"));
             }
+        }
+
+        public void AddPlaylistToSetlist(Playlist playlist)
+        {
+            if (playlist.SongHashes.Count == 0)
+            {
+                ToastManager.ToastError(Localize.Key("Menu.MusicLibrary.EmptyPlaylist"));
+                return;
+            }
+
+            if (playlist.Ephemeral)
+            {
+                // No, we won't add the setlist to itself, thanks
+                ToastManager.ToastError(Localize.Key("Menu.MusicLibrary.CannotAddToSelf"));
+                return;
+            }
+
+            var count = 0;
+
+            foreach (var song in playlist.ToList())
+            {
+                ShowPlaylist.AddSong(song);
+                count++;
+            }
+
+            if (count > 0)
+            {
+                ToastManager.ToastSuccess(Localize.KeyFormat("Menu.MusicLibrary.PlaylistAddedToSet", count));
+            }
+            else
+            {
+                ToastManager.ToastWarning(Localize.Key("Menu.MusicLibrary.NoSongsInPlaylist"));
+            }
+
+            if (count > 0 && ShowPlaylist.Count == count)
+            {
+                // We need to rebuild the navigation scheme the first time we add song(s)
+                SetNavigationScheme(true);
+            }
+
+            RefreshAndReselect();
         }
 
         private void MovePlaylistEntryUp()

--- a/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.SortFilter.cs
+++ b/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.SortFilter.cs
@@ -134,7 +134,7 @@ namespace YARG.Menu.MusicLibrary
             {
                 _sortedSongs = _searchField.Search(SettingsManager.Settings.LibrarySort);
                 // _sortedSongs = ApplyCollapsedSectionsForCurrentSort(_sortedSongs);
-                _searchField.gameObject.SetActive(true);
+                _searchField.gameObject.SetActive(MenuState == MenuState.Library);
             }
             else
             {
@@ -342,15 +342,16 @@ namespace YARG.Menu.MusicLibrary
 
         public void ApplySortFromPopup(SortAttribute sort, bool ascending = true)
         {
-            if (MenuState == MenuState.Playlist && SelectedPlaylist != null)
+            var playlist = MenuState == MenuState.Show ? ShowPlaylist : SelectedPlaylist;
+            if ((MenuState == MenuState.Playlist || MenuState == MenuState.Show) && playlist != null)
             {
                 switch (sort)
                 {
                     case SortAttribute.Name:
-                        SelectedPlaylist.SortByName(ascending);
+                        playlist.SortByName(ascending);
                         break;
                     case SortAttribute.Artist:
-                        SelectedPlaylist.SortByArtist(ascending);
+                        playlist.SortByArtist(ascending);
                         break;
                     default:
                         ToastManager.ToastWarning("Sort not supported in playlists");
@@ -457,11 +458,14 @@ namespace YARG.Menu.MusicLibrary
                 _sortInfoHeaderStarCountText.text = "";
                 _sortInfoHeaderStarIcon.color = _sortInfoHeaderStarIcon.color.WithAlpha(0);
             }
-            else if (MenuState == MenuState.Playlist)
+            else if (MenuState == MenuState.Playlist || MenuState == MenuState.Show)
             {
+                string playlistName = MenuState == MenuState.Show
+                    ? Localize.Key("Menu.MusicLibrary.PlayShow")
+                    : GetPlaylistDisplayName(SelectedPlaylist);
                 _sortInfoHeaderPrimaryText.text = ZString.Concat(
                     TextColorer.StyleString("PLAYLIST ", MenuData.Colors.HeaderTertiary, 600),
-                    TextColorer.StyleString(GetPlaylistDisplayName(SelectedPlaylist), MenuData.Colors.HeaderSecondary, 700));
+                    TextColorer.StyleString(playlistName, MenuData.Colors.HeaderSecondary, 700));
 
                 var countText = TextColorer.StyleString(ZString.Format("{0:N0}", _totalSongCount),
                     MenuData.Colors.HeaderSecondary, 500);

--- a/Assets/Script/Menu/MusicLibrary/PopupMenu.cs
+++ b/Assets/Script/Menu/MusicLibrary/PopupMenu.cs
@@ -172,6 +172,7 @@ namespace YARG.Menu.MusicLibrary
             }
 
             if (_musicLibrary.MenuState != MenuState.Playlist &&
+                _musicLibrary.MenuState != MenuState.Show &&
                 _musicLibrary.MenuState != MenuState.PlaylistSelect &&
                 _musicLibrary.HasSortHeaders)
             {
@@ -243,17 +244,21 @@ namespace YARG.Menu.MusicLibrary
                     bool isInPlaylist = _musicLibrary.MenuState == MenuState.Playlist &&
                         _musicLibrary.SelectedPlaylist != null &&
                         _musicLibrary.SelectedPlaylist != PlaylistContainer.FavoritesPlaylist;
-                    bool isSetlist = isInPlaylist && _musicLibrary.SelectedPlaylist.Ephemeral;
+                    bool isInShow = _musicLibrary.MenuState == MenuState.Show;
+                    var removalPlaylist = isInShow
+                        ? _musicLibrary.ShowPlaylist
+                        : _musicLibrary.SelectedPlaylist;
+                    bool isSetlist = (isInPlaylist || isInShow) && removalPlaylist.Ephemeral;
 
                     void AddRemoveFromPlaylistItem()
                     {
-                        var removeKey = _musicLibrary.SelectedPlaylist.Ephemeral
+                        var removeKey = removalPlaylist.Ephemeral
                             ? "RemoveFromSetlist"
                             : "RemoveFromPlaylist";
                         CreateItem(removeKey, () =>
                         {
                             var songView = viewType as SongViewType;
-                            _musicLibrary.SelectedPlaylist.RemoveSong(songView.SongEntry);
+                            removalPlaylist.RemoveSong(songView.SongEntry);
                             _musicLibrary.RefreshAndReselect();
                             gameObject.SetActive(false);
                             ToastManager.ToastSuccess("Removed from playlist");
@@ -356,7 +361,8 @@ namespace YARG.Menu.MusicLibrary
         {
             SetLocalizedHeader("SortBy");
 
-            if (_musicLibrary.MenuState == MenuState.Playlist)
+            if (_musicLibrary.MenuState == MenuState.Playlist ||
+                _musicLibrary.MenuState == MenuState.Show)
             {
                 CreateItemUnlocalized($"{SortAttribute.Name.ToLocalizedName()} (A-Z)", () =>
                 {

--- a/Assets/Script/Menu/MusicLibrary/PopupMenu.cs
+++ b/Assets/Script/Menu/MusicLibrary/PopupMenu.cs
@@ -48,6 +48,17 @@ namespace YARG.Menu.MusicLibrary
         private ScrollRect _scrollRect;
 
         private State _menuState;
+        private Playlist _playlistToAdd;
+        private bool _openedAddToPlaylistDirectly;
+
+        public void OpenAddToPlaylist(Playlist playlist)
+        {
+            _playlistToAdd = playlist;
+            gameObject.SetActive(true);
+            _openedAddToPlaylistDirectly = true;
+            _menuState = State.AddToPlaylist;
+            UpdateForState();
+        }
 
         private void Awake()
         {
@@ -63,7 +74,7 @@ namespace YARG.Menu.MusicLibrary
                 NavigationScheme.Entry.NavigateSelect,
                 new NavigationScheme.Entry(MenuAction.Red, "Menu.Common.Back", () =>
                 {
-                    if (_menuState == State.Main)
+                    if (_menuState == State.Main || _openedAddToPlaylistDirectly)
                     {
                         gameObject.SetActive(false);
                     }
@@ -83,6 +94,8 @@ namespace YARG.Menu.MusicLibrary
         {
             Navigator.Instance.PopScheme();
             _musicLibrary.RefreshNavigationSchemeAfterPopup();
+            _playlistToAdd = null;
+            _openedAddToPlaylistDirectly = false;
         }
 
         private void UpdateForState()
@@ -281,6 +294,16 @@ namespace YARG.Menu.MusicLibrary
                 }
             }
 
+            if (viewType is PlaylistViewType addablePlaylistView &&
+                !addablePlaylistView.Playlist.Ephemeral)
+            {
+                CreateItem("AddPlaylistToSetlist", () =>
+                {
+                    _musicLibrary.AddPlaylistToSetlist(addablePlaylistView.Playlist);
+                    gameObject.SetActive(false);
+                });
+            }
+
             if (viewType is PlaylistViewType playlistView &&
                 playlistView.Playlist != PlaylistContainer.FavoritesPlaylist)
             {
@@ -461,9 +484,9 @@ namespace YARG.Menu.MusicLibrary
             // Get the list of playlists from PlaylistContainer and create items for each
             foreach (var playlist in PlaylistContainer.Playlists)
             {
-                if (_musicLibrary.MenuState == MenuState.Playlist &&
-                    _musicLibrary.SelectedPlaylist != null &&
-                    ReferenceEquals(playlist, _musicLibrary.SelectedPlaylist))
+                var sourcePlaylist = _playlistToAdd ??
+                    (_musicLibrary.CurrentSelection as PlaylistViewType)?.Playlist;
+                if (ReferenceEquals(playlist, sourcePlaylist))
                 {
                     continue;
                 }
@@ -480,9 +503,9 @@ namespace YARG.Menu.MusicLibrary
                         gameObject.SetActive(false);
                         ToastManager.ToastSuccess($"Added {artist} - {title} to {playlist.Name}");
                     }
-                    else if (_musicLibrary.CurrentSelection is PlaylistViewType playlistView)
+                    else if (sourcePlaylist != null)
                     {
-                        var songs = playlistView.Playlist.ToList();
+                        var songs = sourcePlaylist.ToList();
                         foreach (var song in songs)
                         {
                             playlist.AddSong(song);
@@ -504,10 +527,24 @@ namespace YARG.Menu.MusicLibrary
                 // Show text entry dialog
                 DialogManager.Instance.ShowRenameDialog("New Playlist Name", value =>
                 {
-                    // Make sure we aren't being Jadened
-                    if (value == Localize.Key("Menu.MusicLibrary.CurrentSetlist"))
+                    value = value.Trim();
+
+                    bool nameAlreadyExists = string.Equals(
+                            PlaylistContainer.FavoritesPlaylist.Name,
+                            value,
+                            System.StringComparison.OrdinalIgnoreCase) ||
+                        PlaylistContainer.Playlists.Any(playlist => string.Equals(
+                            playlist.Name,
+                            value,
+                            System.StringComparison.OrdinalIgnoreCase)) ||
+                        string.Equals(
+                            Localize.Key("Menu.MusicLibrary.CurrentSetlist"),
+                            value,
+                            System.StringComparison.OrdinalIgnoreCase);
+
+                    if (string.IsNullOrEmpty(value) || nameAlreadyExists)
                     {
-                        ToastManager.ToastError("You can't create a playlist with that name");
+                        ToastManager.ToastError("A playlist with that name already exists");
                         CloseAfterDialog().Forget();
                         return;
                     }
@@ -519,19 +556,22 @@ namespace YARG.Menu.MusicLibrary
                     {
                         songView.AddToPlaylist(playlist);
                     }
-                    else if (_musicLibrary.CurrentSelection is PlaylistViewType playlistView)
+                    else
                     {
-                        foreach(var song in playlistView.Playlist.ToList())
+                        var sourcePlaylist = _playlistToAdd ??
+                            (_musicLibrary.CurrentSelection as PlaylistViewType)?.Playlist;
+                        if (sourcePlaylist == null)
+                        {
+                            ToastManager.ToastError("You can't add that to a playlist");
+                            PlaylistContainer.DeletePlaylist(playlist);
+                            CloseAfterDialog().Forget();
+                            return;
+                        }
+
+                        foreach (var song in sourcePlaylist.ToList())
                         {
                             playlist.AddSong(song);
                         }
-                    }
-                    else
-                    {
-                        ToastManager.ToastError("You can't add that to a playlist");
-                        PlaylistContainer.DeletePlaylist(playlist);
-                        CloseAfterDialog().Forget();
-                        return;
                     }
 
                     // Close the popup after the rename dialog is fully closed

--- a/Assets/StreamingAssets/lang/en-US.json
+++ b/Assets/StreamingAssets/lang/en-US.json
@@ -350,6 +350,8 @@
                     "RemoveFromPlaylist": "Remove From Playlist",
                     "RemoveFromSetlist": "Remove From Setlist",
                     "CreateNewPlaylist": "Create New...",
+                    "AddPlaylistToSetlist": "Add Playlist to Setlist",
+                    "SaveSetlistToPlaylist": "Save Setlist to Playlist",
                     "RenamePlaylist": "Rename Playlist",
                     "DeletePlaylist": "Delete Playlist",
                     "DeleteSetlist": "Delete Setlist",


### PR DESCRIPTION
## Description

Treats the **Play a Show** setlist as the same ephemeral playlist used by **Current Setlist**.

Songs generated through **Play a Show** are retained when returning to the Music Library and become available through **Current Setlist**.  Users can freely alternate between generated and manually selected songs while building a setlist.

Also adds bulk transfer actions between saved playlists and the current setlist.  Entire playlists can be added to the setlist, while the setlist can be appended to an existing playlist or saved as a new playlist.

### Play a Show and Current Setlist UI/UX Alignment
- Updates the **Play a Show** header from the active library sort to **Playlist Play a Show**.
- Aligns the **Play a Show** popup menu with other playlists:
  - Removes the inapplicable **Go to Section...** option.
  - Provides Song and Artist sorting in ascending or descending order.
  - Adds **Remove from Setlist**.
- Removes the inactive search bar from **Play a Show** and Playlist Manager views.
- Aligns navigation controls with other playlists:
  - Blue opens Filters.
  - Left and right move songs within the setlist.
  - Yellow reopens the **Play a Show** picker.
  - Green hold starts the set.
- Removes redundant navigation entries and adds **Delete Setlist**.
- Improves selection behavior when opening and closing the song picker.
- Fixes a state leak when entering **Play a Show** from a saved playlist and returning to the Music Library.  Previously, the Library could remain restricted to songs from the previously selected playlist.

### Playlist and Setlist Transfers
- Adds **Add Playlist to Setlist**:
  - At the top when viewing a saved playlist or Favorites.
  - In the Playlist Manager's **More Options** menu.
- Moves **Rename Playlist** and **Delete Playlist** below the playlist's songs.
- Adds **Save Setlist to Playlist** to both **Play a Show** and **Current Setlist**.
- Opens the existing **Add to Playlist...** picker when saving a setlist:
  - Selecting an existing playlist appends all setlist songs.
  - Selecting **Create New...** creates a playlist and adds all setlist songs.
- Prevents duplicate playlist names when creating a playlist through this flow.
- Reuses shared labels, actions, and ordering across the related views.

This fixes: https://discord.com/channels/1086048856678084609/1536198809980375261
This addresses: https://discord.com/channels/1086048856678084609/1500909653482143986

## Screenshots or Videos

**Current Setlist** accessed via **Play a Show** dialog and added 3 songs.  *Notice header "Playlist Play a Show"*
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/6691a89b-5824-4daf-aa35-b799bc5301f4" />

**Current Setlist** accessed via **Playlist Manager** after adding one more song manually.  *Notice header "Playlist Current Setlist"*
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/046167b3-b9cd-455e-b998-efca85c9000a" />


Other new similarities:
- Navigator is the same (yellow "Play a Show", blue "Filters".
- "Save Playlist to Setlist" action at the bottom is the same.
- "Delete Setlist" action at the bottom is the same.
- Search bar is hidden.

**Popup Menu** regardless of **Play a Show** or **Current Setlist**
<img width="734" height="651" alt="image" src="https://github.com/user-attachments/assets/324aab96-60e7-4882-b0b7-1de0f11b7438" />
