### PR TITLE
Fix engine preset editor regressions

### DIFF
--- a/Assets/Script/Settings/Metadata/Tabs/PresetSubTab.Generic.cs
+++ b/Assets/Script/Settings/Metadata/Tabs/PresetSubTab.Generic.cs
@@ -320,6 +320,24 @@ namespace YARG.Settings.Metadata
             return null;
         }
 
+        private string GetSubSectionForMode(GameMode mode)
+        {
+            if (typeof(T) == typeof(EnginePreset))
+            {
+                return mode switch
+                {
+                    GameMode.FiveFretGuitar => nameof(EnginePreset.FiveFretGuitar),
+                    GameMode.SixFretGuitar => nameof(EnginePreset.SixFretGuitar),
+                    GameMode.FourLaneDrums or GameMode.FiveLaneDrums => nameof(EnginePreset.Drums),
+                    GameMode.Vocals => nameof(EnginePreset.Vocals),
+                    GameMode.ProKeys => nameof(EnginePreset.ProKeys),
+                    _ => null,
+                };
+            }
+
+            return ModeToSubSection(mode);
+        }
+
         #endregion
 
         public PresetSubTab(CustomContent<T> customContent, IPreviewBuilder previewBuilder, bool hasDescriptions)
@@ -434,6 +452,16 @@ namespace YARG.Settings.Metadata
             else
             {
                 _subSection = null;
+            }
+
+            // Sync engine fields to the selected preview instrument.
+            if (typeof(T) == typeof(EnginePreset))
+            {
+                string modeSubSection = GetSubSectionForMode(PreviewOptions.GameMode);
+                if (modeSubSection != null)
+                {
+                    _subSection = modeSubSection;
+                }
             }
 
             _fieldIndex = 0;
@@ -676,8 +704,6 @@ namespace YARG.Settings.Metadata
             }
 
             // --- Instrument selector dropdown ---
-            // On Color Profile, this switches the sub-section (which colors are edited).
-            // On other tabs, it only changes the preview instrument.
             string currentLabel = InstrumentModes[0].Label;
             foreach (var (_, label, mode) in InstrumentModes)
             {
@@ -703,9 +729,9 @@ namespace YARG.Settings.Metadata
                         PreviewOptions.GameMode = gameMode;
                         tpb.StartingGameMode = gameMode;
 
-                        if (typeof(T) == typeof(ColorProfile))
+                        if (typeof(T) == typeof(ColorProfile) || typeof(T) == typeof(EnginePreset))
                         {
-                            string newSub = ModeToSubSection(gameMode);
+                            string newSub = GetSubSectionForMode(gameMode);
                             if (newSub != null && newSub != _subSection)
                             {
                                 RefreshForSubSection(newSub);
@@ -714,7 +740,15 @@ namespace YARG.Settings.Metadata
                             }
                         }
 
-                        SettingsMenu.Instance.Refresh();
+                        if (typeof(T) == typeof(EnginePreset))
+                        {
+                            SettingsMenu.Instance.RefreshAndKeepPosition();
+                        }
+                        else
+                        {
+                            SettingsMenu.Instance.Refresh();
+                        }
+
                         ReselectInstrumentRow();
                         break;
                     }
@@ -1514,6 +1548,14 @@ namespace YARG.Settings.Metadata
 
         private void BuildField(FieldSettingInfo field, Transform container, NavigationGroup navGroup, T preset)
         {
+            // Six-fret guitar does not support solo taps.
+            if (typeof(T) == typeof(EnginePreset)
+                && _subSection == nameof(EnginePreset.SixFretGuitar)
+                && field.Field.Name == nameof(EnginePreset.FiveFretGuitarPreset.SoloTaps))
+            {
+                return;
+            }
+
             // These legacy key colors belong to the deferred five-lane-keys
             // editor. Pro Keys uses the White/BlackNote and Overlay fields instead.
             if (_subSection == nameof(ColorProfile.ProKeys)
@@ -1789,8 +1831,7 @@ namespace YARG.Settings.Metadata
                     ),
                     (
                         "HitWindow",
-                        // Since the hit window setting is a reference type, we don't need a callback
-                        new HitWindowSetting(hitWindow)
+                        new HitWindowSetting(hitWindow, _ => SettingsMenu.Instance?.RefreshPreview())
                     )
                 });
 
@@ -1877,7 +1918,8 @@ namespace YARG.Settings.Metadata
         private void RefreshForSubSection(string subSection)
         {
             _subSection = subSection;
-            if (TryGetModeForSubSection(subSection, out var subSectionMode))
+            if (typeof(T) == typeof(ColorProfile)
+                && TryGetModeForSubSection(subSection, out var subSectionMode))
             {
                 PreviewOptions.GameMode = subSectionMode;
             }


### PR DESCRIPTION

## Summary

Fixes one regression and two defects in the Engine Preset editor and its live preview:

1. Changing the preview instrument now rebuilds the visible Engine Preset subsection, so five-fret guitar, six-fret guitar, drums, vocals, and Pro Keys show the settings belonging to the selected instrument.
2. Changing a numeric hit-window value now refreshes the highway preview immediately, without requiring the user to toggle Dynamic Hit Window.
3. The `SoloTaps` option is hidden from the six-fret guitar subsection because six-fret guitar has no five-fret solo-tap mechanic. It remains available for five-fret guitar.

## Why

The Engine Preset editor shares one preset model across several instrument-specific subsections. The new preview instrument selector exposed two UI synchronization gaps: changing the selected instrument did not rebuild the visible subsection, and the composite hit-window visual updated the preset object without notifying the preview.

The editor also exposed `SoloTaps` for six-fret guitar, but that option is only relevant to the five-fret guitar engine.

## Steps to reproduce

### Instrument-specific settings

1. Open **Settings → Presets → Engine Presets**.
2. Select an Engine Preset.
3. Change the preview instrument between five-fret guitar, six-fret guitar, drums, vocals, and Pro Keys.
4. Before this fix, the instrument selector changed the preview instrument but could leave the settings list showing the previous instrument's subsection.
#### Cause
- The preview instrument callback updated the shared preview mode but did not consistently rebuild the Engine Preset settings subsection.

### Hit-window preview

1. Open an Engine Preset's guitar or other hit-window settings.
2. Adjust a numeric hit-window value, such as the constant hit-window size.
3. Before this fix, the preset value changed but the highway hit-window display did not update until Dynamic Hit Window was toggled.
#### Cause
- `HitWindowSettingVisual` mutates its shared `HitWindowPreset` reference and calls `ForceInvokeCallback()`. The Engine Preset created that setting without a callback, so the preview rebuild path was never reached for numeric edits. The Dynamic toggle worked because its callback explicitly called `RefreshAndKeepPosition()`.
### Six-fret Solo Taps

1. Open an Engine Preset.
2. Select **Six Fret Guitar** in the preview instrument selector.
3. Before this fix, the editor showed **Solo Taps**, despite six-fret guitar not having the five-fret solo-tap mechanic.
#### Cause
- `SoloTaps` is declared on the shared `FiveFretGuitarPreset` type, which is also reused for six-fret parameters. Filtering it out of the Core model would risk changing serialization and compatibility, so the issue is handled at the Unity editor presentation layer.

## Fix / Design

- Keep the existing Engine Preset model and JSON format unchanged.
- Rebuild the Engine Preset settings list when the preview instrument changes, preserving the selected position.
- Give the composite `HitWindowSetting` a callback that calls `SettingsMenu.RefreshPreview()`. This rebuilds only the preview and does not recreate the settings list or disturb focus.
- Skip `SoloTaps` in `BuildField` only when the current Engine Preset subsection is `EnginePreset.SixFretGuitar`.
- Five-fret behavior, existing preset files, and profile-to-preset GUID references remain unchanged.

## Changes

| File | Change |
|------|--------|
| `Assets/Script/Settings/Metadata/Tabs/PresetSubTab.Generic.cs` | Refresh the Engine Preset subsection when the preview instrument changes; refresh the preview when numeric hit-window values change; hide `SoloTaps` only in the six-fret subsection. |

## Testing done

- **In-game:** manually verified the Engine Preset editor in the Unity runtime. Confirmed that changing the hit-window size updates the preview immediately, and that the six-fret editor no longer shows `SoloTaps` while the five-fret editor retains it.
- **JSON file:** manually verified contents of preset under enginePresets had the updated values for 6 fret and those changes were not affecting the values in the 5 fret section.

## Notes

- This PR does not change the serialized `SoloTaps` field. Existing custom preset JSON files remain readable, and a six-fret preset may retain a legacy value that is simply no longer exposed by the six-fret editor.
