### PR TITLE
Add a setting to allow a user-directed VLC.app or libVLC path

### DIFF
--- a/Assets/Prefabs/Menu/Settings/Visuals/FolderPathSetting.prefab
+++ b/Assets/Prefabs/Menu/Settings/Visuals/FolderPathSetting.prefab
@@ -1,0 +1,618 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &4184945013568993316
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2086640382105371342}
+  - component: {fileID: 1737401350103676205}
+  - component: {fileID: 1482936140848510206}
+  m_Layer: 5
+  m_Name: Path Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2086640382105371342
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4184945013568993316}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6395833747087873664}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -185, y: 0}
+  m_SizeDelta: {x: 520, y: 0}
+  m_Pivot: {x: 1, y: 0.5}
+--- !u!222 &1737401350103676205
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4184945013568993316}
+  m_CullTransparentMesh: 1
+--- !u!114 &1482936140848510206
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4184945013568993316}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: (not found)
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 69b34e9e884c55947b52d9bbbd4258d7, type: 2}
+  m_sharedMaterial: {fileID: 4264900350419322127, guid: 69b34e9e884c55947b52d9bbbd4258d7, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 24
+  m_fontSizeBase: 24
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 10
+  m_fontSizeMax: 14
+  m_fontStyle: 16
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_characterHorizontalScale: 1
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 0
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!1001 &3124624307905060885
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4420504316707193964, guid: 6f46741e648c07044852bd3391146600, type: 3}
+      propertyPath: m_Name
+      value: FolderPathSetting
+      objectReference: {fileID: 0}
+    - target: {fileID: 4420504316707193967, guid: 6f46741e648c07044852bd3391146600, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4420504316707193967, guid: 6f46741e648c07044852bd3391146600, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4420504316707193967, guid: 6f46741e648c07044852bd3391146600, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4420504316707193967, guid: 6f46741e648c07044852bd3391146600, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4420504316707193967, guid: 6f46741e648c07044852bd3391146600, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4420504316707193967, guid: 6f46741e648c07044852bd3391146600, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4420504316707193967, guid: 6f46741e648c07044852bd3391146600, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 1500
+      objectReference: {fileID: 0}
+    - target: {fileID: 4420504316707193967, guid: 6f46741e648c07044852bd3391146600, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 4420504316707193967, guid: 6f46741e648c07044852bd3391146600, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4420504316707193967, guid: 6f46741e648c07044852bd3391146600, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4420504316707193967, guid: 6f46741e648c07044852bd3391146600, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4420504316707193967, guid: 6f46741e648c07044852bd3391146600, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4420504316707193967, guid: 6f46741e648c07044852bd3391146600, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4420504316707193967, guid: 6f46741e648c07044852bd3391146600, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4420504316707193967, guid: 6f46741e648c07044852bd3391146600, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4420504316707193967, guid: 6f46741e648c07044852bd3391146600, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4420504316707193967, guid: 6f46741e648c07044852bd3391146600, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4420504316707193967, guid: 6f46741e648c07044852bd3391146600, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4420504316707193967, guid: 6f46741e648c07044852bd3391146600, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4420504316707193967, guid: 6f46741e648c07044852bd3391146600, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4961476867242781604, guid: 6f46741e648c07044852bd3391146600, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6904207334484646558, guid: 6f46741e648c07044852bd3391146600, type: 3}
+      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
+      value: 1801810542
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects:
+    - targetCorrespondingSourceObject: {fileID: 8331225728328382101, guid: 6f46741e648c07044852bd3391146600, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 2086640382105371342}
+    - targetCorrespondingSourceObject: {fileID: 8331225728328382101, guid: 6f46741e648c07044852bd3391146600, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1740384323607372229}
+    - targetCorrespondingSourceObject: {fileID: 8331225728328382101, guid: 6f46741e648c07044852bd3391146600, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 7059080079722848802}
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 4420504316707193964, guid: 6f46741e648c07044852bd3391146600, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: -7363390449280688402}
+  m_SourcePrefab: {fileID: 100100000, guid: 6f46741e648c07044852bd3391146600, type: 3}
+--- !u!1 &1586441354170508409 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 4420504316707193964, guid: 6f46741e648c07044852bd3391146600, type: 3}
+  m_PrefabInstance: {fileID: 3124624307905060885}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &-7363390449280688402
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1586441354170508409}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 72937b5a0ace4dabbf17db69fd63068c, type: 3}
+  m_Name:
+  m_EditorClassIdentifier: Assembly-CSharp::YARG.Menu.Settings.Visuals.FolderPathSettingVisual
+  _settingLabel: {fileID: 8398173980181265035}
+  _evenBackground: {fileID: 8036200387225160625}
+  _advancedMarker: {fileID: 2771391343436603804}
+  _pathText: {fileID: 1482936140848510206}
+--- !u!1 &2771391343436603804 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 948307881895838089, guid: 6f46741e648c07044852bd3391146600, type: 3}
+  m_PrefabInstance: {fileID: 3124624307905060885}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &6395833747087873664 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 8331225728328382101, guid: 6f46741e648c07044852bd3391146600, type: 3}
+  m_PrefabInstance: {fileID: 3124624307905060885}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &8036200387225160625 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 4961476867242781604, guid: 6f46741e648c07044852bd3391146600, type: 3}
+  m_PrefabInstance: {fileID: 3124624307905060885}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &8398173980181265035 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 6904207334484646558, guid: 6f46741e648c07044852bd3391146600, type: 3}
+  m_PrefabInstance: {fileID: 3124624307905060885}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+--- !u!1001 &3820949843116736673
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 6395833747087873664}
+    m_Modifications:
+    - target: {fileID: 719737562248201140, guid: 1559ee81882cd0045b6d33a64692e938, type: 3}
+      propertyPath: m_Sprite
+      value:
+      objectReference: {fileID: 576907288, guid: d61b57863fe4fc742a1234c2896ca0cd, type: 3}
+    - target: {fileID: 1071800837622904608, guid: 1559ee81882cd0045b6d33a64692e938, type: 3}
+      propertyPath: m_Color.b
+      value: 0.21568628
+      objectReference: {fileID: 0}
+    - target: {fileID: 1071800837622904608, guid: 1559ee81882cd0045b6d33a64692e938, type: 3}
+      propertyPath: m_Color.g
+      value: 0.16862746
+      objectReference: {fileID: 0}
+    - target: {fileID: 1071800837622904608, guid: 1559ee81882cd0045b6d33a64692e938, type: 3}
+      propertyPath: m_Color.r
+      value: 0.9529412
+      objectReference: {fileID: 0}
+    - target: {fileID: 1245898288579793007, guid: 1559ee81882cd0045b6d33a64692e938, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1245898288579793007, guid: 1559ee81882cd0045b6d33a64692e938, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1245898288579793007, guid: 1559ee81882cd0045b6d33a64692e938, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value:
+      objectReference: {fileID: -7363390449280688402}
+    - target: {fileID: 1245898288579793007, guid: 1559ee81882cd0045b6d33a64692e938, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 1245898288579793007, guid: 1559ee81882cd0045b6d33a64692e938, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: Reset
+      objectReference: {fileID: 0}
+    - target: {fileID: 1245898288579793007, guid: 1559ee81882cd0045b6d33a64692e938, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: YARG.Menu.Settings.Visuals.FolderPathSettingVisual, Assembly-CSharp
+      objectReference: {fileID: 0}
+    - target: {fileID: 1245898288579793007, guid: 1559ee81882cd0045b6d33a64692e938, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 3252069457828798820, guid: 1559ee81882cd0045b6d33a64692e938, type: 3}
+      propertyPath: m_Pivot.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3252069457828798820, guid: 1559ee81882cd0045b6d33a64692e938, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5000001
+      objectReference: {fileID: 0}
+    - target: {fileID: 3252069457828798820, guid: 1559ee81882cd0045b6d33a64692e938, type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3252069457828798820, guid: 1559ee81882cd0045b6d33a64692e938, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3252069457828798820, guid: 1559ee81882cd0045b6d33a64692e938, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3252069457828798820, guid: 1559ee81882cd0045b6d33a64692e938, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3252069457828798820, guid: 1559ee81882cd0045b6d33a64692e938, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3252069457828798820, guid: 1559ee81882cd0045b6d33a64692e938, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 32
+      objectReference: {fileID: 0}
+    - target: {fileID: 3252069457828798820, guid: 1559ee81882cd0045b6d33a64692e938, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3252069457828798820, guid: 1559ee81882cd0045b6d33a64692e938, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3252069457828798820, guid: 1559ee81882cd0045b6d33a64692e938, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3252069457828798820, guid: 1559ee81882cd0045b6d33a64692e938, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3252069457828798820, guid: 1559ee81882cd0045b6d33a64692e938, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3252069457828798820, guid: 1559ee81882cd0045b6d33a64692e938, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3252069457828798820, guid: 1559ee81882cd0045b6d33a64692e938, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3252069457828798820, guid: 1559ee81882cd0045b6d33a64692e938, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3252069457828798820, guid: 1559ee81882cd0045b6d33a64692e938, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3252069457828798820, guid: 1559ee81882cd0045b6d33a64692e938, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3252069457828798820, guid: 1559ee81882cd0045b6d33a64692e938, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3252069457828798820, guid: 1559ee81882cd0045b6d33a64692e938, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3252069457828798820, guid: 1559ee81882cd0045b6d33a64692e938, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4441713907549617493, guid: 1559ee81882cd0045b6d33a64692e938, type: 3}
+      propertyPath: m_Name
+      value: SmallIconButton
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 1559ee81882cd0045b6d33a64692e938, type: 3}
+--- !u!224 &1740384323607372229 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 3252069457828798820, guid: 1559ee81882cd0045b6d33a64692e938, type: 3}
+  m_PrefabInstance: {fileID: 3820949843116736673}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &4312601872095803265 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1071800837622904608, guid: 1559ee81882cd0045b6d33a64692e938, type: 3}
+  m_PrefabInstance: {fileID: 3820949843116736673}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+--- !u!1001 &5536973567039816518
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 6395833747087873664}
+    m_Modifications:
+    - target: {fileID: 1071800837622904608, guid: f6ac2a9c2f684f84792c7d7cd00ba18c, type: 3}
+      propertyPath: m_Color.b
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1071800837622904608, guid: f6ac2a9c2f684f84792c7d7cd00ba18c, type: 3}
+      propertyPath: m_Color.g
+      value: 0.8509804
+      objectReference: {fileID: 0}
+    - target: {fileID: 1071800837622904608, guid: f6ac2a9c2f684f84792c7d7cd00ba18c, type: 3}
+      propertyPath: m_Color.r
+      value: 0.18039216
+      objectReference: {fileID: 0}
+    - target: {fileID: 1245898288579793007, guid: f6ac2a9c2f684f84792c7d7cd00ba18c, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1245898288579793007, guid: f6ac2a9c2f684f84792c7d7cd00ba18c, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1245898288579793007, guid: f6ac2a9c2f684f84792c7d7cd00ba18c, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value:
+      objectReference: {fileID: -7363390449280688402}
+    - target: {fileID: 1245898288579793007, guid: f6ac2a9c2f684f84792c7d7cd00ba18c, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 1245898288579793007, guid: f6ac2a9c2f684f84792c7d7cd00ba18c, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: Browse
+      objectReference: {fileID: 0}
+    - target: {fileID: 1245898288579793007, guid: f6ac2a9c2f684f84792c7d7cd00ba18c, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: YARG.Menu.Settings.Visuals.FolderPathSettingVisual, Assembly-CSharp
+      objectReference: {fileID: 0}
+    - target: {fileID: 1245898288579793007, guid: f6ac2a9c2f684f84792c7d7cd00ba18c, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 3252069457828798820, guid: f6ac2a9c2f684f84792c7d7cd00ba18c, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.99999976
+      objectReference: {fileID: 0}
+    - target: {fileID: 3252069457828798820, guid: f6ac2a9c2f684f84792c7d7cd00ba18c, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5000001
+      objectReference: {fileID: 0}
+    - target: {fileID: 3252069457828798820, guid: f6ac2a9c2f684f84792c7d7cd00ba18c, type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 3252069457828798820, guid: f6ac2a9c2f684f84792c7d7cd00ba18c, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3252069457828798820, guid: f6ac2a9c2f684f84792c7d7cd00ba18c, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3252069457828798820, guid: f6ac2a9c2f684f84792c7d7cd00ba18c, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3252069457828798820, guid: f6ac2a9c2f684f84792c7d7cd00ba18c, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3252069457828798820, guid: f6ac2a9c2f684f84792c7d7cd00ba18c, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 125
+      objectReference: {fileID: 0}
+    - target: {fileID: 3252069457828798820, guid: f6ac2a9c2f684f84792c7d7cd00ba18c, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3252069457828798820, guid: f6ac2a9c2f684f84792c7d7cd00ba18c, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3252069457828798820, guid: f6ac2a9c2f684f84792c7d7cd00ba18c, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3252069457828798820, guid: f6ac2a9c2f684f84792c7d7cd00ba18c, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3252069457828798820, guid: f6ac2a9c2f684f84792c7d7cd00ba18c, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 3252069457828798820, guid: f6ac2a9c2f684f84792c7d7cd00ba18c, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3252069457828798820, guid: f6ac2a9c2f684f84792c7d7cd00ba18c, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3252069457828798820, guid: f6ac2a9c2f684f84792c7d7cd00ba18c, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3252069457828798820, guid: f6ac2a9c2f684f84792c7d7cd00ba18c, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: -45
+      objectReference: {fileID: 0}
+    - target: {fileID: 3252069457828798820, guid: f6ac2a9c2f684f84792c7d7cd00ba18c, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3252069457828798820, guid: f6ac2a9c2f684f84792c7d7cd00ba18c, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3252069457828798820, guid: f6ac2a9c2f684f84792c7d7cd00ba18c, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3252069457828798820, guid: f6ac2a9c2f684f84792c7d7cd00ba18c, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4441713907549617493, guid: f6ac2a9c2f684f84792c7d7cd00ba18c, type: 3}
+      propertyPath: m_Name
+      value: SmallRoundButton
+      objectReference: {fileID: 0}
+    - target: {fileID: 5240628994194081110, guid: f6ac2a9c2f684f84792c7d7cd00ba18c, type: 3}
+      propertyPath: m_text
+      value: Browse
+      objectReference: {fileID: 0}
+    - target: {fileID: 5240628994194081110, guid: f6ac2a9c2f684f84792c7d7cd00ba18c, type: 3}
+      propertyPath: 'm_ActiveFontFeatures.Array.data[0]'
+      value: 1801810542
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: f6ac2a9c2f684f84792c7d7cd00ba18c, type: 3}
+--- !u!224 &7059080079722848802 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 3252069457828798820, guid: f6ac2a9c2f684f84792c7d7cd00ba18c, type: 3}
+  m_PrefabInstance: {fileID: 5536973567039816518}
+  m_PrefabAsset: {fileID: 0}

--- a/Assets/Prefabs/Menu/Settings/Visuals/FolderPathSetting.prefab.meta
+++ b/Assets/Prefabs/Menu/Settings/Visuals/FolderPathSetting.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 6d9df991fa6c41fba11ecf9153cf3f9a
+PrefabImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Script/Menu/Settings/Visuals/FolderPathSettingVisual.cs
+++ b/Assets/Script/Menu/Settings/Visuals/FolderPathSettingVisual.cs
@@ -1,0 +1,40 @@
+using TMPro;
+using UnityEngine;
+using YARG.Helpers;
+using YARG.Localization;
+using YARG.Menu.Navigation;
+using YARG.Settings.Types;
+
+namespace YARG.Menu.Settings.Visuals
+{
+    public class FolderPathSettingVisual : BaseSettingVisual<FolderPathSetting>
+    {
+        [SerializeField]
+        private TextMeshProUGUI _pathText;
+
+        public override NavigationScheme GetNavigationScheme() => NavigationScheme.Empty;
+
+        public override void RefreshVisual()
+        {
+            _pathText.text = string.IsNullOrEmpty(Setting.Value)
+                ? Localize.Key("Menu.Settings.UsingDefaultVlcPath")
+                : Setting.Value;
+        }
+
+        public void Browse()
+        {
+            var startingDir = Setting.Value;
+            FileExplorerHelper.OpenChooseFolder(startingDir, folder =>
+            {
+                Setting.Value = folder;
+                RefreshVisual();
+            });
+        }
+
+        public void Reset()
+        {
+            Setting.Value = string.Empty;
+            RefreshVisual();
+        }
+    }
+}

--- a/Assets/Script/Menu/Settings/Visuals/FolderPathSettingVisual.cs.meta
+++ b/Assets/Script/Menu/Settings/Visuals/FolderPathSettingVisual.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 72937b5a0ace4dabbf17db69fd63068c
+timeCreated: 1756000000

--- a/Assets/Script/Settings/SettingsManager.Settings.cs
+++ b/Assets/Script/Settings/SettingsManager.Settings.cs
@@ -209,6 +209,13 @@ namespace YARG.Settings
             public ToggleSetting WaitForSongVideo          { get; } = new(true);
             public ToggleSetting AllowRemoteContent        { get; } = new(true);
 
+            // Empty means "not set" -- VLCMediaPlayer falls back to its own default
+            // (Application.dataPath-based) resolution when this is empty.
+            public FolderPathSetting VlcLibraryPath { get; } = new(string.Empty, path =>
+            {
+                LibVLCSharp.VLCMediaPlayer.LibraryPathOverride = string.IsNullOrEmpty(path) ? null : path;
+            });
+
 
             public SliderSetting InputPollingFrequency { get; } = new(250f, 60f, 1000f,
                 (value) => InputSystem.pollingFrequency = value

--- a/Assets/Script/Settings/SettingsManager.cs
+++ b/Assets/Script/Settings/SettingsManager.cs
@@ -64,6 +64,7 @@ namespace YARG.Settings
                 nameof(Settings.DisablePerSongBackgrounds),
                 new FieldMetadata(nameof(Settings.WaitForSongVideo), isAdvanced: true),
                 nameof(Settings.AllowRemoteContent),
+                new FieldMetadata(nameof(Settings.VlcLibraryPath), isAdvanced: true),
 
                 new HeaderMetadata("Gameplay"),
                 new FieldMetadata(nameof(Settings.InputPollingFrequency), isAdvanced: true),

--- a/Assets/Script/Settings/Types/FolderPathSetting.cs
+++ b/Assets/Script/Settings/Types/FolderPathSetting.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace YARG.Settings.Types
+{
+    // A user-browsable folder path. An empty value means "not set" -- callers
+    // should fall back to their own auto-detection when Value is null/empty.
+    public class FolderPathSetting : AbstractSetting<string>
+    {
+        public override string AddressableName => "Setting/FolderPath";
+
+        public FolderPathSetting(string value, Action<string> onChange = null) : base(onChange)
+        {
+            _value = value ?? string.Empty;
+        }
+
+        protected override void SetValue(string value)
+        {
+            _value = value ?? string.Empty;
+        }
+
+        public override bool ValueEquals(string value) => value == Value;
+    }
+}

--- a/Assets/Script/Settings/Types/FolderPathSetting.cs.meta
+++ b/Assets/Script/Settings/Types/FolderPathSetting.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f20a3789d9594acba01940fb37fc9e36
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Settings/AddressableAssetsData/AssetGroups/Default Local Group.asset
+++ b/Assets/Settings/AddressableAssetsData/AssetGroups/Default Local Group.asset
@@ -150,6 +150,11 @@ MonoBehaviour:
     m_ReadOnly: 0
     m_SerializedLabels: []
     FlaggedDuringContentUpdateRestriction: 0
+  - m_GUID: 6d9df991fa6c41fba11ecf9153cf3f9a
+    m_Address: Setting/FolderPath
+    m_ReadOnly: 0
+    m_SerializedLabels: []
+    FlaggedDuringContentUpdateRestriction: 0
   - m_GUID: 745d7b0a47e64a5498e4f35f00fe8a82
     m_Address: Setting/Volume
     m_ReadOnly: 0

--- a/Assets/StreamingAssets/lang/en-US.json
+++ b/Assets/StreamingAssets/lang/en-US.json
@@ -570,6 +570,7 @@
             "ShowAdvanced": "Show Advanced",
             "HideAdvanced": "Hide Advanced",
             "NoFolder": "<i>No Folder</i>",
+            "UsingDefaultVlcPath": "<i>Auto (default)</i>",
             "SearchHeader": {
                 "AllCategories": "All Categories",
                 "Results": "Results"
@@ -1920,6 +1921,10 @@
             "AllowRemoteContent": {
                 "Name": "Allow Remote Content",
                 "Description": "Allows YARG to download and use content from remote sources. (Does not affect OpenSource and Genrelizer, requires restart to take effect)"
+            },
+            "VlcLibraryPath": {
+                "Name": "VLC / libVLC Path",
+                "Description": "Path to a VLC/libVLC (v4, not v3) install for your OS, for using VLC as the video decoder. Leave empty to use the default (bundled/system) location. If none is found, will gracefully fallback to the Unity video player. Setting likely requires a YARG restart to take effect."
             },
             "WrapAroundNavigation": {
                 "Name": "Wrap-Around Navigation",

--- a/Assets/VLCUnity/Internal/VLCMediaPlayer.cs
+++ b/Assets/VLCUnity/Internal/VLCMediaPlayer.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using UnityEngine;
 
@@ -24,6 +26,24 @@ namespace LibVLCSharp
         private const float BufferingPercentageScale = 100f;
 
         public static LibVLC LibVLC { get; private set; }
+
+        /// <summary>
+        /// Optional override for the base directory passed to <see cref="Core.Initialize"/> on
+        /// Windows/Mac, in place of <see cref="Application.dataPath"/>. Set by non-vendored game
+        /// code (see YARG.Settings.SettingsManager.Settings.cs) before any VLCMediaPlayer.Awake()
+        /// runs. Null/empty means "use the default". Has no effect on Linux (InitializeUnity is a
+        /// no-op there).
+        /// </summary>
+        public static string LibraryPathOverride { get; set; }
+
+        // The base path LibVLC was actually initialized with, so Awake() can detect a
+        // LibraryPathOverride change and re-initialize instead of silently keeping the old
+        // (static, process-lifetime) LibVLC instance.
+        private static string _lastInitializedBasePath;
+
+        private static string GetEffectiveBasePath() =>
+            string.IsNullOrEmpty(LibraryPathOverride) ? Application.dataPath : LibraryPathOverride;
+
         public MediaPlayer MediaPlayer { get; private set;  }
         public override RenderTexture OutputTexture { get; protected set; }
 
@@ -90,11 +110,23 @@ namespace LibVLCSharp
             try
             {
                 if (LibVLC == null)
+                {
                     CreateLibVLC();
+                }
+                else if (_lastInitializedBasePath != GetEffectiveBasePath())
+                {
+                    // LibraryPathOverride changed since LibVLC was last built -- re-run
+                    // CreateLibVLC() so the new path actually gets tried instead of silently
+                    // reusing the old (static, process-lifetime) instance.
+                    Debug.Log($"[VLCMediaPlayer] Configured VLC path changed from '{_lastInitializedBasePath}' to '{GetEffectiveBasePath()}', re-initializing. " +
+                        "If playback still reflects the old install, a full Editor/app restart may be required.");
+                    CreateLibVLC();
+                }
             }
-            catch (DllNotFoundException)
+            catch (Exception ex)
             {
                 // Disable VLC so the game falls back to Unity's video player.
+                Debug.LogWarning($"[VLCMediaPlayer] Failed to initialize libvlc, falling back to Unity's video player: {ex}");
                 enabled = false;
                 return;
             }
@@ -391,10 +423,56 @@ namespace LibVLCSharp
                 LibVLC = null;
             }
 
+// load a non-default VLC library, if a path has been selected
 #if UNITY_STANDALONE_LINUX || UNITY_EDITOR_LINUX || UNITY_EMBEDDED_LINUX
             Core.Initialize(OnLoad.LibVLCDirectory); // Load bundled Linux libvlc.
 #else
-            Core.Initialize(Application.dataPath); // Load VLC dlls
+            string basePath = GetEffectiveBasePath();
+
+#if UNITY_STANDALONE_OSX || UNITY_EDITOR_OSX
+            // InitializeUnity's own Mac path math builds paths with backslashes, which aren't
+            // separators on macOS, so its directory lookup never finds anything real here.
+            // Pre-load the real libvlc/libvlccore/plugins ourselves instead, and use success/
+            // failure here as a pre-check for whether it's even safe to call Core.Initialize
+            // below -- see TryPreloadMac.
+            bool macLibvlcLoaded = TryPreloadMac(basePath, out string macPluginsDir);
+            if (!macLibvlcLoaded && basePath != Application.dataPath)
+            {
+                Debug.LogWarning($"[VLCMediaPlayer] No usable libvlc under configured path '{basePath}'. Trying default location.");
+                basePath = Application.dataPath;
+                macLibvlcLoaded = TryPreloadMac(basePath, out macPluginsDir);
+            }
+
+            if (!macLibvlcLoaded)
+            {
+                Debug.LogWarning("[VLCMediaPlayer] No usable libvlc found -- skipping native init to avoid poisoning it for later attempts this session.");
+                return;
+            }
+#endif
+
+            Debug.Log($"[VLCMediaPlayer] Initializing libvlc with base path '{basePath}' (override: {!string.IsNullOrEmpty(LibraryPathOverride)}).");
+            try
+            {
+                Core.Initialize(basePath);
+            }
+            catch (Exception ex) when (basePath != Application.dataPath)
+            {
+                // User-configured VLC library path didn't yield a working libvlc; soft-fall back
+                // to the default location rather than hard-failing VLC init entirely.
+                Debug.LogWarning($"[VLCMediaPlayer] Failed to initialize libvlc from configured path '{basePath}': {ex.Message}. Falling back to default.");
+                Core.Initialize(Application.dataPath);
+            }
+
+#if UNITY_STANDALONE_OSX || UNITY_EDITOR_OSX
+            // Core.Initialize (above) unconditionally overwrites VLC_PLUGIN_PATH with its own
+            // (backslash-broken) guess. Re-apply ours after it, before LibVLC is constructed
+            // and actually reads the variable.
+            if (macPluginsDir != null)
+            {
+                Environment.SetEnvironmentVariable("VLC_PLUGIN_PATH", macPluginsDir);
+                Debug.Log($"[VLCMediaPlayer] Re-applied VLC_PLUGIN_PATH='{macPluginsDir}' after Core.Initialize (which overwrites it with its own, incompatible guess).");
+            }
+#endif
 #endif
 
             var args = new List<string>();
@@ -409,7 +487,116 @@ namespace LibVLCSharp
             Application.SetStackTraceLogType(LogType.Log, StackTraceLogType.None);
 
             VLCUnityLogger.HookLibVLC(LibVLC);
+
+            _lastInitializedBasePath = GetEffectiveBasePath();
         }
+
+#if UNITY_STANDALONE_OSX || UNITY_EDITOR_OSX
+        // Resolves a user-configured VLC install to its libvlc/libvlccore/plugins and
+        // dlopen-preloads them directly, bypassing Core.Initialize's own directory lookup
+        // (broken on Mac, see above). RTLD_GLOBAL makes later bare-name DllImport resolution
+        // (used throughout LibVLCSharp.dll) find the preloaded image instead.
+        // NativeLibrary isn't available under this project's scripting API compatibility
+        // level, hence the raw dlopen P/Invoke rather than that.
+        [DllImport("libSystem.dylib", EntryPoint = "dlopen")]
+        private static extern IntPtr Dlopen(string path, int mode);
+
+        private const int RTLD_NOW_GLOBAL = 0x2 | 0x8;
+
+        // Last path a preload was attempted from. Native libraries aren't unloaded between
+        // Play sessions within one Editor process, so dlopen-ing a different libvlc later
+        // doesn't replace the first one -- used only to warn when a stale library from an
+        // earlier session may be shadowing the current attempt.
+        private static string _macPreloadedFrom;
+
+        // Finds and dlopen-preloads the real libvlc/libvlccore/plugins under basePath, trying
+        // known VLC install layouts. Returns false if none are found or preloading fails --
+        // callers must not call Core.Initialize in that case: a failed [DllImport] into
+        // LibVLCSharp.dll is cached by the runtime and never retried for the rest of the
+        // process, so calling it against a path known not to work breaks every later attempt
+        // this session too, including a subsequently-corrected LibraryPathOverride. On success,
+        // pluginsDir is the resolved plugins folder, or null if libvlc loaded but no plugins
+        // folder was found nearby (the caller must re-apply it as VLC_PLUGIN_PATH after
+        // Core.Initialize runs -- see call site).
+        private static bool TryPreloadMac(string basePath, out string pluginsDir)
+        {
+            pluginsDir = null;
+
+            const string libvlcName = "libvlc.dylib";
+            const string libvlccoreName = "libvlccore.dylib";
+
+            // Known VLC install layouts: the path itself (already pointing at the folder
+            // containing the libraries), a VLC 3.x app bundle's Contents/MacOS/lib, or a VLC
+            // 4.x app bundle's Contents/Frameworks. Add new ones here rather than replacing
+            // existing ones -- real installs in the wild use all of these.
+            string[] candidates =
+            {
+                basePath,
+                Path.Combine(basePath, "Contents", "MacOS", "lib"),
+                Path.Combine(basePath, "Contents", "Frameworks"),
+            };
+
+            string libDir = null;
+            foreach (var candidate in candidates)
+            {
+                if (File.Exists(Path.Combine(candidate, libvlcName)) &&
+                    File.Exists(Path.Combine(candidate, libvlccoreName)))
+                {
+                    libDir = candidate;
+                    break;
+                }
+            }
+
+            if (libDir == null)
+            {
+                Debug.LogWarning($"[VLCMediaPlayer] Could not find {libvlcName}/{libvlccoreName} under '{basePath}' (checked: {string.Join(", ", candidates)}).");
+                return false;
+            }
+
+            string libvlcPath = Path.Combine(libDir, libvlcName);
+            string libvlccorePath = Path.Combine(libDir, libvlccoreName);
+
+            if (_macPreloadedFrom != null && _macPreloadedFrom != libDir)
+            {
+                Debug.LogWarning($"[VLCMediaPlayer] A different libvlc was already loaded earlier in this Editor session, from '{_macPreloadedFrom}'. " +
+                    "Native libraries aren't unloaded between Play sessions -- restart the Editor to get a clean test of the newly-configured path.");
+            }
+            _macPreloadedFrom = libDir;
+
+            // libvlc depends on libvlccore -- load it first.
+            if (Dlopen(libvlccorePath, RTLD_NOW_GLOBAL) == IntPtr.Zero ||
+                Dlopen(libvlcPath, RTLD_NOW_GLOBAL) == IntPtr.Zero)
+            {
+                Debug.LogWarning($"[VLCMediaPlayer] Failed to pre-load libvlc from '{libDir}'.");
+                return false;
+            }
+
+            // Plugins folder candidates: alongside the libraries directly (also covers a VLC
+            // 4.x app bundle, where this is Contents/Frameworks/plugins); a sibling of libDir
+            // (a VLC 3.x app bundle's Contents/MacOS/plugins next to Contents/MacOS/lib); or
+            // nested under "vlc" alongside the libraries (a standalone SDK build's lib/vlc/plugins).
+            string[] pluginCandidates =
+            {
+                Path.Combine(libDir, "plugins"),
+                Path.Combine(Path.GetDirectoryName(libDir) ?? string.Empty, "plugins"),
+                Path.Combine(libDir, "vlc", "plugins"),
+            };
+
+            pluginsDir = pluginCandidates.FirstOrDefault(Directory.Exists);
+
+            if (pluginsDir != null)
+            {
+                Environment.SetEnvironmentVariable("VLC_PLUGIN_PATH", pluginsDir);
+                Debug.Log($"[VLCMediaPlayer] Pre-loaded libvlc from '{libDir}', plugins from '{pluginsDir}'.");
+            }
+            else
+            {
+                Debug.LogWarning($"[VLCMediaPlayer] Pre-loaded libvlc from '{libDir}' but couldn't find a plugins folder (checked: {string.Join(", ", pluginCandidates)}).");
+            }
+
+            return true;
+        }
+#endif
 
         private void CreateMediaPlayer()
         {


### PR DESCRIPTION
Building on @theli-ua's VLC work, allow the user to set a path other than the default for looking for a VLC lib. Can use .app or lib on MacOS. Doesn't try to be "smart" or "tricky" about anything; if it's not in whatever the plugin thinks is the default path the user must set the path for VLC to be used.

Does involve one little workaround: The MacOS VLC plugin has a bit of weird pathing code in it that we're bypassing if the default path isn't used. Also, tried to make the path setting a bit resilient to players changing libs without a restart, but it's not 100% so added a "may need a restart" warning.

<img width="546" height="49" alt="Screenshot 2026-09-12 at 12 01 27 PM" src="https://github.com/user-attachments/assets/dfa3fcd6-aa80-46c1-a601-6daa26b10393" />
<img width="536" height="50" alt="Screenshot 2026-09-12 at 12 01 56 PM" src="https://github.com/user-attachments/assets/dc6e0efb-b8a7-49b8-a1f6-35b76a3fcb32" />
<img width="540" height="58" alt="Screenshot 2026-09-12 at 12 02 15 PM" src="https://github.com/user-attachments/assets/577adca0-3b72-4480-bb7f-2ab1618d5b55" />
<img width="432" height="59" alt="Screenshot 2026-09-12 at 12 43 52 PM" src="https://github.com/user-attachments/assets/80806277-ea17-4c8c-86b1-fcd5b388c65c" />

