### PR TITLE
Move delayed button arming into ShowCompactConfirmation, fix color flash

### DIFF
--- a/Assets/Script/Menu/Settings/Presets/PresetActions.cs
+++ b/Assets/Script/Menu/Settings/Presets/PresetActions.cs
@@ -68,46 +68,24 @@ namespace YARG.Menu.Settings
             if (preset.DefaultPreset) return;
 
             // Deleting is irreversible, so confirm first (same compact dialog
-            // as "Copy from note"). The delete button starts disabled/grey for
-            // a moment so it can't be hit by accidental mashing.
-            bool armed = false;
-
-            void Delete()
-            {
-                if (!armed) return;
-
-                DialogManager.Instance.ClearDialog();
-
-                _tab.SelectedContent.DeletePreset(preset);
-                _tab.ResetSelectedPreset();
-
-                SettingsMenu.Instance.Refresh();
-            }
-
-            // The cancel button keeps its brighter "safe" color here (delete is
-            // the destructive action, so it stays the red default).
-            var deleteButton = PresetSubTab.ShowCompactConfirmation(
+            // as "Copy from note"), with the delete button disabled for a moment
+            // so it can't be hit by accidental mashing. The cancel button keeps
+            // its brighter "safe" color (delete is the destructive action, so it
+            // gets the red default).
+            PresetSubTab.ShowCompactConfirmation(
                 Localize.Key("Settings.PresetSetting.Dialog.DeletePreset.Title"),
                 Localize.KeyFormat("Settings.PresetSetting.Dialog.DeletePreset.Message", preset.Name),
-                "Menu.Common.Delete", MenuData.Colors.CancelButton, Delete,
-                cancelColor: MenuData.Colors.BrightButton);
+                "Menu.Common.Delete", MenuData.Colors.CancelButton, () =>
+                {
+                    DialogManager.Instance.ClearDialog();
 
-            deleteButton.DisableButton();
-            ArmDeleteButton(deleteButton).Forget();
+                    _tab.SelectedContent.DeletePreset(preset);
+                    _tab.ResetSelectedPreset();
 
-            async UniTaskVoid ArmDeleteButton(ColoredButton button)
-            {
-                await UniTask.Delay(2000, cancellationToken: button.GetCancellationTokenOnDestroy());
-
-                // The dialog may have been cancelled in the meantime
-                if (button == null) return;
-
-                armed = true;
-                button.EnableButton();
-                // EnableButton restores the prefab's original color, not the
-                // red this button was given
-                button.SetBackgroundAndTextColor(MenuData.Colors.CancelButton);
-            }
+                    SettingsMenu.Instance.Refresh();
+                },
+                cancelColor: MenuData.Colors.BrightButton,
+                armDelaySeconds: 2f);
         }
 
         public void ImportPreset()

--- a/Assets/Script/Settings/Metadata/Tabs/PresetSubTab.cs
+++ b/Assets/Script/Settings/Metadata/Tabs/PresetSubTab.cs
@@ -1,8 +1,11 @@
 ﻿using System;
+using System.Threading;
+using Cysharp.Threading.Tasks;
 using TMPro;
 using UnityEngine;
 using Object = UnityEngine.Object;
 using UnityEngine.AddressableAssets;
+using UnityEngine.UI;
 using YARG.Core;
 using YARG.Core.Input;
 using YARG.Localization;
@@ -134,7 +137,7 @@ namespace YARG.Settings.Metadata
         /// the shared <see cref="MakeDialogCompact"/> sizing and the color-picker's
         /// nav convention: Green/confirm runs <paramref name="onConfirm"/>,
         /// Red/back cancels. Returns the confirm <see cref="ColoredButton"/> so the
-        /// caller can further tweak it (e.g. the delete dialog's arm delay).
+        /// caller can further tweak it.
         /// </summary>
         /// <remarks>
         /// The base Dialog pushes a navigate-only scheme in OnEnable; this swaps it
@@ -142,8 +145,14 @@ namespace YARG.Settings.Metadata
         /// so the pop/push stays balanced — this is the one place that convention
         /// lives now that both confirmations share it.
         /// </remarks>
+        /// <param name="armDelaySeconds">
+        /// If greater than zero, the confirm button starts disabled and arms after
+        /// this many seconds. Use for destructive actions (e.g. deletes) so they
+        /// can't be confirmed by accidental mashing.
+        /// </param>
         public static ColoredButton ShowCompactConfirmation(string title, string message,
-            string confirmKey, Color confirmColor, Action onConfirm, Color? cancelColor = null)
+            string confirmKey, Color confirmColor, Action onConfirm, Color? cancelColor = null,
+            float armDelaySeconds = 0f)
         {
             void Cancel() => DialogManager.Instance.ClearDialog();
 
@@ -155,16 +164,76 @@ namespace YARG.Settings.Metadata
             // same delegate can also feed the NavigationScheme.Entry (Action) below.
             var confirmButton = dialog.AddDialogButton(confirmKey, confirmColor, () => onConfirm());
 
+            // The delayed arm only guards the button itself; the armed flag also
+            // gates the controller/keyboard Green entry below so it can't bypass
+            // the delay through the navigation scheme
+            bool armed = armDelaySeconds <= 0f;
+
+            if (armDelaySeconds > 0f)
+            {
+                ArmButtonAfterDelay(confirmButton, confirmColor, armDelaySeconds,
+                    () => armed = true).Forget();
+            }
+
             MakeDialogCompact(dialog);
 
             Navigator.Instance.PopScheme();
             Navigator.Instance.PushSchemeImmediate(new NavigationScheme(new()
             {
-                new NavigationScheme.Entry(MenuAction.Green, "Menu.Common.Confirm", onConfirm),
+                new NavigationScheme.Entry(MenuAction.Green, "Menu.Common.Confirm", () =>
+                {
+                    if (!armed) return;
+                    onConfirm();
+                }),
                 new NavigationScheme.Entry(MenuAction.Red, "Menu.Common.Cancel", Cancel),
             }, null));
 
             return confirmButton;
+        }
+
+        /// <summary>
+        /// Disables the confirm button immediately — fade-free, so it never renders a
+        /// frame in its enabled color — and re-enables it, with its color restored,
+        /// after the given delay. Guards destructive actions against accidental mashing.
+        /// </summary>
+        private static async UniTaskVoid ArmButtonAfterDelay(ColoredButton button,
+            Color confirmColor, float delaySeconds, Action onArmed)
+        {
+            // The button's color-tint transition lerps from the enabled color to
+            // the disabled one over its fade duration, which flashes the enabled
+            // color for a frame; zero the fade while switching
+            var uiButton = button.GetComponentInChildren<Button>();
+            ColorBlock originalColors = default;
+            if (uiButton != null)
+            {
+                originalColors = uiButton.colors;
+                var noFade = originalColors;
+                noFade.fadeDuration = 0f;
+                uiButton.colors = noFade;
+            }
+
+            button.DisableButton();
+
+            await UniTask.Delay((int) (delaySeconds * 1000),
+                cancellationToken: button.GetCancellationTokenOnDestroy());
+
+            // The dialog may have been cancelled in the meantime
+            if (button == null)
+            {
+                return;
+            }
+
+            button.EnableButton();
+            // EnableButton restores the prefab's original color, not the one
+            // this button was given
+            button.SetBackgroundAndTextColor(confirmColor);
+
+            if (uiButton != null)
+            {
+                uiButton.colors = originalColors;
+            }
+
+            onArmed?.Invoke();
         }
 
         // Smaller, dimmer header for sub-sections (Notes, Fret, etc.) within an


### PR DESCRIPTION
## Summary

The compact confirmation dialog's delayed-delete pattern (used by preset
deletion) is now a built-in option (`armDelaySeconds`) on
`PresetSubTab.ShowCompactConfirmation`, instead of caller-side code. This also
fixes two defects in the existing pattern:

1. **One-frame color flash.** The confirm button rendered its enabled color for
   a frame before disabling, because the `Button` color-tint transition lerps
   over its fade duration. The arm path now zeroes the fade while switching, so
   the disabled color applies on the first rendered frame.
2. **Navigation bypass.** The dialog's Green button navigation entry invoked the
   confirm action directly, so a controller/keyboard confirm could trigger a
   destructive action during the "disabled" window. The entry is now gated on
   the armed state (mouse clicks were already guarded by `interactable`).

## Changes

| File | Change |
|------|--------|
| `PresetSubTab.cs` | `ShowCompactConfirmation` gains `armDelaySeconds` (default 0 — existing callers unaffected); new `ArmButtonAfterDelay` disables the button fade-free, arms it after the delay, and flips an `armed` flag that gates the Green scheme entry. |
| `PresetActions.cs` | `DeletePreset` collapses to a single `ShowCompactConfirmation(..., armDelaySeconds: 2f)` call. |

## Testing done

- Unity 6000.3.5f2 batchmode compile: zero `error CS`.
- Core unit tests unchanged (no Core code touched).
- Manual, in-editor (the Unity project has no test assembly; all dialog logic
  is Unity-side):
  - Preset delete: no enabled-color flash; Delete grey for ~2s then arms red;
    confirming deletes the preset and closes the dialog.
  - Keyboard `1` (Green) during the 2s window: no-op. `2` (Red): instant
    cancel.

Companion PR: profile load recovery (`bug/profile-load-recovery`) builds on
this and uses `armDelaySeconds` for its delete confirmations.
