### PR TITLE
Fix Linux microphone scanning

### DIFF
--- a/Assets/Script/Audio/Bass/BassMicManager.cs
+++ b/Assets/Script/Audio/Bass/BassMicManager.cs
@@ -59,6 +59,12 @@ namespace YARG.Audio.BASS
                     return null;
                 }
 
+                if (!IsChannelInRange(device, capture.Channels))
+                {
+                    ReleaseMic(device.DeviceId, device.Channel, capture);
+                    return null;
+                }
+
                 if (!capture.TryClaimChannel(device.Channel))
                 {
                     YargLogger.LogFormatWarning("Mic '{0}' channel {1} is already claimed", device.Name,
@@ -174,7 +180,11 @@ namespace YARG.Audio.BASS
 
                 return BassMicrophoneCapture.WithSystemLock(() =>
                 {
+#if UNITY_EDITOR_LINUX || UNITY_STANDALONE_LINUX
+                    int detected = 2;
+#else
                     int detected = BassMicChannelProbe.DetectChannelCount(deviceId, name) ?? 1;
+#endif
                     _channelCountByDevice[key] = detected;
                     return detected;
                 });
@@ -263,10 +273,17 @@ namespace YARG.Audio.BASS
                 return false;
             }
 
+#if UNITY_EDITOR_LINUX || UNITY_STANDALONE_LINUX
+            if (!IsUsableLinuxDevice(info))
+            {
+                return false;
+            }
+#else
             if (info.Name == "Default")
             {
                 return false;
             }
+#endif
 
             if (info.Name.StartsWith("Loopback", StringComparison.OrdinalIgnoreCase))
             {
@@ -275,6 +292,36 @@ namespace YARG.Audio.BASS
 
             return true;
         }
+
+#if UNITY_EDITOR_LINUX || UNITY_STANDALONE_LINUX
+        private static bool IsLinuxSoundServerDevice(DeviceInfo info)
+        {
+            if (info.IsDefault || info.Name.Equals("Default", StringComparison.OrdinalIgnoreCase) ||
+                info.Name.Equals("Default Audio Device", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            string driver = info.Driver ?? string.Empty;
+            return IsAlsaDevice(driver, "default") || IsAlsaDevice(driver, "pulse") ||
+                IsAlsaDevice(driver, "pipewire");
+        }
+
+        private static bool IsUsableLinuxDevice(DeviceInfo info)
+        {
+            if (IsLinuxSoundServerDevice(info))
+            {
+                return true;
+            }
+
+            string driver = info.Driver ?? string.Empty;
+            return IsAlsaDevice(driver, "hw") || IsAlsaDevice(driver, "plughw");
+        }
+
+        private static bool IsAlsaDevice(string driver, string device) =>
+            driver.Equals(device, StringComparison.OrdinalIgnoreCase) ||
+            driver.StartsWith(device + ":", StringComparison.OrdinalIgnoreCase);
+#endif
 
         private static int FindDeviceIdByName(string name)
         {

--- a/Assets/Script/Audio/Bass/BassMicrophoneCapture.cs
+++ b/Assets/Script/Audio/Bass/BassMicrophoneCapture.cs
@@ -131,6 +131,12 @@ namespace YARG.Audio.BASS
                 Bass.CurrentRecordingDevice = deviceId;
                 int devicePeriod = Bass.GetConfig(Configuration.DevicePeriod);
                 var capture = CreateCapture(deviceId, channels, devicePeriod, ownsDevice);
+#if UNITY_EDITOR_LINUX || UNITY_STANDALONE_LINUX
+                if (capture == null && channels == 2)
+                {
+                    capture = CreateCapture(deviceId, 1, devicePeriod, ownsDevice);
+                }
+#endif
                 if (capture != null)
                 {
                     return capture;


### PR DESCRIPTION
ALSA exposes processing plugins and other pseudo-devices alongside actual capture devices. Probing those entries can be slow, and some plugins such as upmix can crash inside native ALSA code.

List input devices as single-channel inputs without opening each device during scanning; the selected microphone is opened normally afterward.

I always had this scan while scanning for the mics before this commit:
```
ALSA lib control.c:1575:(snd_ctl_open_noupdate) [error.control] Invalid CTL lavrate
ALSA lib control.c:1575:(snd_ctl_open_noupdate) [error.control] Invalid CTL samplerate
ALSA lib control.c:1575:(snd_ctl_open_noupdate) [error.control] Invalid CTL speexrate
ALSA lib control.c:1575:(snd_ctl_open_noupdate) [error.control] Invalid CTL jack
ALSA lib pcm_jack.c:325:(snd_pcm_jack_prepare) [error.] Channel count 0 not equal to no. of ports 2 in JACK
ALSA lib pcm_jack.c:325:(snd_pcm_jack_prepare) [error.] Channel count 0 not equal to no. of ports 2 in JACK
ALSA lib pcm_jack.c:325:(snd_pcm_jack_prepare) [error.] Channel count 0 not equal to no. of ports 2 in JACK
ALSA lib pcm_jack.c:325:(snd_pcm_jack_prepare) [error.] Channel count 0 not equal to no. of ports 2 in JACK
ALSA lib pcm_jack.c:325:(snd_pcm_jack_prepare) [error.] Channel count 0 not equal to no. of ports 2 in JACK
ALSA lib pcm_jack.c:325:(snd_pcm_jack_prepare) [error.] Channel count 0 not equal to no. of ports 2 in JACK
ALSA lib ctl_oss.c:405:(_snd_ctl_oss_open) [error.] Cannot open device /dev/mixer
ALSA lib pcm_oss.c:404:(_snd_pcm_oss_open) [error.] Cannot open device /dev/dsp
ALSA lib pcm_oss.c:404:(_snd_pcm_oss_open) [error.] Cannot open device /dev/dsp
ALSA lib pcm_oss.c:404:(_snd_pcm_oss_open) [error.] Cannot open device /dev/dsp
ALSA lib pcm_oss.c:404:(_snd_pcm_oss_open) [error.] Cannot open device /dev/dsp
ALSA lib pcm_oss.c:404:(_snd_pcm_oss_open) [error.] Cannot open device /dev/dsp
ALSA lib pcm_oss.c:404:(_snd_pcm_oss_open) [error.] Cannot open device /dev/dsp
ALSA lib control.c:1575:(snd_ctl_open_noupdate) [error.control] Invalid CTL speex
ALSA lib control.c:1575:(snd_ctl_open_noupdate) [error.control] Invalid CTL upmix

=================================================================
	Native Crash Reporting
=================================================================
Got a SIGSEGV while executing native code. This usually indicates
a fatal error in the mono runtime or one of the native libraries
used by your application.
=================================================================

=================================================================
	Native stacktrace:
=================================================================
	0x7fb312d1538a - /home/ape/programming/YARG/nightly/yarg_Data/MonoBleedingEdge/x86_64/libmonobdwgc-2.0.so :
	0x7fb312cbdebe - /home/ape/programming/YARG/nightly/yarg_Data/MonoBleedingEdge/x86_64/libmonobdwgc-2.0.so :
	0x7fb312c433c0 - /home/ape/programming/YARG/nightly/yarg_Data/MonoBleedingEdge/x86_64/libmonobdwgc-2.0.so :
	0x7fb31fe3e6f0 - /usr/lib/libc.so.6 :
	0x7fb31c0c31c7 - /usr/lib/libasound.so.2 : snd_pcm_area_copy
	0x7fb31c0c33a4 - /usr/lib/libasound.so.2 : snd_pcm_areas_copy
	0x7fb1a9b6e462 - /usr/lib/alsa-lib/libasound_module_pcm_upmix.so :
	0x7fb1a9b6e98d - /usr/lib/alsa-lib/libasound_module_pcm_upmix.so :
	0x7fb1a9b6e153 - /usr/lib/alsa-lib/libasound_module_pcm_upmix.so :
	0x7fb31c05e9e5 - /usr/lib/libasound.so.2 :
	0x7fb31c0b6f30 - /usr/lib/libasound.so.2 :
	0x7fb31c09b294 - /usr/lib/libasound.so.2 :
	0x7fb31c09b6bd - /usr/lib/libasound.so.2 :
	0x7fb31122d37e - /home/ape/programming/YARG/nightly/yarg_Data/Plugins/libbass.so :

=================================================================
	Telemetry Dumper:
=================================================================
Thread 0x7fb15ffff6c0 may have been prematurely finalized* Assertion at mono-threads.c:702, condition `info' not met, function:mono_thread_info_current,

An error has occured in the native fault reporting. Some diagnostic information will be unavailable.

=================================================================
	Native stacktrace:
=================================================================
	0x7fb312d1538a - /home/ape/programming/YARG/nightly/yarg_Data/MonoBleedingEdge/x86_64/libmonobdwgc-2.0.so :
	0x7fb312e5f80a - /home/ape/programming/YARG/nightly/yarg_Data/MonoBleedingEdge/x86_64/libmonobdwgc-2.0.so : mono_assertion_message_disabled
	0x7fb312e54e40 - /home/ape/programming/YARG/nightly/yarg_Data/MonoBleedingEdge/x86_64/libmonobdwgc-2.0.so :
	0x7fb312e56308 - /home/ape/programming/YARG/nightly/yarg_Data/MonoBleedingEdge/x86_64/libmonobdwgc-2.0.so :
	0x7fb312e02bc0 - /home/ape/programming/YARG/nightly/yarg_Data/MonoBleedingEdge/x86_64/libmonobdwgc-2.0.so :
	0x7fb312d1551d - /home/ape/programming/YARG/nightly/yarg_Data/MonoBleedingEdge/x86_64/libmonobdwgc-2.0.so :
	0x7fb312cbdebe - /home/ape/programming/YARG/nightly/yarg_Data/MonoBleedingEdge/x86_64/libmonobdwgc-2.0.so :
	0x7fb312c433c0 - /home/ape/programming/YARG/nightly/yarg_Data/MonoBleedingEdge/x86_64/libmonobdwgc-2.0.so :
	0x7fb31fe3e6f0 - /usr/lib/libc.so.6 :
	0x7fb31c0c31c7 - /usr/lib/libasound.so.2 : snd_pcm_area_copy
	0x7fb31c0c33a4 - /usr/lib/libasound.so.2 : snd_pcm_areas_copy
	0x7fb1a9b6e462 - /usr/lib/alsa-lib/libasound_module_pcm_upmix.so :
	0x7fb1a9b6e98d - /usr/lib/alsa-lib/libasound_module_pcm_upmix.so :
	0x7fb1a9b6e153 - /usr/lib/alsa-lib/libasound_module_pcm_upmix.so :
	0x7fb31c05e9e5 - /usr/lib/libasound.so.2 :
	0x7fb31c0b6f30 - /usr/lib/libasound.so.2 :
	0x7fb31c09b294 - /usr/lib/libasound.so.2 :
	0x7fb31c09b6bd - /usr/lib/libasound.so.2 :
	0x7fb31122d37e - /home/ape/programming/YARG/nightly/yarg_Data/Plugins/libbass.so :

=================================================================
	External Debugger Dump:
=================================================================
/tmp/mono-gdb-commands.3019735:1: Error in sourced command file:
ptrace: Operation not permitted.

Exiting early due to double fault.
```