### PR TITLE
Fix genre spacer improperly being set to be active

### DIFF
--- a/Assets/Prefabs/Menu/MusicLibrary/MusicLibraryMenu.prefab
+++ b/Assets/Prefabs/Menu/MusicLibrary/MusicLibraryMenu.prefab
@@ -9092,7 +9092,7 @@ MonoBehaviour:
   m_IgnoreLayout: 0
   m_MinWidth: -1
   m_MinHeight: -1
-  m_PreferredWidth: 10
+  m_PreferredWidth: 8
   m_PreferredHeight: 18
   m_FlexibleWidth: -1
   m_FlexibleHeight: -1

--- a/Assets/Script/Menu/MusicLibrary/Sidebar.cs
+++ b/Assets/Script/Menu/MusicLibrary/Sidebar.cs
@@ -361,12 +361,13 @@ namespace YARG.Menu.MusicLibrary
                 _subgenre.fontSize = baseFontSize * shrinkFactor;
             }
 
+            _genreSpacer.SetActive(!string.IsNullOrEmpty(subgenreText));
+
             if (measureText.Length > maxCharsBeforeWrap && !string.IsNullOrEmpty(subgenreText))
             {
                 _genreVerticalLayoutGroup.SetActive(true);
                 _genreHorizontalLayoutGroup.SetActive(false);
                 _genre.transform.SetParent(_genreVerticalLayoutGroup.transform, false);
-                _genreSpacer.SetActive(false);
                 _subgenre.transform.SetParent(_genreVerticalLayoutGroup.transform, false);
             }
             else
@@ -374,7 +375,6 @@ namespace YARG.Menu.MusicLibrary
                 _genreVerticalLayoutGroup.SetActive(false);
                 _genreHorizontalLayoutGroup.SetActive(true);
                 _genre.transform.SetParent(_genreHorizontalLayoutGroup.transform, false);
-                _genreSpacer.SetActive(true);
                 _subgenre.transform.SetParent(_genreHorizontalLayoutGroup.transform, false);
             }
             _genre.transform.SetAsFirstSibling();


### PR DESCRIPTION
Fix regression on this bug:
https://discord.com/channels/1086048856678084609/1517562980538257648

Originally fixed in https://github.com/YARC-Official/YARG/pull/1523 but regressed on 8/18 (the genre+subgenre overflow stuff)