### PR TITLE
Move Playable filter from 'Sort By' to 'Filters' menu

### DIFF
--- a/Assets/Script/Menu/Filters/FilterSortDropdownSetting.cs
+++ b/Assets/Script/Menu/Filters/FilterSortDropdownSetting.cs
@@ -26,6 +26,9 @@ namespace YARG.Menu.Filters
                 if (sort == SortAttribute.Unspecified)
                     continue;
 
+                if (sort == SortAttribute.Playable)
+                    continue;
+
                 if (sort == SortAttribute.Playcount && PlayerContainer.OnlyHasBotsActive())
                     continue;
 

--- a/Assets/Script/Menu/Filters/FiltersMenu.cs
+++ b/Assets/Script/Menu/Filters/FiltersMenu.cs
@@ -23,6 +23,7 @@ using YARG.Player;
 using YARG.Playlists;
 using YARG.Song;
 using YARG.Settings;
+using YARG.Settings.Types;
 
 namespace YARG.Menu.Filters
 {
@@ -113,6 +114,7 @@ namespace YARG.Menu.Filters
 
         private readonly Dictionary<FilterKey, FilterCategoryRow> _leftRows = new();
         private Toggle _showRecommendationsToggle;
+        private Toggle _onlyShowPlayableToggle;
 
         private readonly Dictionary<string, bool> _genreEnabled =
             new(StringComparer.OrdinalIgnoreCase);
@@ -184,6 +186,7 @@ namespace YARG.Menu.Filters
         private FilterHelpBarState _lastHelpBarState;
         private bool _pendingHelpBarRefresh;
         private bool _showRecommendationsOnOpen;
+        private bool _onlyShowPlayableOnOpen;
 
         protected override void SingletonAwake()
         {
@@ -217,6 +220,7 @@ namespace YARG.Menu.Filters
             Refresh();
             SaveFilters();
             _showRecommendationsOnOpen = SettingsManager.Settings.ShowRecommendedSongs.Value;
+            _onlyShowPlayableOnOpen = SettingsManager.Settings.OnlyShowPlayableSongs.Value;
             RefreshHelpBar();
         }
 
@@ -353,7 +357,12 @@ namespace YARG.Menu.Filters
             AddHeader(container, Localize.Key("Menu.Filters.OptionsHeader"));
             rowIndex = 0;
             AddDropdown(container, navGroup, Localize.Key("Menu.Filters.SortedBy"))?.AssignIndex(rowIndex++);
-            AddToggle(container, navGroup, Localize.Key("Menu.Filters.ShowRecommendations"))?.AssignIndex(rowIndex++);
+            AddToggle(container, navGroup, Localize.Key("Menu.Filters.ShowRecommendations"),
+                "Filters.ShowRecommendations", SettingsManager.Settings.ShowRecommendedSongs,
+                toggle => _showRecommendationsToggle = toggle)?.AssignIndex(rowIndex++);
+            AddToggle(container, navGroup, Localize.Key("Menu.Filters.OnlyShowPlayableSongs"),
+                "Filters.OnlyShowPlayableSongs", SettingsManager.Settings.OnlyShowPlayableSongs,
+                toggle => _onlyShowPlayableToggle = toggle)?.AssignIndex(rowIndex++);
 
             AddHeader(container, Localize.Key("Menu.Filters.FiltersHeader"));
             rowIndex = 0;
@@ -539,13 +548,14 @@ namespace YARG.Menu.Filters
             return row.GetComponent<BaseSettingVisual>();
         }
 
-        private BaseSettingVisual AddToggle(Transform container, NavigationGroup navGroup, string label)
+        private BaseSettingVisual AddToggle(Transform container, NavigationGroup navGroup, string label,
+            string settingName, ToggleSetting setting, Action<Toggle> assignToggle)
         {
             var prefab = _showRecommendationsTogglePrefab;
             if (prefab == null) return null;
 
             var row = Instantiate(prefab, container);
-            SetupShowRecommendationsToggle(row, label);
+            SetupToggle(row, label, settingName, setting, assignToggle);
 
             var navigatable = row.GetComponent<BaseSettingNavigatable>();
             if (navigatable != null)
@@ -670,7 +680,8 @@ namespace YARG.Menu.Filters
             SetSortedByLabel(row, label);
         }
 
-        public void SetupShowRecommendationsToggle(GameObject row, string label)
+        private static void SetupToggle(GameObject row, string label, string settingName,
+            ToggleSetting setting, Action<Toggle> assignToggle)
         {
             if (row == null)
                 return;
@@ -679,10 +690,9 @@ namespace YARG.Menu.Filters
             if (visual == null)
                 return;
 
-            visual.AssignPresetSetting("Filters.ShowRecommendations", false, SettingsManager.Settings.ShowRecommendedSongs);
+            visual.AssignPresetSetting(settingName, false, setting);
             SetToggleLabel(row, label);
-
-            _showRecommendationsToggle = row.GetComponentInChildren<Toggle>(true);
+            assignToggle?.Invoke(row.GetComponentInChildren<Toggle>(true));
         }
 
         private static void SetSortedByLabel(GameObject row, string label)
@@ -1160,6 +1170,14 @@ namespace YARG.Menu.Filters
         {
             var predicates = new List<Func<SongEntry, bool>>();
 
+            if (SettingsManager.Settings.OnlyShowPlayableSongs.Value)
+            {
+                var playableSongs = SongContainer.GetSortedCategory(SortAttribute.Playable)
+                    .SelectMany(category => category.Songs)
+                    .ToHashSet();
+                predicates.Add(playableSongs.Contains);
+            }
+
             if (TryGetSelectedSet(_genreEnabled, GetAllGenresCached(), NormalizeFilterKey, out var genres))
                 predicates.Add(entry => genres.Contains(entry.Genre.SearchStr));
 
@@ -1243,6 +1261,8 @@ namespace YARG.Menu.Filters
             EnsureAllDefaults();
             SetAllFilters(true);
             SetShowAnyOfFilters(false);
+            SettingsManager.Settings.OnlyShowPlayableSongs.Value = false;
+            _onlyShowPlayableToggle?.SetIsOnWithoutNotify(false);
             UpdateAllSummaries();
 
             // If right panel is visible, update toggles there too
@@ -1691,6 +1711,13 @@ namespace YARG.Menu.Filters
 
             return Localize.Key(IntensityLabelKeys[index]);
         }
+
+        public static string GetStandardIntensityLabel(int intensity)
+        {
+            return intensity >= 0 && intensity < IntensityLabelKeys.Length
+                ? GetIntensityLabelByIndex(intensity)
+                : null;
+        }
 #endregion
 
 #region Playlists
@@ -1840,6 +1867,8 @@ namespace YARG.Menu.Filters
 
             bool showRecommendationsChanged = _showRecommendationsOnOpen !=
                 SettingsManager.Settings.ShowRecommendedSongs.Value;
+            bool onlyShowPlayableChanged = _onlyShowPlayableOnOpen !=
+                SettingsManager.Settings.OnlyShowPlayableSongs.Value;
             // Must check before SaveFilters() so we don't overwrite the previous state
             // otherwise filter changes won't trigger a library refresh
             bool filtersChanged = HaveFiltersChanged();
@@ -1850,7 +1879,7 @@ namespace YARG.Menu.Filters
             if (library != null)
             {
                 library.SetSidebarDifficultiesVisible(true);
-                if (filtersChanged || showRecommendationsChanged)
+                if (filtersChanged || showRecommendationsChanged || onlyShowPlayableChanged)
                 {
                     library.RefreshAndReselect();
                 }

--- a/Assets/Script/Menu/Filters/FiltersMenu.cs
+++ b/Assets/Script/Menu/Filters/FiltersMenu.cs
@@ -1636,6 +1636,7 @@ namespace YARG.Menu.Filters
         {
             var counts = GetIntensityCounts(instrument);
             var ordered = new List<string>(IntensityLabelKeys.Length + 2);
+            var nonstandardIntensities = new SortedSet<int>();
 
             for (int i = 0; i < IntensityLabelKeys.Length; i++)
             {
@@ -1644,9 +1645,17 @@ namespace YARG.Menu.Filters
                     ordered.Add(label);
             }
 
-            var unknownLabel = Localize.Key(IntensityLabelUnknownKey);
-            if (counts.TryGetValue(unknownLabel, out int unknownCount) && unknownCount > 0)
-                ordered.Add(unknownLabel);
+            foreach (var song in SongContainer.Songs)
+            {
+                if (TryGetIntensity(song, instrument, out int intensity) &&
+                    (intensity < 0 || intensity >= IntensityLabelKeys.Length))
+                {
+                    nonstandardIntensities.Add(intensity);
+                }
+            }
+
+            foreach (int intensity in nonstandardIntensities)
+                ordered.Add(GetIntensityLabel(intensity));
 
             var noPartLabel = Localize.Key(IntensityLabelNoPartKey);
             if (counts.TryGetValue(noPartLabel, out int noPartCount) && noPartCount > 0)
@@ -1674,34 +1683,28 @@ namespace YARG.Menu.Filters
 
         private static string GetIntensityLabel(SongEntry entry, Instrument instrument)
         {
+            return TryGetIntensity(entry, instrument, out int intensity)
+                ? GetIntensityLabel(intensity)
+                : Localize.Key(IntensityLabelNoPartKey);
+        }
+
+        private static bool TryGetIntensity(SongEntry entry, Instrument instrument, out int intensity)
+        {
             if (instrument == Instrument.EliteDrums)
             {
                 var preferredInstrument = MidiDrumkitHelper.GetPreferredInstrumentForSong(entry);
                 if (!preferredInstrument.HasValue)
-                    return Localize.Key(IntensityLabelNoPartKey);
+                {
+                    intensity = default;
+                    return false;
+                }
 
-                var preferredPart = entry[preferredInstrument.Value];
-                if (!preferredPart.IsActive())
-                    return Localize.Key(IntensityLabelNoPartKey);
-
-                int preferredIntensity = preferredPart.Intensity;
-                if (preferredIntensity < 0) return Localize.Key(IntensityLabelUnknownKey);
-
-                if (preferredIntensity >= IntensityLabelKeys.Length)
-                    return GetIntensityLabelByIndex(IntensityLabelKeys.Length - 1);
-
-                return GetIntensityLabelByIndex(preferredIntensity);
+                instrument = preferredInstrument.Value;
             }
 
             var part = entry[instrument];
-            if (!part.IsActive()) return Localize.Key(IntensityLabelNoPartKey);
-
-            int intensity = part.Intensity;
-            if (intensity < 0) return Localize.Key(IntensityLabelUnknownKey);
-
-            if (intensity >= IntensityLabelKeys.Length) return GetIntensityLabelByIndex(IntensityLabelKeys.Length - 1);
-
-            return GetIntensityLabelByIndex(intensity);
+            intensity = part.Intensity;
+            return part.IsActive();
         }
 
         private static string GetIntensityLabelByIndex(int index)
@@ -1717,6 +1720,12 @@ namespace YARG.Menu.Filters
             return intensity >= 0 && intensity < IntensityLabelKeys.Length
                 ? GetIntensityLabelByIndex(intensity)
                 : null;
+        }
+
+        public static string GetIntensityLabel(int intensity)
+        {
+            return GetStandardIntensityLabel(intensity) ??
+                Localize.KeyFormat("Menu.MusicLibrary.Sort.Intensity", intensity);
         }
 #endregion
 

--- a/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.SortFilter.cs
+++ b/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.SortFilter.cs
@@ -304,13 +304,15 @@ namespace YARG.Menu.MusicLibrary
             }
 
             SortAttribute nextSort;
-            if (SettingsManager.Settings.LibrarySort >= SortAttribute.Playable)
+            if (SettingsManager.Settings.LibrarySort >= SortAttribute.Random)
             {
                 nextSort = SortAttribute.Name;
             }
             else
             {
                 nextSort = (SortAttribute) ((int) SettingsManager.Settings.LibrarySort + 1);
+                if (nextSort == SortAttribute.Playable)
+                    nextSort = SortAttribute.Random;
             }
 
             ChangeSort(nextSort);
@@ -375,7 +377,7 @@ namespace YARG.Menu.MusicLibrary
                         MenuData.Colors.HeaderSecondary,
                         700);
                 }
-                else if (SettingsManager.Settings.LibrarySort < SortAttribute.Instrument)
+                else
                 {
                     var sortingBy = TextColorer.StyleString("SORTED BY ",
                         MenuData.Colors.HeaderTertiary,
@@ -386,18 +388,6 @@ namespace YARG.Menu.MusicLibrary
                         700);
 
                     _sortInfoHeaderPrimaryText.text = ZString.Concat(sortingBy, sortKey);
-                }
-                else
-                {
-                    var playableSongs = TextColorer.StyleString("PLAYABLE ON ",
-                        MenuData.Colors.HeaderTertiary,
-                        600);
-
-                    var sortKey = TextColorer.StyleString(SettingsManager.Settings.LibrarySort.ToLocalizedName(),
-                        MenuData.Colors.HeaderSecondary,
-                        700);
-
-                    _sortInfoHeaderPrimaryText.text = ZString.Concat(playableSongs, sortKey);
                 }
 
                 string countText;

--- a/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
+++ b/Assets/Script/Menu/MusicLibrary/MusicLibraryMenu.cs
@@ -187,6 +187,18 @@ namespace YARG.Menu.MusicLibrary
         protected override void OnEnable()
         {
             base.OnEnable();
+
+            // Playable Songs used to be a sort that also filtered the library. Preserve that
+            // preference while migrating it to the independent filter.
+            if (SettingsManager.Settings.LibrarySort == SortAttribute.Playable)
+            {
+                SettingsManager.Settings.OnlyShowPlayableSongs.SetValueWithoutNotify(true);
+                var previousSort = SettingsManager.Settings.PreviousLibrarySort;
+                SettingsManager.Settings.LibrarySort = previousSort == SortAttribute.Playable ||
+                    previousSort == SortAttribute.Unspecified
+                    ? SortAttribute.Name
+                    : previousSort;
+            }
             SetSidebarDifficultiesVisible(true);
 
             _heldInputs.Clear();
@@ -612,10 +624,14 @@ namespace YARG.Menu.MusicLibrary
                         };
                     }
 
+                    string shortcutName = SettingsManager.Settings.LibrarySort == SortAttribute.Source
+                        ? displayName
+                        : section.CategoryGroup;
+
                     sortHeader = new SortHeaderViewType(
                         displayName,
                         section.Songs.Length,
-                        section.CategoryGroup,
+                        shortcutName,
                         section.Songs,
                         _collapsedHeaders[SettingsManager.Settings.LibrarySort].Contains(section),
                         onHeaderClicked);

--- a/Assets/Script/Menu/MusicLibrary/PopupMenu.cs
+++ b/Assets/Script/Menu/MusicLibrary/PopupMenu.cs
@@ -389,20 +389,17 @@ namespace YARG.Menu.MusicLibrary
             {
                 // Skip theses because they don't make sense
                 if (sort == SortAttribute.Unspecified)
-                {
                     continue;
-                }
+
+                if (sort == SortAttribute.Playable)
+                    continue;
 
                 // Skip Play count if there are no real players
                 if (sort == SortAttribute.Playcount && PlayerContainer.OnlyHasBotsActive())
-                {
                     continue;
-                }
 
                 if (sort >= SortAttribute.Instrument)
-                {
                     break;
-                }
 
                 CreateItemUnlocalized(sort.ToLocalizedName(), () =>
                 {

--- a/Assets/Script/Player/PlayerContainer.cs
+++ b/Assets/Script/Player/PlayerContainer.cs
@@ -182,9 +182,12 @@ namespace YARG.Player
 
         private static void ActiveProfilesChanged()
         {
-            if (SettingsManager.Settings.LibrarySort == SortAttribute.Playable ||
+            if (SettingsManager.Settings.OnlyShowPlayableSongs.Value ||
                 SettingsManager.Settings.LibrarySort == SortAttribute.Playcount)
             {
+                if (SettingsManager.Settings.OnlyShowPlayableSongs.Value)
+                    FiltersMenu.RefreshActiveFilterPredicate();
+
                 MusicLibraryMenu.SetReload(MusicLibraryReloadState.Full);
             }
 

--- a/Assets/Script/Settings/SettingsManager.Settings.cs
+++ b/Assets/Script/Settings/SettingsManager.Settings.cs
@@ -262,6 +262,7 @@ namespace YARG.Settings
 
             public ToggleSetting ShowFavoriteButton { get; } = new(true);
             public ToggleSetting ShowRecommendedSongs { get; } = new(true, ShowRecommendedSongsCallback);
+            public ToggleSetting OnlyShowPlayableSongs { get; } = new(false, RefreshLibraryFilterCallback);
 
             public DropdownSetting<SongLengthLabelMode> SongLengthLabels { get; }
                 = new(SongLengthLabelMode.RangeLabels, _ => RefreshSongs())
@@ -871,6 +872,27 @@ namespace YARG.Settings
                     return;
                 }
 
+                var library = Object.FindFirstObjectByType<MusicLibraryMenu>();
+                if (library != null)
+                {
+                    library.RefreshAndReselect();
+                }
+                else
+                {
+                    MusicLibraryMenu.SetReload(MusicLibraryReloadState.Partial);
+                }
+            }
+
+            private static void RefreshLibraryFilterCallback(bool value)
+            {
+                if (FiltersMenu.Instance != null && FiltersMenu.Instance.gameObject.activeInHierarchy)
+                {
+                    // Defer refresh until the filters menu closes to avoid switching navigation schemes.
+                    MusicLibraryMenu.SetReload(MusicLibraryReloadState.Partial);
+                    return;
+                }
+
+                FiltersMenu.RefreshActiveFilterPredicate();
                 var library = Object.FindFirstObjectByType<MusicLibraryMenu>();
                 if (library != null)
                 {

--- a/Assets/Script/Song/SongContainer.cs
+++ b/Assets/Script/Song/SongContainer.cs
@@ -907,13 +907,13 @@ namespace YARG.Song
                     if (!intensities.TryGetValue(intensity, out var songs))
                         continue;
 
-                    string label = YARG.Menu.Filters.FiltersMenu.GetStandardIntensityLabel(intensity);
+                    string label = YARG.Menu.Filters.FiltersMenu.GetIntensityLabel(intensity);
                     categories[index++] = new SongCategory(label, songs.ToArray(), label);
                 }
 
                 foreach (var intensity in intensities.Where(pair => pair.Key < 0 || pair.Key > 6))
                 {
-                    string label = Localize.KeyFormat("Menu.MusicLibrary.Sort.Intensity", intensity.Key);
+                    string label = YARG.Menu.Filters.FiltersMenu.GetIntensityLabel(intensity.Key);
                     categories[index++] = new SongCategory(label, intensity.Value.ToArray(), label);
                 }
             }

--- a/Assets/Script/Song/SongContainer.cs
+++ b/Assets/Script/Song/SongContainer.cs
@@ -874,13 +874,13 @@ namespace YARG.Song
             {
                 try
                 {
-                    var arr = new SongCategory[instrument.Value.Count];
+                    var noPart = _songs.Where(song => !song[instrument.Key].IsActive()).ToList();
+                    noPart.Sort(new IntensityComparer(instrument.Key));
+
+                    var arr = new SongCategory[instrument.Value.Count + (noPart.Count > 0 ? 1 : 0)];
                     int index = 0;
-                    foreach (var difficulty in instrument.Value)
-                    {
-                        string categoryName = $"{instrument.Key.ToSortAttribute().ToLocalizedName()} [{difficulty.Key}]";
-                        arr[index++] = new SongCategory(categoryName, difficulty.Value.ToArray(), categoryName);
-                    }
+                    AddIntensityCategories(arr, ref index, instrument.Value);
+                    AddNoPartCategory(arr, ref index, noPart);
                     _sortInstruments.Add(instrument.Key, arr);
                 }
                 catch (Exception ex)
@@ -889,14 +889,42 @@ namespace YARG.Song
                 }
             }
 
-            _sortAggregateDrums = new SongCategory[_sortedSongs.AggregateDrums.Count];
+            var noAggregateDrumsPart = _songs.Where(song => !MidiDrumkitHelper.HasAnyDrumPart(song)).ToList();
+            noAggregateDrumsPart.Sort(new AggregateDrumsIntensityComparer());
+            _sortAggregateDrums = new SongCategory[
+                _sortedSongs.AggregateDrums.Count + (noAggregateDrumsPart.Count > 0 ? 1 : 0)];
             {
                 int index = 0;
-                foreach (var difficulty in _sortedSongs.AggregateDrums)
+                AddIntensityCategories(_sortAggregateDrums, ref index, _sortedSongs.AggregateDrums);
+                AddNoPartCategory(_sortAggregateDrums, ref index, noAggregateDrumsPart);
+            }
+
+            static void AddIntensityCategories(SongCategory[] categories, ref int index,
+                SortedDictionary<int, List<SongEntry>> intensities)
+            {
+                for (int intensity = 0; intensity <= 6; intensity++)
                 {
-                    string categoryName = $"{SortAttribute.AggregateDrums.ToLocalizedName()} [{difficulty.Key}]";
-                    _sortAggregateDrums[index++] = new SongCategory(categoryName, difficulty.Value.ToArray(), categoryName);
+                    if (!intensities.TryGetValue(intensity, out var songs))
+                        continue;
+
+                    string label = YARG.Menu.Filters.FiltersMenu.GetStandardIntensityLabel(intensity);
+                    categories[index++] = new SongCategory(label, songs.ToArray(), label);
                 }
+
+                foreach (var intensity in intensities.Where(pair => pair.Key < 0 || pair.Key > 6))
+                {
+                    string label = Localize.KeyFormat("Menu.MusicLibrary.Sort.Intensity", intensity.Key);
+                    categories[index++] = new SongCategory(label, intensity.Value.ToArray(), label);
+                }
+            }
+
+            static void AddNoPartCategory(SongCategory[] categories, ref int index, List<SongEntry> noPart)
+            {
+                if (noPart.Count == 0)
+                    return;
+
+                string label = Localize.Key("Menu.MusicLibrary.Sort.NoPart");
+                categories[index++] = new SongCategory(label, noPart.ToArray(), label);
             }
 
             static SongEntry[] SetAllSongs(Dictionary<HashWrapper, List<SongEntry>> entries)

--- a/Assets/StreamingAssets/lang/en-US.json
+++ b/Assets/StreamingAssets/lang/en-US.json
@@ -331,6 +331,7 @@
             "PlayableSongs": "PLAYABLE SONGS",
             "RandomSong": "RANDOM SONG",
             "Sort": {
+                "Intensity": "Intensity: {0}",
                 "Unplayed": "Unplayed Songs",
                 "NoPart": "No Part",
                 "Percentage": {
@@ -580,6 +581,7 @@
             "ShowAnyOfHeader": "Show Any Of",
             "SortedBy": "Sorted By",
             "ShowRecommendations": "Show Recommendations",
+            "OnlyShowPlayableSongs": "Only Show Playable Songs",
             "ResetAllFilters": "(Hold) Reset All Filters",
             "SelectAll": "Select All",
             "DeselectAll": "Deselect All",


### PR DESCRIPTION
## Description

### Playable Songs: Sort Option -> Filter

Moved **Playable Songs** from **More Options -> Sort By...** to a persistent **Filters -> Only Show Playable Songs** toggle.  Its value is remembered between game sessions.

Holding **Reset All Filters** disables this option, preserving a single action that restores the complete song library.

The new toggle uses the same playability rules as the former **Playable Songs** sort:

1. With an active **5-Fret Guitar** profile, songs qualify if they contain any compatible chart: Guitar, Bass, Rhythm Guitar, Co-op Guitar, or 5-Lane Keys.  This is based on everything the controller can play, not only the instrument used most recently.

   - This intentionally differs from the **Intensities** filter, which uses the profile's most recently played instrument.  For example, **Intensities -> Warm Up** filters Guitar intensity after playing Guitar.  It will switch to filter on Bass intensity after playing Bass.
   - **Intensities -> No Part** is included as a separate bucket.  Disabling it requires songs to contain the profile's most recently played instrument.
   - These filters can be combined: **Only Show Playable Songs** checks general controller compatibility, while **Intensities** can require a specific instrument or intensity.

2. With active **5-Fret Guitar** and **Vocals** profiles, songs must contain both a guitar-controller-compatible chart and a singable Vocals or Harmony chart.

3. With two active **5-Fret Guitar** profiles, songs need only one compatible chart.  Both players may select the same chart.  Two unique parts *are not* required.

### Instrument Sorting No Longer Filters Songs

Previously, selecting an instrument under **Sort By...** also removed songs without that instrument.  Instrument sorting now includes the complete library and places songs without the selected part in a final **No Part** group.

For example, sorting by **Guitar (5-Fret)** while **Only Show Playable Songs** is enabled may still show Keys-only or Bass-only songs under **No Part**, because those songs remain playable with a five-fret guitar controller.  To require Guitar specifically, disable **Intensities -> No Part** while the active intensity context is Guitar.

Instrument section headers now use the same standard intensity names as the Filters menu:

- **Warm Up**
- **Apprentice**
- **Solid**
- **Moderate**
- **Challenging**
- **Nightmare**
- **Impossible**

Nonstandard intensity values appear afterward in numerical order as **Intensity: -1**, **Intensity: 7**, **Intensity: 8**, and so on.  **No Part** always appears last.

The selected instrument is already shown in the sticky **Sorted By** header, so it is no longer repeated in every intensity section header.

### Source Display Names in Go To Section

When sorting by **Source**, library section headers already displayed the complete source name, but **More Options -> Go To Section...** displayed the raw abbreviated source ID.

The section picker now uses the same derived display names as the visible source headers.

## Screenshots

Playable Songs: Sort Option -> Filter

**Only Show Playable Songs** Filter toggle
<img width="1413" height="919" alt="image" src="https://github.com/user-attachments/assets/1cf54644-469d-4a15-b36f-f95844234ba1" />

**Playable Songs** Changes Numerator Instead of Denominator
<img width="1893" height="1065" alt="image" src="https://github.com/user-attachments/assets/a0bf9ac4-c971-4e6c-99f0-92bdf4c1d88c" />


*(unchanged)* Existing **Intensities ({profile} on {chart})** Filters
<img width="1413" height="726" alt="image" src="https://github.com/user-attachments/assets/8dfff0a7-dcce-4154-b86a-986f38ec4555" />

### Instrument Sorting No Longer Filters Songs

**Sorted By > Guitar (5-Fret)**
- Standard intensity names copied from Filters
- Included **No Part** group, and denominator **Songs** is no longer reduced
- New Group Sort (standard > expanded > **No Part**)
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/a40e001f-d9f5-477d-8a3e-c2e9db966ba0" />

### Source Display Names in **Go To Section**

<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/da0897cf-36c3-44cc-9866-7aa23d3efe02" />