### PR TITLE
Update PlasticBand-Unity to v0.9.2

### DIFF
--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -33,7 +33,7 @@
     "com.nobi.roundedcorners": "https://github.com/kirevdokimov/Unity-UI-Rounded-Corners.git",
     "com.starasgames.tmpro-dynamic-data-cleaner": "1.0.0",
     "com.thenathannator.hidrogen": "0.5.3",
-    "com.thenathannator.plasticband": "0.9.1",
+    "com.thenathannator.plasticband": "0.9.2",
     "com.unity.2d.sprite": "1.0.0",
     "com.unity.addressables": "2.8.0",
     "com.unity.ai.navigation": "2.0.9",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -75,7 +75,7 @@
       "url": "https://package.openupm.com"
     },
     "com.thenathannator.plasticband": {
-      "version": "0.9.1",
+      "version": "0.9.2",
       "depth": 0,
       "source": "registry",
       "dependencies": {


### PR DESCRIPTION
Fixes Xbox 360 RB1 drumkits being detected as GH kits, and adds a couple IDs for PS CRKD guitars that I missed previously.

([Full release notes](https://github.com/TheNathannator/PlasticBand-Unity/releases/tag/v0.9.2))