### PR TITLE
Don't stop the Unity VideoPlayer right after it finishes preparing

### DIFF
--- a/Assets/Script/Gameplay/BackgroundManager.cs
+++ b/Assets/Script/Gameplay/BackgroundManager.cs
@@ -581,8 +581,6 @@ namespace YARG.Gameplay
             const double endTimeThreshold = 0;
             const double dontLoopThreshold = 0.85;
 
-            player.Stop();
-
             if (_source == VenueSource.Song && !GameManager.Song.VideoLoop)
             {
                 _videoStartTime = GameManager.Song.VideoStartTimeSeconds;

--- a/Assets/Script/Gameplay/YargVideoPlayer.cs
+++ b/Assets/Script/Gameplay/YargVideoPlayer.cs
@@ -317,6 +317,8 @@ public class YargVideoPlayer : MonoBehaviour
             return;
         }
 
+        // OpenAsync() starts playing, so stop before handing over to the caller.
+        Stop();
 
         prepareCompleted?.Invoke(this);
     }


### PR DESCRIPTION
`OnVideoPrepared()` calls `player.Stop()` before reading `player.length` and before seeking to the configured start offset.

That stop is only needed for the VLC backend, where `VLCMediaPlayer.OpenAsync()` starts playback as soon as the media opens. The Unity VideoPlayer does not auto-play (`playOnAwake` is disabled on the component), so there is nothing to stop — and stopping it returns it to an unprepared state, where `length` reports 0 and seeks are silently dropped.

On that path, that means:

- **Songs with a non-zero `video_start_time` never show their video.** The loop branch is skipped, `_videoEndTime` is set to `player.length` (0), and `Update()` then returns early on `if (_videoEndTime == 0)` every frame, so `Play()` is never reached. Without an offset the bug is masked: the loop branch is taken instead and `_videoEndTime` becomes `NaN`, which that check doesn't match.
- **Every video is treated as loopable**, regardless of its real length.
- **`video_start_time` itself is a no-op**, since the seek is dropped.

Stopping only on the VLC path leaves that backend unchanged and lets the Unity path keep the prepared state it just acquired.

Tested on Linux with two song folders sharing the same video file via hard link and differing only by `video_start_time`. Before: only the song without an offset played. After: videos play with positive, negative and absent offsets, the offset is actually applied, and a video as long as its song is no longer marked as looping. The VLC path was also compared against an unmodified build and behaves the same.

Fixes #1133 and #374.