### PR TITLE
Decode video in software on NVIDIA/Linux

### DIFF
--- a/Assets/VLCUnity/Internal/VLCMediaPlayer.cs
+++ b/Assets/VLCUnity/Internal/VLCMediaPlayer.cs
@@ -404,6 +404,15 @@ namespace LibVLCSharp
 
             args.AddRange(libVLCArguments?.Where(arg => !string.IsNullOrWhiteSpace(arg)) ?? Array.Empty<string>());
 
+#if UNITY_STANDALONE_LINUX || UNITY_EDITOR_LINUX
+            // VLC only supports the nvdec GL interop on its own GLX output, not on the external
+            // context we render into, so the video would freeze on its first frame.
+            if (SystemInfo.graphicsDeviceVendor.IndexOf("NVIDIA", StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                args.Add("--codec=avcodec");
+            }
+#endif
+
             LibVLC = new LibVLC(enableDebugLogs: false, args.ToArray()); // You can customize LibVLC with advanced CLI options here https://wiki.videolan.org/VLC_command-line_help/
                                                                         // Setup Error Logging
             Application.SetStackTraceLogType(LogType.Log, StackTraceLogType.None);


### PR DESCRIPTION
If you are one of the 3 people running YARC with VLC support on Linux you will notice that videos freeze on Nvidia GPUs, this will become a lot more common when distros start shipping vlc 4 as default.

DISCLAIMER: Had to do some heavy Claude usage to find the root of the issue.

### Problem
On Linux with the proprietary NVIDIA driver, song background videos show their
first frame and then appear frozen for the rest of the song.

It looks like a stall, but nothing is actually stalled. Playback, timing and
looping all keep working: the VLC clock advances in lockstep with the song, the
plugin reports ~13 new frames per second, it rotates its texture pointers, and
the `Graphics.Blit` into the output `RenderTexture` runs every frame. The only
thing that never happens is the texture contents changing. Reading the output
texture back makes it unambiguous -- the hash of its pixels changes once, when
the first frame lands, and then stays constant:

videoTime=0.294  hash=747916189
videoTime=0.798  hash=747916189
videoTime=5.326  hash=747916189

### Cause

libVLC picks the `nvdec` decoder and pairs it with the `glinterop_nvdec` OpenGL
interop. VLC only supports that interop on its own GLX output, and guards
against it in `modules/video_output/opengl/display.c`:

```c
// VDPAU/NVDEC GL interop works only with GLX. Override the "gl" option to force it.
if (surface->type == VLC_WINDOW_TYPE_XID)
{
    switch (vd->source->i_chroma)
    {
        case VLC_CODEC_NVDEC_OPAQUE: ...
            gl_name = strdup("glx");
```
That guard only fires for a real X11 window. The Unity plugin renders through
the external wextern window and vgl output, so it never applies and VLC
selects an interop the context cannot handle:

using vout window module "wextern"
using opengl module "vgl"
using glinterop module "glinterop_nvdec"
using video decoder module "nvdec"

Every layer reports success, which is why this is invisible without reading the
pixels back.

### Fix

Restrict the decoder list to avcodec on NVIDIA/Linux, so frames go through
glinterop_sw. Hardware decoding is left untouched everywhere else.

The plugin's other Linux paths don't help: forcing the DMA-BUF fallback
(VLC_UNITY_GLX_FORCE_DMABUF=1) needs the DRI3 extension, which is missing
under XWayland, and the EGL backend (VLC_UNITY_LINUX_OPENGL_BACKEND=egl)
renders nothing at all. --glinterop=none doesn't work either, since the nvdec
decoder still outputs opaque CUDA chromas.

### Testing

RTX 3090, NVIDIA 610.57.04, Manjaro/XWayland, Unity 6000.3.5f2 standalone Linux
build. Video backgrounds frozen before, playing normally after. Verified by
pixel-hashing the output texture across the whole song.

Unaffected on AMD/Mesa, where VA-API is used and the nvdec path is never
reached -- confirmed on a BC-250 (gfx1013).