### PR TITLE
Enable dedicated open lane on 5F Guitar

### DIFF
--- a/Assets/Script/Gameplay/Player/DrumsPlayer.cs
+++ b/Assets/Script/Gameplay/Player/DrumsPlayer.cs
@@ -580,7 +580,7 @@ namespace YARG.Gameplay.Player
 
         }
 
-        protected override void InitializeSpawnedLane(LaneElement lane, int laneIndex)
+        protected override void InitializeBRELane(LaneElement lane, int laneIndex)
         {
             int highwayIndex = -1;
             HighwayOrderingInfo highwayOrderingInfo = default;

--- a/Assets/Script/Gameplay/Player/DrumsPlayer.cs
+++ b/Assets/Script/Gameplay/Player/DrumsPlayer.cs
@@ -1026,7 +1026,7 @@ namespace YARG.Gameplay.Player
 
                 if (padToPress is not null)
                 {
-                    _fretArray.SetPressedDrum(padToPress.Value, lowestDelta < DRUM_PAD_FLASH_HOLD_DURATION, GetAnimType(padToPress.Value));
+                    _fretArray.SetPressedImpulse(padToPress.Value, lowestDelta < DRUM_PAD_FLASH_HOLD_DURATION, GetAnimType(padToPress.Value));
                     _fretArray.UpdateAccentColorState(padToPress.Value,
                         _animTypeToPadToLastPressedDelta[Fret.AnimType.CorrectHard][padToPress.Value] <
                         DRUM_PAD_FLASH_HOLD_DURATION);

--- a/Assets/Script/Gameplay/Player/FiveFretGuitarPlayer.cs
+++ b/Assets/Script/Gameplay/Player/FiveFretGuitarPlayer.cs
@@ -30,19 +30,21 @@ namespace YARG.Gameplay.Player
 
         private const int SHIFT_INDICATOR_MEASURES_BEFORE = 5;
 
-        public const int LANE_COUNT = 5;
+        public bool UsingOpenLane { get; private set; }
 
-        private static Dictionary<GuitarAction, FiveFretGuitarFret> _actionToFret = new() {
-            { GuitarAction.Fret1,    FiveFretGuitarFret.Green},
-            { GuitarAction.Fret2,     FiveFretGuitarFret.Red},
-            { GuitarAction.Fret3,   FiveFretGuitarFret.Yellow},
-            { GuitarAction.Fret4,     FiveFretGuitarFret.Blue},
-            { GuitarAction.Fret5,   FiveFretGuitarFret.Orange},
+        private static Dictionary<int, FiveFretGuitarFret> _actionToFret = new() {
+            { YargFiveFretGuitarEngine.OPEN_BRE_INPUT, FiveFretGuitarFret.Open },
+            { (int)GuitarAction.Fret1,                 FiveFretGuitarFret.Green },
+            { (int)GuitarAction.Fret2,                 FiveFretGuitarFret.Red },
+            { (int)GuitarAction.Fret3,                 FiveFretGuitarFret.Yellow },
+            { (int)GuitarAction.Fret4,                 FiveFretGuitarFret.Blue },
+            { (int)GuitarAction.Fret5,                 FiveFretGuitarFret.Orange },
         };
 
         // Record of the most recent time that each BRE lane has been lit up by any of the actions that map to it
         private Dictionary<FiveFretGuitarFret, double> _fretToMostRecentTime = new()
         {
+            { FiveFretGuitarFret.Open,      0 },
             { FiveFretGuitarFret.Green,     0 },
             { FiveFretGuitarFret.Red,       0 },
             { FiveFretGuitarFret.Yellow,    0 },
@@ -53,16 +55,16 @@ namespace YARG.Gameplay.Player
 
         // Key is a FiveFretGuitarFret
         // Value is the fret's lateral position on the fret array
-        private Dictionary<int, int> _lanePositions;
+        private Dictionary<int, int> _highwayOrdering;
 
         private float GetLanePositionOrCentered(int fret)
         {
-            if (_lanePositions.ContainsKey(fret))
+            if (_highwayOrdering.ContainsKey(fret))
             {
-                return _lanePositions[fret];
+                return _highwayOrdering[fret];
             }
 
-            return (LANE_COUNT - 1) / 2;
+            return (LaneCount - 1) / 2;
         }
 
         private FiveFretGuitarFret GetFretIndex(GuitarAction action)
@@ -80,17 +82,8 @@ namespace YARG.Gameplay.Player
 
         public int GetLanePosition(FiveFretGuitarFret fret)
         {
-            return _lanePositions[(int)fret];
+            return _highwayOrdering[(int)fret];
         }
-
-        public static Dictionary<int, int> DEFAULT_HIGHWAY_ORDERING = new()
-            {
-                { (int)FiveFretGuitarFret.Green,     0 },
-                { (int)FiveFretGuitarFret.Red,       1 },
-                { (int)FiveFretGuitarFret.Yellow,    2 },
-                { (int)FiveFretGuitarFret.Blue,      3 },
-                { (int)FiveFretGuitarFret.Orange,    4 }
-            };
 
         public override bool ShouldUpdateInputsOnResume => true;
 
@@ -153,9 +146,6 @@ namespace YARG.Gameplay.Player
             {
                 _stem = SongStem.Rhythm;
             }
-
-            BRELanes = new LaneElement[LANE_COUNT];
-            LaneCount = LANE_COUNT;
 
             base.Initialize(index, player, chart, trackView, mixer, currentHighScore);
         }
@@ -236,8 +226,8 @@ namespace YARG.Gameplay.Player
 
 
             _fretArray.Initialize(
-                _lanePositions,
-                LANE_COUNT,
+                _highwayOrdering,
+                LaneCount,
                 null,
                 Player.ColorProfile.FiveFretGuitar,
                 Player.ThemePreset,
@@ -274,9 +264,9 @@ namespace YARG.Gameplay.Player
 
         protected override void ResetLastHitTimes()
         {
-            foreach (var fret in _lanePositions.Keys)
+            foreach (var fret in _highwayOrdering.Keys)
             {
-                _fretToMostRecentTime[(FiveFretGuitarFret) fret] = 0;
+                _fretToMostRecentTime[(FiveFretGuitarFret)fret] = 0;
             }
         }
 
@@ -292,9 +282,9 @@ namespace YARG.Gameplay.Player
             if (Engine.IsCodaActive)
             {
                 // Set emission color of BRE lanes depending on currently available score value
-                foreach (var (breLaneIndex, highwayOrderingIndex) in _lanePositions)
+                foreach (var (fret, highwayOrderingIndex) in _highwayOrdering)
                 {
-                    var mostRecentTime = _fretToMostRecentTime[(FiveFretGuitarFret)breLaneIndex];
+                    var mostRecentTime = _fretToMostRecentTime[(FiveFretGuitarFret)fret];
                     var normalizedTimeSinceLastHit = CodaSection.GetNormalizedTimeSinceLastHit(visualTime, mostRecentTime);
                     BRELanes[highwayOrderingIndex].SetEmissionColor(normalizedTimeSinceLastHit);
                 }
@@ -361,7 +351,7 @@ namespace YARG.Gameplay.Player
             if (nextShift.Time <= visualTime)
             {
                 _rangeShiftEventQueue.Dequeue();
-                foreach (var fretIndex in _lanePositions.Keys)
+                foreach (var fretIndex in _highwayOrdering.Keys)
                 {
                     _fretArray.SetFretColorPulse(fretIndex, false, (float) nextShift.BeatDuration);
                 }
@@ -450,20 +440,43 @@ namespace YARG.Gameplay.Player
                 Player.Profile.CurrentInstrument,
                 note.LaneNote,
                 GetLanePositionOrCentered(note.Fret),
-                LANE_COUNT,
+                LaneCount,
                 Player.ColorProfile.FiveFretGuitar.GetNoteColor(note.Fret).ToUnityColor()
             );
         }
 
-        protected override void InitializeSpawnedLane(LaneElement lane, int laneIndex)
+        // TrackPlayer doesn't know how each player subclass handles highway orderings; all it knows
+        // is the number of BRE lanes. It's naively giving us laneIndices from 0 to n, where n is
+        // LaneCount-1. 0 represents the left side of the highway and n represents the right. That's
+        // the position that's represented by the values in _highwayOrdering, but we want to operate
+        // over the dictionary keys, not values. Thus, we need to answer the question of "what fret
+        // lives at the position we're being given?"
+        protected override void InitializeBRELane(LaneElement lane, int laneIndex)
         {
-            var index = Player.Profile.LeftyFlip ? (LANE_COUNT - 1) - laneIndex : laneIndex;
+            int lanedFret = -1;
+
+            foreach (var (fret, position) in _highwayOrdering)
+            {
+                if (position == laneIndex)
+                {
+                    lanedFret = fret;
+                    break;
+                }
+            }
+
+            if (lanedFret == -1)
+            {
+                YargLogger.LogError("Tried to make a BRE lane for a fret with no highway position.");
+                return;
+            }
+
+            
             lane.SetAppearance(
                 Player.Profile.CurrentInstrument,
+                lanedFret,
                 laneIndex,
-                laneIndex,
-                LANE_COUNT,
-                Player.ColorProfile.FiveFretGuitar.GetNoteColor(index + 1).ToUnityColor());
+                LaneCount,
+                Player.ColorProfile.FiveFretGuitar.GetNoteColor(lanedFret).ToUnityColor());
         }
 
         protected override void ModifyLaneFromNote(LaneElement lane, GuitarNote note)
@@ -485,7 +498,7 @@ namespace YARG.Gameplay.Player
 
         private void OnLaneHit(int action)
         {
-            var asFret = _actionToFret[(GuitarAction)action];
+            var asFret = _actionToFret[action];
 
             _fretToMostRecentTime[asFret] = GameManager.VisualTime;
             _fretArray.PlayCodaHitAnimation((int)asFret);
@@ -495,6 +508,17 @@ namespace YARG.Gameplay.Player
         {
             base.OnCodaStart(coda);
             CurrentCoda.OnLaneHit += OnLaneHit;
+
+            CurrentCoda.SetLaneIndexes(new()
+            {
+                // Open forwards its inputs to the green scoring zone
+                { YargFiveFretGuitarEngine.OPEN_BRE_INPUT, (int)FiveFretGuitarFret.Green },
+                { (int)GuitarAction.GreenFret, (int)FiveFretGuitarFret.Green },
+                { (int)GuitarAction.RedFret, (int)FiveFretGuitarFret.Red },
+                { (int)GuitarAction.YellowFret, (int)FiveFretGuitarFret.Yellow },
+                { (int)GuitarAction.BlueFret, (int)FiveFretGuitarFret.Blue },
+                { (int)GuitarAction.OrangeFret, (int)FiveFretGuitarFret.Orange },
+            });
 
             _fretArray.SetBreMode(true);
         }
@@ -859,7 +883,7 @@ namespace YARG.Gameplay.Player
         private void SetDefaultActiveFrets()
         {
             var newFrets = new List<int>();
-            foreach (var fretIdx in _lanePositions.Keys)
+            foreach (var fretIdx in _highwayOrdering.Keys)
             {
                 newFrets.Add(fretIdx);
             }
@@ -873,19 +897,25 @@ namespace YARG.Gameplay.Player
 
         private void MakeHighwayOrdering()
         {
-            if (Player.Profile.LeftyFlip)
+            UsingOpenLane = GryboHighwayHelpers.ShouldUseOpenLane(Player.Profile.OpenLaneDisplayType, NoteTrack.Notes);
+
+            LaneCount = UsingOpenLane ? 6 : 5;
+            BRELanes = new LaneElement[LaneCount];
+
+            switch ((UsingOpenLane, Player.Profile.LeftyFlip))
             {
-                _lanePositions = new()
-                {
-                    { (int)FiveFretGuitarFret.Orange,    0 },
-                    { (int)FiveFretGuitarFret.Blue,      1 },
-                    { (int)FiveFretGuitarFret.Yellow,    2 },
-                    { (int)FiveFretGuitarFret.Red,       3 },
-                    { (int)FiveFretGuitarFret.Green,     4 }
-                };
-            } else
-            {
-                _lanePositions = DEFAULT_HIGHWAY_ORDERING;
+                case (false, false):
+                    _highwayOrdering = GryboHighwayHelpers.DEFAULT_HIGHWAY_ORDERING;
+                    break;
+                case (false, true):
+                    _highwayOrdering = GryboHighwayHelpers.LEFTY_HIGHWAY_ORDERING;
+                    break;
+                case (true, false):
+                    _highwayOrdering = GryboHighwayHelpers.OPEN_LANE_HIGHWAY_ORDERING;
+                    break;
+                case (true, true):
+                    _highwayOrdering = GryboHighwayHelpers.OPEN_LANE_LEFTY_HIGHWAY_ORDERING;
+                    break;
             }
         }
     }

--- a/Assets/Script/Gameplay/Player/FiveFretGuitarPlayer.cs
+++ b/Assets/Script/Gameplay/Player/FiveFretGuitarPlayer.cs
@@ -481,7 +481,7 @@ namespace YARG.Gameplay.Player
 
         protected override void ModifyLaneFromNote(LaneElement lane, GuitarNote note)
         {
-            if (note.Fret is (int) FiveFretGuitarFret.Open or (int) FiveFretGuitarFret.Wildcard)
+            if (NoteIsFullWidth(note))
             {
                 lane.ToggleFullWidth(true);
             }
@@ -501,7 +501,15 @@ namespace YARG.Gameplay.Player
             var asFret = _actionToFret[action];
 
             _fretToMostRecentTime[asFret] = GameManager.VisualTime;
-            _fretArray.PlayCodaHitAnimation((int)asFret);
+
+            if (asFret is FiveFretGuitarFret.Open && !UsingOpenLane)
+            {
+                _fretArray.PlayFullWidthHitAnimation();
+            }
+            else
+            {
+                _fretArray.PlayCodaHitAnimation((int) asFret);
+            }
         }
 
         protected override void OnCodaStart(CodaSection coda)
@@ -541,13 +549,13 @@ namespace YARG.Gameplay.Player
             {
                 (NotePool.GetByKey(note) as FiveFretGuitarNoteElement)?.HitNote();
 
-                if (note.Fret != (int) FiveFretGuitarFret.Open && note.Fret != (int) FiveFretGuitarFret.Wildcard)
+                if (NoteIsFullWidth(note))
                 {
-                    _fretArray.PlayHitAnimation(note.Fret);
+                    _fretArray.PlayFullWidthHitAnimation();
                 }
                 else
                 {
-                    _fretArray.PlayOpenHitAnimation();
+                    _fretArray.PlayHitAnimation(note.Fret);
                 }
             }
         }
@@ -615,7 +623,14 @@ namespace YARG.Gameplay.Player
             // Play open-strum miss if no frets are held
             if (!anyHeld)
             {
-                _fretArray.PlayOpenMissAnimation();
+                if (UsingOpenLane)
+                {
+                    _fretArray.PlayMissAnimation((int)FiveFretGuitarFret.Open);
+                }
+                else
+                {
+                    _fretArray.PlayFullWidthMissAnimation();
+                }
             }
         }
 
@@ -629,13 +644,8 @@ namespace YARG.Gameplay.Player
                     continue;
                 }
 
-                if (note.Fret != (int) FiveFretGuitarFret.Open && note.Fret != (int) FiveFretGuitarFret.Wildcard)
+                if (NoteIsFullWidth(note))
                 {
-                    _fretArray.SetSustained(note.Fret, true);
-                }
-                else
-                {
-                    // Must be an open or wildcard
                     if (note.Fret == (int) FiveFretGuitarFret.Open)
                     {
                         StrikelineAnimator.SetParticleColor(Player.ColorProfile.FiveFretGuitar.GetNoteColor(note.Fret).ToUnityColor());
@@ -646,6 +656,10 @@ namespace YARG.Gameplay.Player
                     }
 
                     StrikelineAnimator.SetSustaining(true);
+                }
+                else
+                {
+                    _fretArray.SetSustained(note.Fret, true);
                 }
 
                 _sustainCount++;
@@ -664,14 +678,13 @@ namespace YARG.Gameplay.Player
 
                 (NotePool.GetByKey(note) as FiveFretGuitarNoteElement)?.SustainEnd(finished);
 
-                if (note.Fret != (int) FiveFretGuitarFret.Open && note.Fret != (int) FiveFretGuitarFret.Wildcard)
+                if (NoteIsFullWidth(note))
                 {
-                    _fretArray.SetSustained(note.Fret, false);
+                    StrikelineAnimator.SetSustaining(false);
                 }
                 else
                 {
-                    // Must be an open or wildcard
-                    StrikelineAnimator.SetSustaining(false);
+                    _fretArray.SetSustained(note.Fret, false);
                 }
 
                 _sustainCount--;
@@ -860,6 +873,16 @@ namespace YARG.Gameplay.Player
                 // In case we have no samples for this shift event, 0.5 is a reasonable default
                 shift.BeatDuration = firstBeatTime < double.MaxValue ? (lastBeatTime - firstBeatTime) / SHIFT_INDICATOR_MEASURES_BEFORE : 0.5;
             }
+        }
+
+        public bool NoteIsFullWidth(GuitarNote note)
+        {
+            return note.Fret switch
+            {
+                (int) FiveFretGuitarFret.Open => !UsingOpenLane,
+                (int) FiveFretGuitarFret.Wildcard => true,
+                _ => false
+            };
         }
 
         private void SetActiveFretsForShiftEvent(FiveFretRangeShift range)

--- a/Assets/Script/Gameplay/Player/FiveFretGuitarPlayer.cs
+++ b/Assets/Script/Gameplay/Player/FiveFretGuitarPlayer.cs
@@ -396,7 +396,7 @@ namespace YARG.Gameplay.Player
                 var openInputDelta = GameManager.VisualTime - _fretToMostRecentTime[FiveFretGuitarFret.Open];
 
 
-                _fretArray.SetPressedDrum(
+                _fretArray.SetPressedImpulse(
                     (int) FiveFretGuitarFret.Open,
                     _openSustaining || (openInputDelta < DEDICATED_OPEN_FLASH_HOLD_DURATION),
                     Fret.AnimType.CorrectNormal
@@ -974,14 +974,6 @@ namespace YARG.Gameplay.Player
                     _highwayOrdering = GryboHighwayHelpers.OPEN_LANE_LEFTY_HIGHWAY_ORDERING;
                     break;
             }
-        }
-
-        // It's not possible to hold an open note (no, holding the strum bar down doesn't count),
-        // so the dedicated open lane needs the same visual trick we use on drums to make it look
-        // fully lit when hit
-        private void ZeroOutOpenHitTime()
-        {
-
         }
     }
 }

--- a/Assets/Script/Gameplay/Player/FiveFretGuitarPlayer.cs
+++ b/Assets/Script/Gameplay/Player/FiveFretGuitarPlayer.cs
@@ -28,6 +28,8 @@ namespace YARG.Gameplay.Player
     {
         private const double SUSTAIN_END_MUTE_THRESHOLD = 0.1;
 
+        private const double DEDICATED_OPEN_FLASH_HOLD_DURATION = 0.05;
+
         private const int SHIFT_INDICATOR_MEASURES_BEFORE = 5;
 
         public bool UsingOpenLane { get; private set; }
@@ -44,7 +46,7 @@ namespace YARG.Gameplay.Player
         // Record of the most recent time that each BRE lane has been lit up by any of the actions that map to it
         private Dictionary<FiveFretGuitarFret, double> _fretToMostRecentTime = new()
         {
-            { FiveFretGuitarFret.Open,      0 },
+            { FiveFretGuitarFret.Open,      0 }, // We'll also use this for driving the dedicated open fret's "flashing" effect, like on drums
             { FiveFretGuitarFret.Green,     0 },
             { FiveFretGuitarFret.Red,       0 },
             { FiveFretGuitarFret.Yellow,    0 },
@@ -56,6 +58,9 @@ namespace YARG.Gameplay.Player
         // Key is a FiveFretGuitarFret
         // Value is the fret's lateral position on the fret array
         private Dictionary<int, int> _highwayOrdering;
+
+        // Used to control fret brightness for the dedicated open lane
+        private bool _openSustaining = false;
 
         private float GetLanePositionOrCentered(int fret)
         {
@@ -268,6 +273,8 @@ namespace YARG.Gameplay.Player
             {
                 _fretToMostRecentTime[(FiveFretGuitarFret)fret] = 0;
             }
+
+
         }
 
         public override void SetReplayTime(double time)
@@ -382,7 +389,18 @@ namespace YARG.Gameplay.Player
         {
             for (var action = GuitarAction.GreenFret; action <= GuitarAction.OrangeFret; action++)
             {
-                _fretArray.SetPressed((int)GetFretIndex(action), Engine.IsFretHeld(action));
+                _fretArray.SetPressed((int) GetFretIndex(action), Engine.IsFretHeld(action));
+            }
+
+            if (UsingOpenLane) {
+                var openInputDelta = GameManager.VisualTime - _fretToMostRecentTime[FiveFretGuitarFret.Open];
+
+
+                _fretArray.SetPressedDrum(
+                    (int) FiveFretGuitarFret.Open,
+                    _openSustaining || (openInputDelta < DEDICATED_OPEN_FLASH_HOLD_DURATION),
+                    Fret.AnimType.CorrectNormal
+                );
             }
         }
 
@@ -555,6 +573,11 @@ namespace YARG.Gameplay.Player
                 }
                 else
                 {
+                    if (note.Fret is (int) FiveFretGuitarFret.Open)
+                    {
+                        _fretToMostRecentTime[FiveFretGuitarFret.Open] = GameManager.VisualTime;
+                    }
+
                     _fretArray.PlayHitAnimation(note.Fret);
                 }
             }
@@ -626,6 +649,7 @@ namespace YARG.Gameplay.Player
                 if (UsingOpenLane)
                 {
                     _fretArray.PlayMissAnimation((int)FiveFretGuitarFret.Open);
+                    _fretToMostRecentTime[FiveFretGuitarFret.Open] = GameManager.VisualTime;
                 }
                 else
                 {
@@ -644,9 +668,14 @@ namespace YARG.Gameplay.Player
                     continue;
                 }
 
+                if (note.Fret is (int) FiveFretGuitarFret.Open)
+                {
+                    _openSustaining = true;
+                }
+
                 if (NoteIsFullWidth(note))
                 {
-                    if (note.Fret == (int) FiveFretGuitarFret.Open)
+                    if (note.Fret is (int) FiveFretGuitarFret.Open)
                     {
                         StrikelineAnimator.SetParticleColor(Player.ColorProfile.FiveFretGuitar.GetNoteColor(note.Fret).ToUnityColor());
                     }
@@ -677,6 +706,11 @@ namespace YARG.Gameplay.Player
                 }
 
                 (NotePool.GetByKey(note) as FiveFretGuitarNoteElement)?.SustainEnd(finished);
+
+                if (note.Fret is (int) FiveFretGuitarFret.Open)
+                {
+                    _openSustaining = false;
+                }
 
                 if (NoteIsFullWidth(note))
                 {
@@ -940,6 +974,14 @@ namespace YARG.Gameplay.Player
                     _highwayOrdering = GryboHighwayHelpers.OPEN_LANE_LEFTY_HIGHWAY_ORDERING;
                     break;
             }
+        }
+
+        // It's not possible to hold an open note (no, holding the strum bar down doesn't count),
+        // so the dedicated open lane needs the same visual trick we use on drums to make it look
+        // fully lit when hit
+        private void ZeroOutOpenHitTime()
+        {
+
         }
     }
 }

--- a/Assets/Script/Gameplay/Player/FiveLaneKeysPlayer.cs
+++ b/Assets/Script/Gameplay/Player/FiveLaneKeysPlayer.cs
@@ -35,17 +35,8 @@ namespace YARG.Assets.Script.Gameplay.Player
         // Value is the fret's lateral position on the fret array
         private Dictionary<int, int> _highwayOrdering;
 
-
-        // When an action happens, we'll use this to determine which _actionToMostRecentTime entry to update
-        // This is usually 1:1, but if there's no dedicated open lane enabled, then we'll redirect open note inputs to the
-        // green lane visuals because they share a notional scoring zone behind the scenes
-        private Dictionary<FiveLaneKeysAction, FiveLaneKeysBreLaneIndex> _actionToBreLaneIndex = new();
-
-        // When a BRE lane element needs to know how bright it should be, it'll use this table to get the right BRE lane index
-        private Dictionary<int, FiveLaneKeysBreLaneIndex> _highwayOrderingIndexToBreLaneIndex;
-
         // Record of the most recent time that each BRE lane has been lit up by any of the actions that map to it
-        private Dictionary<FiveLaneKeysBreLaneIndex, double> _breLaneIndexToMostRecentTime = new();
+        private Dictionary<FiveFretGuitarFret, double> _fretToMostRecentTime = new();
 
         private float GetLanePositionOrCentered(int fret)
         {
@@ -255,9 +246,9 @@ namespace YARG.Assets.Script.Gameplay.Player
 
         protected override void ResetLastHitTimes()
         {
-            foreach (var breLaneIndex in _highwayOrderingIndexToBreLaneIndex.Values)
+            foreach (var fret in _highwayOrdering.Keys)
             {
-                _breLaneIndexToMostRecentTime[breLaneIndex] = 0;
+                _fretToMostRecentTime[(FiveFretGuitarFret)fret] = 0;
             }
         }
 
@@ -272,9 +263,9 @@ namespace YARG.Assets.Script.Gameplay.Player
             if (Engine.IsCodaActive)
             {
                 // Set emission color of BRE lanes depending on time since last hit
-                foreach (var (highwayOrderingIndex, breLaneIndex) in _highwayOrderingIndexToBreLaneIndex)
+                foreach (var (fret, highwayOrderingIndex) in _highwayOrdering)
                 {
-                    var mostRecentTime = _breLaneIndexToMostRecentTime[breLaneIndex];
+                    var mostRecentTime = _fretToMostRecentTime[(FiveFretGuitarFret)fret];
                     var normalizedTimeSinceLastHit = CodaSection.GetNormalizedTimeSinceLastHit(visualTime, mostRecentTime);
                     BRELanes[highwayOrderingIndex].SetEmissionColor(normalizedTimeSinceLastHit);
                 }
@@ -489,11 +480,18 @@ namespace YARG.Assets.Script.Gameplay.Player
 
         private void OnLaneHit(int action)
         {
-            var breIndex = _actionToBreLaneIndex[(FiveLaneKeysAction)action];
+            var asFret = GetFretIndex((FiveLaneKeysAction)action);
 
-            _breLaneIndexToMostRecentTime[breIndex] = GameManager.VisualTime;
+            _fretToMostRecentTime[asFret] = GameManager.VisualTime;
 
-            _fretArray.PlayCodaHitAnimation((int)((FiveLaneKeysAction)action).ToFret());
+            if (asFret is FiveFretGuitarFret.Open && !UsingOpenLane)
+            {
+                _fretArray.PlayFullWidthHitAnimation();
+            }
+            else
+            {
+                _fretArray.PlayCodaHitAnimation((int)((FiveLaneKeysAction)action).ToFret());
+            }
         }
 
         protected override void OnCodaStart(CodaSection coda)
@@ -503,12 +501,12 @@ namespace YARG.Assets.Script.Gameplay.Player
             CurrentCoda.SetLaneIndexes(new()
             {
                 // Open forwards its inputs to the green scoring zone, since opens aren't supposed to be part of 5LK
-                {(int)FiveLaneKeysAction.OpenNote, (int)FiveLaneKeysBreLaneIndex.Green },
-                {(int)FiveLaneKeysAction.GreenKey, (int)FiveLaneKeysBreLaneIndex.Green },
-                {(int)FiveLaneKeysAction.RedKey, (int)FiveLaneKeysBreLaneIndex.Red },
-                {(int)FiveLaneKeysAction.YellowKey, (int)FiveLaneKeysBreLaneIndex.Yellow },
-                {(int)FiveLaneKeysAction.BlueKey, (int)FiveLaneKeysBreLaneIndex.Blue },
-                {(int)FiveLaneKeysAction.OrangeKey, (int)FiveLaneKeysBreLaneIndex.Orange },
+                {(int)FiveLaneKeysAction.OpenNote, (int)FiveFretGuitarFret.Green },
+                {(int)FiveLaneKeysAction.GreenKey, (int)FiveFretGuitarFret.Green },
+                {(int)FiveLaneKeysAction.RedKey, (int)FiveFretGuitarFret.Red },
+                {(int)FiveLaneKeysAction.YellowKey, (int)FiveFretGuitarFret.Yellow },
+                {(int)FiveLaneKeysAction.BlueKey, (int)FiveFretGuitarFret.Blue },
+                {(int)FiveLaneKeysAction.OrangeKey, (int)FiveFretGuitarFret.Orange },
             });
 
             _fretArray.SetBreMode(true);
@@ -836,58 +834,12 @@ namespace YARG.Assets.Script.Gameplay.Player
             {
                 LaneCount = 6;
                 _highwayOrdering = GryboHighwayHelpers.OPEN_LANE_HIGHWAY_ORDERING;
-                _actionToBreLaneIndex = new()
-                {
-                    { FiveLaneKeysAction.OpenNote, FiveLaneKeysBreLaneIndex.Open },
-                    { FiveLaneKeysAction.GreenKey, FiveLaneKeysBreLaneIndex.Green },
-                    { FiveLaneKeysAction.RedKey, FiveLaneKeysBreLaneIndex.Red },
-                    { FiveLaneKeysAction.YellowKey, FiveLaneKeysBreLaneIndex.Yellow },
-                    { FiveLaneKeysAction.BlueKey, FiveLaneKeysBreLaneIndex.Blue },
-                    { FiveLaneKeysAction.OrangeKey, FiveLaneKeysBreLaneIndex.Orange },
-                };
-
-                _highwayOrderingIndexToBreLaneIndex = new()
-                {
-                    { _highwayOrdering[(int)FiveFretGuitarFret.Open], FiveLaneKeysBreLaneIndex.Open },
-                    { _highwayOrdering[(int)FiveFretGuitarFret.Green], FiveLaneKeysBreLaneIndex.Green },
-                    { _highwayOrdering[(int)FiveFretGuitarFret.Red], FiveLaneKeysBreLaneIndex.Red },
-                    { _highwayOrdering[(int)FiveFretGuitarFret.Yellow], FiveLaneKeysBreLaneIndex.Yellow },
-                    { _highwayOrdering[(int)FiveFretGuitarFret.Blue], FiveLaneKeysBreLaneIndex.Blue },
-                    { _highwayOrdering[(int)FiveFretGuitarFret.Orange], FiveLaneKeysBreLaneIndex.Orange },
-                };
             }
             else
             {
                 LaneCount = 5;
                 _highwayOrdering = GryboHighwayHelpers.DEFAULT_HIGHWAY_ORDERING;
-                _actionToBreLaneIndex = new()
-                {
-                    { FiveLaneKeysAction.OpenNote, FiveLaneKeysBreLaneIndex.Green },
-                    { FiveLaneKeysAction.GreenKey, FiveLaneKeysBreLaneIndex.Green },
-                    { FiveLaneKeysAction.RedKey, FiveLaneKeysBreLaneIndex.Red },
-                    { FiveLaneKeysAction.YellowKey, FiveLaneKeysBreLaneIndex.Yellow },
-                    { FiveLaneKeysAction.BlueKey, FiveLaneKeysBreLaneIndex.Blue },
-                    { FiveLaneKeysAction.OrangeKey, FiveLaneKeysBreLaneIndex.Orange },
-                };
-
-                _highwayOrderingIndexToBreLaneIndex = new()
-                {
-                    { _highwayOrdering[(int)FiveFretGuitarFret.Green], FiveLaneKeysBreLaneIndex.Green },
-                    { _highwayOrdering[(int)FiveFretGuitarFret.Red], FiveLaneKeysBreLaneIndex.Red },
-                    { _highwayOrdering[(int)FiveFretGuitarFret.Yellow], FiveLaneKeysBreLaneIndex.Yellow },
-                    { _highwayOrdering[(int)FiveFretGuitarFret.Blue], FiveLaneKeysBreLaneIndex.Blue },
-                    { _highwayOrdering[(int)FiveFretGuitarFret.Orange], FiveLaneKeysBreLaneIndex.Orange },
-                };
             }
-        }
-        private enum FiveLaneKeysBreLaneIndex
-        {
-            Open, // Not scored, only visually exists if the Dedicated Open Lane setting is enabled
-            Green,
-            Red,
-            Yellow,
-            Blue,
-            Orange
         }
     }
 }

--- a/Assets/Script/Gameplay/Player/FiveLaneKeysPlayer.cs
+++ b/Assets/Script/Gameplay/Player/FiveLaneKeysPlayer.cs
@@ -533,7 +533,7 @@ namespace YARG.Assets.Script.Gameplay.Player
 
             if (!IsNormalNote(note))
             {
-                _fretArray.PlayOpenHitAnimation();
+                _fretArray.PlayFullWidthHitAnimation();
             }
             else
             {
@@ -554,7 +554,7 @@ namespace YARG.Assets.Script.Gameplay.Player
 
             if (key is (int) FiveLaneKeysAction.OpenNote && !UsingOpenLane)
             {
-                _fretArray.PlayOpenMissAnimation();
+                _fretArray.PlayFullWidthMissAnimation();
             }
             else
             {

--- a/Assets/Script/Gameplay/Player/FiveLaneKeysPlayer.cs
+++ b/Assets/Script/Gameplay/Player/FiveLaneKeysPlayer.cs
@@ -84,17 +84,7 @@ namespace YARG.Assets.Script.Gameplay.Player
                 note.FiveLaneKeysAction is not FiveLaneKeysAction.Wildcard;
         }
 
-        private static Dictionary<int, int> OPEN_LANE_HIGHWAY_ORDERING = new()
-        {
-            { (int) FiveFretGuitarFret.Open,    0 },
-            { (int) FiveFretGuitarFret.Green,   1 },
-            { (int) FiveFretGuitarFret.Red,     2 },
-            { (int) FiveFretGuitarFret.Yellow,  3 },
-            { (int) FiveFretGuitarFret.Blue,    4 },
-            { (int) FiveFretGuitarFret.Orange,  5 }
-        };
-
-public override bool ShouldUpdateInputsOnResume => true;
+        public override bool ShouldUpdateInputsOnResume => true;
 
         /// See <see cref="StarMultiplierThresholds"/>
         private static float[] GuitarStarMultiplierThresholds => new[]
@@ -456,7 +446,7 @@ public override bool ShouldUpdateInputsOnResume => true;
             );
         }
 
-        protected override void InitializeSpawnedLane(LaneElement lane, int laneIndex)
+        protected override void InitializeBRELane(LaneElement lane, int laneIndex)
         {
             if (UsingOpenLane)
             {
@@ -515,10 +505,10 @@ public override bool ShouldUpdateInputsOnResume => true;
                 // Open forwards its inputs to the green scoring zone, since opens aren't supposed to be part of 5LK
                 {(int)FiveLaneKeysAction.OpenNote, (int)FiveLaneKeysBreLaneIndex.Green },
                 {(int)FiveLaneKeysAction.GreenKey, (int)FiveLaneKeysBreLaneIndex.Green },
-                {(int)FiveLaneKeysAction.RedKey, (int)FiveLaneKeysBreLaneIndex.Green },
-                {(int)FiveLaneKeysAction.YellowKey, (int)FiveLaneKeysBreLaneIndex.Green },
-                {(int)FiveLaneKeysAction.BlueKey, (int)FiveLaneKeysBreLaneIndex.Green },
-                {(int)FiveLaneKeysAction.OrangeKey, (int)FiveLaneKeysBreLaneIndex.Green },
+                {(int)FiveLaneKeysAction.RedKey, (int)FiveLaneKeysBreLaneIndex.Red },
+                {(int)FiveLaneKeysAction.YellowKey, (int)FiveLaneKeysBreLaneIndex.Yellow },
+                {(int)FiveLaneKeysAction.BlueKey, (int)FiveLaneKeysBreLaneIndex.Blue },
+                {(int)FiveLaneKeysAction.OrangeKey, (int)FiveLaneKeysBreLaneIndex.Orange },
             });
 
             _fretArray.SetBreMode(true);
@@ -840,12 +830,12 @@ public override bool ShouldUpdateInputsOnResume => true;
 
         private void MakeHighwayOrdering()
         {
-            UsingOpenLane = ShouldUseOpenLane();
+            UsingOpenLane = GryboHighwayHelpers.ShouldUseOpenLane(Player.Profile.OpenLaneDisplayType, NoteTrack.Notes);
 
             if (UsingOpenLane)
             {
                 LaneCount = 6;
-                _highwayOrdering = OPEN_LANE_HIGHWAY_ORDERING;
+                _highwayOrdering = GryboHighwayHelpers.OPEN_LANE_HIGHWAY_ORDERING;
                 _actionToBreLaneIndex = new()
                 {
                     { FiveLaneKeysAction.OpenNote, FiveLaneKeysBreLaneIndex.Open },
@@ -869,7 +859,7 @@ public override bool ShouldUpdateInputsOnResume => true;
             else
             {
                 LaneCount = 5;
-                _highwayOrdering = FiveFretGuitarPlayer.DEFAULT_HIGHWAY_ORDERING;
+                _highwayOrdering = GryboHighwayHelpers.DEFAULT_HIGHWAY_ORDERING;
                 _actionToBreLaneIndex = new()
                 {
                     { FiveLaneKeysAction.OpenNote, FiveLaneKeysBreLaneIndex.Green },
@@ -890,35 +880,9 @@ public override bool ShouldUpdateInputsOnResume => true;
                 };
             }
         }
-
-        private bool ShouldUseOpenLane()
-        {
-            switch (Player.Profile.OpenLaneDisplayType)
-            {
-                case OpenLaneDisplayType.Never:
-                    return false;
-                case OpenLaneDisplayType.Always:
-                    return true;
-                case OpenLaneDisplayType.IfChartContainsOpens:
-                    foreach (var note in NoteTrack.Notes)
-                    {
-                        foreach (var child in note.AllNotes)
-                        {
-                            if (child.Fret is (int)FiveFretGuitarFret.Open)
-                            {
-                                return true;
-                            }
-                        }
-                    }
-                    return false;
-                default:
-                    throw new ArgumentOutOfRangeException("Unrecognized OpenLaneDisplayType");
-            }
-        }
-
         private enum FiveLaneKeysBreLaneIndex
         {
-            Open, // Only exists if the Dedicated Open Lane setting is enabled
+            Open, // Not scored, only visually exists if the Dedicated Open Lane setting is enabled
             Green,
             Red,
             Yellow,

--- a/Assets/Script/Gameplay/Player/ProKeysPlayer.cs
+++ b/Assets/Script/Gameplay/Player/ProKeysPlayer.cs
@@ -527,7 +527,7 @@ namespace YARG.Gameplay.Player
             lane.OffsetXPosition(_currentOffset);
         }
 
-        protected override void InitializeSpawnedLane(LaneElement lane, int index)
+        protected override void InitializeBRELane(LaneElement lane, int index)
         {
             int noteIndex = index % 12;
             int octaveIndex = index / 12;
@@ -652,7 +652,7 @@ namespace YARG.Gameplay.Player
 
                 var laneParameters = _breLaneParameters[i];
 
-                InitializeSpawnedLane(newLane, laneParameters.CenterKey);
+                InitializeBRELane(newLane, laneParameters.CenterKey);
                 newLane.MultiplyScale(laneParameters.Width);
                 newLane.MultiplyScale(0.95f);
                 newLane.EnableFromPool();

--- a/Assets/Script/Gameplay/Player/TrackPlayer.cs
+++ b/Assets/Script/Gameplay/Player/TrackPlayer.cs
@@ -802,7 +802,7 @@ namespace YARG.Gameplay.Player
                 }
 
                 newLane.SetTimeRange(timeStart, timeEnd);
-                InitializeSpawnedLane(newLane, i);
+                InitializeBRELane(newLane, i);
                 newLane.EnableFromPool();
 
                 newLane.SetEmissionColor(0);
@@ -1028,7 +1028,7 @@ namespace YARG.Gameplay.Player
 
         protected abstract void InitializeSpawnedNote(IPoolable poolable, TNote note);
         protected abstract void InitializeSpawnedLane(LaneElement lane, TNote note);
-        protected abstract void InitializeSpawnedLane(LaneElement lane, int laneIndex);
+        protected abstract void InitializeBRELane(LaneElement lane, int laneIndex);
         protected virtual void ModifyLaneFromNote(LaneElement lane, TNote note) {}
 
         protected abstract void RescaleLanesForBRE();

--- a/Assets/Script/Gameplay/Visuals/Fret/Fret.cs
+++ b/Assets/Script/Gameplay/Visuals/Fret/Fret.cs
@@ -206,7 +206,7 @@ namespace YARG.Gameplay.Visuals
             ThemeBind.HitEffect.Play();
         }
 
-        public void PlayOpenHitParticles()
+        public void PlayFullWidthHitParticles()
         {
             ThemeBind.OpenHitEffect.Play();
         }

--- a/Assets/Script/Gameplay/Visuals/Fret/FretArray.cs
+++ b/Assets/Script/Gameplay/Visuals/Fret/FretArray.cs
@@ -173,7 +173,10 @@ namespace YARG.Gameplay.Visuals
             _frets[index].SetPressed(pressed);
         }
 
-        public void SetPressedDrum(int index, bool pressed, Fret.AnimType animType)
+        // Used for frets that can only receive a momentary input rather than being held. This includes all
+        // drum frets, as well as the dedicated open lane fret for 5F Guitar (no, holding the strum bar down
+        // doesn't count)
+        public void SetPressedImpulse(int index, bool pressed, Fret.AnimType animType)
         {
             _frets[index].SetPressedDrum(pressed, animType);
         }

--- a/Assets/Script/Gameplay/Visuals/Fret/FretArray.cs
+++ b/Assets/Script/Gameplay/Visuals/Fret/FretArray.cs
@@ -206,12 +206,12 @@ namespace YARG.Gameplay.Visuals
             _frets[index].PlayHitParticles();
         }
 
-        public void PlayOpenHitAnimation()
+        public void PlayFullWidthHitAnimation()
         {
             foreach (var (_, fret) in _frets)
             {
                 fret.PlayHitAnimation();
-                fret.PlayOpenHitParticles();
+                fret.PlayFullWidthHitParticles();
             }
         }
 
@@ -224,7 +224,7 @@ namespace YARG.Gameplay.Visuals
             }
         }
 
-        public void PlayOpenMissAnimation()
+        public void PlayFullWidthMissAnimation()
         {
             foreach (var (_, fret) in _frets)
             {

--- a/Assets/Script/Gameplay/Visuals/TrackElements/Guitar/FiveFretGuitarNoteElement.cs
+++ b/Assets/Script/Gameplay/Visuals/TrackElements/Guitar/FiveFretGuitarNoteElement.cs
@@ -56,7 +56,7 @@ namespace YARG.Gameplay.Visuals
 
             var noteGroups = IsStarPowerVisible ? StarPowerNoteGroups : NoteGroups;
 
-            if (!IsFullWidth())
+            if (!Player.NoteIsFullWidth(NoteRef))
             {
                 // Deal with regular single-lane notes
                 var lane = Player.GetLanePosition((FiveFretGuitarFret)NoteRef.Fret);
@@ -250,16 +250,6 @@ namespace YARG.Gameplay.Visuals
             _normalSustainLine.gameObject.SetActive(false);
             _openSustainLine.gameObject.SetActive(false);
             _wildcardSustainLine.gameObject.SetActive(false);
-        }
-
-        private bool IsFullWidth()
-        {
-            return NoteRef.Fret switch
-            {
-                (int) FiveFretGuitarFret.Open => !Player.UsingOpenLane,
-                (int) FiveFretGuitarFret.Wildcard => true,
-                _ => false
-            };
         }
     }
 }

--- a/Assets/Script/Gameplay/Visuals/TrackElements/Guitar/FiveFretGuitarNoteElement.cs
+++ b/Assets/Script/Gameplay/Visuals/TrackElements/Guitar/FiveFretGuitarNoteElement.cs
@@ -56,13 +56,13 @@ namespace YARG.Gameplay.Visuals
 
             var noteGroups = IsStarPowerVisible ? StarPowerNoteGroups : NoteGroups;
 
-            if (NoteRef.Fret != (int) FiveFretGuitarFret.Open && NoteRef.Fret != (int) FiveFretGuitarFret.Wildcard)
+            if (!IsFullWidth())
             {
-                // Deal with non-open notes
+                // Deal with regular single-lane notes
                 var lane = Player.GetLanePosition((FiveFretGuitarFret)NoteRef.Fret);
 
                 // Set the position
-                transform.localPosition = new Vector3(GetElementX(lane, FiveFretGuitarPlayer.LANE_COUNT), 0f, 0f);
+                transform.localPosition = new Vector3(GetElementX(lane, Player.LaneCount), 0f, 0f);
 
                 // Get which note model to use
                 NoteGroup = NoteRef.Type switch
@@ -77,7 +77,7 @@ namespace YARG.Gameplay.Visuals
             }
             else if (NoteRef.Fret == (int) FiveFretGuitarFret.Open)
             {
-                // Deal with open notes
+                // Deal with (non-dedicated-lane) open notes
 
                 // Set the position
                 transform.localPosition = Vector3.zero;
@@ -250,6 +250,16 @@ namespace YARG.Gameplay.Visuals
             _normalSustainLine.gameObject.SetActive(false);
             _openSustainLine.gameObject.SetActive(false);
             _wildcardSustainLine.gameObject.SetActive(false);
+        }
+
+        private bool IsFullWidth()
+        {
+            return NoteRef.Fret switch
+            {
+                (int) FiveFretGuitarFret.Open => !Player.UsingOpenLane,
+                (int) FiveFretGuitarFret.Wildcard => true,
+                _ => false
+            };
         }
     }
 }

--- a/Assets/Script/Gameplay/Visuals/TrackElements/Guitar/FiveFretGuitarNoteElement.cs
+++ b/Assets/Script/Gameplay/Visuals/TrackElements/Guitar/FiveFretGuitarNoteElement.cs
@@ -207,9 +207,10 @@ namespace YARG.Gameplay.Visuals
             System.Drawing.Color colorNoStarPower;
             System.Drawing.Color color;
 
-            // Open HOPO/Tap notes use a dedicated color (the prefab's
+            // Fullwidth Open HOPO/Tap notes use a dedicated color (the prefab's
             // EmissionAddition: 1 washes to white by default)
-            if (NoteRef.Fret == (int) FiveFretGuitarFret.Open &&
+            if (!Player.UsingOpenLane &&
+                NoteRef.Fret is (int) FiveFretGuitarFret.Open &&
                 NoteRef.Type is GuitarNoteType.Hopo or GuitarNoteType.Tap)
             {
                 colorNoStarPower = colors.OpenHopoNote;

--- a/Assets/Script/Helpers/Extensions/GameModeExtensions.cs
+++ b/Assets/Script/Helpers/Extensions/GameModeExtensions.cs
@@ -61,6 +61,7 @@ namespace YARG.Helpers.Extensions
                 {
                     (ProfileSettingStrings.LEFTY_FLIP, null),
                     (ProfileSettingStrings.RANGE_DISABLE, "RANGE SHIFT MARKERS"),
+                    (ProfileSettingStrings.OPEN_LANE_DISPLAY_TYPE, "DEDICATED OPEN NOTE LANE"),
                 },
                 GameMode.EliteDrums => new()
                 {

--- a/Assets/Script/Helpers/GryboHighwayHelpers.cs
+++ b/Assets/Script/Helpers/GryboHighwayHelpers.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using YARG.Core;
+using YARG.Core.Chart;
+
+namespace YARG.Helpers
+{
+    public static class GryboHighwayHelpers
+    {
+        public static bool ShouldUseOpenLane(OpenLaneDisplayType displayType, List<GuitarNote> notes)
+        {
+            switch (displayType)
+            {
+                case OpenLaneDisplayType.Never:
+                    return false;
+                case OpenLaneDisplayType.Always:
+                    return true;
+                case OpenLaneDisplayType.IfChartContainsOpens:
+                    foreach (var note in notes)
+                    {
+                        foreach (var child in note.AllNotes)
+                        {
+                            if (child.Fret is (int) FiveFretGuitarFret.Open)
+                            {
+                                return true;
+                            }
+                        }
+                    }
+                    return false;
+                default:
+                    throw new ArgumentOutOfRangeException("Unrecognized OpenLaneDisplayType");
+            }
+        }
+
+        public static Dictionary<int, int> DEFAULT_HIGHWAY_ORDERING = new()
+        {
+            { (int)FiveFretGuitarFret.Green,     0 },
+            { (int)FiveFretGuitarFret.Red,       1 },
+            { (int)FiveFretGuitarFret.Yellow,    2 },
+            { (int)FiveFretGuitarFret.Blue,      3 },
+            { (int)FiveFretGuitarFret.Orange,    4 },
+        };
+
+        public static Dictionary<int, int> LEFTY_HIGHWAY_ORDERING = new()
+        {
+            { (int)FiveFretGuitarFret.Orange,    0 },
+            { (int)FiveFretGuitarFret.Blue,      1 },
+            { (int)FiveFretGuitarFret.Yellow,    2 },
+            { (int)FiveFretGuitarFret.Red,       3 },
+            { (int)FiveFretGuitarFret.Green,     4 },
+        };
+
+        public static Dictionary<int, int> OPEN_LANE_HIGHWAY_ORDERING = new()
+        {
+            { (int) FiveFretGuitarFret.Open,    0 },
+            { (int) FiveFretGuitarFret.Green,   1 },
+            { (int) FiveFretGuitarFret.Red,     2 },
+            { (int) FiveFretGuitarFret.Yellow,  3 },
+            { (int) FiveFretGuitarFret.Blue,    4 },
+            { (int) FiveFretGuitarFret.Orange,  5 },
+        };
+
+        public static Dictionary<int, int> OPEN_LANE_LEFTY_HIGHWAY_ORDERING = new()
+        {
+            { (int) FiveFretGuitarFret.Orange,  0 },
+            { (int) FiveFretGuitarFret.Blue,    1 },
+            { (int) FiveFretGuitarFret.Yellow,  2 },
+            { (int) FiveFretGuitarFret.Red,     3 },
+            { (int) FiveFretGuitarFret.Green,   4 },
+            { (int) FiveFretGuitarFret.Open,    5 },
+        };
+    }
+}

--- a/Assets/Script/Helpers/GryboHighwayHelpers.cs.meta
+++ b/Assets/Script/Helpers/GryboHighwayHelpers.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 86770db84a2072c4181d696b8c66e845

--- a/Assets/Script/Settings/Preview/FakeTrackPlayer.cs
+++ b/Assets/Script/Settings/Preview/FakeTrackPlayer.cs
@@ -9,6 +9,7 @@ using YARG.Core.Game;
 using YARG.Gameplay;
 using YARG.Gameplay.Player;
 using YARG.Gameplay.Visuals;
+using YARG.Helpers;
 using YARG.Helpers.Extensions;
 using YARG.Menu.Settings;
 using YARG.Settings.Customization;
@@ -72,7 +73,7 @@ namespace YARG.Settings.Preview
                 GameMode.FiveFretGuitar,
                 new Info
                 {
-                    HighwayOrdering = FiveFretGuitarPlayer.DEFAULT_HIGHWAY_ORDERING,
+                    HighwayOrdering = GryboHighwayHelpers.DEFAULT_HIGHWAY_ORDERING,
                     LaneCount = 5,
 
                     FretColorProvider = (colorProfile) => colorProfile.FiveFretGuitar,


### PR DESCRIPTION
[Corresponding YARG.Core PR](https://github.com/YARC-Official/YARG.Core/pull/450)

Enables the previously-5LK-exclusive **Dedicated Open Lane** setting for the 5F Guitar game mode.

As a related bonus, also brings these changes for BREs:
* Open inputs during BREs now generate score, albeit shared with the green scoring zone
* Speaking of scoring zones, they were apparently broken on 5F (all just one big "green" zone) - that's been fixed
* Open inputs now produce open particle effects during BREs, including on 5LK
* Because 5LK doesn't make opens animate the green BRE lane anymore, I was able to simplify a lot of the convoluted <int,int> dictionaries in FiveLaneKeysPlayer
* Renamed various methods and other identifiers for clarity and consistency, like renaming the BRE-themed `InitializeSpawnedLane` to `InitializeBRELane`