### PR TITLE
Add high score display to the difficulty select screen

### DIFF
--- a/Assets/Prefabs/Menu/DifficultySelect/DifficultySelectMenu.prefab
+++ b/Assets/Prefabs/Menu/DifficultySelect/DifficultySelectMenu.prefab
@@ -387,6 +387,7 @@ RectTransform:
   - {fileID: 12410771327885534}
   - {fileID: 4565207930683620499}
   - {fileID: 950919677875588641}
+  - {fileID: 901000000000000002}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -494,6 +495,7 @@ MonoBehaviour:
   _songTitleText: {fileID: 7778603426334286436}
   _artistText: {fileID: 4129190891411151634}
   _sourceIcon: {fileID: 4587722383312202436}
+  _highScoreDisplay: {fileID: 901000000000000003}
   _difficultyItemPrefab: {fileID: 7078011472145303745, guid: 4442d264050ba2d48a3625616ee2f9d4,
     type: 3}
   _difficultyGreenPrefab: {fileID: 3092605043918072569, guid: aaad0bd4bf6af2c4a958ed68b782cf2a,
@@ -2526,4 +2528,529 @@ RectTransform:
   m_CorrespondingSourceObject: {fileID: 375337769934742335, guid: 81863a63e0d96cf459c263ee0ea6f98e,
     type: 3}
   m_PrefabInstance: {fileID: 7861624607540713672}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &901000000000000001
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 901000000000000002}
+  - component: {fileID: 901000000000000003}
+  m_Layer: 5
+  m_Name: High Score
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &901000000000000002
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 901000000000000001}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 901000000000000006}
+  m_Father: {fileID: 1731608351740115695}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 40, y: 125}
+  m_SizeDelta: {x: 520, y: 110}
+  m_Pivot: {x: 0, y: 0}
+--- !u!114 &901000000000000003
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 901000000000000001}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ad75092999bd442fb022380289ea8d12, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _content: {fileID: 901000000000000005}
+  _label: {fileID: 901000000000000013}
+  _instrumentDifficultyView: {fileID: 5230765499028152697}
+  _starView: {fileID: 3371392803339281613}
+  _scoreText: {fileID: 901000000000000023}
+--- !u!1 &901000000000000005
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 901000000000000006}
+  m_Layer: 5
+  m_Name: Content
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &901000000000000006
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 901000000000000005}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 901000000000000011}
+  - {fileID: 4543123366897271629}
+  - {fileID: 3775123634151246095}
+  - {fileID: 901000000000000021}
+  m_Father: {fileID: 901000000000000002}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &901000000000000010
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 901000000000000011}
+  - component: {fileID: 901000000000000012}
+  - component: {fileID: 901000000000000013}
+  m_Layer: 5
+  m_Name: Label
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &901000000000000011
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 901000000000000010}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 901000000000000006}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 12.5, y: 0}
+  m_SizeDelta: {x: 300, y: 28}
+  m_Pivot: {x: 0, y: 1}
+--- !u!222 &901000000000000012
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 901000000000000010}
+  m_CullTransparentMesh: 1
+--- !u!114 &901000000000000013
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 901000000000000010}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: High Score
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 65a8a6500dc773741bd815e54cd7c1ec, type: 2}
+  m_sharedMaterial: {fileID: -8996134669666270778, guid: 65a8a6500dc773741bd815e54cd7c1ec,
+    type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 28
+  m_fontSizeBase: 28
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1 &901000000000000020
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 901000000000000021}
+  - component: {fileID: 901000000000000022}
+  - component: {fileID: 901000000000000023}
+  m_Layer: 5
+  m_Name: Score
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &901000000000000021
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 901000000000000020}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 901000000000000006}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 160, y: 20}
+  m_SizeDelta: {x: 150, y: 32}
+  m_Pivot: {x: 0, y: 0.5}
+--- !u!222 &901000000000000022
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 901000000000000020}
+  m_CullTransparentMesh: 1
+--- !u!114 &901000000000000023
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 901000000000000020}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 0
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 65a8a6500dc773741bd815e54cd7c1ec, type: 2}
+  m_sharedMaterial: {fileID: -8996134669666270778, guid: 65a8a6500dc773741bd815e54cd7c1ec,
+    type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 32
+  m_fontSizeBase: 32
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 1
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 0
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1001 &901000000000000030
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 901000000000000006}
+    m_Modifications:
+    - target: {fileID: 3714506624951436115, guid: 2757d4382315f8a46a8a0c2e76c0f881, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3714506624951436115, guid: 2757d4382315f8a46a8a0c2e76c0f881, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3714506624951436115, guid: 2757d4382315f8a46a8a0c2e76c0f881, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3714506624951436115, guid: 2757d4382315f8a46a8a0c2e76c0f881, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3714506624951436115, guid: 2757d4382315f8a46a8a0c2e76c0f881, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 75
+      objectReference: {fileID: 0}
+    - target: {fileID: 3714506624951436115, guid: 2757d4382315f8a46a8a0c2e76c0f881, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 20
+      objectReference: {fileID: 0}
+    - target: {fileID: 3714506624951436115, guid: 2757d4382315f8a46a8a0c2e76c0f881, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3714506624951436115, guid: 2757d4382315f8a46a8a0c2e76c0f881, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3714506624951436115, guid: 2757d4382315f8a46a8a0c2e76c0f881, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3714506624951436115, guid: 2757d4382315f8a46a8a0c2e76c0f881, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3714506624951436115, guid: 2757d4382315f8a46a8a0c2e76c0f881, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6436490635875856399, guid: 2757d4382315f8a46a8a0c2e76c0f881, type: 3}
+      propertyPath: m_Name
+      value: Instrument Difficulty
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 2757d4382315f8a46a8a0c2e76c0f881, type: 3}
+--- !u!114 &5230765499028152697 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4906556586326073703, guid: 2757d4382315f8a46a8a0c2e76c0f881, type: 3}
+  m_PrefabInstance: {fileID: 901000000000000030}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2fa008f8a4acc064e87ffe6a81592afc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!224 &4543123366897271629 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 3714506624951436115, guid: 2757d4382315f8a46a8a0c2e76c0f881, type: 3}
+  m_PrefabInstance: {fileID: 901000000000000030}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &901000000000000040
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 901000000000000006}
+    m_Modifications:
+    - target: {fileID: 4099137989180180775, guid: 8a14b88e9f52a4e41818129ae6aff258, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4099137989180180775, guid: 8a14b88e9f52a4e41818129ae6aff258, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4099137989180180775, guid: 8a14b88e9f52a4e41818129ae6aff258, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4099137989180180775, guid: 8a14b88e9f52a4e41818129ae6aff258, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4099137989180180775, guid: 8a14b88e9f52a4e41818129ae6aff258, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 104
+      objectReference: {fileID: 0}
+    - target: {fileID: 4099137989180180775, guid: 8a14b88e9f52a4e41818129ae6aff258, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 58
+      objectReference: {fileID: 0}
+    - target: {fileID: 4099137989180180775, guid: 8a14b88e9f52a4e41818129ae6aff258, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.75
+      objectReference: {fileID: 0}
+    - target: {fileID: 4099137989180180775, guid: 8a14b88e9f52a4e41818129ae6aff258, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.75
+      objectReference: {fileID: 0}
+    - target: {fileID: 4099137989180180775, guid: 8a14b88e9f52a4e41818129ae6aff258, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4099137989180180775, guid: 8a14b88e9f52a4e41818129ae6aff258, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4099137989180180775, guid: 8a14b88e9f52a4e41818129ae6aff258, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4099137989180180775, guid: 8a14b88e9f52a4e41818129ae6aff258, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4099137989180180775, guid: 8a14b88e9f52a4e41818129ae6aff258, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6897579188400701165, guid: 8a14b88e9f52a4e41818129ae6aff258, type: 3}
+      propertyPath: m_Name
+      value: StarView
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 8a14b88e9f52a4e41818129ae6aff258, type: 3}
+--- !u!114 &3371392803339281613 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2470621721023489253, guid: 8a14b88e9f52a4e41818129ae6aff258, type: 3}
+  m_PrefabInstance: {fileID: 901000000000000040}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 00cf00732a11481283c3c981d23f2d0a, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!224 &3775123634151246095 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 4099137989180180775, guid: 8a14b88e9f52a4e41818129ae6aff258, type: 3}
+  m_PrefabInstance: {fileID: 901000000000000040}
   m_PrefabAsset: {fileID: 0}

--- a/Assets/Script/Menu/DifficultySelect/DifficultySelectMenu.cs
+++ b/Assets/Script/Menu/DifficultySelect/DifficultySelectMenu.cs
@@ -65,6 +65,10 @@ namespace YARG.Menu.DifficultySelect
 
         [Space]
         [SerializeField]
+        private HighScoreDisplay _highScoreDisplay;
+
+        [Space]
+        [SerializeField]
         private DifficultyItem _difficultyItemPrefab;
         [SerializeField]
         private DifficultyItem _difficultyGreenPrefab;
@@ -172,6 +176,23 @@ namespace YARG.Menu.DifficultySelect
             SelectionOrigin selectionOrigin)
         {
             UpdateScrollbarForSelection();
+
+            // While the instrument or difficulty submenu is open, the high score display
+            // follows the highlighted option so it can be compared before confirming
+            if (_menuState == State.Instrument &&
+                _navGroup.SelectedIndex is { } instrumentIndex &&
+                instrumentIndex >= 0 && instrumentIndex < _possibleInstruments.Count)
+            {
+                _highScoreDisplay.Show(GlobalVariables.State.CurrentSong, CurrentPlayer,
+                    _possibleInstruments[instrumentIndex], CurrentPlayer.Profile.CurrentDifficulty);
+            }
+            else if (_menuState == State.Difficulty &&
+                _navGroup.SelectedIndex is { } difficultyIndex &&
+                difficultyIndex >= 0 && difficultyIndex < _possibleDifficulties.Count)
+            {
+                _highScoreDisplay.Show(GlobalVariables.State.CurrentSong, CurrentPlayer,
+                    CurrentPlayer.Profile.CurrentInstrument, _possibleDifficulties[difficultyIndex]);
+            }
         }
 
         private void UpdateScrollbarForSelection()
@@ -220,6 +241,9 @@ namespace YARG.Menu.DifficultySelect
             _navGroup.ClearNavigatables();
             _container.DestroyChildren();
             StatsManager.Instance.UpdateActivePlayers();
+
+            _highScoreDisplay.Show(GlobalVariables.State.CurrentSong, CurrentPlayer,
+                CurrentPlayer.Profile.CurrentInstrument, CurrentPlayer.Profile.CurrentDifficulty);
 
             // Create the menu
             switch (_menuState)

--- a/Assets/Script/Menu/DifficultySelect/HighScoreDisplay.cs
+++ b/Assets/Script/Menu/DifficultySelect/HighScoreDisplay.cs
@@ -1,0 +1,74 @@
+using Cysharp.Text;
+using TMPro;
+using UnityEngine;
+using YARG.Core;
+using YARG.Core.Song;
+using YARG.Helpers;
+using YARG.Localization;
+using YARG.Menu.MusicLibrary;
+using YARG.Player;
+using YARG.Scores;
+
+namespace YARG.Menu.DifficultySelect
+{
+    public class HighScoreDisplay : MonoBehaviour
+    {
+        [SerializeField]
+        private GameObject _content;
+        [SerializeField]
+        private TextMeshProUGUI _label;
+        [SerializeField]
+        private InstrumentDifficultyView _instrumentDifficultyView;
+        [SerializeField]
+        private StarView _starView;
+        [SerializeField]
+        private TextMeshProUGUI _scoreText;
+
+        private void Awake()
+        {
+            _label.text = Localize.Key("Menu.DifficultySelect", "HighScore");
+        }
+
+        public void Show(SongEntry song, YargPlayer player, Instrument instrument, Difficulty difficulty)
+        {
+            var profile = player.Profile;
+
+            // The best result for the selected instrument and difficulty, using the
+            // High Score History setting's metric (score vs percentage), with the
+            // Elite Drums kit special case
+            var record = profile.GameMode == GameMode.EliteDrums
+                ? ScoreContainer.GetPreferredHighScoreForDifficulty(
+                    song.Hash, profile.Id, MidiDrumkitHelper.Instruments, difficulty)
+                : ScoreContainer.GetPreferredHighScoreForDifficulty(
+                    song.Hash, profile.Id, instrument, difficulty);
+
+            if (record is null)
+            {
+                Hide();
+                return;
+            }
+
+            _content.SetActive(true);
+
+            _instrumentDifficultyView.SetInfo(new ViewType.ScoreInfo
+            {
+                Score = record.Score,
+                Difficulty = record.Difficulty,
+                Percent = record.GetPercent(),
+                Instrument = record.Instrument,
+                IsFc = record.IsFc
+            });
+
+            _starView.SetStars(record.Stars);
+
+            var scoreColor = record.IsFc ? "#ffd029" : "#ffffff";
+            _scoreText.SetTextFormat("<mspace=.5em><color={1}>{0:N0}</color></mspace>",
+                record.Score, scoreColor);
+        }
+
+        public void Hide()
+        {
+            _content.SetActive(false);
+        }
+    }
+}

--- a/Assets/Script/Menu/DifficultySelect/HighScoreDisplay.cs.meta
+++ b/Assets/Script/Menu/DifficultySelect/HighScoreDisplay.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ad75092999bd442fb022380289ea8d12
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Script/Scores/ScoreContainer.cs
+++ b/Assets/Script/Scores/ScoreContainer.cs
@@ -283,6 +283,65 @@ namespace YARG.Scores
                 : GetBestPercentageScore(songChecksum, playerId, instrument, allowCacheUpdate);
         }
 
+        /// <summary>
+        /// Get the best result (score or percentage, following the high score history setting's metric)
+        /// for a specific song, player, instrument and difficulty.
+        /// </summary>
+        public static PlayerScoreRecord GetPreferredHighScoreForDifficulty(HashWrapper songChecksum,
+            Guid playerId, Instrument instrument, Difficulty difficulty)
+        {
+            try
+            {
+                return UseHighestScore
+                    ? _db.QueryPlayerSongHighScore(songChecksum, playerId, instrument,
+                        highestDifficultyOnly: false, currentDifficultyOnly: true, difficulty)
+                    : _db.QueryPlayerSongHighestPercentage(songChecksum, playerId, instrument,
+                        highestDifficultyOnly: false, currentDifficultyOnly: true, difficulty);
+            }
+            catch (Exception e)
+            {
+                YargLogger.LogException(e, $"Failed to load high score from database for player with ID {playerId}.");
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Get the best result at a specific difficulty across several instruments
+        /// (used for Elite Drums kits, which can play multiple drum instruments).
+        /// </summary>
+        public static PlayerScoreRecord GetPreferredHighScoreForDifficulty(HashWrapper songChecksum,
+            Guid playerId, IReadOnlyList<Instrument> instruments, Difficulty difficulty)
+        {
+            PlayerScoreRecord best = null;
+            foreach (var instrument in instruments)
+            {
+                var record = GetPreferredHighScoreForDifficulty(songChecksum, playerId, instrument, difficulty);
+                if (record is null) continue;
+
+                if (best is null || IsPreferredOver(record, best))
+                {
+                    best = record;
+                }
+            }
+
+            return best;
+        }
+
+        private static bool IsPreferredOver(PlayerScoreRecord candidate, PlayerScoreRecord current)
+        {
+            if (UseHighestScore)
+            {
+                return candidate.Score > current.Score;
+            }
+
+            // Matches the percentage query's ordering: percent, then score, then FC
+            if (candidate.GetPercent() != current.GetPercent())
+                return candidate.GetPercent() > current.GetPercent();
+            if (candidate.Score != current.Score)
+                return candidate.Score > current.Score;
+            return candidate.IsFc && !current.IsFc;
+        }
+
         public static bool UseBandHighScoresForCurrentPlayers
             => PlayerContainer.Players.Count(player => !player.Profile.IsBot) != 1;
 

--- a/Assets/StreamingAssets/lang/en-US.json
+++ b/Assets/StreamingAssets/lang/en-US.json
@@ -285,6 +285,7 @@
             "SitOut": "Sit Out",
 			"Disconnect" : "Disconnect",
             "Done": "Done",
+            "HighScore": "High Score",
             "WarningPlayerNoInputDevice" : "This player has no input device assigned! Assign one from the Profiles menu.",
             "WarningVocalistNoMicrophone" : "This vocalist has no microphone assigned! Assign one from the Profiles menu."
         },


### PR DESCRIPTION
Added this because there is no score display on the song browsing screen. It adds a score/star/% indicator on the difficulty select screen, bound to the selected instrument and difficulty.

<img width="2032" height="1220" alt="image" src="https://github.com/user-attachments/assets/472fe2f7-16df-4fcd-aa5f-32c59a538690" />

No score: 
<img width="2032" height="1220" alt="image" src="https://github.com/user-attachments/assets/017595e6-2f19-41f1-83dd-6e0b7c605f36" />
