### PR TITLE
Guard NeonLightManager against unassigned material references

### DIFF
--- a/Assets/Script/Venue/Lights/NeonLightManager.cs
+++ b/Assets/Script/Venue/Lights/NeonLightManager.cs
@@ -37,15 +37,30 @@ namespace YARG.Venue
             _lightManager = FindFirstObjectByType<LightManager>();
 
 			for (int i = 0; i < _neonMaterialsFullColor.Length; i++) {
+				if (_neonMaterialsFullColor[i].Material == null)
+				{
+					continue;
+				}
+
 				_neonMaterialsFullColor[i].InitialColor = (_neonMaterialsFullColor[i].Material.GetColor(_emissionColor));
 			}
         }
 
         private void Update()
         {
+            if (_lightManager == null)
+            {
+                return;
+            }
+
             // Update all of the materials
             foreach (var material in _neonMaterials)
             {
+				if (material == null)
+				{
+					continue;
+				}
+
 				var lightState = _lightManager.GenericLightState;
 				material.SetFloat(_emissionMultiplier, lightState.Intensity);
 
@@ -62,6 +77,11 @@ namespace YARG.Venue
             for (int i = 0; i < _neonMaterialsFullColor.Length; i++)
             {
 				var neon = _neonMaterialsFullColor[i];
+
+				if (neon.Material == null)
+				{
+					continue;
+				}
 
 				switch ((neon.Location, neon.SpotLocation))
 				{


### PR DESCRIPTION
Fixes repeated `NullReferenceException`/`UnassignedReferenceException` spam from `NeonLightManager.Update()` when a venue leaves either the legacy `_neonMaterials` list or the `_neonMaterialsFullColor` list unpopulated.

Per the venue creation wiki, `_neonMaterials` is documented as backwards-compat only — venues are told to use `_neonMaterialsFullColor` instead — but the script never treated either list as optional, so any venue using only one of the two would spam exceptions every frame.

Adds null checks in `Start()` and `Update()` so unassigned material slots are skipped instead of throwing.