### PR TITLE
Smooth VisualTime: advance by frame time

### DIFF
--- a/Assets/Script/Playback/SongRunner.cs
+++ b/Assets/Script/Playback/SongRunner.cs
@@ -225,6 +225,16 @@ namespace YARG.Playback
         private double _previousInputTime    = double.MinValue;
         private double _inputSystemTimeFloor = double.NegativeInfinity;
 
+        // Smoothed visual clock. The input system's event timestamps (which drive InputTime)
+        // can advance in bursts due to event coalescing, which makes directly-derived VisualTime
+        // lurch between frames even when frames present at a steady rate. VisualTime instead
+        // advances by frame time and follows the input clock with a bounded correction.
+        private double _smoothedVisualTime = double.NaN;
+
+        private const double VISUAL_SMOOTH_SNAP = 0.1;    // s; snap to target on seeks/rewinds
+        private const double VISUAL_SMOOTH_GAIN = 0.25;   // fraction of remaining error per frame
+        private const double VISUAL_SMOOTH_MAX_CORRECTION = 0.001; // s per frame
+
         #endregion
 
         /// <summary>
@@ -400,7 +410,7 @@ namespace YARG.Playback
             double inputSystemTime = Math.Max(InputManager.InputUpdateTime, _inputSystemTimeFloor);
             InputTime = GetInputTime(inputSystemTime);
             SongTime = InputTime + (AudioCalibration * SongSpeed);
-            VisualTime = InputTime + (VideoCalibration * SongSpeed);
+            VisualTime = SmoothVisualTime(InputTime + (VideoCalibration * SongSpeed));
 
             // Project the frame's input timestamp with the same high-resolution clock used by the
             // mixer control timeline. This avoids measuring frame age as audio drift.
@@ -409,6 +419,30 @@ namespace YARG.Playback
             double controlTargetTime = GetAudioPlaybackTime(syncInputTime);
             double heardTargetTime = controlTargetTime + (AudioCalibration * SongSpeed);
             _audioSynchronizer.Synchronize(controlTargetTime, heardTargetTime, SongSpeed, syncSystemTime);
+        }
+
+        /// <summary>
+        /// Advances the visual clock smoothly. The input-driven target can jump when input
+        /// event timestamps coalesce, so advance by frame time and correct toward the target
+        /// with a bounded, damped adjustment. Snaps on large discontinuities (seeks, rewinds).
+        /// </summary>
+        private double SmoothVisualTime(double targetVisualTime)
+        {
+            if (double.IsNaN(_smoothedVisualTime) ||
+                Math.Abs(targetVisualTime - _smoothedVisualTime) > VISUAL_SMOOTH_SNAP)
+            {
+                _smoothedVisualTime = targetVisualTime;
+                return targetVisualTime;
+            }
+
+            _smoothedVisualTime += Time.deltaTime * SongSpeed;
+
+            double correction = Math.Clamp(
+                (targetVisualTime - _smoothedVisualTime) * VISUAL_SMOOTH_GAIN,
+                -VISUAL_SMOOTH_MAX_CORRECTION, VISUAL_SMOOTH_MAX_CORRECTION);
+            _smoothedVisualTime += correction;
+
+            return _smoothedVisualTime;
         }
 
         /// <summary>
@@ -435,6 +469,7 @@ namespace YARG.Playback
             InputTime = GetInputTime(inputSystemTime);
             SongTime = InputTime + (AudioCalibration * SongSpeed);
             VisualTime = InputTime + (VideoCalibration * SongSpeed);
+            _smoothedVisualTime = VisualTime;
 
             YargLogger.LogFormatDebug(
                 "Set input time base.\n" +


### PR DESCRIPTION
## Problem

I noticed visible stutter of the note highway (and other gameplay visuals) at semi-regular intervals, worse during busy sections, while the framerate counter stays at or above the display refresh rate. Reproduced on Windows/Vulkan, Linux/Vulkan (Steam Deck), and macOS/Metal, at 60 Hz and 120 Hz.

## Root cause

`VisualTime` is computed as a direct function of `InputManager.InputUpdateTime` (captured at input update), not the Unity frame clock. Input event timestamps coalesce at the OS/driver level: that clock sometimes advances ~2 frame-periods in one update and redistributes over subsequent updates. `VisualTime` inherits those jumps, so the animation lurches on frames that were presented perfectly.

Instrumented capture (macOS, Metal, 120 Hz, one song; per-frame log of `Time.deltaTime`, GC counts, and per-frame `VisualTime` deltas):

| Metric | Value |
|---|---|
| Frames captured | 26,894 over 241 s |
| `Time.deltaTime` | median 8.30 ms, p99 16.7 ms — steady 120 Hz presentation |
| Frames where `VisualTime` jumped >1.5× its median step | **1,914 (~7%)** |
| Restricted to frames with perfect `dt` (8.0–8.6 ms) | **921 jumps of ~14.6–15.3 ms** (≈2 frame periods), max 25.9 ms |
| Jump pattern | bursts of 2–4 jumps (~50–100 ms apart), recurring every ~0.2–0.7 s |
| GC collections during the song | 3 — not correlated |

Representative 0.7 s excerpt from the capture (times in ms; the third column is the animation clock's per-frame step — it should read ~8.3 everywhere):

| t | dt | visualDt |
|---|---|---|
| 0.042 | 9.3 | **16.1** |
| 0.066 | 8.5 | 8.4 |
| 0.092 | 8.4 | **15.2** |
| 0.117 | 8.3 | 8.3 |
| 0.142 | 8.4 | **14.9** |
| 0.158 | 16.7 | 10.3 |
| 0.550 | 8.3 | **15.3** |
| 0.592 | 16.7 | 16.8 |
| 0.600 | 8.3 | **15.1** |
| 0.650 | 8.4 | **15.2** |
| 0.692 | 8.3 | **14.6** |
| 0.742 | 8.4 | **15.3** |

Every bolded row is a frame that rendered on time (dt ≈ 8.3 ms) while the animation clock skipped ahead two frame-periods.

Other suspects were: rendering (dt is clean during the jumps), GC (3 collections/song, uncorrelated), main-thread audio stalls (no dt spikes coincide), and the audio-sync rework from #1558/#1589 (it never writes `VisualTime`).

## Fix

`SongRunner.UpdatePlayback` now advances the visual clock by frame time and follows the input clock with a bounded, damped correction:

- advance `_smoothedVisualTime += Time.deltaTime * SongSpeed` each frame;
- correct toward the input-derived target with gain 0.25, clamped to ±1 ms per frame;
- snap to the target on large discontinuities (>0.1 s: seeks, rewind anchors, pause/resume re-anchors; all anchor points also reset the smoother explicitly).

`InputTime`, `SongTime`, and all hit-window/judging logic remain on the authoritative input timestamps, input timing accuracy is untouched. Only the *presentation* timeline is smoothed. The correction is closed-loop, so the visual clock cannot drift from the input clock (steady-state error is a fraction of a millisecond; a 15 ms input-clock jump is spread over ~7 frames at ≤1 ms each).

## After the fix (same capture setup, same song)

| Metric | Before | After |
|---|---|---|
| Smooth-frame (dt 8.0–8.6 ms) `visualDt` | p99 15.0 ms, max 25.9 ms | **p99 9.2 ms, max 9.4 ms** |
| Smooth-frame jumps >12.5 ms | 921 of 22,409 | **0 of 24,185** |
| All-frame jumps >1.5× median | 1,914 | 541 — each coincides with a genuinely dropped frame (visual clock now moves only when frames actually drop) |

Visually: smooth; the only remaining hitches are missed vblanks.

## Testing done

- Instrumented before/after captures as above (macOS, Metal, 120 Hz).
- Play-test on the fixed build: no visible stutter during songs that previously showed it clearly; hit windows subjectively unchanged.
- [pending] Steam Deck (Linux/Vulkan) play-test.

## Notes for reviewers

- The smoothing constants (gain 0.25, ±1 ms/frame, 0.1 s snap) are a little arbitrary, but seemed to work, open to adjustment.
- The probe used for measurement is intentionally not part of this PR. (I can push that as a branch if anyone wants to get the logging code. It might be useful to have it hidden away in a debug menu as an option)
