### PR TITLE
4-Lane/Pro Drums Aggregate-Light Score/Sort/Filter

### DIFF
--- a/Assets/Script/Helpers/MidiDrumkitHelper.cs
+++ b/Assets/Script/Helpers/MidiDrumkitHelper.cs
@@ -14,6 +14,23 @@ namespace YARG.Helpers
             Instrument.FourLaneDrums
         };
 
+        // Four-lane drum controllers can play both chart types, but should prefer Pro Drums.
+        public static readonly Instrument[] FourLaneInstruments =
+        {
+            Instrument.ProDrums,
+            Instrument.FourLaneDrums
+        };
+
+        public static Instrument[] GetInstruments(GameMode gameMode)
+        {
+            return gameMode switch
+            {
+                GameMode.EliteDrums => Instruments,
+                GameMode.FourLaneDrums => FourLaneInstruments,
+                _ => null
+            };
+        }
+
         public static bool HasAnyDrumPart(SongEntry song)
         {
             foreach (var instrument in Instruments)
@@ -29,7 +46,18 @@ namespace YARG.Helpers
 
         public static Instrument? GetPreferredInstrumentForSong(SongEntry song)
         {
-            foreach (var instrument in Instruments)
+            return GetPreferredInstrumentForSong(song, Instruments);
+        }
+
+        public static Instrument? GetPreferredInstrumentForSong(SongEntry song, GameMode gameMode)
+        {
+            var instruments = GetInstruments(gameMode);
+            return instruments == null ? null : GetPreferredInstrumentForSong(song, instruments);
+        }
+
+        public static Instrument? GetPreferredInstrumentForSong(SongEntry song, Instrument[] instruments)
+        {
+            foreach (var instrument in instruments)
             {
                 if (song.HasInstrument(instrument))
                 {

--- a/Assets/Script/Menu/Filters/FiltersMenu.cs
+++ b/Assets/Script/Menu/Filters/FiltersMenu.cs
@@ -52,6 +52,7 @@ namespace YARG.Menu.Filters
             public readonly Dictionary<string, bool> Enabled;
             public readonly Func<string, string> LabelTransform;
             public readonly Instrument IntensityInstrument;
+            public readonly GameMode? IntensityGameMode;
 
             public FilterGroup Group => Key.Group;
 
@@ -61,7 +62,8 @@ namespace YARG.Menu.Filters
                 Func<Dictionary<string, int>> getCounts,
                 Dictionary<string, bool> enabled,
                 Func<string, string> labelTransform = null,
-                Instrument intensityInstrument = default)
+                Instrument intensityInstrument = default,
+                GameMode? intensityGameMode = null)
             {
                 Key = key;
                 GetValues = getValues;
@@ -69,6 +71,7 @@ namespace YARG.Menu.Filters
                 Enabled = enabled;
                 LabelTransform = labelTransform;
                 IntensityInstrument = intensityInstrument;
+                IntensityGameMode = intensityGameMode;
             }
         }
 
@@ -77,12 +80,15 @@ namespace YARG.Menu.Filters
             public readonly Guid ProfileId;
             public readonly string ProfileName;
             public readonly Instrument Instrument;
+            public readonly GameMode? GameMode;
 
-            public IntensityFilterContext(Guid profileId, string profileName, Instrument instrument)
+            public IntensityFilterContext(Guid profileId, string profileName, Instrument instrument,
+                GameMode? gameMode = null)
             {
                 ProfileId = profileId;
                 ProfileName = profileName;
                 Instrument = instrument;
+                GameMode = gameMode;
             }
         }
         [SerializeField]
@@ -144,7 +150,7 @@ namespace YARG.Menu.Filters
         private static Dictionary<string, int> _cachedPlaylistCounts;
         private static IReadOnlyList<string> _cachedCharters;
         private static IReadOnlyList<string> _cachedLengths;
-        private static readonly Dictionary<Instrument, IReadOnlyList<string>> _cachedIntensitiesByInstrument = new();
+        private static readonly Dictionary<(Instrument, GameMode?), IReadOnlyList<string>> _cachedIntensities = new();
 
         private static int _cachedGenreSongCount = -1;
         private static int _cachedSubgenreSongCount = -1;
@@ -448,7 +454,8 @@ namespace YARG.Menu.Filters
                 contexts.Add(new IntensityFilterContext(
                     profile.Id,
                     profile.Name,
-                    instrument));
+                    instrument,
+                    profile.GameMode));
             }
 
             return contexts;
@@ -463,7 +470,12 @@ namespace YARG.Menu.Filters
             string profileName = string.IsNullOrWhiteSpace(context.ProfileName)
                 ? Localize.Key(IntensityLabels.UnknownKey)
                 : context.ProfileName;
-            string instrumentName = context.Instrument.ToLocalizedName();
+            string instrumentName = context.GameMode switch
+            {
+                GameMode.EliteDrums => SortAttribute.AggregateDrums.ToLocalizedName(),
+                GameMode.FourLaneDrums => Localize.Key("Menu.Filters.Intensities.FourLaneProDrums"),
+                _ => context.Instrument.ToLocalizedName()
+            };
             string contextLabel = $"({profileName} on {instrumentName})";
 
             return $"{baseLabel} {TextColorer.StyleString(contextLabel, MenuData.Colors.TrackDefaultSecondary, 400)}";
@@ -505,14 +517,14 @@ namespace YARG.Menu.Filters
         private void ResetIntensityFilters(YargProfile profile)
         {
             var instrument = GetIntensityInstrumentForProfile(profile);
-            ResetIntensityFilters(profile.Id, instrument);
+            ResetIntensityFilters(profile.Id, instrument, profile.GameMode);
         }
 
-        private void ResetIntensityFilters(Guid profileId, Instrument instrument)
+        private void ResetIntensityFilters(Guid profileId, Instrument instrument, GameMode? gameMode = null)
         {
             var enabled = GetIntensityEnabled(profileId);
             enabled.Clear();
-            foreach (var value in GetAllIntensitiesCached(instrument))
+            foreach (var value in GetAllIntensitiesCached(instrument, gameMode))
                 enabled[value] = true;
 
             var key = new FilterKey(FilterGroup.Intensity, profileId);
@@ -964,12 +976,14 @@ namespace YARG.Menu.Filters
             foreach (var context in GetIntensityFilterContexts())
             {
                 var instrument = context.Instrument;
+                var gameMode = context.GameMode;
                 yield return new FilterDef(
                     new FilterKey(FilterGroup.Intensity, context.ProfileId),
-                    () => GetAllIntensitiesCached(instrument),
-                    () => GetIntensityCounts(instrument),
+                    () => GetAllIntensitiesCached(instrument, gameMode),
+                    () => GetIntensityCounts(instrument, gameMode),
                     GetIntensityEnabled(context.ProfileId),
-                    intensityInstrument: instrument);
+                    intensityInstrument: instrument,
+                    intensityGameMode: gameMode);
             }
 
             yield return new FilterDef(
@@ -1245,10 +1259,11 @@ namespace YARG.Menu.Filters
                 if (def.Group != FilterGroup.Intensity) continue;
 
                 var instrument = def.IntensityInstrument;
+                var gameMode = def.IntensityGameMode;
                 if (TryGetSelectedSet(def.Enabled, def.GetValues(), NormalizeFilterKey, out var intensities))
                     predicates.Add(entry =>
                     {
-                        var label = GetIntensityLabel(entry, instrument);
+                        var label = GetIntensityLabel(entry, instrument, gameMode);
                         return label != null && intensities.Contains(NormalizeFilterKey(label));
                     });
             }
@@ -1604,25 +1619,26 @@ namespace YARG.Menu.Filters
 #endregion
 
 #region Intensities
-        private static IReadOnlyList<string> GetAllIntensitiesCached(Instrument instrument)
+        private static IReadOnlyList<string> GetAllIntensitiesCached(Instrument instrument, GameMode? gameMode = null)
         {
             if (_cachedIntensitySongCount != SongContainer.Count)
             {
                 _cachedIntensitySongCount = SongContainer.Count;
-                _cachedIntensitiesByInstrument.Clear();
+                _cachedIntensities.Clear();
             }
 
-            if (_cachedIntensitiesByInstrument.TryGetValue(instrument, out var cached))
+            var cacheKey = (instrument, gameMode);
+            if (_cachedIntensities.TryGetValue(cacheKey, out var cached))
                 return cached;
 
-            var built = BuildIntensityList(instrument);
-            _cachedIntensitiesByInstrument[instrument] = built;
+            var built = BuildIntensityList(instrument, gameMode);
+            _cachedIntensities[cacheKey] = built;
             return built;
         }
 
-        private static IReadOnlyList<string> BuildIntensityList(Instrument instrument)
+        private static IReadOnlyList<string> BuildIntensityList(Instrument instrument, GameMode? gameMode)
         {
-            var counts = GetIntensityCounts(instrument);
+            var counts = GetIntensityCounts(instrument, gameMode);
             var ordered = new List<string>(IntensityLabels.LabelCount + 2);
             var nonstandardIntensities = new SortedSet<int>();
 
@@ -1635,7 +1651,7 @@ namespace YARG.Menu.Filters
 
             foreach (var song in SongContainer.Songs)
             {
-                if (TryGetIntensity(song, instrument, out int intensity) &&
+                if (TryGetIntensity(song, instrument, gameMode, out int intensity) &&
                     (intensity < 0 || intensity >= IntensityLabels.LabelCount))
                 {
                     nonstandardIntensities.Add(intensity);
@@ -1652,13 +1668,13 @@ namespace YARG.Menu.Filters
             return ordered;
         }
 
-        private static Dictionary<string, int> GetIntensityCounts(Instrument instrument)
+        private static Dictionary<string, int> GetIntensityCounts(Instrument instrument, GameMode? gameMode = null)
         {
             var dict = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
 
             foreach (var song in SongContainer.Songs)
             {
-                var label = GetIntensityLabel(song, instrument);
+                var label = GetIntensityLabel(song, instrument, gameMode);
                 if (string.IsNullOrWhiteSpace(label))
                     continue;
 
@@ -1669,16 +1685,36 @@ namespace YARG.Menu.Filters
             return dict;
         }
 
-        private static string GetIntensityLabel(SongEntry entry, Instrument instrument)
+        private static string GetIntensityLabel(SongEntry entry, Instrument instrument, GameMode? gameMode = null)
         {
-            return TryGetIntensity(entry, instrument, out int intensity)
+            return TryGetIntensity(entry, instrument, gameMode, out int intensity)
                 ? GetIntensityLabel(intensity)
                 : Localize.Key(IntensityLabels.NoPartKey);
         }
 
         private static bool TryGetIntensity(SongEntry entry, Instrument instrument, out int intensity)
         {
-            if (instrument == Instrument.EliteDrums)
+            return TryGetIntensity(entry, instrument, null, out intensity);
+        }
+
+        private static bool TryGetIntensity(SongEntry entry, Instrument instrument, GameMode? gameMode,
+            out int intensity)
+        {
+            var drumInstruments = gameMode.HasValue
+                ? MidiDrumkitHelper.GetInstruments(gameMode.Value)
+                : null;
+            if (drumInstruments != null)
+            {
+                var preferredInstrument = MidiDrumkitHelper.GetPreferredInstrumentForSong(entry, drumInstruments);
+                if (!preferredInstrument.HasValue)
+                {
+                    intensity = default;
+                    return false;
+                }
+
+                instrument = preferredInstrument.Value;
+            }
+            else if (instrument == Instrument.EliteDrums)
             {
                 var preferredInstrument = MidiDrumkitHelper.GetPreferredInstrumentForSong(entry);
                 if (!preferredInstrument.HasValue)

--- a/Assets/Script/Scores/ScoreContainer.cs
+++ b/Assets/Script/Scores/ScoreContainer.cs
@@ -283,9 +283,10 @@ namespace YARG.Scores
             }
 
             var player = PlayerContainer.Players.First(entry => !entry.Profile.IsBot);
-            playerScoreRecord = player.Profile.GameMode == GameMode.EliteDrums
+            var drumInstruments = MidiDrumkitHelper.GetInstruments(player.Profile.GameMode);
+            playerScoreRecord = drumInstruments != null
                 ? GetPreferredHighScoreForInstruments(
-                    songChecksum, player.Profile.Id, MidiDrumkitHelper.Instruments)
+                    songChecksum, player.Profile.Id, drumInstruments)
                 : GetPreferredHighScore(
                     songChecksum, player.Profile.Id, player.Profile.CurrentInstrument);
         }
@@ -549,9 +550,10 @@ namespace YARG.Scores
         {
             try
             {
-                List<PlayerScoreWithChecksum> records = profile.GameMode == GameMode.EliteDrums
+                var drumInstruments = MidiDrumkitHelper.GetInstruments(profile.GameMode);
+                List<PlayerScoreWithChecksum> records = drumInstruments != null
                     ? _db.QueryPlayerBestStarsForInstruments(
-                        profile, MidiDrumkitHelper.Instruments, SettingsManager.Settings.HighScoreHistory.Value,
+                        profile, drumInstruments, SettingsManager.Settings.HighScoreHistory.Value,
                         SongContainer.SongsByHash.Keys, SongContainer.LibraryRevision)
                     : _db.QueryPlayerBestStars(
                         profile, SettingsManager.Settings.HighScoreHistory.Value, SongContainer.SongsByHash.Keys,

--- a/Assets/Script/Scores/ScoreDatabase.cs
+++ b/Assets/Script/Scores/ScoreDatabase.cs
@@ -545,11 +545,12 @@ namespace YARG.Scores
                     AND PlayerScores.PlayerId = ?
                     AND PlayerScores.IsReplay = 0";
 
-            bool useAggregateDrums = profile.GameMode == GameMode.EliteDrums;
+            var drumInstruments = MidiDrumkitHelper.GetInstruments(profile.GameMode);
+            bool useAggregateDrums = drumInstruments != null;
 
             if (useAggregateDrums)
             {
-                query += $" AND PlayerScores.Instrument {BuildInstrumentInClause(MidiDrumkitHelper.Instruments)} ";
+                query += $" AND PlayerScores.Instrument {BuildInstrumentInClause(drumInstruments)} ";
             }
             // If the profile instrument is bad, we can still return all scores for the profile
             else if (profile.HasValidInstrument)
@@ -564,7 +565,7 @@ namespace YARG.Scores
             if (useAggregateDrums)
             {
                 var parameters = new List<object> { profile.Id };
-                parameters.AddRange(BuildInstrumentParams(MidiDrumkitHelper.Instruments));
+                parameters.AddRange(BuildInstrumentParams(drumInstruments));
                 return _db.Query<PlayCountRecord>(query, parameters.ToArray());
             }
 

--- a/Assets/Script/Song/SongContainer.cs
+++ b/Assets/Script/Song/SongContainer.cs
@@ -563,8 +563,9 @@ namespace YARG.Song
 
             var profile = player.Profile;
             bool useBandScores = ScoreContainer.UseBandHighScoresForCurrentPlayers;
-            var cacheInstrument = profile.GameMode == GameMode.EliteDrums
-                ? Instrument.EliteDrums
+            var drumInstruments = MidiDrumkitHelper.GetInstruments(profile.GameMode);
+            var cacheInstrument = drumInstruments != null
+                ? drumInstruments[0]
                 : profile.CurrentInstrument;
             if (_starsCacheValid &&
                 _starsCacheProfileId == profile.Id &&
@@ -589,9 +590,9 @@ namespace YARG.Song
             }
 
             Instrument instrument = player.Profile.CurrentInstrument;
-            bool useAggregateDrums = profile.GameMode == GameMode.EliteDrums;
+            bool useAggregateDrums = drumInstruments != null;
             IComparer<SongEntry> comparer = useAggregateDrums
-                ? new AggregateDrumsIntensityComparer()
+                ? new AggregateDrumsIntensityComparer(drumInstruments)
                 : new IntensityComparer(instrument);
 
             // Use Dictionary instead of array due to complex enum values
@@ -602,7 +603,7 @@ namespace YARG.Song
                 StarAmount key = StarAmount.NoPart;
                 if (useAggregateDrums)
                 {
-                    var preferredInstrument = MidiDrumkitHelper.GetPreferredInstrumentForSong(song);
+                    var preferredInstrument = MidiDrumkitHelper.GetPreferredInstrumentForSong(song, drumInstruments);
                     if (preferredInstrument.HasValue && song[preferredInstrument.Value].IsActive())
                     {
                         if (!_runtimeStars.TryGetValue(song, out key))
@@ -670,7 +671,10 @@ namespace YARG.Song
 
             YargProfile profile = player.Profile;
             Instrument instrument = profile.CurrentInstrument;
-            IntensityComparer comparer = new(instrument);
+            var drumInstruments = MidiDrumkitHelper.GetInstruments(profile.GameMode);
+            IComparer<SongEntry> comparer = drumInstruments != null
+                ? new AggregateDrumsIntensityComparer(drumInstruments)
+                : new IntensityComparer(instrument);
             string[] bucketKeys =
             {
                 Localize.Key("Menu.MusicLibrary.Sort.Percentage.100"),
@@ -694,20 +698,30 @@ namespace YARG.Song
             // instrument, difficulty, and High Score History mode.
             if (_songs.Length > 0)
             {
-                ScoreContainer.GetBestPercentageScore(
-                    _songs[0].Hash, profile.Id, instrument, allowCacheUpdate: true);
+                if (drumInstruments != null)
+                    ScoreContainer.GetBestPercentageScoreForInstruments(
+                        _songs[0].Hash, profile.Id, drumInstruments, allowCacheUpdate: true);
+                else
+                    ScoreContainer.GetBestPercentageScore(
+                        _songs[0].Hash, profile.Id, instrument, allowCacheUpdate: true);
             }
 
             foreach (SongEntry song in _songs)
             {
-                if (!song[instrument].IsActive())
+                var preferredInstrument = drumInstruments != null
+                    ? MidiDrumkitHelper.GetPreferredInstrumentForSong(song, drumInstruments)
+                    : instrument;
+                if (!preferredInstrument.HasValue || !song[preferredInstrument.Value].IsActive())
                 {
                     InsertSorted(buckets[^1], song, comparer);
                     continue;
                 }
 
-                PlayerScoreRecord record = ScoreContainer.GetBestPercentageScore(
-                    song.Hash, profile.Id, instrument, allowCacheUpdate: false);
+                PlayerScoreRecord record = drumInstruments != null
+                    ? ScoreContainer.GetBestPercentageScoreForInstruments(
+                        song.Hash, profile.Id, drumInstruments, allowCacheUpdate: false)
+                    : ScoreContainer.GetBestPercentageScore(
+                        song.Hash, profile.Id, instrument, allowCacheUpdate: false);
                 if (record == null || record.GetPercent() <= 0f)
                 {
                     InsertSorted(buckets[^2], song, comparer);
@@ -766,7 +780,10 @@ namespace YARG.Song
 
             YargProfile profile = player.Profile;
             Instrument instrument = profile.CurrentInstrument;
-            IntensityComparer comparer = new(instrument);
+            var drumInstruments = MidiDrumkitHelper.GetInstruments(profile.GameMode);
+            IComparer<SongEntry> comparer = drumInstruments != null
+                ? new AggregateDrumsIntensityComparer(drumInstruments)
+                : new IntensityComparer(instrument);
             int[] thresholds = { 500000, 400000, 300000, 200000, 150000, 100000, 75000, 50000, 30000, 10000, 1 };
             var categorySongs = new List<SongEntry>[thresholds.Length];
             for (int i = 0; i < categorySongs.Length; i++)
@@ -780,20 +797,30 @@ namespace YARG.Song
 
             if (_songs.Length > 0)
             {
-                ScoreContainer.GetHighScore(
-                    _songs[0].Hash, profile.Id, instrument, allowCacheUpdate: true);
+                if (drumInstruments != null)
+                    ScoreContainer.GetHighScoreForInstruments(
+                        _songs[0].Hash, profile.Id, drumInstruments, allowCacheUpdate: true);
+                else
+                    ScoreContainer.GetHighScore(
+                        _songs[0].Hash, profile.Id, instrument, allowCacheUpdate: true);
             }
 
             foreach (SongEntry song in _songs)
             {
-                if (!song[instrument].IsActive())
+                var preferredInstrument = drumInstruments != null
+                    ? MidiDrumkitHelper.GetPreferredInstrumentForSong(song, drumInstruments)
+                    : instrument;
+                if (!preferredInstrument.HasValue || !song[preferredInstrument.Value].IsActive())
                 {
                     InsertSorted(noPart, song, comparer);
                     continue;
                 }
 
-                PlayerScoreRecord record = ScoreContainer.GetHighScore(
-                    song.Hash, profile.Id, instrument, allowCacheUpdate: false);
+                PlayerScoreRecord record = drumInstruments != null
+                    ? ScoreContainer.GetHighScoreForInstruments(
+                        song.Hash, profile.Id, drumInstruments, allowCacheUpdate: false)
+                    : ScoreContainer.GetHighScore(
+                        song.Hash, profile.Id, instrument, allowCacheUpdate: false);
                 if (record == null || record.Score <= 0)
                 {
                     InsertSorted(unplayed, song, comparer);
@@ -867,7 +894,7 @@ namespace YARG.Song
             }
         }
 
-        private static void InsertSorted(List<SongEntry> songs, SongEntry song, IntensityComparer comparer)
+        private static void InsertSorted(List<SongEntry> songs, SongEntry song, IComparer<SongEntry> comparer)
         {
             int index = songs.BinarySearch(song, comparer);
             songs.Insert(~index, song);
@@ -958,7 +985,7 @@ namespace YARG.Song
             }
 
             var noAggregateDrumsPart = _songs.Where(song => !MidiDrumkitHelper.HasAnyDrumPart(song)).ToList();
-            noAggregateDrumsPart.Sort(new AggregateDrumsIntensityComparer());
+            noAggregateDrumsPart.Sort(new AggregateDrumsIntensityComparer(MidiDrumkitHelper.Instruments));
             _sortAggregateDrums = new SongCategory[
                 _sortedSongs.AggregateDrums.Count + (noAggregateDrumsPart.Count > 0 ? 1 : 0)];
             {
@@ -1255,10 +1282,17 @@ namespace YARG.Song
 
         readonly struct AggregateDrumsIntensityComparer : IComparer<SongEntry>
         {
+            private readonly Instrument[] _instruments;
+
+            public AggregateDrumsIntensityComparer(Instrument[] instruments)
+            {
+                _instruments = instruments;
+            }
+
             public int Compare(SongEntry x, SongEntry y)
             {
-                int intensityX = GetPreferredIntensity(x);
-                int intensityY = GetPreferredIntensity(y);
+                int intensityX = GetPreferredIntensity(x, _instruments);
+                int intensityY = GetPreferredIntensity(y, _instruments);
 
                 if (intensityX == intensityY)
                 {
@@ -1276,9 +1310,9 @@ namespace YARG.Song
                 return intensityX.CompareTo(intensityY);
             }
 
-            private static int GetPreferredIntensity(SongEntry entry)
+            private static int GetPreferredIntensity(SongEntry entry, Instrument[] instruments)
             {
-                var instrument = MidiDrumkitHelper.GetPreferredInstrumentForSong(entry);
+                var instrument = MidiDrumkitHelper.GetPreferredInstrumentForSong(entry, instruments);
                 return instrument.HasValue ? entry[instrument.Value].Intensity : -1;
             }
         }

--- a/Assets/StreamingAssets/lang/en-US.json
+++ b/Assets/StreamingAssets/lang/en-US.json
@@ -622,6 +622,7 @@
             "Charters": "Charters",
             "Intensities": {
                 "Name": "Intensities",
+                "FourLaneProDrums": "4-Lane/Pro Drums",
                 "WarmUp": "Warm Up",
                 "Apprentice": "Apprentice",
                 "Solid": "Solid",


### PR DESCRIPTION
## Description

Similar to the **MIDI Drumkit** controller type - which treats Elite, Pro, 5-Lane, and 4-Lane drum charts as one instrument when filtering, sorting, and displaying scores - the **Drumkit (4-Lane, Pro)** controller type now treats Pro and 4-Lane drum charts as the same instrument for those purposes.
Pro Drums remains the preferred chart when both types are available. Because 4-Lane and Pro Drums are already tightly connected, this change does not add a separate combined sort option for them.

This fixes: https://discord.com/channels/1086048856678084609/1480751460890185930.
This fixes: https://discord.com/channels/1086048856678084609/1547657960589885580.


## Screenshots

<img width="1280" height="768" alt="image" src="https://github.com/user-attachments/assets/95c7db98-ed3a-47b8-9310-f200de684aea" />

<img width="1280" height="768" alt="image" src="https://github.com/user-attachments/assets/a4863447-d6de-4ea8-a851-12219d591a5d" />
