### PR TITLE
make both venue rngs even 1 to 100 ranges

### DIFF
--- a/Assets/Script/Venue/Animator/VenueHashLibrary.cs
+++ b/Assets/Script/Venue/Animator/VenueHashLibrary.cs
@@ -180,8 +180,8 @@ namespace YARG.Venue
 
         public void Randomize(Animator animator)
         {
-            float value = UnityEngine.Random.Range(100f, 1f);
-            value = MathF.Round(value);
+            //end is max exclusive intended range is 1-100
+            float value = UnityEngine.Random.Range(101, 1);
             animator.SafeSetFloat(RNG, value);
         }
     }

--- a/Assets/Script/Venue/Animator/VenueHashLibrary.cs
+++ b/Assets/Script/Venue/Animator/VenueHashLibrary.cs
@@ -181,7 +181,7 @@ namespace YARG.Venue
         public void Randomize(Animator animator)
         {
             //end is max exclusive intended range is 1-100
-            float value = UnityEngine.Random.Range(101, 1);
+            float value = UnityEngine.Random.Range(1, 101);
             animator.SafeSetFloat(RNG, value);
         }
     }

--- a/Assets/Script/Venue/Characters/VRMCharacter.cs
+++ b/Assets/Script/Venue/Characters/VRMCharacter.cs
@@ -136,7 +136,8 @@ namespace YARG.Venue.Characters
 
             if (HasRng)
             {
-                var random = UnityEngine.Random.Range(0, 9);
+                //end is max exclusive intended range is 1-100
+                var random = UnityEngine.Random.Range(1, 101);
                 _animator.SetInteger(_rngHash, random);
                 CurrentRng = random;
             }


### PR DESCRIPTION
changes VRM character RNG to be the same 1-100 range as Venue Animator
also change Venue Animator to use integer range randomizer to make the distribution even.

still not exact parity because VRM character RNG is an Integer parameter while venue animator RNG is a float parameter (with only integer values)