### PR TITLE
Show the previous best score on the score screen

### DIFF
--- a/Assets/Scenes/ScoreScene.unity
+++ b/Assets/Scenes/ScoreScene.unity
@@ -1909,6 +1909,7 @@ RectTransform:
   m_Children:
   - {fileID: 1284876699}
   - {fileID: 2142688262}
+  - {fileID: 902000000000000002}
   m_Father: {fileID: 3376582597958617714}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0.5}
@@ -2222,6 +2223,7 @@ MonoBehaviour:
   _artistName: {fileID: 924495893}
   _bandStarView: {fileID: 1284876700}
   _bandScore: {fileID: 1305557732}
+  _previousBestText: {fileID: 902000000000000004}
   _bandScoreNotSavedPill: {fileID: 202862751}
   _cardScrollRect: {fileID: 1251677025}
   _horizontalScrollRate: 30
@@ -2865,3 +2867,161 @@ SceneRoots:
   m_Roots:
   - {fileID: 1731608351534815124}
   - {fileID: 666214235}
+--- !u!1 &902000000000000001
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 902000000000000002}
+  - component: {fileID: 902000000000000003}
+  - component: {fileID: 902000000000000004}
+  - component: {fileID: 902000000000000005}
+  m_Layer: 5
+  m_Name: Previous Best
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &902000000000000002
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 902000000000000001}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1649697619}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 0}
+  m_AnchoredPosition: {x: 0, y: -4}
+  m_SizeDelta: {x: 0, y: 34}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &902000000000000003
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 902000000000000001}
+  m_CullTransparentMesh: 1
+--- !u!114 &902000000000000004
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 902000000000000001}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 0
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Previous Best 0
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 65a8a6500dc773741bd815e54cd7c1ec, type: 2}
+  m_sharedMaterial: {fileID: -8996134669666270778, guid: 65a8a6500dc773741bd815e54cd7c1ec, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4288904573
+  m_fontColor: {r: 0.49019608, g: 0.49019608, b: 0.6392157, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 28
+  m_fontSizeBase: 28
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 4
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_characterHorizontalScale: 1
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 0
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!114 &902000000000000005
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 902000000000000001}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreLayout: 1
+  m_MinWidth: -1
+  m_MinHeight: -1
+  m_PreferredWidth: -1
+  m_PreferredHeight: -1
+  m_FlexibleWidth: -1
+  m_FlexibleHeight: -1
+  m_LayoutPriority: 1

--- a/Assets/Script/Gameplay/GameManager.cs
+++ b/Assets/Script/Gameplay/GameManager.cs
@@ -698,6 +698,7 @@ namespace YARG.Gameplay
                     .Average(),
 
                 ReplayInfo = replayInfo,
+                PreviousBest = GetPreviousBest(),
             };
 
             RecordScores(replayInfo);
@@ -705,6 +706,28 @@ namespace YARG.Gameplay
             // Go to the score screen
             GlobalVariables.Instance.LoadScene(SceneIndex.Score);
             return true;
+        }
+
+        /// <summary>
+        /// The record that was standing before this run, for the score screen's header.
+        /// Must be read before <see cref="RecordScores"/> saves this run.
+        /// </summary>
+        private int? GetPreviousBest()
+        {
+            var humans = _players.Where(p => !p.Player.Profile.IsBot).ToList();
+
+            if (humans.Count == 1)
+            {
+                // The same setting-driven record the in-song high score popup compares against
+                return humans[0].LastHighScore;
+            }
+
+            if (humans.Count > 1)
+            {
+                return ScoreContainer.GetBandHighScore(Song.Hash)?.BandScore;
+            }
+
+            return null;
         }
 
         private void RecordScores(ReplayInfo replayInfo)

--- a/Assets/Script/Menu/ScoreScreen/ScoreScreenContainer.cs
+++ b/Assets/Script/Menu/ScoreScreen/ScoreScreenContainer.cs
@@ -23,6 +23,13 @@ namespace YARG.Menu.ScoreScreen
 
         public double MeanAverageOffset;
 
+        /// <summary>
+        /// The record that was standing before this run: the player's own best for a
+        /// single human player, or the band best when several humans played.
+        /// Null when there is no previous record (or no human players).
+        /// </summary>
+        public int? PreviousBest;
+
 #nullable enable
         public ReplayInfo? ReplayInfo;
         public bool? ReplayWasConsistent;

--- a/Assets/Script/Menu/ScoreScreen/ScoreScreenMenu.cs
+++ b/Assets/Script/Menu/ScoreScreen/ScoreScreenMenu.cs
@@ -53,6 +53,8 @@ namespace YARG.Menu.ScoreScreen
         private StarView _bandStarView;
         [SerializeField]
         private TextMeshProUGUI _bandScore;
+        [SerializeField]
+        private TextMeshProUGUI _previousBestText;
         [FormerlySerializedAs("_bandScoreNotSavedPill")]
         [SerializeField]
         private ColoredPillElement _scoreStatusPill;
@@ -152,6 +154,18 @@ namespace YARG.Menu.ScoreScreen
             // Set the band score and stars
             _bandStarView.SetStars(scoreScreenStats.BandStars);
             _bandScore.text = scoreScreenStats.BandScore.ToString("N0");
+
+            // Show the record that was standing before this run
+            if (scoreScreenStats.PreviousBest is { } previousBest && !GlobalVariables.State.IsReplay)
+            {
+                _previousBestText.gameObject.SetActive(true);
+                _previousBestText.text =
+                    $"{Localize.Key("Menu.ScoreScreen.PreviousBest")}  {previousBest:N0}";
+            }
+            else
+            {
+                _previousBestText.gameObject.SetActive(false);
+            }
 
             // Put the scores in!
             CreateScoreCards(scoreScreenStats);

--- a/Assets/StreamingAssets/lang/en-US.json
+++ b/Assets/StreamingAssets/lang/en-US.json
@@ -550,6 +550,7 @@
         },
         "ScoreScreen" : {
             "BandScoreNotSaved" : "Score not saved",
+            "PreviousBest" : "Previous Best",
             "InconsistentReplay": "Inconsistent Replay",
             "RestartSong" : "Restart Song",
             "ShowAdvanced": "Show Advanced",


### PR DESCRIPTION
I thought this would be especially helpful for players with the `Disable Text Notifications` setting enabled to be able to compare their high score to the previous one. 

Score beat: 
<img width="2032" height="1220" alt="image" src="https://github.com/user-attachments/assets/93d53024-ada2-422c-9ff1-a12f749040cd" />


Score not beat (still shown for reference): 
<img width="2032" height="1220" alt="image" src="https://github.com/user-attachments/assets/74373dba-9fc9-4563-af4f-f509185af13a" />
