### PR TITLE
Add build preprocessor to fail on missing scripts in scenes and prefabs

### DIFF
--- a/Assets/Editor/Build/MissingScriptBuildValidator.cs
+++ b/Assets/Editor/Build/MissingScriptBuildValidator.cs
@@ -1,0 +1,93 @@
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEditor.Build;
+using UnityEditor.Build.Reporting;
+using UnityEditor.SceneManagement;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+namespace Editor.Build
+{
+    /// <summary>
+    /// Scans all scenes and prefabs for missing C# scripts, throwing an error if any are found.
+    /// Runs automatically at the start of standalone player builds in the Editor and CI (never in Play Mode).
+    /// </summary>
+    public class MissingScriptBuildValidator : IPreprocessBuildWithReport
+    {
+        // Runs early (before default order 0) to fail fast before asset packaging and player compilation.
+        public int callbackOrder => -100;
+
+        public void OnPreprocessBuild(BuildReport report)
+        {
+            ValidateScenes();
+            ValidatePrefabs();
+        }
+
+        private static void ValidateScenes()
+        {
+            var scenesToValidate = new List<string>();
+
+            foreach (var sceneSetting in EditorBuildSettings.scenes)
+            {
+                if (sceneSetting.enabled && !string.IsNullOrEmpty(sceneSetting.path))
+                {
+                    scenesToValidate.Add(sceneSetting.path);
+                }
+            }
+
+            foreach (var scenePath in scenesToValidate)
+            {
+                var scene = SceneManager.GetSceneByPath(scenePath);
+                bool wasLoaded = scene.isLoaded;
+
+                if (!wasLoaded)
+                {
+                    scene = EditorSceneManager.OpenScene(scenePath, OpenSceneMode.Additive);
+                }
+
+                try
+                {
+                    foreach (var root in scene.GetRootGameObjects())
+                    {
+                        ValidateGameObject(root, scenePath);
+                    }
+                }
+                finally
+                {
+                    if (!wasLoaded && scene.IsValid())
+                    {
+                        EditorSceneManager.CloseScene(scene, true);
+                    }
+                }
+            }
+        }
+
+        private static void ValidatePrefabs()
+        {
+            var prefabGuids = AssetDatabase.FindAssets("t:Prefab", new[] { "Assets" });
+            foreach (var guid in prefabGuids)
+            {
+                var path = AssetDatabase.GUIDToAssetPath(guid);
+                var prefab = AssetDatabase.LoadAssetAtPath<GameObject>(path);
+                if (prefab != null)
+                {
+                    ValidateGameObject(prefab, path);
+                }
+            }
+        }
+
+        private static void ValidateGameObject(GameObject targetObject, string assetPath)
+        {
+            var transforms = targetObject.GetComponentsInChildren<Transform>(true);
+            foreach (var transform in transforms)
+            {
+                var current = transform.gameObject;
+                int count = GameObjectUtility.GetMonoBehavioursWithMissingScriptCount(current);
+                if (count > 0)
+                {
+                    throw new BuildFailedException($"Build aborted: Found {count} missing script(s) on '{current.name}' in '{assetPath}'.");
+                }
+            }
+        }
+    }
+}

--- a/Assets/Editor/Build/MissingScriptBuildValidator.cs.meta
+++ b/Assets/Editor/Build/MissingScriptBuildValidator.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2ff1dfa2ba2ce35489e88181fb6aa9f9


### PR DESCRIPTION
We had a nightly build that was broken because it was missing scripts on windows

This preprocessor will treat that as an error instead of a warning.  Normally Unity allows it to be a warning for messy day-to-day editing.  For a nightly build we shouldn't be doing this.

This scans every prefab and scene in the project, looks for components with `Script: None (MonoScript)` which would be caused by a missing .cs file and throws an exception

Only runs when making a build, not when pressing play in editor