### PR TITLE
Bug/profile load recovery

### DIFF
--- a/Assets/Script/Menu/Persistent/Toasts/ToastManager.cs
+++ b/Assets/Script/Menu/Persistent/Toasts/ToastManager.cs
@@ -55,10 +55,18 @@ namespace YARG.Menu.Persistent
         private readonly struct ToastInfo
         {
             public readonly ToastType Type;
-            public readonly string Text;
+
+            /// <summary>Resolved when the toast is shown, not when it is queued;
+            /// startup toasts enqueue before localization has loaded.</summary>
+            public readonly Func<string> Text;
             public readonly Action OnClick;
 
             public ToastInfo(ToastType type, string text, Action onClick)
+                : this(type, () => text, onClick)
+            {
+            }
+
+            public ToastInfo(ToastType type, Func<string> text, Action onClick)
             {
                 Type = type;
                 Text = text;
@@ -81,7 +89,7 @@ namespace YARG.Menu.Persistent
 
             while (transform.childCount < MAX_TOAST_COUNT && _toastQueue.TryDequeue(out var toast))
             {
-                ShowToast(toast.Type, toast.Text, toast.OnClick);
+                ShowToast(toast.Type, toast.Text(), toast.OnClick);
             }
         }
 
@@ -118,6 +126,15 @@ namespace YARG.Menu.Persistent
             => AddToast(ToastType.Warning, text, onClick);
 
         /// <summary>
+        /// Adds a warning toast whose text is resolved when it is shown. Use for
+        /// toasts queued during startup, before localization has loaded.
+        /// </summary>
+        /// <param name="textProvider">Produces the text of the toast.</param>
+        /// <param name="onClick">Action to perform when the toast is clicked.</param>
+        public static void ToastWarning(Func<string> textProvider, Action onClick = null)
+            => AddToast(ToastType.Warning, textProvider, onClick);
+
+        /// <summary>
         /// Adds an error message toast to the toast queue.
         /// </summary>
         /// <param name="text">Text of the toast.</param>
@@ -126,6 +143,11 @@ namespace YARG.Menu.Persistent
             => AddToast(ToastType.Error, text, onClick);
 
         private static void AddToast(ToastType type, string text, Action onClick)
+        {
+            _toastQueue.Enqueue(new ToastInfo(type, text, onClick));
+        }
+
+        private static void AddToast(ToastType type, Func<string> text, Action onClick)
         {
             _toastQueue.Enqueue(new ToastInfo(type, text, onClick));
         }

--- a/Assets/Script/Menu/ProfileList/ProfileListMenu.cs
+++ b/Assets/Script/Menu/ProfileList/ProfileListMenu.cs
@@ -84,6 +84,7 @@ namespace YARG.Menu.ProfileList
             AddListGroup(Localize.Key("Menu.ProfileList.ActiveProfiles"), activeProfiles);
             AddListGroup(Localize.Key("Menu.ProfileList.Players"), otherProfiles.Where(e => !e.IsBot));
             AddListGroup(Localize.Key("Menu.ProfileList.Bots"), otherProfiles.Where(e => e.IsBot));
+            AddUnloadedGroup(Localize.Key("Menu.ProfileList.CouldNotLoad"));
 
             if (selectedProfile == null)
             {
@@ -109,6 +110,25 @@ namespace YARG.Menu.ProfileList
             {
                 var go = Instantiate(_profileViewPrefab, _profileList);
                 go.GetComponent<ProfileView>().Init(this, profile, _profileSidebar);
+                _navigationGroup.AddNavigatable(go);
+            }
+        }
+
+        private void AddUnloadedGroup(string header)
+        {
+            if (PlayerContainer.UnloadedProfiles.Count == 0)
+            {
+                return;
+            }
+
+            var headerGo = Instantiate(_profileListHeaderPrefab, _profileList);
+            headerGo.GetComponentInChildren<TextMeshProUGUI>().text = header;
+            _navigationGroup.AddNavigatable(headerGo);
+
+            foreach (var record in PlayerContainer.UnloadedProfiles)
+            {
+                var go = Instantiate(_profileViewPrefab, _profileList);
+                go.GetComponent<ProfileView>().InitUnloaded(this, record, _profileSidebar);
                 _navigationGroup.AddNavigatable(go);
             }
         }

--- a/Assets/Script/Menu/ProfileList/ProfileView.cs
+++ b/Assets/Script/Menu/ProfileList/ProfileView.cs
@@ -11,11 +11,14 @@ using YARG.Core.Audio;
 using YARG.Core.Game;
 using YARG.Core.Logging;
 using YARG.Input;
+using YARG.Localization;
 using YARG.Menu;
+using YARG.Menu.Data;
 using YARG.Menu.Dialogs;
 using YARG.Menu.Navigation;
 using YARG.Menu.Persistent;
 using YARG.Player;
+using YARG.Settings.Metadata;
 
 namespace YARG.Menu.ProfileList
 {
@@ -50,6 +53,9 @@ namespace YARG.Menu.ProfileList
 
         public YargProfile Profile { get; private set; }
 
+        /// <summary>The set-aside record this view represents, or null for a normal profile row.</summary>
+        public PlayerContainer.UnloadedProfile UnloadedRecord { get; private set; }
+
         private ProfileListMenu _profileListMenu;
         private ProfileSidebar  _profileSidebar;
 
@@ -58,6 +64,35 @@ namespace YARG.Menu.ProfileList
             _profileListMenu = menu;
             _profileSidebar = sidebar;
             UpdateDisplay(profile);
+        }
+
+        /// <summary>
+        /// Shows a set-aside profile record that this version of the game could
+        /// not load. The row is inert except for its delete button.
+        /// </summary>
+        public void InitUnloaded(ProfileListMenu menu, PlayerContainer.UnloadedProfile record, ProfileSidebar sidebar)
+        {
+            _profileListMenu = menu;
+            _profileSidebar = sidebar;
+            UnloadedRecord = record;
+
+            _profileName.text = Localize.KeyFormat("Menu.ProfileList.UnloadedEntry", record.Name);
+
+            // No connecting, disconnecting, or reordering an unloaded record. The
+            // connect group starts inactive in the prefab and also contains the
+            // row's delete button, so activate it and hide only the connect button
+            _connectGroup.SetActive(true);
+            _disconnectGroup.SetActive(false);
+            var connectButton = _connectGroup.GetComponentInChildren<ColoredButton>();
+            if (connectButton != null)
+            {
+                connectButton.gameObject.SetActive(false);
+            }
+
+            _moveUpButton.interactable = false;
+            _moveDownButton.interactable = false;
+
+            _profilePicture.sprite = _profileGenericSprite;
         }
 
         public void UpdateDisplay(YargProfile profile)
@@ -108,33 +143,59 @@ namespace YARG.Menu.ProfileList
 
             if (selected)
             {
+                // Unloaded records have nothing to show in the sidebar
+                if (UnloadedRecord is not null)
+                {
+                    _profileSidebar.HideContents();
+                    return;
+                }
+
                 _profileSidebar.UpdateSidebar(Profile, this);
             }
         }
 
         public async void RemoveProfile()
         {
+            if (UnloadedRecord is not null)
+            {
+                RemoveUnloadedProfile();
+                return;
+            }
+
+            // Bots currently delete instantly; give them the delayed-confirmation
+            // dialog too so they can't be removed by an accidental click
+            if (Profile.IsBot)
+            {
+                PresetSubTab.ShowCompactConfirmation(
+                    Localize.KeyFormat("Menu.Dialog.ConfirmDelete.Title", Profile.Name),
+                    Localize.Key("Menu.ProfileList.BotDelete"),
+                    "Menu.Common.Delete", MenuData.Colors.CancelButton, () =>
+                    {
+                        DialogManager.Instance.ClearDialog();
+                        RemoveNow();
+                    },
+                    cancelColor: MenuData.Colors.BrightButton,
+                    armDelaySeconds: 2f);
+                return;
+            }
+
             bool remove = false;
 
-            // Confirm that the user wants to delete the profile first, UNLESS it's a bot
-            if (!Profile.IsBot)
-            {
-                var dialog = DialogManager.Instance.ShowConfirmDeleteDialog(
-                    "Deleting this profile is permanent and you will lose all stats and binds. Play history will " +
-                    "remain and can be accessed in the <b>History</b> tab.", () => { remove = true; }, Profile.Name);
+            // Confirm that the user wants to delete the profile first by typing its name
+            var dialog = DialogManager.Instance.ShowConfirmDeleteDialog(
+                "Deleting this profile is permanent and you will lose all stats and binds. Play history will " +
+                "remain and can be accessed in the <b>History</b> tab.", () => { remove = true; }, Profile.Name);
 
-                // Wait...
-                await dialog.WaitUntilClosed();
-            }
-            else
-            {
-                remove = true;
-            }
+            // Wait...
+            await dialog.WaitUntilClosed();
 
             if (!remove) return;
 
-            // Then remove
+            RemoveNow();
+        }
 
+        private void RemoveNow()
+        {
             if (Selected)
             {
                 _profileSidebar.HideContents();
@@ -142,8 +203,37 @@ namespace YARG.Menu.ProfileList
 
             if (PlayerContainer.RemoveProfile(Profile))
             {
-                Destroy(gameObject);
+                // Rebuild the list so emptied group headers disappear immediately
+                _profileListMenu.RefreshList();
             }
+        }
+
+        private void RemoveUnloadedProfile()
+        {
+            // Delayed-confirmation dialog (the button arms after a short delay);
+            // the section header and row description already explain why the
+            // profile couldn't load, so the message stays short
+            PresetSubTab.ShowCompactConfirmation(
+                Localize.Key("Menu.ProfileList.UnloadedDeleteTitle"),
+                Localize.Key("Menu.ProfileList.UnloadedDelete"),
+                "Menu.Common.Delete", MenuData.Colors.CancelButton, () =>
+                {
+                    DialogManager.Instance.ClearDialog();
+
+                    if (Selected)
+                    {
+                        _profileSidebar.HideContents();
+                    }
+
+                    if (PlayerContainer.DeleteUnloadedProfile(UnloadedRecord))
+                    {
+                        // Rebuild the list so an emptied "Couldn't Load" group's
+                        // header goes away immediately
+                        _profileListMenu.RefreshList();
+                    }
+                },
+                cancelColor: MenuData.Colors.BrightButton,
+                armDelaySeconds: 2f);
         }
 
         public async UniTask<bool> PromptAddDevice()

--- a/Assets/Script/Menu/Settings/Presets/PresetActions.cs
+++ b/Assets/Script/Menu/Settings/Presets/PresetActions.cs
@@ -68,46 +68,24 @@ namespace YARG.Menu.Settings
             if (preset.DefaultPreset) return;
 
             // Deleting is irreversible, so confirm first (same compact dialog
-            // as "Copy from note"). The delete button starts disabled/grey for
-            // a moment so it can't be hit by accidental mashing.
-            bool armed = false;
-
-            void Delete()
-            {
-                if (!armed) return;
-
-                DialogManager.Instance.ClearDialog();
-
-                _tab.SelectedContent.DeletePreset(preset);
-                _tab.ResetSelectedPreset();
-
-                SettingsMenu.Instance.Refresh();
-            }
-
-            // The cancel button keeps its brighter "safe" color here (delete is
-            // the destructive action, so it stays the red default).
-            var deleteButton = PresetSubTab.ShowCompactConfirmation(
+            // as "Copy from note"), with the delete button disabled for a moment
+            // so it can't be hit by accidental mashing. The cancel button keeps
+            // its brighter "safe" color (delete is the destructive action, so it
+            // gets the red default).
+            PresetSubTab.ShowCompactConfirmation(
                 Localize.Key("Settings.PresetSetting.Dialog.DeletePreset.Title"),
                 Localize.KeyFormat("Settings.PresetSetting.Dialog.DeletePreset.Message", preset.Name),
-                "Menu.Common.Delete", MenuData.Colors.CancelButton, Delete,
-                cancelColor: MenuData.Colors.BrightButton);
+                "Menu.Common.Delete", MenuData.Colors.CancelButton, () =>
+                {
+                    DialogManager.Instance.ClearDialog();
 
-            deleteButton.DisableButton();
-            ArmDeleteButton(deleteButton).Forget();
+                    _tab.SelectedContent.DeletePreset(preset);
+                    _tab.ResetSelectedPreset();
 
-            async UniTaskVoid ArmDeleteButton(ColoredButton button)
-            {
-                await UniTask.Delay(2000, cancellationToken: button.GetCancellationTokenOnDestroy());
-
-                // The dialog may have been cancelled in the meantime
-                if (button == null) return;
-
-                armed = true;
-                button.EnableButton();
-                // EnableButton restores the prefab's original color, not the
-                // red this button was given
-                button.SetBackgroundAndTextColor(MenuData.Colors.CancelButton);
-            }
+                    SettingsMenu.Instance.Refresh();
+                },
+                cancelColor: MenuData.Colors.BrightButton,
+                armDelaySeconds: 2f);
         }
 
         public void ImportPreset()

--- a/Assets/Script/Player/PlayerContainer.cs
+++ b/Assets/Script/Player/PlayerContainer.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using Cysharp.Threading.Tasks;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using PlasticBand.Devices;
 using UnityEngine.InputSystem;
 using YARG.Core;
@@ -33,9 +34,11 @@ namespace YARG.Player
         public  static string ProfilesDirectory => Path.Combine(PathHelper.PersistentDataPath, "profiles");
         private static string ProfilesPath      => Path.Combine(ProfilesDirectory, "profiles.json");
         private static string ProfilesBackupPath => Path.Combine(ProfilesDirectory, "profiles.json.bak");
+        private static string UnloadedProfilesPath => Path.Combine(ProfilesDirectory, "profiles.json.unloaded");
 
         private static readonly List<YargProfile> _profiles = new();
         private static readonly List<YargPlayer>  _players  = new();
+        private static readonly List<UnloadedProfile> _unloadedProfiles = new();
 
         private static readonly Dictionary<Guid, YargProfile>       _profilesById     = new();
         private static readonly Dictionary<YargProfile, YargPlayer> _playersByProfile = new();
@@ -50,6 +53,26 @@ namespace YARG.Player
         /// A list of all of the profiles (taken or not).
         /// </summary>
         public static IReadOnlyList<YargProfile> Profiles => _profiles;
+
+        /// <summary>
+        /// A list of profile records this version of the game could not load.
+        /// </summary>
+        public static IReadOnlyList<UnloadedProfile> UnloadedProfiles => _unloadedProfiles;
+
+        /// <summary>
+        /// Permanently removes a set-aside profile record. The only automatic
+        /// removal is a successful retry on load.
+        /// </summary>
+        public static bool DeleteUnloadedProfile(UnloadedProfile record)
+        {
+            if (!_unloadedProfiles.Remove(record))
+            {
+                return false;
+            }
+
+            SaveUnloadedProfiles();
+            return true;
+        }
 
         /// <summary>
         /// A list of all of the active players.
@@ -298,97 +321,380 @@ namespace YARG.Player
             return true;
         }
 
+        /// <summary>
+        /// A profile record the current version of the game could not load.
+        /// Kept in a sidecar file, retried whenever the game version changes,
+        /// and never deleted automatically.
+        /// </summary>
+        public sealed class UnloadedProfile
+        {
+            /// <summary>Display-only copy of the record's name; never trusted data.</summary>
+            public string Name;
+
+            /// <summary>The game version that last attempted (and failed) to load this record.</summary>
+            public string LastTriedVersion;
+
+            /// <summary>The error from the last failed attempt.</summary>
+            public string LastError;
+
+            /// <summary>The original profile record, preserved verbatim.</summary>
+            public JToken Record;
+        }
+
+        /// <summary>
+        /// Outcome of reading and parsing a single profiles file.
+        /// </summary>
+        private sealed class ProfileFileResult
+        {
+            public static readonly ProfileFileResult Missing = new();
+
+            /// <summary>Raw JSON tokens of each element in the profile array.</summary>
+            public List<JToken> Tokens { get; } = new();
+
+            /// <summary>Whether the file was read and parsed as a JSON array (even an empty one).</summary>
+            public bool StructurallyReadable;
+        }
+
         public static int LoadProfiles()
         {
-            bool usedBackup = false;
-
             _profiles.Clear();
             _profilesById.Clear();
+            _unloadedProfiles.Clear();
 
             // Players must be disposed
             _players.ForEach(i => i.Dispose());
             _players.Clear();
 
-            string profilesPath = ProfilesPath;
-            if (!File.Exists(profilesPath))
-            {
-                // If the file doesn't exist, then there are no profiles
-                _isInitialized = true;
-                return 0;
-            }
+            var main = LoadProfileFile(ProfilesPath, "profiles.json");
+            bool fileMissing = ReferenceEquals(main, ProfileFileResult.Missing);
+            bool usedBackup = false;
+            ProfileFileResult source = null;
 
-            string profilesJson = File.ReadAllText(profilesPath);
-            List<YargProfile> profiles = null;
-            try
+            if (!fileMissing && main.StructurallyReadable)
             {
-                profiles = JsonConvert.DeserializeObject<List<YargProfile>>(profilesJson);
+                source = main;
             }
-            catch (Exception ex)
+            else if (!fileMissing)
             {
-                YargLogger.LogException(ex, "Error while loading profiles! Recovery will be attempted.");
-            }
+                // The main file is unreadable or not a JSON array, so recover from the backup
+                var backup = LoadProfileFile(ProfilesBackupPath, "profiles.json.bak");
+                YargLogger.LogWarning("Failed to parse the main profiles file, attempting recovery from the backup.");
 
-            if (profiles is null)
-            {
-                // Attempt to load from backup before giving up
-                profiles = LoadProfilesFromBackup();
-
-                if (profiles.Count > 0)
+                if (backup.StructurallyReadable)
                 {
-                    // Flag that we used the backup so we can immediately save once everything is loaded
-                    YargLogger.LogWarning("Failed to load profiles from main file, using backup.");
+                    source = backup;
                     usedBackup = true;
                 }
-                else
+
+                // If neither source is usable, continue with zero profiles rather than aborting
+            }
+
+            // Register profiles one at a time so a single bad record can't abort the
+            // rest; records this version can't load are set aside, never deleted
+            int rejectedByThisVersion = 0;
+
+            if (source is not null)
+            {
+                string sourceName = usedBackup ? "profiles.json.bak" : "profiles.json";
+                foreach (var token in source.Tokens)
                 {
-                    YargLogger.LogWarning("Failed to load profiles! Bindings loading will be skipped.");
-                    return 0;
+                    if (TryRegisterProfileToken(token, out _, out string error, out bool setAside))
+                    {
+                        continue;
+                    }
+
+                    YargLogger.LogFormatWarning("Skipped invalid profile record in {0}", sourceName + ": " + error);
+                    rejectedByThisVersion++;
+
+                    if (setAside)
+                    {
+                        AddUnloadedProfile(token, error);
+                    }
                 }
             }
 
-            _profiles.AddRange(profiles);
+            // Retry records that last failed under a different version of the game;
+            // records that still fail get their attempt stamp moved forward
+            LoadUnloadedProfiles();
+            RetryUnloadedProfiles(out int promotedCount, out int retriedFailedCount);
+            rejectedByThisVersion += retriedFailedCount;
 
-            // Store profiles by ID
-            foreach (var profile in _profiles)
-            {
-                profile.GrandfatherIn();
-                _profilesById.Add(profile.Id, profile);
-            }
-
+            // Bindings loading handles orphaned records itself, so it is safe (and intended)
+            // even when the valid profile count is zero
             BindingsContainer.LoadBindings();
 
+            // Initialization must hold after every non-throwing recovery path, or no
+            // profile could ever be saved again
             _isInitialized = true;
 
             if (usedBackup)
             {
-                // Rewrite the main profiles file with the backup data
-                SaveProfiles(false);
+                // Preserve the unreadable source before the sanitized rewrite replaces it
+                CopyAsideFailedSource(ProfilesPath, ProfilesPath + ".invalid");
             }
-            else
+
+            if (usedBackup || rejectedByThisVersion > 0 || promotedCount > 0)
             {
-                // If we didn't use the backup, that means loading was good so we should save a new backup
+                // Rewrite the active files from the sanitized set; set-aside records
+                // live on in the sidecar, so nothing is lost
+                SaveProfiles(false);
                 SaveBackupProfiles();
+            }
+            else if (!fileMissing)
+            {
+                // Loading was good, so refresh the backup as usual
+                SaveBackupProfiles();
+            }
+
+            if (rejectedByThisVersion > 0 || promotedCount > 0 || retriedFailedCount > 0)
+            {
+                SaveUnloadedProfiles();
+            }
+
+            if (rejectedByThisVersion > 0)
+            {
+                var message = Localize.KeyFormat("Toast.ProfileLoadWarning", rejectedByThisVersion);
+                ToastManager.ToastWarning(message);
             }
 
             return _profiles.Count;
         }
 
-        private static List<YargProfile> LoadProfilesFromBackup()
+        /// <summary>
+        /// Converts and registers a single profile record. Any record-local failure
+        /// (deserialization, validation, migration) returns false with an error
+        /// message instead of throwing. Duplicate IDs also return false, but with
+        /// <paramref name="setAside"/> cleared since retrying them cannot help.
+        /// </summary>
+        private static bool TryRegisterProfileToken(JToken token, out YargProfile profile, out string error, out bool setAside)
         {
-            if (!File.Exists(ProfilesBackupPath))
-            {
-                return new List<YargProfile>();
-            }
+            profile = null;
+            error = string.Empty;
+            setAside = true;
 
-            string profilesJson = File.ReadAllText(ProfilesBackupPath);
             try
             {
-                return JsonConvert.DeserializeObject<List<YargProfile>>(profilesJson);
+                // This includes OnDeserialized validation failures, malformed
+                // individual records, and null elements
+                profile = token.ToObject<YargProfile>();
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                YargLogger.LogFormatError("Failed to load profiles from backup file: {0}", e.Message);
-                return new List<YargProfile>();
+                error = ex.Message;
+                return false;
+            }
+
+            if (profile is null)
+            {
+                error = "Profile record is null.";
+                return false;
+            }
+
+            try
+            {
+                profile.GrandfatherIn();
+            }
+            catch (Exception ex)
+            {
+                error = "Migration failed: " + ex.Message;
+                profile = null;
+                return false;
+            }
+
+            if (_profilesById.ContainsKey(profile.Id))
+            {
+                error = $"Duplicate profile ID {profile.Id}.";
+                profile = null;
+                setAside = false;
+                return false;
+            }
+
+            _profiles.Add(profile);
+            _profilesById.Add(profile.Id, profile);
+            return true;
+        }
+
+        /// <summary>
+        /// Reattempts sidecar records whose last failure was under a different
+        /// game version. Promotions become normal profiles; records that still
+        /// fail get their attempt stamp moved to the current version.
+        /// </summary>
+        private static void RetryUnloadedProfiles(out int promotedCount, out int retriedFailedCount)
+        {
+            promotedCount = 0;
+            retriedFailedCount = 0;
+
+            string currentVersion = GlobalVariables.Instance.CurrentVersion;
+
+            for (int i = _unloadedProfiles.Count - 1; i >= 0; i--)
+            {
+                var record = _unloadedProfiles[i];
+
+                if (record.Record is null)
+                {
+                    // Malformed sidecar entry; leave it alone rather than delete user data
+                    continue;
+                }
+
+                // Only reattempt records that failed under a different build
+                if (record.LastTriedVersion == currentVersion)
+                {
+                    continue;
+                }
+
+                if (TryRegisterProfileToken(record.Record, out var profile, out string error, out bool setAside))
+                {
+                    YargLogger.LogInfo($"Profile '{profile.Name}' loaded after being set aside by version {record.LastTriedVersion}.");
+                    _unloadedProfiles.RemoveAt(i);
+                    promotedCount++;
+                }
+                else if (setAside)
+                {
+                    YargLogger.LogWarning($"Profile '{record.Name}' (set aside by {record.LastTriedVersion}) still fails under {currentVersion}: {error}");
+                    record.LastTriedVersion = currentVersion;
+                    record.LastError = error;
+                    retriedFailedCount++;
+                }
+                else
+                {
+                    YargLogger.LogWarning($"Profile '{record.Name}' (set aside by {record.LastTriedVersion}) cannot be registered yet: {error}");
+                }
+            }
+        }
+
+        private static void AddUnloadedProfile(JToken token, string error)
+        {
+            var name = (token as JObject)?["Name"]?.Value<string>();
+            _unloadedProfiles.Add(new UnloadedProfile
+            {
+                Name = string.IsNullOrEmpty(name) ? "(unknown)" : name,
+                LastTriedVersion = GlobalVariables.Instance.CurrentVersion,
+                LastError = error,
+                Record = token,
+            });
+        }
+
+        private static void LoadUnloadedProfiles()
+        {
+            if (!File.Exists(UnloadedProfilesPath))
+            {
+                return;
+            }
+
+            try
+            {
+                var records = JsonConvert.DeserializeObject<List<UnloadedProfile>>(
+                    File.ReadAllText(UnloadedProfilesPath));
+
+                if (records is not null)
+                {
+                    _unloadedProfiles.AddRange(records);
+                }
+            }
+            catch (Exception ex)
+            {
+                YargLogger.LogError("Failed to read the unloaded-profiles sidecar: " + ex.Message);
+            }
+        }
+
+        public static void SaveUnloadedProfiles()
+        {
+            try
+            {
+                if (_unloadedProfiles.Count == 0)
+                {
+                    if (File.Exists(UnloadedProfilesPath))
+                    {
+                        File.Delete(UnloadedProfilesPath);
+                    }
+
+                    return;
+                }
+
+                File.WriteAllText(UnloadedProfilesPath,
+                    JsonConvert.SerializeObject(_unloadedProfiles, Formatting.Indented));
+            }
+            catch (Exception ex)
+            {
+                YargLogger.LogError("Failed to write the unloaded-profiles sidecar: " + ex.Message);
+            }
+        }
+
+        /// <summary>
+        /// Parses a profiles file element-by-element so one invalid record
+        /// cannot discard the valid ones.
+        /// </summary>
+        private static ProfileFileResult LoadProfileFile(string path, string name)
+        {
+            if (!File.Exists(path))
+            {
+                return ProfileFileResult.Missing;
+            }
+
+            string profilesJson;
+            try
+            {
+                profilesJson = File.ReadAllText(path);
+            }
+            catch (Exception ex)
+            {
+                YargLogger.LogError($"Failed to read {name}: {ex.Message}");
+                return new ProfileFileResult();
+            }
+
+            JArray root;
+            try
+            {
+                if (JToken.Parse(profilesJson) is not JArray array)
+                {
+                    YargLogger.LogFormatError("{0} does not contain a JSON array.", name);
+                    return new ProfileFileResult();
+                }
+
+                root = array;
+            }
+            catch (Exception ex)
+            {
+                YargLogger.LogError($"Failed to parse {name}: {ex.Message}");
+                return new ProfileFileResult();
+            }
+
+            var result = new ProfileFileResult
+            {
+                StructurallyReadable = true,
+            };
+
+            // Records are converted at registration time so their raw form can be
+            // preserved verbatim if they fail
+            foreach (var token in root)
+            {
+                result.Tokens.Add(token);
+            }
+
+            return result;
+        }
+
+        private static void CopyAsideFailedSource(string sourcePath, string destPath)
+        {
+            try
+            {
+                if (!File.Exists(sourcePath))
+                {
+                    return;
+                }
+
+                if (File.Exists(destPath))
+                {
+                    string timestamp = DateTime.UtcNow.ToString("yyyyMMddHHmmssfff");
+                    destPath += "." + timestamp;
+                }
+
+                File.Copy(sourcePath, destPath);
+                YargLogger.LogFormatWarning("Preserved failed profile source as {0}.", Path.GetFileName(destPath));
+            }
+            catch (Exception ex)
+            {
+                YargLogger.LogFormatError("Failed to preserve failed profile source: {0}", ex.Message);
             }
         }
 

--- a/Assets/Script/Player/PlayerContainer.cs
+++ b/Assets/Script/Player/PlayerContainer.cs
@@ -453,8 +453,10 @@ namespace YARG.Player
 
             if (rejectedByThisVersion > 0)
             {
-                var message = Localize.KeyFormat("Toast.ProfileLoadWarning", rejectedByThisVersion);
-                ToastManager.ToastWarning(message);
+                // Deferred text: the toast is queued during startup, before
+                // localization has loaded, so resolve the key when shown
+                ToastManager.ToastWarning(() =>
+                    Localize.KeyFormat("Menu.Toast.ProfileLoadWarning", rejectedByThisVersion));
             }
 
             return _profiles.Count;

--- a/Assets/Script/Settings/Metadata/Tabs/PresetSubTab.cs
+++ b/Assets/Script/Settings/Metadata/Tabs/PresetSubTab.cs
@@ -1,8 +1,11 @@
 ﻿using System;
+using System.Threading;
+using Cysharp.Threading.Tasks;
 using TMPro;
 using UnityEngine;
 using Object = UnityEngine.Object;
 using UnityEngine.AddressableAssets;
+using UnityEngine.UI;
 using YARG.Core;
 using YARG.Core.Input;
 using YARG.Localization;
@@ -134,7 +137,7 @@ namespace YARG.Settings.Metadata
         /// the shared <see cref="MakeDialogCompact"/> sizing and the color-picker's
         /// nav convention: Green/confirm runs <paramref name="onConfirm"/>,
         /// Red/back cancels. Returns the confirm <see cref="ColoredButton"/> so the
-        /// caller can further tweak it (e.g. the delete dialog's arm delay).
+        /// caller can further tweak it.
         /// </summary>
         /// <remarks>
         /// The base Dialog pushes a navigate-only scheme in OnEnable; this swaps it
@@ -142,8 +145,14 @@ namespace YARG.Settings.Metadata
         /// so the pop/push stays balanced — this is the one place that convention
         /// lives now that both confirmations share it.
         /// </remarks>
+        /// <param name="armDelaySeconds">
+        /// If greater than zero, the confirm button starts disabled and arms after
+        /// this many seconds. Use for destructive actions (e.g. deletes) so they
+        /// can't be confirmed by accidental mashing.
+        /// </param>
         public static ColoredButton ShowCompactConfirmation(string title, string message,
-            string confirmKey, Color confirmColor, Action onConfirm, Color? cancelColor = null)
+            string confirmKey, Color confirmColor, Action onConfirm, Color? cancelColor = null,
+            float armDelaySeconds = 0f)
         {
             void Cancel() => DialogManager.Instance.ClearDialog();
 
@@ -155,16 +164,76 @@ namespace YARG.Settings.Metadata
             // same delegate can also feed the NavigationScheme.Entry (Action) below.
             var confirmButton = dialog.AddDialogButton(confirmKey, confirmColor, () => onConfirm());
 
+            // The delayed arm only guards the button itself; the armed flag also
+            // gates the controller/keyboard Green entry below so it can't bypass
+            // the delay through the navigation scheme
+            bool armed = armDelaySeconds <= 0f;
+
+            if (armDelaySeconds > 0f)
+            {
+                ArmButtonAfterDelay(confirmButton, confirmColor, armDelaySeconds,
+                    () => armed = true).Forget();
+            }
+
             MakeDialogCompact(dialog);
 
             Navigator.Instance.PopScheme();
             Navigator.Instance.PushSchemeImmediate(new NavigationScheme(new()
             {
-                new NavigationScheme.Entry(MenuAction.Green, "Menu.Common.Confirm", onConfirm),
+                new NavigationScheme.Entry(MenuAction.Green, "Menu.Common.Confirm", () =>
+                {
+                    if (!armed) return;
+                    onConfirm();
+                }),
                 new NavigationScheme.Entry(MenuAction.Red, "Menu.Common.Cancel", Cancel),
             }, null));
 
             return confirmButton;
+        }
+
+        /// <summary>
+        /// Disables the confirm button immediately — fade-free, so it never renders a
+        /// frame in its enabled color — and re-enables it, with its color restored,
+        /// after the given delay. Guards destructive actions against accidental mashing.
+        /// </summary>
+        private static async UniTaskVoid ArmButtonAfterDelay(ColoredButton button,
+            Color confirmColor, float delaySeconds, Action onArmed)
+        {
+            // The button's color-tint transition lerps from the enabled color to
+            // the disabled one over its fade duration, which flashes the enabled
+            // color for a frame; zero the fade while switching
+            var uiButton = button.GetComponentInChildren<Button>();
+            ColorBlock originalColors = default;
+            if (uiButton != null)
+            {
+                originalColors = uiButton.colors;
+                var noFade = originalColors;
+                noFade.fadeDuration = 0f;
+                uiButton.colors = noFade;
+            }
+
+            button.DisableButton();
+
+            await UniTask.Delay((int) (delaySeconds * 1000),
+                cancellationToken: button.GetCancellationTokenOnDestroy());
+
+            // The dialog may have been cancelled in the meantime
+            if (button == null)
+            {
+                return;
+            }
+
+            button.EnableButton();
+            // EnableButton restores the prefab's original color, not the one
+            // this button was given
+            button.SetBackgroundAndTextColor(confirmColor);
+
+            if (uiButton != null)
+            {
+                uiButton.colors = originalColors;
+            }
+
+            onArmed?.Invoke();
         }
 
         // Smaller, dimmer header for sub-sections (Notes, Fret, etc.) within an

--- a/Assets/StreamingAssets/lang/en-US.json
+++ b/Assets/StreamingAssets/lang/en-US.json
@@ -224,6 +224,7 @@
             "ResumeAfterFailInvalidate": "Score saving disabled: Resuming after failure invalidated score.",
             "ProfileCreated": "Profile created for new device: {0}\nTime to do some YARGin!",
             "TooManyPauses": "Score saving disabled: Too many pauses.",
+            "ProfileLoadWarning": "{0} profile(s) could not be loaded by this version of YARG. They are kept and will be retried after an update, or can be removed from the profile list.",
             "UnsupportedDevice": "Automatic profile creation is not supported for {0}!"
         },
         "Dialog": {

--- a/Assets/StreamingAssets/lang/en-US.json
+++ b/Assets/StreamingAssets/lang/en-US.json
@@ -509,7 +509,12 @@
             "AddBot": "Add Bot",
             "AddProfile": "Add Profile",
             "Bots" : "Bots",
-            "Players" : "Players"
+            "Players" : "Players",
+            "CouldNotLoad": "Couldn't Load",
+            "UnloadedEntry": "{0} <alpha=#66>— could not be loaded by this version of YARG",
+            "UnloadedDeleteTitle": "Delete Profile?",
+            "UnloadedDelete": "Deleting it is permanent.",
+            "BotDelete": "Deleting this bot is permanent."
         },
         "ScoreScreen" : {
             "BandScoreNotSaved" : "Score not saved",


### PR DESCRIPTION
## Note
**Contains:** https://github.com/YARC-Official/YARG/pull/1635 so this PR can be merged on its own, superseding that one, or if 1635 is merged first, the diff here will be much smaller.

## Summary

An unrecognized profile record no longer prevents all profiles from loading.
Loading parses the JSON array element-by-element, keeps every valid record, and **sets aside** records this version can't load in a sidecar file instead of deleting them. Those records are retried automatically whenever the game version changes, so a profile written by a newer/other build reappears on its own once a compatible version runs — and the user can see and delete the set-aside entries in the profile list. `PlayerContainer` is always initialized afterwards, so new profiles can always be created and saved.

## Why

When switching between builds I noticed that profiles would be completely empty on one build but not another where I had made changes to the profile structure for the harmonies prototype. `LoadProfiles()` deserialized the whole `List<YargProfile>` in one call. A single record that failed deserialization (e.g. an unknown `GameMode` value from a newer/incompatible build) threw, so **no** profiles loaded. The backup path had the identical flaw, and `_isInitialized` was never set, so `SaveProfiles()` refused to write, so any profiles created by the user after that point *also* disappeared. This matters beyond the crash: once resilient loading exists, naively "sanitizing" the file would silently destroy data written by another version (stable ↔ nightly), so unloadable records are preserved and retried instead of dropped. (The user can choose to delete the profiles that could not load, see below)

## Design

- **Sidecar, not inline tombstones:** unloadable records live in `profiles/profiles.json.unloaded`, not inside `profiles.json`. Inline tombstones would deserialize as garbage default `YargProfile`s on older readers (unknown fields ignored) and be silently destroyed on their next save. The active file only ever contains valid records.
- **Version-stamped retries:** each sidecar entry records the app version string (`GlobalVariables.Instance.CurrentVersion`) that last attempted it. On load, entries whose stamp differs from the current version are retried: success promotes them into the active set; failure moves the stamp forward. Identical version strings mean identical reader behavior, so no retry. (The per-profile schema `Version` field can't be used for this — both sides of a stable/nightly split may write the same number.)
- **Never auto-delete:** the only automatic removal of a sidecar entry is a successful retry. Malformed sidecar entries are left alone.
- **UI:** set-aside records appear in a "Couldn't Load" group in the profile list. It shows the name plus a dimmed "could not be loaded by this version of YARG" suffix, keeps the delete button (delayed-confirmation dialog, per the companion PR) but removes the "connect" button since it will not work.
- Per-element recovery with file-level fallback: a structurally unreadable main file still falls back to the backup (original preserved as `profiles.json.invalid`, timestamped on collision); a readable main file with bad records keeps its valid records and is never replaced wholesale.
- `_isInitialized = true` on every non-throwing path, including zero valid profiles; bindings always load (their orphan handling is pre-existing).
- No schema migration: unsupported records are preserved verbatim for a later compatible version.
- Startup toast uses a new deferred-text path in `ToastManager`: the toast is queued in `GlobalVariables.SingletonAwake()`, before localization loads, so its text resolves when displayed, not when enqueued (previously any startup-time localized toast would render its raw key).

## Changes

| File | Change |
|------|--------|
| `PlayerContainer.cs` | `LoadProfileFile()` returns raw tokens per element; `TryRegisterProfileToken()` is the single failure-safe registration path (null/duplicate/migration guards); `LoadProfiles()` orchestrates registration, sidecar retry (`RetryUnloadedProfiles`), always-init, sanitized rewrite, and the aggregate toast. New `UnloadedProfile` record type + sidecar load/save + public `UnloadedProfiles`/`DeleteUnloadedProfile` API. |
| `ProfileListMenu.cs` | New "Couldn't Load" group listing set-aside records via `ProfileView.InitUnloaded`. |
| `ProfileView.cs` | Unloaded mode for the existing row prefab (no new prefab). Bot deletion gains a delayed-confirmation dialog (previously instant, no prompt). Regular profile deletion is unchanged. All delete paths refresh the list so emptied group headers disappear immediately. |
| `ToastManager.cs` | Toast text may be supplied as a `Func<string>` resolved at display time; existing string overloads unchanged. |
| `en-US.json` | Add `Menu.Toast.ProfileLoadWarning`, `Menu.ProfileList.CouldNotLoad` / `UnloadedEntry` / `UnloadedDeleteTitle` / `UnloadedDelete` / `BotDelete`. Other languages via Crowdin. |

## Scope notes for reviewers

- Bot delete behavior changes (instant → delayed confirmation). Regular profile deletion keeps the existing type-the-name dialog; whether to move it onto the delayed dialog too is left for a future change. I felt adding the delay to the bot-deletion was safe as it doesn't require the cumbersome name entry, but prevents a stray click from deleting a configured bot.
- List-refresh-on-delete now applies to all rows, fixing the pre-existing stale empty-group-header behavior.
- The profile-delete dialog's hardcoded message predates this PR and is untouched here.

## Testing done

- Unity 6000.3.5f2 batchmode compile: zero `error CS`.
- Core unit tests: 463 passed, 2 skipped (unchanged; no Core code touched).
- All functional verification is manual: the Unity project has no test assembly or Unity Test Framework setup, and the loader under change is Unity-side (`PathHelper` persistent-data paths, `GlobalVariables` singleton, `ToastManager`), so the existing Core unit-test project cannot exercise it.

Verified in-editor: mixed valid/invalid load; per-record log warnings; one aggregate toast (deferred text renders the localized sentence) and no re-toast on same-version relaunch; sidecar contents (name/version/error/verbatim record); sanitized rewrite of `profiles.json` and `.bak`; "Couldn't Load" group rendering; delete-all-3 flow (dialog arms, closes on confirm, group header disappears, sidecar emptied); restore-from-archive re-stamp run (version string changed → retry → still-failing records re-stamped, toast with correct text); keyboard Green blocked during the arm window, Red cancels instantly.

Not yet exercised (corruption scenarios, hand-mangled files in a scratch persistent-data dir): only-invalid file; malformed main + valid backup; malformed main + malformed backup; duplicate IDs. Promotion of a record under a version that can parse it is exercised only via the retry/re-stamp path so far; the positive promotion case is expected to be demonstrated by a party-vocals-capable build reading this sidecar.

I've added a test file so the behavior can be reproduced, just remove the .json extension and place it in the profiles folder. It's set to last tried 0.15 so any nightly build should trigger with it.
[profiles.json.unloaded.json](https://github.com/user-attachments/files/31340076/profiles.json.unloaded.json)

## Sample screenshots of new UI
<img width="1604" height="900" alt="Screenshot 2026-08-21 at 18 05 05" src="https://github.com/user-attachments/assets/ba4e166f-34f7-4bca-b88f-bb5860bdc405" />
<img width="490" height="423" alt="Screenshot 2026-08-22 at 13 53 20" src="https://github.com/user-attachments/assets/78e5edfc-021d-4e9a-87d6-e1a311e35750" />
<img width="799" height="337" alt="Screenshot 2026-08-22 at 13 53 45" src="https://github.com/user-attachments/assets/2c201a94-5e48-4dfe-8d4f-01c79aae3ab8" />
