### PR TITLE
6f visual fixes

### DIFF
--- a/Assets/Prefabs/Gameplay/Visual/Themes/RectangularTheme.prefab
+++ b/Assets/Prefabs/Gameplay/Visual/Themes/RectangularTheme.prefab
@@ -72875,7 +72875,7 @@ PrefabInstance:
     - target: {fileID: 1897114193844750814, guid: e04222ae8a4f0c542926dc9ce20a58e0, type: 3}
       propertyPath: 'm_Materials.Array.data[0]'
       value: 
-      objectReference: {fileID: 2100000, guid: ca25bdb13a7a11ac9890ee42e51b499d, type: 2}
+      objectReference: {fileID: 2100000, guid: 02c9ed313e29b6641a8e0b394540a79c, type: 2}
     - target: {fileID: 1897114193844750814, guid: e04222ae8a4f0c542926dc9ce20a58e0, type: 3}
       propertyPath: 'm_Materials.Array.data[1]'
       value: 

--- a/Assets/Script/Gameplay/Player/SixFretGuitarPlayer.cs
+++ b/Assets/Script/Gameplay/Player/SixFretGuitarPlayer.cs
@@ -275,15 +275,60 @@ namespace YARG.Gameplay.Player
             foreach (var note in chordParent.AllNotes)
             {
                 (NotePool.GetByKey(note) as SixFretGuitarNoteElement)?.HitNote();
+            }
 
-                if (note.Fret != (int)SixFretGuitarFret.Open && note.Fret != (int)SixFretGuitarFret.Wildcard)
+            // Color the fret hit particles based on which notes were hit:
+            // black particles for black frets, white for white frets, a mix of
+            // the two for barres (both halves of a pad), and the open particles
+            // for open/wild notes. One burst per fret pad, not per note.
+            var colors = Player.ColorProfile.SixFretGuitar;
+            var blackParticles = colors.BlackParticles.ToUnityColor();
+            var whiteParticles = colors.WhiteParticles.ToUnityColor();
+
+            bool openHit = false;
+            int blackLanes = 0;
+            int whiteLanes = 0;
+
+            foreach (var note in chordParent.AllNotes)
+            {
+                if (note.Fret == (int) SixFretGuitarFret.Open || note.Fret == (int) SixFretGuitarFret.Wildcard)
                 {
-                    _fretArray.PlayHitAnimation(note.Fret);
+                    openHit = true;
+                    continue;
+                }
+
+                // Fret-pair index (0-2), independent of lefty flip; fret objects
+                // are keyed by fret value, not visual lane
+                int pair = note.Fret <= (int) SixFretGuitarFret.Black3
+                    ? note.Fret - (int) SixFretGuitarFret.Black1
+                    : note.Fret - (int) SixFretGuitarFret.White1;
+                if (note.Fret <= (int) SixFretGuitarFret.Black3)
+                {
+                    blackLanes |= 1 << pair;
                 }
                 else
                 {
-                    _fretArray.PlayFullWidthHitAnimation();
+                    whiteLanes |= 1 << pair;
                 }
+            }
+
+            if (openHit)
+            {
+                _fretArray.PlayFullWidthHitAnimation();
+            }
+
+            for (int pair = 0; pair < LaneCount; pair++)
+            {
+                bool black = (blackLanes & (1 << pair)) != 0;
+                bool white = (whiteLanes & (1 << pair)) != 0;
+                if (!black && !white) continue;
+
+                var particleColor = black && white
+                    ? UnityEngine.Color.Lerp(blackParticles, whiteParticles, 0.5f)
+                    : black ? blackParticles : whiteParticles;
+
+                // Both halves of a pad share one fret object, keyed by the black fret
+                _fretArray.PlayHitAnimation((int) SixFretGuitarFret.Black1 + pair, particleColor);
             }
         }
 

--- a/Assets/Script/Gameplay/Visuals/Fret/Fret.cs
+++ b/Assets/Script/Gameplay/Visuals/Fret/Fret.cs
@@ -304,6 +304,17 @@ namespace YARG.Gameplay.Visuals
             ThemeBind.HitEffect.Play();
         }
 
+        /// <summary>
+        /// Plays the hit particles with the given color. Used by six-fret so the
+        /// burst matches the note hit: black for black frets, white for white
+        /// frets, and a black/white mix for barres.
+        /// </summary>
+        public void PlayHitParticles(UnityEngine.Color color)
+        {
+            ThemeBind.HitEffect.SetColor(color);
+            ThemeBind.HitEffect.Play();
+        }
+
         public void PlayFullWidthHitParticles()
         {
             ThemeBind.OpenHitEffect.Play();

--- a/Assets/Script/Gameplay/Visuals/Fret/FretArray.cs
+++ b/Assets/Script/Gameplay/Visuals/Fret/FretArray.cs
@@ -246,6 +246,16 @@ namespace YARG.Gameplay.Visuals
             _frets[index].PlayHitParticles();
         }
 
+        /// <summary>
+        /// Plays the hit animation and particles with an explicit particle color
+        /// (six-fret colors the burst based on which note was hit).
+        /// </summary>
+        public void PlayHitAnimation(int index, Color particleColor)
+        {
+            _frets[index].PlayHitAnimation();
+            _frets[index].PlayHitParticles(particleColor);
+        }
+
         public void PlayCodaHitAnimation(int index)
         {
             if (!_frets.TryGetValue(index, out var fret))

--- a/Assets/Script/Gameplay/Visuals/TrackElements/Guitar/SixFretGuitarNoteElement.cs
+++ b/Assets/Script/Gameplay/Visuals/TrackElements/Guitar/SixFretGuitarNoteElement.cs
@@ -127,6 +127,15 @@ namespace YARG.Gameplay.Visuals
             NoteGroup.SetActive(true);
             NoteGroup.Initialize();
 
+            // Open HOPO/Tap notes have EmissionAddition: 1 in the prefab, which
+            // washes the note color to white. Reset it so the dedicated
+            // OpenHopoNote color field is visible.
+            if (NoteRef.Fret == (int) SixFretGuitarFret.Open &&
+                NoteRef.Type is GuitarNoteType.Hopo or GuitarNoteType.Tap)
+            {
+                NoteGroup.ResetEmissionAddition();
+            }
+
             if (NoteRef.IsSustain)
             {
                 _sustainLine.gameObject.SetActive(true);
@@ -209,7 +218,21 @@ namespace YARG.Gameplay.Visuals
             System.Drawing.Color primaryColor, primaryNoSp;
             System.Drawing.Color secondaryColor = default, secondaryNoSp = default;
 
-            if (NoteRef.Fret == (int) SixFretGuitarFret.Open || NoteRef.Fret == (int) SixFretGuitarFret.Wildcard)
+            if (NoteRef.Fret == (int) SixFretGuitarFret.Open &&
+                NoteRef.Type is GuitarNoteType.Hopo or GuitarNoteType.Tap)
+            {
+                // Open HOPO/Tap notes use a dedicated color (the prefab's
+                // EmissionAddition: 1 washes to white by default; ResetEmissionAddition
+                // in InitializeElement nullifies it so this color is visible).
+                primaryColor = isSp ? colors.OpenHopoNoteStarPower : colors.OpenHopoNote;
+                primaryNoSp = colors.OpenHopoNote;
+                // No real secondary for open notes; mirror primary so the
+                // sustain-line blend in SustainLine.SetState is a no-op.
+                secondaryColor = primaryColor;
+                secondaryNoSp = primaryNoSp;
+            }
+            else if (NoteRef.Fret == (int) SixFretGuitarFret.Open ||
+                     NoteRef.Fret == (int) SixFretGuitarFret.Wildcard)
             {
                 primaryColor = isSp ? colors.GetNoteStarPowerColor(NoteRef.Fret) : colors.GetNoteColor(NoteRef.Fret);
                 primaryNoSp = colors.GetNoteColor(NoteRef.Fret);

--- a/Assets/Script/Gameplay/Visuals/TrackElements/Guitar/SixFretGuitarNoteElement.cs
+++ b/Assets/Script/Gameplay/Visuals/TrackElements/Guitar/SixFretGuitarNoteElement.cs
@@ -213,6 +213,10 @@ namespace YARG.Gameplay.Visuals
             {
                 primaryColor = isSp ? colors.GetNoteStarPowerColor(NoteRef.Fret) : colors.GetNoteColor(NoteRef.Fret);
                 primaryNoSp = colors.GetNoteColor(NoteRef.Fret);
+                // No real secondary color for open/wildcard; mirror primary so the
+                // sustain-line blend in SustainLine.SetState is a no-op (same as Up/Down).
+                secondaryColor = primaryColor;
+                secondaryNoSp = primaryNoSp;
             }
             else
             {
@@ -275,8 +279,13 @@ namespace YARG.Gameplay.Visuals
 
             if (!NoteRef.IsSustain) return;
 
-            _sustainLine.SetState(SustainState, primaryColor.ToUnityColor());
+            // Set the secondary color before SetState, because SetState blends the
+            // stored secondary color into the sustain line color. Setting it after
+            // (as it was before) left the blend one update behind — null on the
+            // first call, so barre sustains rendered pure primary while Waiting and
+            // only showed the correct blend once activated (Hitting).
             _sustainLine.SetSecondaryColor(secondaryColor.ToUnityColor());
+            _sustainLine.SetState(SustainState, primaryColor.ToUnityColor());
         }
 
         protected override void HideElement()

--- a/Assets/Script/Settings/Preview/FakeNote.cs
+++ b/Assets/Script/Settings/Preview/FakeNote.cs
@@ -151,11 +151,19 @@ namespace YARG.Settings.Preview
             // Open HOPO notes use a dedicated color (the prefab's
             // EmissionAddition: 1 washes to white by default)
             if (NoteRef.NoteType == ThemeNoteType.OpenHOPO &&
-                FakeTrackPlayer.SelectedGameMode == GameMode.FiveFretGuitar)
+                (FakeTrackPlayer.SelectedGameMode == GameMode.FiveFretGuitar ||
+                 FakeTrackPlayer.SelectedGameMode == GameMode.SixFretGuitar))
             {
-                color = (useStarPower
-                    ? colorProfile.FiveFretGuitar.OpenHopoNoteStarPower
-                    : colorProfile.FiveFretGuitar.OpenHopoNote).ToUnityColor();
+                color = FakeTrackPlayer.SelectedGameMode switch
+                {
+                    GameMode.FiveFretGuitar => (useStarPower
+                        ? colorProfile.FiveFretGuitar.OpenHopoNoteStarPower
+                        : colorProfile.FiveFretGuitar.OpenHopoNote).ToUnityColor(),
+                    GameMode.SixFretGuitar => (useStarPower
+                        ? colorProfile.SixFretGuitar.OpenHopoNoteStarPower
+                        : colorProfile.SixFretGuitar.OpenHopoNote).ToUnityColor(),
+                    _ => color
+                };
             }
 
             // Miss is the highest-priority preview override.

--- a/Assets/Script/Settings/Preview/FakeNoteGenerators.cs
+++ b/Assets/Script/Settings/Preview/FakeNoteGenerators.cs
@@ -392,8 +392,8 @@ namespace YARG.Settings.Preview
     {
         public FakeNoteData CreateNote(double time, IFakeNoteRandom random)
         {
-            // 0 = Open, 1-6 = 6 frets, 7 = Wildcard
-            int fret = random.Range(0, 8);
+            // 0 = Open, 1-6 = 6 frets (no wildcard in the six-fret preview)
+            int fret = random.Range(0, 7);
 
             // Open notes
             if (fret == 0)
@@ -404,18 +404,6 @@ namespace YARG.Settings.Preview
                     Fret = (int) SixFretGuitarFret.Open,
                     CenterNote = true,
                     NoteType = ThemeNoteType.Open
-                };
-            }
-
-            // Wildcard
-            if (fret == 7)
-            {
-                return new FakeNoteData
-                {
-                    Time = time,
-                    Fret = (int) SixFretGuitarFret.Wildcard,
-                    CenterNote = true,
-                    NoteType = ThemeNoteType.Wildcard
                 };
             }
 
@@ -461,14 +449,6 @@ namespace YARG.Settings.Preview
                     {
                         Time = time,
                         Fret = (int) SixFretGuitarFret.Open,
-                        CenterNote = true,
-                        NoteType = noteType
-                    };
-                case ThemeNoteType.Wildcard:
-                    return new FakeNoteData
-                    {
-                        Time = time,
-                        Fret = (int) SixFretGuitarFret.Wildcard,
                         CenterNote = true,
                         NoteType = noteType
                     };

--- a/Assets/StreamingAssets/lang/en-US.json
+++ b/Assets/StreamingAssets/lang/en-US.json
@@ -2375,11 +2375,8 @@
                 "BlackNoteStarPower": {
                     "Name": "Black Note Star Power"
                 },
-                "BlackFret": {
-                    "Name": "Black Fret"
-                },
-                "WhiteFret": {
-                    "Name": "White Fret"
+                "Fret": {
+                    "Name": "Fret"
                 },
                 "BlackFretInner": {
                     "Name": "Black Fret Inner"


### PR DESCRIPTION
* removes black/white fret color in color preset in favor of just "fret" (but don't fret, inner is still 2 colors)
* allows to set open note colors
* plays correctly colored hit effects
* fixes sustain coloring
* removes wildcard from 6f preview

needs corresponding core pr merged