### PR TITLE
Update PlasticBand-Unity to v0.10.0

### DIFF
--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -33,7 +33,7 @@
     "com.nobi.roundedcorners": "https://github.com/kirevdokimov/Unity-UI-Rounded-Corners.git",
     "com.starasgames.tmpro-dynamic-data-cleaner": "1.0.0",
     "com.thenathannator.hidrogen": "0.5.3",
-    "com.thenathannator.plasticband": "0.9.2",
+    "com.thenathannator.plasticband": "0.10.0",
     "com.unity.2d.sprite": "1.0.0",
     "com.unity.addressables": "2.8.0",
     "com.unity.ai.navigation": "2.0.9",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -75,7 +75,7 @@
       "url": "https://package.openupm.com"
     },
     "com.thenathannator.plasticband": {
-      "version": "0.9.2",
+      "version": "0.10.0",
       "depth": 0,
       "source": "registry",
       "dependencies": {


### PR DESCRIPTION
([Original release page](https://github.com/TheNathannator/PlasticBand-Unity/releases/tag/v0.10.0))

## Fixed

- The touch bar on the Xbox 360 Pro Keyboard is now properly handled when using an Xbox 360 receiver via libusb.
- The touch bar on World Tour guitars is now properly handled.

## Removed

- The accelerometers on Guitar Hero guitars are no longer fully exposed, as they are not reliably implemented between different guitar models. Only standard tilt remains exposed.