### PR TITLE
Fix ASIO init crash on drivers with non-ASCII paths

### DIFF
--- a/Assets/Script/Audio/Bass/Asio/BassAsioDriver.cs
+++ b/Assets/Script/Audio/Bass/Asio/BassAsioDriver.cs
@@ -86,7 +86,16 @@ namespace YARG.Audio.BASS.Asio
 
             var deviceInfo = BassAsio.GetDeviceInfo(_deviceId);
             DriverName = string.IsNullOrWhiteSpace(deviceInfo.Name) ? $"ASIO {_deviceId}" : deviceInfo.Name;
-            DriverId = string.IsNullOrWhiteSpace(deviceInfo.Driver) ? DriverName : deviceInfo.Driver;
+            try
+            {
+                DriverId = string.IsNullOrWhiteSpace(deviceInfo.Driver) ? DriverName : deviceInfo.Driver;
+            }
+            catch (Exception exception)
+            {
+                YargLogger.LogException(exception, "Failed to read ASIO driver path; falling back to the driver name");
+                DriverId = DriverName;
+            }
+
             SampleRate = sampleRate;
             CallbackFrames = Math.Max(1, driverInfo.PreferredBufferLength);
             InputCount = Math.Max(0, driverInfo.Inputs);


### PR DESCRIPTION
## Description
Selecting certain ASIO output devices could fail with "Failed to initialize ASIO: DEVICE. Using Default audio output.", even when the driver itself works correctly outside YARG (verified independently in REAPER).

The root cause is a crash, not a driver problem: `BassAsioDriver.Initialize()` reads the driver's file path via `AsioDeviceInfo.Driver` to build `DriverId`. Under Mono, ManagedBass's `Marshal.PtrToStringAnsi` throws `ExecutionEngineException: Illegal byte sequence` when that path contains non-ASCII bytes.


```
--------------- EXCEPTION ---------------
at BassAsioOutput.cs:Start:115
Failed to start ASIO output
System.ExecutionEngineException: String conversion error: Illegal byte sequence encounted in the input.
  at (wrapper managed-to-native) System.Runtime.InteropServices.Marshal.PtrToStringAnsi(intptr)
  at ManagedBass.Asio.AsioDeviceInfo.PtrToString (System.IntPtr ptr) [0x00014] in <809bd455d7834ae285abc4562d093e07>:0
  at ManagedBass.Asio.AsioDeviceInfo.get_Driver () [0x00000] in <809bd455d7834ae285abc4562d093e07>:0
  at YARG.Audio.BASS.Asio.BassAsioDriver.Initialize () [0x000b3] in Assets/Script/Audio/Bass/Asio/BassAsioDriver.cs:89
  at YARG.Audio.BASS.Asio.BassAsioOutput.Start () [0x00035] in Assets/Script/Audio/Bass/Asio/BassAsioOutput.cs:93
-----------------------------------------
```

RØDE's ASIO driver installs under a path containing "ø", which trips this. The exception went uncaught, aborting ASIO initialization entirely instead of just losing one piece of display metadata.

```
C:\Program Files (x86)\RØDE Microphones\RODECaster ASIO
```

This wraps the `.Driver` read in try/catch and falls back to the already-safe `DriverName` for `DriverId` on failure, logging the exception so the fallback is traceable if it ever affects microphone input matching (`BassAsioOutput.ClaimInput` compares saved mic bindings against `DriverId`).

Tested locally with a RODECaster Pro ASIO driver, which failed to initialize 100% of the time before this change and now initializes successfully.

## Screenshots
<img width="586" height="281" alt="Screenshot 2026-08-28 214753" src="https://github.com/user-attachments/assets/6f6544b5-880f-4114-9371-6bafaf7a8d48" />

