### PR TITLE
Add in new crowd settings

### DIFF
--- a/Assets/Script/Gameplay/GameManager.Audio.cs
+++ b/Assets/Script/Gameplay/GameManager.Audio.cs
@@ -5,7 +5,6 @@ using DG.Tweening.Core;
 using DG.Tweening.Plugins.Options;
 using UnityEngine;
 using YARG.Core.Audio;
-using YARG.Playback;
 using YARG.Settings;
 
 namespace YARG.Gameplay
@@ -115,9 +114,6 @@ namespace YARG.Gameplay
 
         public void ChangeStarPowerStatus(bool active)
         {
-            if (SettingsManager.Settings.UseCrowdFx.Value == CrowdFxMode.Disabled)
-                return;
-
             StarPowerActivations += active ? 1 : -1;
             if (StarPowerActivations < 0)
                 StarPowerActivations = 0;

--- a/Assets/Script/Gameplay/GameManager.Loading.cs
+++ b/Assets/Script/Gameplay/GameManager.Loading.cs
@@ -266,6 +266,7 @@ namespace YARG.Gameplay
 
             var noFail = ReplayData?.NoFail ?? SettingsManager.Settings.NoFail.Value != NoFailMode.Off;
             EngineManager.InitializeHappiness(noFail);
+            CrowdEventHandler.UpdateCrowdMuteState(force: true);
 
             EngineManager.OnCodaStart += StartCoda;
             EngineManager.OnCodaEnd += EndCoda;

--- a/Assets/Script/Gameplay/Player/BasePlayer.cs
+++ b/Assets/Script/Gameplay/Player/BasePlayer.cs
@@ -12,7 +12,6 @@ using YARG.Gameplay.HUD;
 using YARG.Helpers.Extensions;
 using YARG.Helpers.UI;
 using YARG.Input;
-using YARG.Playback;
 using YARG.Player;
 using YARG.Settings;
 
@@ -392,7 +391,8 @@ namespace YARG.Gameplay.Player
         protected virtual void OnStarPowerStatus(bool active)
         {
             var deploySample = SfxSample.StarPowerDeploy;
-            if (SettingsManager.Settings.UseCrowdFx.Value == CrowdFxMode.Enabled)
+            if (SettingsManager.Settings.UseCrowdCheering.Value &&
+                !GlobalVariables.State.CrowdSfxVenueOverride)
             {
                 deploySample = SfxSample.StarPowerDeployCrowd;
             }

--- a/Assets/Script/Menu/ScoreScreen/ScoreScreenMenu.cs
+++ b/Assets/Script/Menu/ScoreScreen/ScoreScreenMenu.cs
@@ -28,7 +28,6 @@ using YARG.Song;
 using YARG.Playlists;
 using YARG.Helpers.Extensions;
 using YARG.Core.Engine;
-using YARG.Playback;
 using YARG.Settings;
 
 namespace YARG.Menu.ScoreScreen
@@ -103,10 +102,11 @@ namespace YARG.Menu.ScoreScreen
             ShowReplayAnalysis(song, scoreScreenStats);
 
         // Play audience chatter, unless we are viewing a replay score
-        if (SettingsManager.Settings.UseCrowdFx.Value == CrowdFxMode.Enabled && !GlobalVariables.State.IsReplay)
-            {
-                GlobalAudioHandler.PlaySoundEffect(SfxSample.Chatter, 1.0);
-            }
+        if (SettingsManager.Settings.UseCrowdCheering.Value &&
+            !GlobalVariables.State.CrowdSfxVenueOverride && !GlobalVariables.State.IsReplay)
+        {
+            GlobalAudioHandler.PlaySoundEffect(SfxSample.Chatter, 1.0);
+        }
 
             // Set text
             _songTitle.text = song.Name;

--- a/Assets/Script/Playback/CrowdEventHandler.cs
+++ b/Assets/Script/Playback/CrowdEventHandler.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using YARG.Core.Audio;
 using YARG.Core.Chart;
@@ -10,13 +10,6 @@ using YARG.Settings;
 
 namespace YARG.Playback
 {
-    public enum CrowdFxMode
-    {
-        Disabled,
-        StarpowerClapsOnly,
-        Enabled
-    }
-
     public class CrowdEventHandler : IDisposable
     {
         public CrowdState CrowdState     { get; private set; } = CrowdState.Realtime;
@@ -52,7 +45,16 @@ namespace YARG.Playback
         private readonly double _musicStartTime;
         private readonly double _musicEndTime;
 
-        private bool UseCrowdFx => SettingsManager.Settings.UseCrowdFx.Value == CrowdFxMode.Enabled
+        private bool UseCrowdCheering => SettingsManager.Settings.UseCrowdCheering.Value
+            && !GlobalVariables.State.CrowdSfxVenueOverride;
+
+        private bool UseCrowdIdle => SettingsManager.Settings.UseCrowdIdle.Value
+            && !GlobalVariables.State.CrowdSfxVenueOverride;
+
+        private bool UseStarPowerClaps => SettingsManager.Settings.UseStarPowerClaps.Value
+            && !GlobalVariables.State.CrowdSfxVenueOverride;
+
+        private bool UsePerformanceClaps => SettingsManager.Settings.UsePerformanceClaps.Value
             && !GlobalVariables.State.CrowdSfxVenueOverride;
 
         public CrowdEventHandler(SongChart chart, GameManager gameManager)
@@ -80,11 +82,6 @@ namespace YARG.Playback
                 _musicEndTime = musicEnd.Time;
             }
 
-            if (SettingsManager.Settings.UseCrowdFx.Value == CrowdFxMode.StarpowerClapsOnly)
-            {
-                StopAllCrowdSounds();
-                ChangeCrowdMuteState(true);
-            }
         }
 
         public void SetClapScheduler(CrowdClapScheduler scheduler)
@@ -100,17 +97,18 @@ namespace YARG.Playback
                 return;
             }
 
-            if (UseCrowdFx)
+            if (UseCrowdIdle || (UseCrowdCheering && _startWithMurmur))
             {
                 _selectedOpenSample = _openSamples[UnityEngine.Random.Range(0, _openSamples.Length)];
+                GlobalAudioHandler.PlaySoundEffect(_selectedOpenSample, 1.0);
+            }
+
+            if (UseCrowdCheering)
+            {
                 _selectedStartSample = _startSamples[UnityEngine.Random.Range(0, _startSamples.Length)];
                 _selectedEndSample = _endSamples[UnityEngine.Random.Range(0, _endSamples.Length)];
 
-                if (_startWithMurmur)
-                {
-                    GlobalAudioHandler.PlaySoundEffect(_selectedOpenSample, 1.0);
-                }
-                else
+                if (!_startWithMurmur)
                 {
                     GlobalAudioHandler.PlaySoundEffect(_selectedStartSample, 1.0);
                     _startSamplePlayed = true;
@@ -129,11 +127,8 @@ namespace YARG.Playback
             {
                 _engineManager.OnSongFailed += OnSongFailed;
 
-                if (UseCrowdFx)
-                {
-                    _engineManager.OnHappinessUnderThreshold += OnHappinessUnderThreshold;
-                    _engineManager.OnHappinessOverThreshold += OnHappinessOverThreshold;
-                }
+                _engineManager.OnHappinessUnderThreshold += OnHappinessUnderThreshold;
+                _engineManager.OnHappinessOverThreshold += OnHappinessOverThreshold;
             }
         }
 
@@ -164,11 +159,11 @@ namespace YARG.Playback
             {
                 _startSamplePlayed = true;
 
-                if (SettingsManager.Settings.UseCrowdFx.Value == CrowdFxMode.Enabled)
+                if (UseCrowdCheering)
                 {
-                    if (_startWithMurmur)
+                    if (_startWithMurmur && !UseCrowdIdle)
                     {
-                        // GlobalAudioHandler.StopSoundEffect(_selectedOpenSample, 1.0);
+                        GlobalAudioHandler.StopSoundEffect(_selectedOpenSample, 1.0);
                     }
 
                     GlobalAudioHandler.PlaySoundEffect(_selectedStartSample, 0.25);
@@ -180,7 +175,7 @@ namespace YARG.Playback
                 _endSamplePlayed = true;
 
                 // Play the end sample if it hasn't been played yet
-                if (SettingsManager.Settings.UseCrowdFx.Value == CrowdFxMode.Enabled)
+                if (UseCrowdCheering)
                 {
                     GlobalAudioHandler.PlaySoundEffect(_selectedEndSample, 0.5);
                 }
@@ -191,37 +186,23 @@ namespace YARG.Playback
 
         private void UpdateClapEnabled()
         {
-            var crowdFxMode = SettingsManager.Settings.UseCrowdFx.Value;
-
-            bool crowdFxEnabled = crowdFxMode != CrowdFxMode.Disabled;
-            bool venueAllowsCrowdSfx = !GlobalVariables.State.CrowdSfxVenueOverride;
             bool starPowerActive = _gameManager.StarPowerActivations > 0;
             bool crowdIsHappy = _engineManager.Happiness >= 1.0f;
-            bool clapsOnlyDuringStarPower = crowdFxMode == CrowdFxMode.StarpowerClapsOnly;
 
-            bool clapTriggerActive = starPowerActive || (!clapsOnlyDuringStarPower && crowdIsHappy);
-            bool shouldEnableClaps = _started && crowdFxEnabled && venueAllowsCrowdSfx && clapTriggerActive;
+            bool clapTriggerActive = (UseStarPowerClaps && starPowerActive) ||
+                (UsePerformanceClaps && crowdIsHappy);
+            bool shouldEnableClaps = _started && clapTriggerActive;
 
             _clapScheduler?.SetEnabled(shouldEnableClaps);
         }
 
         private void OnHappinessUnderThreshold()
         {
-            if (SettingsManager.Settings.UseCrowdFx.Value == CrowdFxMode.Disabled)
-            {
-                return;
-            }
-
             ChangeCrowdMuteState(true);
         }
 
         private void OnHappinessOverThreshold()
         {
-            if (SettingsManager.Settings.UseCrowdFx.Value == CrowdFxMode.Disabled)
-            {
-                return;
-            }
-
             ChangeCrowdMuteState(false);
         }
 
@@ -234,13 +215,18 @@ namespace YARG.Playback
             }
         }
 
-        private void ChangeCrowdMuteState(bool muted)
+        private void ChangeCrowdMuteState(bool muted, bool force = false)
         {
-            if (IsCrowdMuted != muted)
+            if (IsCrowdMuted != muted || force)
             {
                 _gameManager.ChangeStemMuteState(SongStem.Crowd, muted, 1.0f);
                 IsCrowdMuted = muted;
             }
+        }
+
+        public void UpdateCrowdMuteState(bool force = false)
+        {
+            ChangeCrowdMuteState(_engineManager.IsCrowdBelowThreshold, force);
         }
 
         public void StopAllCrowdSounds()

--- a/Assets/Script/Settings/SettingsManager.Settings.cs
+++ b/Assets/Script/Settings/SettingsManager.Settings.cs
@@ -21,7 +21,6 @@ using YARG.Menu.History;
 using YARG.Menu.MusicLibrary;
 using YARG.Menu.Persistent;
 using YARG.Menu.Settings;
-using YARG.Playback;
 using YARG.Player;
 using YARG.Scores;
 using YARG.Settings.Metadata;
@@ -403,12 +402,13 @@ namespace YARG.Settings
                 AudioFxMode.On
             };
 
-            public DropdownSetting<CrowdFxMode> UseCrowdFx { get; } = new(CrowdFxMode.Enabled)
-            {
-                CrowdFxMode.Disabled,
-                CrowdFxMode.StarpowerClapsOnly,
-                CrowdFxMode.Enabled
-            };
+            public ToggleSetting UseCrowdCheering { get; } = new(true);
+
+            public ToggleSetting UseCrowdIdle { get; } = new(true);
+
+            public ToggleSetting UseStarPowerClaps { get; } = new(true);
+
+            public ToggleSetting UsePerformanceClaps { get; } = new(true);
 
             public ToggleSetting UseVenueSfx { get; } = new(true);
 

--- a/Assets/Script/Settings/SettingsManager.cs
+++ b/Assets/Script/Settings/SettingsManager.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using UnityEngine;
 using YARG.Core.Audio;
 using YARG.Core.Logging;
@@ -35,6 +36,8 @@ namespace YARG.Settings
         }
 
         private static string _serializedSettings;
+
+        private static bool _settingsCanBeSaved = true;
 
         public static string OutputDeviceAtStartup { get; private set; } = "Default";
 
@@ -138,12 +141,17 @@ namespace YARG.Settings
                 new HeaderMetadata("Gameplay"),
                 nameof(Settings.MuteOnMiss),
                 nameof(Settings.UseStarpowerFx),
-                nameof(Settings.UseCrowdFx),
                 nameof(Settings.UseVenueSfx),
                 nameof(Settings.OverstrumAndOverhitSoundEffects),
                 new FieldMetadata(nameof(Settings.AlwaysOnDrumSFX), isAdvanced: true),
                 new FieldMetadata(nameof(Settings.UseWhammyFx), isAdvanced: true),
                 new FieldMetadata(nameof(Settings.WhammyPitchShiftAmount), isAdvanced: true),
+
+                new HeaderMetadata("CrowdFX"),
+                nameof(Settings.UseCrowdCheering),
+                nameof(Settings.UseCrowdIdle),
+                nameof(Settings.UseStarPowerClaps),
+                nameof(Settings.UsePerformanceClaps),
 
                 new HeaderMetadata("Other"),
                 new FieldMetadata(nameof(Settings.UseChipmunkSpeed), isAdvanced: true),
@@ -317,28 +325,28 @@ namespace YARG.Settings
 
         public static void LoadSettings()
         {
+            _settingsCanBeSaved = true;
+            bool settingsFileExists = File.Exists(SettingsFile);
+
             // Create settings container
             try
             {
                 string text = _serializedSettings ?? File.ReadAllText(SettingsFile);
                 _serializedSettings = null;
-                Settings = JsonConvert.DeserializeObject<SettingContainer>(text, JsonSettings);
+
+                var settingsJson = JObject.Parse(text);
+                settingsJson = SettingsMigration.Migrate(settingsJson, out _settingsCanBeSaved);
+                Settings = JsonConvert.DeserializeObject<SettingContainer>(
+                    settingsJson.ToString(Formatting.None), JsonSettings);
             }
             catch (Exception e)
             {
+                _settingsCanBeSaved = !settingsFileExists;
                 YargLogger.LogException(e, "Failed to load settings!");
             }
 
             // If null, recreate
             Settings ??= new SettingContainer();
-
-            if (Settings.ReverbImplementation != null &&
-                !Enum.IsDefined(typeof(ReverbMode), Settings.ReverbImplementation.Value))
-            {
-                int raw = (int)(object)Settings.ReverbImplementation.Value;
-                ReverbMode migrated = raw == 0 ? ReverbMode.Performance : ReverbMode.Quality;
-                Settings.ReverbImplementation.SetValueWithoutNotify(migrated);
-            }
 
             AudioOutputMode outputMode = GlobalAudioHandler.GetOutputMode(Settings.OutputDevice.Value);
             Settings.OutputMode.SetValueWithoutNotify(outputMode);
@@ -367,10 +375,11 @@ namespace YARG.Settings
         {
             // If the game tries to save the settings before they are loaded, it can wipe the settings file
             // (such as closing the game before they load)
-            if (SettingContainer.IsInitialized && Settings is not null)
+            if (SettingContainer.IsInitialized && Settings is not null && _settingsCanBeSaved)
             {
-                var json = JsonConvert.SerializeObject(Settings, JsonSettings);
-                File.WriteAllText(SettingsFile, json);
+                var json = JObject.Parse(JsonConvert.SerializeObject(Settings, JsonSettings));
+                SettingsMigration.SetCurrentSchemaVersion(json);
+                File.WriteAllText(SettingsFile, json.ToString(Formatting.Indented));
             }
         }
 

--- a/Assets/Script/Settings/SettingsMigration.cs
+++ b/Assets/Script/Settings/SettingsMigration.cs
@@ -1,0 +1,165 @@
+using System;
+using Newtonsoft.Json.Linq;
+using YARG.Core.Logging;
+
+namespace YARG.Settings
+{
+    internal static class SettingsMigration
+    {
+        internal const int CURRENT_SETTINGS_SCHEMA_VERSION = 1;
+
+        private const string SETTINGS_SCHEMA_VERSION_PROPERTY = "SettingsSchemaVersion";
+        private const string LEGACY_CROWD_FX_SETTING = "UseCrowdFx";
+
+        private const string CROWD_CHEERING_SETTING = nameof(SettingsManager.SettingContainer.UseCrowdCheering);
+        private const string CROWD_IDLE_SETTING = nameof(SettingsManager.SettingContainer.UseCrowdIdle);
+        private const string STAR_POWER_CLAPS_SETTING = nameof(SettingsManager.SettingContainer.UseStarPowerClaps);
+        private const string PERFORMANCE_CLAPS_SETTING = nameof(SettingsManager.SettingContainer.UsePerformanceClaps);
+        private const string REVERB_IMPLEMENTATION_SETTING =
+            nameof(SettingsManager.SettingContainer.ReverbImplementation);
+
+        private enum LegacyCrowdFxMode
+        {
+            Disabled = 0,
+            StarpowerClapsOnly = 1,
+            Enabled = 2
+        }
+
+        internal static JObject Migrate(JObject settings, out bool canSave)
+        {
+            canSave = true;
+
+            if (!TryGetSettingsSchemaVersion(settings, out var version))
+            {
+                canSave = false;
+                YargLogger.LogWarning("Settings file has an invalid schema version and will not be saved.");
+                return settings;
+            }
+
+            if (version > CURRENT_SETTINGS_SCHEMA_VERSION)
+            {
+                canSave = false;
+                YargLogger.LogFormatWarning(
+                    "Settings file uses unsupported schema version {0} and will not be saved.", version);
+                return settings;
+            }
+
+            while (version < CURRENT_SETTINGS_SCHEMA_VERSION)
+            {
+                switch (version)
+                {
+                    case 0:
+                        MigrateSettingsV0ToV1(settings);
+                        version = 1;
+                        break;
+                    default:
+                        canSave = false;
+                        YargLogger.LogFormatWarning(
+                            "Settings file has no migration for schema version {0} and will not be saved.", version);
+                        return settings;
+                }
+            }
+
+            SetCurrentSchemaVersion(settings);
+            return settings;
+        }
+
+        internal static void SetCurrentSchemaVersion(JObject settings)
+        {
+            settings[SETTINGS_SCHEMA_VERSION_PROPERTY] = CURRENT_SETTINGS_SCHEMA_VERSION;
+        }
+
+        private static bool TryGetSettingsSchemaVersion(JObject settings, out int version)
+        {
+            version = 0;
+
+            if (!settings.TryGetValue(SETTINGS_SCHEMA_VERSION_PROPERTY, out var token))
+            {
+                return true;
+            }
+
+            if (!TryGetInteger(token, out var rawVersion) || rawVersion < 0 || rawVersion > int.MaxValue)
+            {
+                return false;
+            }
+
+            version = (int) rawVersion;
+            return true;
+        }
+
+        private static void MigrateSettingsV0ToV1(JObject settings)
+        {
+            MigrateLegacyCrowdSettings(settings);
+            MigrateLegacyReverbImplementation(settings);
+        }
+
+        private static void MigrateLegacyCrowdSettings(JObject settings)
+        {
+            if (!TryGetLegacyCrowdFxMode(settings, out var crowdFxMode))
+            {
+                return;
+            }
+
+            SetIfMissing(settings, CROWD_CHEERING_SETTING, crowdFxMode == LegacyCrowdFxMode.Enabled);
+            SetIfMissing(settings, CROWD_IDLE_SETTING, crowdFxMode == LegacyCrowdFxMode.Enabled);
+            SetIfMissing(settings, STAR_POWER_CLAPS_SETTING, crowdFxMode != LegacyCrowdFxMode.Disabled);
+            SetIfMissing(settings, PERFORMANCE_CLAPS_SETTING, crowdFxMode == LegacyCrowdFxMode.Enabled);
+            settings.Remove(LEGACY_CROWD_FX_SETTING);
+        }
+
+        private static void SetIfMissing(JObject settings, string propertyName, bool value)
+        {
+            if (!settings.ContainsKey(propertyName))
+            {
+                settings[propertyName] = value;
+            }
+        }
+
+        private static bool TryGetLegacyCrowdFxMode(JObject settings, out LegacyCrowdFxMode mode)
+        {
+            mode = default;
+
+            if (!settings.TryGetValue(LEGACY_CROWD_FX_SETTING, out var token))
+            {
+                return false;
+            }
+
+            if (token.Type != JTokenType.Integer && token.Type != JTokenType.String)
+            {
+                return false;
+            }
+
+            return Enum.TryParse(token.ToString(), true, out mode) &&
+                mode is LegacyCrowdFxMode.Disabled or LegacyCrowdFxMode.StarpowerClapsOnly or LegacyCrowdFxMode.Enabled;
+        }
+
+        private static void MigrateLegacyReverbImplementation(JObject settings)
+        {
+            if (!settings.TryGetValue(REVERB_IMPLEMENTATION_SETTING, out var token) ||
+                !TryGetInteger(token, out var raw))
+            {
+                return;
+            }
+
+            if (raw is (int) ReverbMode.Performance or (int) ReverbMode.Quality)
+            {
+                return;
+            }
+
+            settings[REVERB_IMPLEMENTATION_SETTING] = (int) ReverbMode.Quality;
+        }
+
+        private static bool TryGetInteger(JToken token, out long value)
+        {
+            value = 0;
+
+            if (token.Type != JTokenType.Integer)
+            {
+                return false;
+            }
+
+            value = (long) token;
+            return true;
+        }
+    }
+}

--- a/Assets/Script/Settings/SettingsMigration.cs
+++ b/Assets/Script/Settings/SettingsMigration.cs
@@ -146,7 +146,7 @@ namespace YARG.Settings
                 return;
             }
 
-            settings[REVERB_IMPLEMENTATION_SETTING] = (int) ReverbMode.Quality;
+            settings[REVERB_IMPLEMENTATION_SETTING] = (int) ReverbMode.Performance;
         }
 
         private static bool TryGetInteger(JToken token, out long value)

--- a/Assets/Script/Settings/SettingsMigration.cs.meta
+++ b/Assets/Script/Settings/SettingsMigration.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cdee32d5453cadf009b3438fc855d249
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/StreamingAssets/lang/en-US.json
+++ b/Assets/StreamingAssets/lang/en-US.json
@@ -1041,6 +1041,7 @@
             "Experimental": "Experimental",
             "HUD": "HUD",
             "Gameplay": "Gameplay",
+            "CrowdFX": "Crowd FX",
             "OutputConfiguration": "Output Configuration",
             "Accessibility": "Accessibility"
         },
@@ -1587,14 +1588,21 @@
                     "On": "On"
                 }
             },
-            "UseCrowdFx": {
-                "Name": "Use Crowd SFX",
-                "Description": "If enabled, crowd sounds will be played.\nIf set to Starpower Claps Only, crowd sounds will only be played during Starpower.",
-                "Dropdown": {
-                    "Disabled": "Disabled",
-                    "StarpowerClapsOnly": "Starpower Claps Only",
-                    "Enabled": "Enabled"
-                }
+            "UseCrowdCheering": {
+                "Name": "Crowd Cheering",
+                "Description": "Play crowd cheering sound effects at the start, during Star Power, at the end of songs, and on score screens."
+            },
+            "UseCrowdIdle": {
+                "Name": "Crowd Idle",
+                "Description": "Play the crowd's idle background noise during the song."
+            },
+            "UseStarPowerClaps": {
+                "Name": "Star Power Claps",
+                "Description": "Play crowd claps along to the beat while Star Power is active."
+            },
+            "UsePerformanceClaps": {
+                "Name": "Performance Claps",
+                "Description": "Play crowd claps along to the beat when performing well."
             },
             "UseVenueSfx": {
                 "Name": "Use Venue SFX",


### PR DESCRIPTION
Replaces drop down with three crowd settings

Crowd idle means the mid-song crowd idling

With Crowd cheer on we hear the idle, then cheer, then silence

I do not personally like the crowd idle noise for the entire song, and I do not like claps, so I turn on crowd cheer only

Also includes a formal settings migration method

<img width="1479" height="828" alt="image" src="https://github.com/user-attachments/assets/7394925e-2890-4a2b-b97b-9c8e6f8238da" />


