### PR TITLE
Fix sitting-out vocal mode gating

### DIFF
--- a/Assets/Script/Menu/DifficultySelect/DifficultySelectMenu.cs
+++ b/Assets/Script/Menu/DifficultySelect/DifficultySelectMenu.cs
@@ -811,10 +811,12 @@ namespace YARG.Menu.DifficultySelect
                 }
 
                 // Loop through all of the players up to the current one
-                // to see what has already been selected.
+                // to see what has already been selected. Skip sitting-out players —
+                // their CurrentInstrument shouldn't lock later players into a vocals mode.
                 for (int i = 0; i < _playerIndex; i++)
                 {
                     var player = PlayerContainer.Players[i];
+                    if (player.SittingOut) continue;
                     var playerInstrument = player.Profile.CurrentInstrument;
                     if (playerInstrument is Instrument.Vocals or Instrument.Harmony)
                     {


### PR DESCRIPTION
## Summary

Ignore sitting-out players when Difficulty Select enforces a common vocal mode. A player who selected Vocals or Harmony and then sits out no longer locks later active players to that mode.

## Why

`PlayerContainer.Players` retains sitting-out players, and their `CurrentInstrument` remains unchanged. The vocal-mode gating loop therefore treated a non-playing profile as an active constraint. This could prevent an active player from selecting other valid vocal modes and made the menu seem like it was missing options.

## Steps to reproduce

1. Add at least two players with a song that supports both Vocals and Harmony.
2. Set the first player to Vocals or Harmony.
3. Sit the first player out.
4. Move to the second active player and open instrument selection.
5. **Before the fix:** the sitting-out player's instrument constrained the available vocal mode.
6. **After the fix:** the active player can select any available vocal mode.

Also verify that an active earlier vocal player still constrains later active vocal players to the same mode.

## Root cause

`HasPlayableInstrument()` scans earlier entries in `PlayerContainer.Players` and returns the first prior vocal player's mode. Sitting-out players remain in that list, so their stale `CurrentInstrument` was treated as an active selection.

## Fix

Skip `player.SittingOut` entries before reading `CurrentInstrument` in the prior-player vocal gating loop. This keeps the connected-player list unchanged and applies the playing-player filter only where the constraint is calculated.

## Changes

| File | Change |
|------|--------|
| `Assets/Script/Menu/DifficultySelect/DifficultySelectMenu.cs` | Ignore sitting-out players in the prior-player Vocals/Harmony mode-lock loop. |

## Testing done

- In-game verification (2026-09-05): verified in the Unity runtime with a sitting-out vocal player, active opposite-mode selection, active-player mode locking, and back-navigation/rejoining.

Videos showing issue [on Discord](https://discord.com/channels/1086048856678084609/1545886048884752516)