### PR TITLE
Add experimental vocal lyric font scaling

### DIFF
--- a/Assets/Script/Gameplay/Player/Vocals/VocalLyricContainer.cs
+++ b/Assets/Script/Gameplay/Player/Vocals/VocalLyricContainer.cs
@@ -42,6 +42,9 @@ namespace YARG.Gameplay.Player
         private TextMeshPro[] _scrollingWidthTesters;
         private TextMeshPro[] _staticWidthTesters;
 
+        private static float VocalFontScale =>
+            1f + SettingsManager.Settings.VocalFontScaling.Value / 100f;
+
         public static int GetLaneIndex(int totalHarms, int harmIndex)
         {
             var combineHarmonyLyrics = !SettingsManager.Settings.UseThreeLaneLyricsInHarmony.Value;
@@ -78,15 +81,17 @@ namespace YARG.Gameplay.Player
             string displayText = lyric.HarmonyHidden && allowHiding ? string.Empty : lyric.Text;
 
             float width = 0f;
+            float fontScale = VocalFontScale;
             if (!string.IsNullOrEmpty(displayText))
             {
                 var tester = GetScrollingWidthTester(GetLaneIndex(totalHarms, harmIndex));
                 tester.fontStyle = lyric.NonPitched ? FontStyles.Italic : FontStyles.Normal;
                 tester.text = displayText;
-                width = tester.GetPreferredValues().x;
+                width = tester.GetPreferredValues().x * fontScale;
             }
 
-            return new VocalScrollingLyricSyllableElement.PreparedLyric(lyric, allowHiding, width);
+            return new VocalScrollingLyricSyllableElement.PreparedLyric(
+                lyric, allowHiding, width, fontScale);
         }
 
         public VocalStaticLyricPhraseElement.PreparedPhrase PrepareStaticLyricPhrase(
@@ -100,9 +105,10 @@ namespace YARG.Gameplay.Player
             var tester = GetStaticWidthTester(GetLaneIndex(totalHarms, harmIndex));
             tester.fontStyle = FontStyles.Normal;
             tester.text = preparedPhrase.FutureText;
-            var width = tester.GetPreferredValues().x;
+            float fontScale = VocalFontScale;
+            var width = tester.GetPreferredValues().x * fontScale;
 
-            return preparedPhrase.WithWidth(width);
+            return preparedPhrase.WithLayout(width, fontScale);
         }
 
         public LyricSpawnResult TrySpawnScrollingLyric(VocalScrollingLyricSyllableElement.PreparedLyric preparedLyric,

--- a/Assets/Script/Gameplay/Visuals/VocalElements/VocalScrollingLyricSyllableElement.cs
+++ b/Assets/Script/Gameplay/Visuals/VocalElements/VocalScrollingLyricSyllableElement.cs
@@ -13,15 +13,18 @@ namespace YARG.Gameplay.Visuals
             public readonly string DisplayText;
             public readonly FontStyles FontStyle;
             public readonly float Width;
+            public readonly float FontScale;
             public readonly bool IsHidden;
 
-            public PreparedLyric(LyricEvent lyric, bool allowHiding, float width)
+            public PreparedLyric(LyricEvent lyric, bool allowHiding, float width,
+                float fontScale)
             {
                 Lyric = lyric;
                 DisplayText = lyric.HarmonyHidden && allowHiding ? string.Empty : lyric.Text;
                 FontStyle = lyric.NonPitched ? FontStyles.Italic : FontStyles.Normal;
                 IsHidden = string.IsNullOrEmpty(DisplayText);
                 Width = IsHidden ? 0f : width;
+                FontScale = fontScale;
             }
         }
 
@@ -42,7 +45,15 @@ namespace YARG.Gameplay.Visuals
         [SerializeField]
         private TextMeshPro _lyricText;
 
+        private Vector3 _defaultTextScale;
+
         public float Width => _preparedLyric.Width;
+
+        protected override void GameplayAwake()
+        {
+            base.GameplayAwake();
+            _defaultTextScale = _lyricText.transform.localScale;
+        }
 
         public void Initialize(PreparedLyric preparedLyric, double minTime,
             bool isStarpower, int harmonyIndex, bool allowHiding)
@@ -61,6 +72,7 @@ namespace YARG.Gameplay.Visuals
         {
             _lyricText.text = _preparedLyric.DisplayText;
             _lyricText.fontStyle = _preparedLyric.FontStyle;
+            _lyricText.transform.localScale = _defaultTextScale * _preparedLyric.FontScale;
 
             // Disable automatically if the text is just nothing
             if (string.IsNullOrEmpty(_lyricText.text))

--- a/Assets/Script/Gameplay/Visuals/VocalElements/VocalStaticLyricPhraseElement.cs
+++ b/Assets/Script/Gameplay/Visuals/VocalElements/VocalStaticLyricPhraseElement.cs
@@ -18,31 +18,34 @@ namespace YARG.Gameplay.Visuals
             public readonly List<StaticLyricSyllable> Syllables;
             public readonly string                                        FutureText;
             public readonly float                                         Width;
+            public readonly float                                         FontScale;
             public readonly double                                        Duration;
 
             public PreparedPhrase(VocalsPhrase phrase, List<VocalsPhrase> scoringPhrases,
-                bool allowHiding, float width)
+                bool allowHiding, float width, float fontScale = 1f)
             {
                 Phrase = phrase;
                 Duration = phrase.TimeLength;
                 Syllables = BuildSyllables(phrase, scoringPhrases, allowHiding);
                 FutureText = BuildFutureText(Syllables);
                 Width = width;
+                FontScale = fontScale;
             }
 
             private PreparedPhrase(VocalsPhrase phrase, double duration,
-                List<StaticLyricSyllable> syllables, string futureText, float width)
+                List<StaticLyricSyllable> syllables, string futureText, float width, float fontScale)
             {
                 Phrase = phrase;
                 Duration = duration;
                 Syllables = syllables;
                 FutureText = futureText;
                 Width = width;
+                FontScale = fontScale;
             }
 
-            public PreparedPhrase WithWidth(float width)
+            public PreparedPhrase WithLayout(float width, float fontScale)
             {
-                return new PreparedPhrase(Phrase, Duration, Syllables, FutureText, width);
+                return new PreparedPhrase(Phrase, Duration, Syllables, FutureText, width, fontScale);
             }
         }
 
@@ -57,9 +60,17 @@ namespace YARG.Gameplay.Visuals
         [SerializeField]
         private TextMeshPro _phraseText;
 
+        private Vector3 _defaultTextScale;
+
         public float Width => _preparedPhrase.Width;
 
         public double Duration => _preparedPhrase.Duration;
+
+        protected override void GameplayAwake()
+        {
+            base.GameplayAwake();
+            _defaultTextScale = _phraseText.transform.localScale;
+        }
 
         public void Initialize(PreparedPhrase preparedPhrase, float x)
         {
@@ -73,6 +84,7 @@ namespace YARG.Gameplay.Visuals
         {
             transform.localPosition = transform.localPosition.WithX(_x);
             _phraseText.text = _preparedPhrase.FutureText;
+            _phraseText.transform.localScale = _defaultTextScale * _preparedPhrase.FontScale;
             _lastRenderState = int.MinValue;
         }
 

--- a/Assets/Script/Settings/SettingsManager.Settings.cs
+++ b/Assets/Script/Settings/SettingsManager.Settings.cs
@@ -768,6 +768,7 @@ namespace YARG.Settings
             };
             public ToggleSetting SaveScoresWithBots { get; } = new(false);
             public SliderSetting FontScaling { get; } = new(0f, 0f, 100f, FontScalingCallback);
+            public SliderSetting VocalFontScaling { get; } = new(0f, 0f, 200f);
 
             public DropdownSetting<AudioOutputMode> OutputMode { get; } = new(AudioOutputMode.Shared,
                 OutputModeCallback)

--- a/Assets/Script/Settings/SettingsManager.cs
+++ b/Assets/Script/Settings/SettingsManager.cs
@@ -287,6 +287,7 @@ namespace YARG.Settings
                 nameof(Settings.ReverbImplementation),
                 new HeaderMetadata("Accessibility"),
                 nameof(Settings.FontScaling),
+                nameof(Settings.VocalFontScaling),
                 new HeaderMetadata("OutputConfiguration"),
                 new FieldMetadata(nameof(Settings.OutputMode), visibleWhen: IsWindows),
                 nameof(Settings.OutputDevice),

--- a/Assets/StreamingAssets/lang/en-US.json
+++ b/Assets/StreamingAssets/lang/en-US.json
@@ -1290,6 +1290,10 @@
                 "Name": "Font Scaling",
                 "Description": "Scales the minimum font size to be more visible"
             },
+            "VocalFontScaling": {
+                "Name": "Vocal Font Scaling",
+                "Description": "Increases the size of lyrics shown on the vocal highway by up to 200%. May not work with harmonies."
+            },
             "FullscreenMode": {
                 "Name": "Fullscreen Mode",
                 "Description": "Changes the fullscreen mode.",


### PR DESCRIPTION
## Summary

Adds an experimental accessibility setting called **Vocal Font Scaling**.

The setting increases the size of lyrics displayed on the vocal highway, making them easier to read when a vocal track is active. It supports an additional 0–200% scale and defaults to 0%, preserving the existing presentation.

## Changes

- Add Vocal Font Scaling under Experimental → Accessibility.
- Scale both scrolling vocal lyrics and static lyric phrases.
- Scale measured lyric widths so enlarged lyrics retain appropriate spacing.
- Add English localization describing the 200% maximum and noting that the setting may not work with harmonies.

## Motivation

Lyrics displayed on the vocal highway can be considerably smaller than the karaoke-style lyrics displayed when no vocal track is active. This option gives players an accessibility control for improving lyric readability.

## Testing

- Manually tested during gameplay with an active vocal track.
- Verified the setting and lyric scaling work as intended through the supported range.
- Rebased onto the latest `dev` branch and resolved the updated vocal lyric APIs.
- Successfully built a Windows 64-bit player from the rebased commit with `YARG_TEST_BUILD` enabled.
- Verified the Unity build completed without C# compiler errors.

## Notes

No external assets, libraries, or third-party source code are included. Harmony layouts may not work correctly at higher scaling values, so the setting is experimental and its description communicates that limitation.